### PR TITLE
Add paste output mode for clipboard and Ctrl+V simulation

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -43,9 +43,10 @@ translate = false
 # threads = 4
 
 [output]
-# Primary output mode: "type" or "clipboard"
+# Primary output mode: "type", "clipboard", or "paste"
 # - type: Simulates keyboard input at cursor position (requires ydotool)
 # - clipboard: Copies text to clipboard (requires wl-copy)
+# - paste: Copies to clipboard then pastes with Ctrl+V (requires wl-copy and ydotool)
 mode = "type"
 
 # Fall back to clipboard if typing fails

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -303,12 +303,16 @@ Primary output method.
 **Values:**
 - `type` - Simulate keyboard input at cursor position (requires ydotool)
 - `clipboard` - Copy text to clipboard (requires wl-copy)
+- `paste` - Copy to clipboard then paste with Ctrl+V (requires wl-copy and ydotool)
 
 **Example:**
 ```toml
 [output]
-mode = "clipboard"
+mode = "paste"
 ```
+
+**Note about paste mode:**
+The `paste` mode is designed to work around non-US keyboard layout issues. Instead of typing characters directly (which assumes US keyboard layout), it copies text to the clipboard and then simulates Ctrl+V to paste it. This works regardless of keyboard layout but requires both wl-copy (for clipboard access) and ydotool (for Ctrl+V simulation).
 
 ### fallback_to_clipboard
 
@@ -317,6 +321,8 @@ mode = "clipboard"
 **Required:** No
 
 When `true` and `mode = "type"`, falls back to clipboard if typing fails.
+
+**Note:** This setting has no effect when `mode = "paste"` since paste mode doesn't use fallback behavior.
 
 **Example:**
 ```toml
@@ -532,6 +538,7 @@ Most configuration options can be overridden via command line:
 | hotkey.key | `--hotkey` |
 | whisper.model | `--model` |
 | output.mode = "clipboard" | `--clipboard` |
+| output.mode = "paste" | `--paste` |
 | Verbosity | `-v`, `-vv`, `-q` |
 
 **Example:**

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,6 +294,8 @@ pub enum OutputMode {
     Type,
     /// Copy to clipboard (requires wl-copy)
     Clipboard,
+    /// Copy to clipboard then paste with Ctrl+V (requires wl-copy and ydotool)
+    Paste,
 }
 
 fn default_true() -> bool {
@@ -431,6 +433,7 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     if let Ok(mode) = std::env::var("VOXTYPE_OUTPUT_MODE") {
         config.output.mode = match mode.to_lowercase().as_str() {
             "clipboard" => OutputMode::Clipboard,
+            "paste" => OutputMode::Paste,
             _ => OutputMode::Type,
         };
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,9 @@ pub enum OutputError {
     #[error("Text injection failed: {0}")]
     InjectionFailed(String),
 
+    #[error("Ctrl+V simulation failed: {0}")]
+    CtrlVFailed(String),
+
     #[error("All output methods failed. Ensure wtype, ydotool, or wl-copy is available.")]
     AllMethodsFailed,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ struct Cli {
     #[arg(long)]
     clipboard: bool,
 
+    /// Force paste mode (clipboard + Ctrl+V)
+    #[arg(long)]
+    paste: bool,
+
     /// Override whisper model (tiny, base, small, medium, large-v3, large-v3-turbo)
     #[arg(long, value_name = "MODEL")]
     model: Option<String>,
@@ -168,6 +172,9 @@ async fn main() -> anyhow::Result<()> {
     // Apply CLI overrides
     if cli.clipboard {
         config.output.mode = config::OutputMode::Clipboard;
+    }
+    if cli.paste {
+        config.output.mode = config::OutputMode::Paste;
     }
     if let Some(model) = cli.model {
         config.whisper.model = model;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -6,9 +6,12 @@
 //! 1. wtype - Wayland-native, best Unicode/CJK support, no daemon needed
 //! 2. ydotool - Works on X11/Wayland/TTY, requires daemon
 //! 3. clipboard - Universal fallback via wl-copy
+//! 
+//! Paste mode (clipboard + Ctrl+V) helps with system with non US keyboard layouts.
 
 pub mod clipboard;
 pub mod wtype;
+pub mod paste;
 pub mod ydotool;
 
 use crate::config::OutputConfig;
@@ -52,6 +55,12 @@ pub fn create_output_chain(config: &OutputConfig) -> Vec<Box<dyn TextOutput>> {
         crate::config::OutputMode::Clipboard => {
             // Only clipboard
             chain.push(Box::new(clipboard::ClipboardOutput::new(
+                config.notification.on_transcription,
+            )));
+        }
+        crate::config::OutputMode::Paste => {
+            // Only paste mode (no fallback as requested)
+            chain.push(Box::new(paste::PasteOutput::new(
                 config.notification.on_transcription,
             )));
         }

--- a/src/output/paste.rs
+++ b/src/output/paste.rs
@@ -1,0 +1,197 @@
+//! Paste-based text output
+//!
+//! Uses wl-copy to copy text to clipboard, then simulates Ctrl+V with ydotool.
+//! This works around non-US keyboard layout issues by avoiding direct typing.
+//!
+//! Requires:
+//! - wl-copy installed (for clipboard access)
+//! - ydotool installed (for Ctrl+V simulation)
+//! - ydotoold daemon running (systemctl --user start ydotool)
+
+use super::TextOutput;
+use crate::error::OutputError;
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+/// Paste-based text output (clipboard + Ctrl+V)
+pub struct PasteOutput {
+    /// Whether to show a desktop notification
+    notify: bool,
+}
+
+impl PasteOutput {
+    /// Create a new paste output
+    pub fn new(notify: bool) -> Self {
+        Self { notify }
+    }
+
+    /// Send a desktop notification
+    async fn send_notification(&self, text: &str) {
+        // Truncate preview for notification
+        let preview = if text.len() > 80 {
+            format!("{}...", &text[..80])
+        } else {
+            text.to_string()
+        };
+
+        let _ = Command::new("notify-send")
+            .args([
+                "--app-name=Voxtype",
+                "--urgency=low",
+                "--expire-time=3000",
+                "Pasted text",
+                &preview,
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+    }
+
+    /// Copy text to clipboard using wl-copy
+    async fn copy_to_clipboard(&self, text: &str) -> Result<(), OutputError> {
+        // Spawn wl-copy with stdin pipe
+        let mut child = Command::new("wl-copy")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    OutputError::WlCopyNotFound
+                } else {
+                    OutputError::InjectionFailed(e.to_string())
+                }
+            })?;
+
+        // Write text to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(text.as_bytes())
+                .await
+                .map_err(|e| OutputError::InjectionFailed(e.to_string()))?;
+            
+            // Close stdin to signal EOF
+            drop(stdin);
+        }
+
+        // Wait for completion
+        let status = child
+            .wait()
+            .await
+            .map_err(|e| OutputError::InjectionFailed(e.to_string()))?;
+
+        if !status.success() {
+            return Err(OutputError::InjectionFailed(
+                "wl-copy exited with error".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Simulate Ctrl+V key combination using ydotool
+    async fn simulate_ctrl_v(&self) -> Result<(), OutputError> {
+        // Use ydotool to press Ctrl+V (Left Ctrl + V)
+        // 29 = KEY_LEFTCTRL, 47 = KEY_V
+        // Format: key_code:1 (press) then key_code:0 (release)
+        let output = Command::new("ydotool")
+            .args(["key", "29:1", "47:1", "47:0", "29:0"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    OutputError::YdotoolNotFound
+                } else {
+                    OutputError::CtrlVFailed(e.to_string())
+                }
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            // Check for common errors
+            if stderr.contains("socket") || stderr.contains("connect") || stderr.contains("daemon")
+            {
+                return Err(OutputError::YdotoolNotRunning);
+            }
+
+            return Err(OutputError::CtrlVFailed(stderr.to_string()));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl TextOutput for PasteOutput {
+    async fn output(&self, text: &str) -> Result<(), OutputError> {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        // Step 1: Copy to clipboard
+        self.copy_to_clipboard(text).await?;
+	
+	// Small delay to ensure clipboard is set before pasting
+	tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Step 2: Simulate Ctrl+V
+        self.simulate_ctrl_v().await?;
+
+        // Send notification if enabled
+        if self.notify {
+            self.send_notification(text).await;
+        }
+
+        tracing::info!("Text pasted via clipboard + Ctrl+V ({} chars)", text.len());
+        Ok(())
+    }
+
+    async fn is_available(&self) -> bool {
+        // Check if wl-copy exists
+        let wl_copy_available = Command::new("which")
+            .arg("wl-copy")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if !wl_copy_available {
+            return false;
+        }
+
+        // Check if ydotool exists
+        let ydotool_available = Command::new("which")
+            .arg("ydotool")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if !ydotool_available {
+            return false;
+        }
+
+        // Check if ydotoold is running by trying a no-op
+        Command::new("ydotool")
+            .args(["key", ""])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn name(&self) -> &'static str {
+        "paste (clipboard + Ctrl+V)"
+    }
+}


### PR DESCRIPTION
ydotool currently simulates US keyboard input and doesn't offer layout switching. This new output mode addresses this by copying characters to the clipboard and pasting them, ensuring accented characters are preserved and improving compatibility with layouts like Dvorak. This method isn't appropriate where Ctrl+V performs a different action, such as in Vim's command mode.