### PR TITLE
Add cancel transcription feature

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,6 +134,8 @@ pub enum RecordAction {
     Stop,
     /// Toggle recording state
     Toggle,
+    /// Cancel current recording or transcription (discard without output)
+    Cancel,
 }
 
 #[derive(Subcommand)]
@@ -302,6 +304,17 @@ mod tests {
                 assert!(restart, "should have restart=true");
             }
             _ => panic!("Expected Setup Model command"),
+        }
+    }
+
+    #[test]
+    fn test_record_cancel() {
+        let cli = Cli::parse_from(["voxtype", "record", "cancel"]);
+        match cli.command {
+            Some(Commands::Record { action: RecordAction::Cancel }) => {
+                // Success - cancel action parsed correctly
+            }
+            _ => panic!("Expected Record Cancel command"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -214,6 +214,12 @@ pub struct HotkeyConfig {
     /// When disabled, use `voxtype record start/stop/toggle` to control recording
     #[serde(default = "default_true")]
     pub enabled: bool,
+
+    /// Optional cancel key (evdev KEY_* constant name, without KEY_ prefix)
+    /// When pressed, cancels the current recording or transcription
+    /// Examples: "ESC", "BACKSPACE", "F12"
+    #[serde(default)]
+    pub cancel_key: Option<String>,
 }
 
 /// Audio capture configuration
@@ -589,6 +595,7 @@ impl Default for Config {
                 modifiers: vec![],
                 mode: ActivationMode::default(),
                 enabled: true,
+                cancel_key: None,
             },
             audio: AudioConfig {
                 device: "default".to_string(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -92,6 +92,29 @@ fn cleanup_pid_file(path: &PathBuf) {
     }
 }
 
+/// Check if cancel has been requested (via file trigger)
+fn check_cancel_requested() -> bool {
+    let cancel_file = Config::runtime_dir().join("cancel");
+    if cancel_file.exists() {
+        // Remove the file to acknowledge the cancel
+        let _ = std::fs::remove_file(&cancel_file);
+        true
+    } else {
+        false
+    }
+}
+
+/// Clean up any stale cancel file on startup
+fn cleanup_cancel_file() {
+    let cancel_file = Config::runtime_dir().join("cancel");
+    if cancel_file.exists() {
+        let _ = std::fs::remove_file(&cancel_file);
+    }
+}
+
+/// Result type for transcription task
+type TranscriptionResult = std::result::Result<String, crate::error::TranscribeError>;
+
 /// Main daemon that orchestrates all components
 pub struct Daemon {
     config: Config,
@@ -102,6 +125,8 @@ pub struct Daemon {
     post_processor: Option<PostProcessor>,
     // Background task for loading model on-demand
     model_load_task: Option<tokio::task::JoinHandle<std::result::Result<Box<dyn crate::transcribe::Transcriber>, crate::error::TranscribeError>>>,
+    // Background task for transcription (allows cancel during transcription)
+    transcription_task: Option<tokio::task::JoinHandle<TranscriptionResult>>,
 }
 
 impl Daemon {
@@ -159,6 +184,7 @@ impl Daemon {
             text_processor,
             post_processor,
             model_load_task: None,
+            transcription_task: None,
         }
     }
 
@@ -176,14 +202,14 @@ impl Daemon {
         }
     }
 
-    /// Stop recording and transcribe the audio
-    async fn stop_and_transcribe(
-        &self,
+    /// Start transcription task (non-blocking, stores JoinHandle for later completion)
+    /// Returns true if transcription was started, false if skipped (too short)
+    async fn start_transcription_task(
+        &mut self,
         state: &mut State,
         audio_capture: &mut Option<Box<dyn AudioCapture>>,
         transcriber: Option<Arc<Box<dyn crate::transcribe::Transcriber>>>,
-        output_chain: &[Box<dyn output::TextOutput>],
-    ) {
+    ) -> bool {
         let duration = state.recording_duration().unwrap_or_default();
         tracing::info!("Recording stopped ({:.1}s)", duration.as_secs_f32());
 
@@ -209,7 +235,7 @@ impl Daemon {
                         );
                         *state = State::Idle;
                         self.update_state("idle");
-                        return;
+                        return false;
                     }
 
                     tracing::info!(
@@ -219,82 +245,104 @@ impl Daemon {
                     *state = State::Transcribing { audio: samples.clone() };
                     self.update_state("transcribing");
 
-                    // Run transcription in blocking task
-                    let text_result = if let Some(t) = transcriber {
-                        tokio::task::spawn_blocking(move || {
+                    // Spawn transcription task (non-blocking)
+                    if let Some(t) = transcriber {
+                        self.transcription_task = Some(tokio::task::spawn_blocking(move || {
                             t.transcribe(&samples)
-                        }).await
+                        }));
+                        return true;
                     } else {
-                        // This should not happen as we'll load the model on-demand
-                        Ok(Err(crate::error::TranscribeError::InitFailed("No transcriber available".to_string())))
-                    };
-
-                    match text_result {
-                        Ok(Ok(text)) => {
-                            if text.is_empty() {
-                                tracing::debug!("Transcription was empty");
-                                *state = State::Idle;
-                                self.update_state("idle");
-                            } else {
-                                tracing::info!("Transcribed: {:?}", text);
-
-                                // Apply text processing (replacements, punctuation)
-                                let processed_text = self.text_processor.process(&text);
-                                if processed_text != text {
-                                    tracing::debug!("After text processing: {:?}", processed_text);
-                                }
-
-                                // Apply post-processing command if configured
-                                let final_text = if let Some(ref post_processor) = self.post_processor {
-                                    tracing::info!("Post-processing: {:?}", processed_text);
-                                    let result = post_processor.process(&processed_text).await;
-                                    tracing::info!("Post-processed: {:?}", result);
-                                    result
-                                } else {
-                                    processed_text
-                                };
-
-                                // Output the text
-                                *state = State::Outputting { text: final_text.clone() };
-
-                                if let Err(e) = output::output_with_fallback(
-                                    output_chain,
-                                    &final_text
-                                ).await {
-                                    tracing::error!("Output failed: {}", e);
-                                }
-
-                                *state = State::Idle;
-                                self.update_state("idle");
-                            }
-                        }
-                        Ok(Err(e)) => {
-                            tracing::error!("Transcription failed: {}", e);
-                            *state = State::Idle;
-                            self.update_state("idle");
-                        }
-                        Err(e) => {
-                            tracing::error!("Transcription task failed: {}", e);
-                            *state = State::Idle;
-                            self.update_state("idle");
-                        }
+                        tracing::error!("No transcriber available");
+                        self.play_feedback(SoundEvent::Error);
+                        *state = State::Idle;
+                        self.update_state("idle");
+                        return false;
                     }
                 }
                 Err(e) => {
                     tracing::warn!("Recording error: {}", e);
                     *state = State::Idle;
                     self.update_state("idle");
+                    return false;
                 }
             }
         } else {
             *state = State::Idle;
             self.update_state("idle");
+            return false;
+        }
+    }
+
+    /// Handle transcription completion (called when transcription_task completes)
+    async fn handle_transcription_result(
+        &self,
+        state: &mut State,
+        result: std::result::Result<TranscriptionResult, tokio::task::JoinError>,
+        output_chain: &[Box<dyn output::TextOutput>],
+    ) {
+        match result {
+            Ok(Ok(text)) => {
+                if text.is_empty() {
+                    tracing::debug!("Transcription was empty");
+                    *state = State::Idle;
+                    self.update_state("idle");
+                } else {
+                    tracing::info!("Transcribed: {:?}", text);
+
+                    // Apply text processing (replacements, punctuation)
+                    let processed_text = self.text_processor.process(&text);
+                    if processed_text != text {
+                        tracing::debug!("After text processing: {:?}", processed_text);
+                    }
+
+                    // Apply post-processing command if configured
+                    let final_text = if let Some(ref post_processor) = self.post_processor {
+                        tracing::info!("Post-processing: {:?}", processed_text);
+                        let result = post_processor.process(&processed_text).await;
+                        tracing::info!("Post-processed: {:?}", result);
+                        result
+                    } else {
+                        processed_text
+                    };
+
+                    // Output the text
+                    *state = State::Outputting { text: final_text.clone() };
+
+                    if let Err(e) = output::output_with_fallback(
+                        output_chain,
+                        &final_text
+                    ).await {
+                        tracing::error!("Output failed: {}", e);
+                    }
+
+                    *state = State::Idle;
+                    self.update_state("idle");
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::error!("Transcription failed: {}", e);
+                *state = State::Idle;
+                self.update_state("idle");
+            }
+            Err(e) => {
+                // JoinError - task was cancelled or panicked
+                if e.is_cancelled() {
+                    tracing::debug!("Transcription task was cancelled");
+                } else {
+                    tracing::error!("Transcription task panicked: {}", e);
+                }
+                *state = State::Idle;
+                self.update_state("idle");
+            }
         }
     }
 
     /// Run the daemon main loop
     pub async fn run(&mut self) -> Result<()> {
         tracing::info!("Starting voxtype daemon");
+
+        // Clean up any stale cancel file from previous runs
+        cleanup_cancel_file();
 
         // Write PID file for external control via signals
         self.pid_file_path = write_pid_file();
@@ -474,11 +522,10 @@ impl Daemon {
                                     transcriber_preloaded.clone()
                                 };
 
-                                self.stop_and_transcribe(
+                                self.start_transcription_task(
                                     &mut state,
                                     &mut audio_capture,
                                     transcriber,
-                                    &output_chain,
                                 ).await;
                             }
                         }
@@ -559,12 +606,11 @@ impl Daemon {
                                     transcriber_preloaded.clone()
                                 };
 
-                                // Stop recording and transcribe
-                                self.stop_and_transcribe(
+                                // Stop recording and start transcription
+                                self.start_transcription_task(
                                     &mut state,
                                     &mut audio_capture,
                                     transcriber,
-                                    &output_chain,
                                 ).await;
                             }
                         }
@@ -573,11 +619,81 @@ impl Daemon {
                             // In toggle mode, we ignore key release events
                             tracing::trace!("Ignoring HotkeyEvent::Released in toggle mode");
                         }
+
+                        // === CANCEL KEY (works in both modes) ===
+                        (HotkeyEvent::Cancel, _) => {
+                            tracing::debug!("Received HotkeyEvent::Cancel");
+
+                            if state.is_recording() {
+                                tracing::info!("Recording cancelled via hotkey");
+
+                                // Stop recording and discard audio
+                                if let Some(mut capture) = audio_capture.take() {
+                                    let _ = capture.stop().await;
+                                }
+
+                                // Cancel any pending model load task
+                                if let Some(task) = self.model_load_task.take() {
+                                    task.abort();
+                                }
+
+                                state = State::Idle;
+                                self.update_state("idle");
+                                self.play_feedback(SoundEvent::Cancelled);
+
+                                if self.config.output.notification.on_recording_stop {
+                                    send_notification("Cancelled", "Recording discarded").await;
+                                }
+                            } else if matches!(state, State::Transcribing { .. }) {
+                                tracing::info!("Transcription cancelled via hotkey");
+
+                                // Abort the transcription task
+                                if let Some(task) = self.transcription_task.take() {
+                                    task.abort();
+                                }
+
+                                state = State::Idle;
+                                self.update_state("idle");
+                                self.play_feedback(SoundEvent::Cancelled);
+
+                                if self.config.output.notification.on_recording_stop {
+                                    send_notification("Cancelled", "Transcription aborted").await;
+                                }
+                            } else {
+                                tracing::trace!("Cancel ignored - not recording or transcribing");
+                            }
+                        }
                     }
                 }
 
-                // Check for recording timeout
+                // Check for recording timeout and cancel requests
                 _ = tokio::time::sleep(Duration::from_millis(100)), if state.is_recording() => {
+                    // Check for cancel request first
+                    if check_cancel_requested() {
+                        tracing::info!("Recording cancelled");
+
+                        // Stop recording and discard audio
+                        if let Some(mut capture) = audio_capture.take() {
+                            let _ = capture.stop().await;
+                        }
+
+                        // Cancel any pending model load task
+                        if let Some(task) = self.model_load_task.take() {
+                            task.abort();
+                        }
+
+                        state = State::Idle;
+                        self.update_state("idle");
+                        self.play_feedback(SoundEvent::Cancelled);
+
+                        if self.config.output.notification.on_recording_stop {
+                            send_notification("Cancelled", "Recording discarded").await;
+                        }
+
+                        continue;
+                    }
+
+                    // Check for recording timeout
                     if let Some(duration) = state.recording_duration() {
                         if duration > max_duration {
                             tracing::warn!(
@@ -672,12 +788,42 @@ impl Daemon {
                             transcriber_preloaded.clone()
                         };
 
-                        self.stop_and_transcribe(
+                        self.start_transcription_task(
                             &mut state,
                             &mut audio_capture,
                             transcriber,
-                            &output_chain,
                         ).await;
+                    }
+                }
+
+                // Handle transcription task completion
+                result = async {
+                    match self.transcription_task.as_mut() {
+                        Some(task) => task.await,
+                        None => std::future::pending().await,
+                    }
+                }, if self.transcription_task.is_some() => {
+                    self.transcription_task = None;
+                    self.handle_transcription_result(&mut state, result, &output_chain).await;
+                }
+
+                // Check for cancel during transcription
+                _ = tokio::time::sleep(Duration::from_millis(100)), if matches!(state, State::Transcribing { .. }) => {
+                    if check_cancel_requested() {
+                        tracing::info!("Transcription cancelled");
+
+                        // Abort the transcription task
+                        if let Some(task) = self.transcription_task.take() {
+                            task.abort();
+                        }
+
+                        state = State::Idle;
+                        self.update_state("idle");
+                        self.play_feedback(SoundEvent::Cancelled);
+
+                        if self.config.output.notification.on_recording_stop {
+                            send_notification("Cancelled", "Transcription aborted").await;
+                        }
                     }
                 }
 
@@ -698,6 +844,11 @@ impl Daemon {
         // Cleanup
         if let Some(mut listener) = hotkey_listener {
             listener.stop().await?;
+        }
+
+        // Abort any pending transcription task
+        if let Some(task) = self.transcription_task.take() {
+            task.abort();
         }
 
         // Remove state file on shutdown

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -19,6 +19,8 @@ pub enum HotkeyEvent {
     Pressed,
     /// The hotkey was released
     Released,
+    /// The cancel key was pressed (abort recording/transcription)
+    Cancel,
 }
 
 /// Trait for hotkey detection implementations


### PR DESCRIPTION
## Summary

Implements cancel transcription feature requested in #29. Users can now abort recording or transcription mid-way before text is output.

**Two trigger mechanisms:**

1. **CLI command** (`voxtype record cancel`) - Works with compositor keybindings
2. **evdev cancel key** (`cancel_key` config option) - Built-in hotkey for X11/GNOME/KDE users

## Changes

- Add `Cancel` variant to `RecordAction` enum
- Add `cancel_key` config option to `HotkeyConfig`
- Add `HotkeyEvent::Cancel` for evdev listener
- Refactor transcription to use non-blocking `JoinHandle` for abort capability
- Add `SoundEvent::Cancelled` with audio feedback for all themes
- Handle cancel during both Recording and Transcribing states

## Usage

```toml
# Optional evdev cancel key
[hotkey]
key = "rightctrl"
cancel_key = "escape"
```

```bash
# CLI command for compositor keybindings
voxtype record cancel
```

## Test plan

- [ ] Manual test: Start recording, press cancel key, verify no output
- [ ] Manual test: Start recording, speak, send `voxtype record cancel`, verify no output
- [ ] Manual test: Verify cancel sound plays
- [ ] Manual test: Verify notification appears
- [ ] Verify all existing tests pass (72 tests)

Closes #29