### PR TITLE
Set language on mod key

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -13,6 +13,14 @@ key = "SCROLLLOCK"
 # Example: modifiers = ["LEFTCTRL", "LEFTALT"]
 modifiers = []
 
+# Language-specific modifier mappings
+# Maps modifier keys to language codes for transcription
+# Example: RIGHTSHIFT = "hu" (Hungarian), RIGHTCTRL = "en" (English)
+# When no language modifier is pressed, uses the default language from [whisper] section
+[hotkey.language_modifiers]
+# RIGHTSHIFT = "lang1"
+# RIGHTCTRL  = "lang2"
+
 [audio]
 # Audio input device ("default" uses system default)
 # List devices with: pactl list sources short

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,14 @@ modifiers = []
 # When disabled, use `voxtype record start/stop/toggle` to control recording
 # enabled = true
 
+# Language-specific modifier mappings
+# Maps modifier keys to language codes for transcription
+# Example: RIGHTSHIFT = "hu" (Hungarian), RIGHTCTRL = "en" (English)
+# When no language modifier is pressed, uses the default language from [whisper] section
+[hotkey.language_modifiers]
+# RIGHTSHIFT = "hu"
+# RIGHTCTRL = "en"
+
 [audio]
 # Audio input device ("default" uses system default)
 # List devices with: pactl list sources short
@@ -168,6 +176,11 @@ pub struct HotkeyConfig {
     /// When disabled, use `voxtype record start/stop/toggle` to control recording
     #[serde(default = "default_true")]
     pub enabled: bool,
+
+    /// Language-specific modifier mappings
+    /// Maps modifier keys to language codes for transcription
+    #[serde(default)]
+    pub language_modifiers: HashMap<String, String>,
 }
 
 /// Audio capture configuration
@@ -329,6 +342,7 @@ impl Default for Config {
                 modifiers: vec![],
                 mode: ActivationMode::default(),
                 enabled: true,
+                language_modifiers: HashMap::new(),
             },
             audio: AudioConfig {
                 device: "default".to_string(),

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -13,12 +13,12 @@ use crate::error::HotkeyError;
 use tokio::sync::mpsc;
 
 /// Events emitted by the hotkey listener
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HotkeyEvent {
     /// The hotkey was pressed
-    Pressed,
+    Pressed { language: Option<String> },
     /// The hotkey was released
-    Released,
+    Released { language: Option<String> },
 }
 
 /// Trait for hotkey detection implementations


### PR DESCRIPTION
This feature allows you to assign language profiles to modifier key combinations (for example, RCTRL+SCR_LCK to "en", RSHIFT+SCR_LCK to "it"), while preserving the original modifier key behavior. The goal is to enhance transcription accuracy by providing a cue for the spoken language.