### PR TITLE
Add multi-GPU detection and selection support

### DIFF
--- a/packaging/debian/voxtype.service
+++ b/packaging/debian/voxtype.service
@@ -14,5 +14,12 @@ RestartSec=5
 # Note: User must be in 'input' group for evdev access
 # Before enabling this service, run: voxtype setup --download
 
+# GPU Selection (for systems with multiple GPUs):
+# Create ~/.config/systemd/user/voxtype.service.d/gpu.conf with:
+#   [Service]
+#   Environment="VOXTYPE_VULKAN_DEVICE=nvidia"
+# Valid values: nvidia, amd, intel
+# Run: voxtype setup gpu  to see detected GPUs
+
 [Install]
 WantedBy=graphical-session.target

--- a/packaging/systemd/voxtype.service
+++ b/packaging/systemd/voxtype.service
@@ -14,5 +14,12 @@ RestartSec=5
 # Note: User must be in 'input' group for evdev access
 # Before enabling this service, run: voxtype setup --download
 
+# GPU Selection (for systems with multiple GPUs):
+# Create ~/.config/systemd/user/voxtype.service.d/gpu.conf with:
+#   [Service]
+#   Environment="VOXTYPE_VULKAN_DEVICE=nvidia"
+# Valid values: nvidia, amd, intel
+# Run: voxtype setup gpu  to see detected GPUs
+
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
## Summary

On systems with multiple GPUs (e.g., Intel integrated + NVIDIA discrete), the Vulkan backend may select the wrong GPU by default. This PR adds support for selecting a specific GPU.

- Adds `VOXTYPE_VULKAN_DEVICE` environment variable to select GPU by vendor (`nvidia`, `amd`, `intel`)
- `detect_gpus()` function that enumerates all available GPUs (not just the first)
- Updated `voxtype setup gpu` output to show all detected GPUs with vendor info
- When multiple GPUs are detected, shows guidance on how to select a specific one
- GPU selection applied automatically when creating transcriber via `VK_LOADER_DRIVERS_SELECT`

Example output with multiple GPUs:
```
GPUs detected:
  1. [Intel] TigerLake-H GT1 [UHD Graphics] (rev 01)
  2. [NVIDIA] GeForce RTX 3060 Laptop GPU

Multiple GPUs detected. To select a specific GPU, set:
  VOXTYPE_VULKAN_DEVICE=nvidia   # Use NVIDIA GPU
  VOXTYPE_VULKAN_DEVICE=amd      # Use AMD GPU
  VOXTYPE_VULKAN_DEVICE=intel    # Use Intel GPU
```

Addresses #46

## Test plan

- [ ] Test on single-GPU system (should work as before)
- [ ] Test on multi-GPU system with `VOXTYPE_VULKAN_DEVICE` set
- [ ] Verify `voxtype setup gpu` shows all GPUs
- [ ] Verify systemd drop-in documentation is clear