### PR TITLE
fix: update PKGBUILD path substitution in install script for local builds

### DIFF
--- a/packaging/arch/PKGBUILD-local
+++ b/packaging/arch/PKGBUILD-local
@@ -25,13 +25,14 @@ optdepends=(
     'pulseaudio: audio capture (alternative)'
 )
 backup=('etc/voxtype/config.toml')
+options=(!lto)
 
 # Build from local source - no download needed
 source=()
 sha256sums=()
 
 # Point to the project root (two levels up from packaging/arch/)
-_srcdir="/home/pete/workspace/voxtype"
+_srcdir="${PWD%/*/*}"
 
 pkgver() {
     cd "$_srcdir"

--- a/scripts/install-arch.sh
+++ b/scripts/install-arch.sh
@@ -14,8 +14,9 @@ echo "==> Building voxtype Arch package..."
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 
-# Copy PKGBUILD
-cp "$PROJECT_ROOT/packaging/arch/PKGBUILD-local" "$BUILD_DIR/PKGBUILD"
+# Copy PKGBUILD and substitute the project root path
+sed "s|_srcdir=\".*\"|_srcdir=\"$PROJECT_ROOT\"|" \
+    "$PROJECT_ROOT/packaging/arch/PKGBUILD-local" > "$BUILD_DIR/PKGBUILD"
 
 # Build and install
 cd "$BUILD_DIR"


### PR DESCRIPTION
The existing build script uses specific usernames and assumptions. This modification improves its adaptability.
lto is disabled since it did not build on my machine with it. I am not a Rust dev so take what you find reasonable