### PR TITLE
Add remote Whisper server support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -355,6 +367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +415,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -454,6 +486,25 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs_extra"
@@ -536,6 +587,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +745,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jni"
@@ -695,6 +854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +912,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -980,6 +1155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1171,15 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1090,6 +1280,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rodio"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1327,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1177,6 +1416,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,10 +1484,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1240,6 +1510,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1288,6 +1569,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1457,6 +1748,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1827,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "whisper-rs",
 ]
 
@@ -1591,6 +1925,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whisper-rs"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +2024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1951,6 +2312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,3 +2325,92 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ nix = { version = "0.29", features = ["signal", "process"] }  # Unix signals for
 cpal = "0.15"
 hound = "3"  # WAV file reading/writing
 
+# HTTP client for remote transcription
+ureq = { version = "2", features = ["json"] }
+
 # Audio playback (for feedback sounds)
 rodio = { version = "0.19", default-features = false, features = ["wav"] }
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -11,6 +11,7 @@ Voxtype is a push-to-talk voice-to-text tool for Linux. Optimized for Wayland, w
 - [Hotkeys](#hotkeys)
 - [Compositor Keybindings](#compositor-keybindings)
 - [Whisper Models](#whisper-models)
+- [Remote Whisper Servers](#remote-whisper-servers)
 - [Output Modes](#output-modes)
 - [Post-Processing with LLMs](#post-processing-with-llms)
 - [Tips & Best Practices](#tips--best-practices)
@@ -453,6 +454,149 @@ Point to any whisper.cpp compatible model:
 ```toml
 [whisper]
 model = "/path/to/my/custom-model.bin"
+```
+
+---
+
+## Remote Whisper Servers
+
+Voxtype can offload transcription to a remote server running whisper.cpp or any OpenAI-compatible Whisper API. This feature was designed for users who self-host Whisper servers on their own hardware (e.g., a home GPU server), but it can also connect to cloud-based services.
+
+> **Privacy Notice**
+>
+> When using remote transcription, your audio is transmitted over the network to the configured server. **If privacy is a concern, you should carefully consider who operates the remote server and how your data is handled.**
+>
+> - **Self-hosted servers**: You maintain full control over your data
+> - **Cloud services (OpenAI, etc.)**: Your audio is processed by third parties and may be subject to their privacy policies, data retention, and usage terms
+>
+> For maximum privacy, use Voxtype's default local transcription mode, which processes all audio entirely on your machine with no network connectivity.
+
+### Why Use Remote Transcription?
+
+Remote transcription is valuable when:
+
+1. **Your local hardware is too slow**: Larger Whisper models (large-v3, large-v3-turbo) require significant compute. A laptop CPU might take 10-30x the audio duration, while a remote GPU can transcribe in real-time or faster.
+
+2. **You have a home GPU server**: Many users have a separate machine with a powerful GPU. Remote transcription lets you leverage that hardware while using Voxtype's superior output method (virtual keyboard instead of clipboard paste).
+
+3. **Teams sharing infrastructure**: Organizations with centralized ML inference servers can share a single Whisper deployment.
+
+4. **Thin clients**: Use Voxtype on a lightweight laptop while offloading compute to more powerful hardware on your network.
+
+### Setting Up a Self-Hosted Whisper Server
+
+The recommended server is **whisper.cpp server**, which implements the OpenAI Whisper API:
+
+```bash
+# Clone whisper.cpp
+git clone https://github.com/ggerganov/whisper.cpp
+cd whisper.cpp
+
+# Build the server
+make server
+
+# Download a model
+./models/download-ggml-model.sh large-v3-turbo
+
+# Run the server (adjust for your GPU)
+./server -m models/ggml-large-v3-turbo.bin --host 0.0.0.0 --port 8080
+```
+
+For GPU acceleration, build with CUDA, Vulkan, or Metal support:
+
+```bash
+# CUDA (NVIDIA)
+make server GGML_CUDA=1
+
+# Vulkan (AMD/NVIDIA/Intel)
+make server GGML_VULKAN=1
+
+# Metal (macOS)
+make server GGML_METAL=1
+```
+
+### Configuring Voxtype for Remote Transcription
+
+Edit your `~/.config/voxtype/config.toml`:
+
+```toml
+[whisper]
+# Switch to remote backend
+backend = "remote"
+
+# Language setting still applies
+language = "en"
+
+# Your whisper.cpp server address
+remote_endpoint = "http://192.168.1.100:8080"
+
+# Model name sent to server (whisper.cpp ignores this, but OpenAI requires it)
+remote_model = "whisper-1"
+
+# Request timeout in seconds (increase for large files or slow networks)
+remote_timeout_secs = 30
+
+# Optional: API key (not needed for whisper.cpp, required for OpenAI)
+# remote_api_key = "your-api-key"
+```
+
+### Using with Cloud Services (OpenAI, etc.)
+
+While this feature was built for self-hosted servers, it also works with OpenAI's hosted Whisper API and other compatible services:
+
+```toml
+[whisper]
+backend = "remote"
+language = "en"
+remote_endpoint = "https://api.openai.com"
+remote_model = "whisper-1"
+remote_timeout_secs = 30
+```
+
+Set your API key via environment variable (more secure than config file):
+
+```bash
+export VOXTYPE_WHISPER_API_KEY="sk-..."
+```
+
+> **Cloud Service Considerations**
+>
+> - **Cost**: OpenAI charges per minute of audio (~$0.006/min)
+> - **Privacy**: Your audio is transmitted to and processed by OpenAI's servers
+> - **Latency**: Network round-trip adds delay compared to local processing
+> - **Reliability**: Depends on internet connectivity and service availability
+>
+> For most users, local transcription with GPU acceleration provides better privacy, lower latency, and no ongoing costs.
+
+### Security Recommendations
+
+1. **Use HTTPS for non-local servers**: Voxtype warns if you configure an HTTP endpoint for non-localhost addresses, as audio would be transmitted unencrypted.
+
+2. **Prefer environment variables for API keys**: Use `VOXTYPE_WHISPER_API_KEY` instead of putting keys in config files.
+
+3. **Firewall your self-hosted server**: If running whisper.cpp server, ensure it's only accessible from trusted networks.
+
+### Troubleshooting Remote Transcription
+
+**Connection refused**:
+- Verify the server is running and listening on the expected port
+- Check firewall rules on both client and server
+- Ensure the endpoint URL includes the protocol (`http://` or `https://`)
+
+**Timeout errors**:
+- Increase `remote_timeout_secs` in your config
+- Check network latency between client and server
+- For large audio files, the server may need more time to process
+
+**Authentication errors**:
+- Verify your API key is correct
+- Check if the key is set via environment variable or config
+- Ensure the `Authorization: Bearer` header is being sent
+
+**Run with verbose logging** to diagnose issues:
+
+```bash
+voxtype -vv
 ```
 
 ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,7 +66,12 @@ max_duration_secs = 60
 # volume = 0.7
 
 [whisper]
-# Model to use for transcription
+# Transcription backend: "local" or "remote"
+# - local: Use whisper.cpp locally (default)
+# - remote: Send audio to a remote whisper.cpp server or OpenAI-compatible API
+# backend = "local"
+
+# Model to use for transcription (local backend)
 # Options: tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large-v3, large-v3-turbo
 # .en models are English-only but faster and more accurate for English
 # large-v3-turbo is faster than large-v3 with minimal accuracy loss (recommended for GPU)
@@ -83,6 +88,23 @@ translate = false
 
 # Number of CPU threads for inference (omit for auto-detection)
 # threads = 4
+
+# --- Remote backend settings (used when backend = "remote") ---
+#
+# Remote server endpoint URL (required for remote backend)
+# Examples:
+#   - whisper.cpp server: "http://192.168.1.100:8080"
+#   - OpenAI API: "https://api.openai.com"
+# remote_endpoint = "http://192.168.1.100:8080"
+#
+# Model name to send to remote server (default: "whisper-1")
+# remote_model = "whisper-1"
+#
+# API key for remote server (optional, or use VOXTYPE_WHISPER_API_KEY env var)
+# remote_api_key = ""
+#
+# Timeout for remote requests in seconds (default: 30)
+# remote_timeout_secs = 30
 
 [output]
 # Primary output mode: "type" or "clipboard"
@@ -455,9 +477,24 @@ fn load_custom_icon_theme(path: &str) -> Result<ResolvedIcons, String> {
     })
 }
 
+/// Whisper transcription backend
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum WhisperBackend {
+    /// Local transcription using whisper.cpp
+    #[default]
+    Local,
+    /// Remote transcription via OpenAI-compatible API
+    Remote,
+}
+
 /// Whisper speech-to-text configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WhisperConfig {
+    /// Transcription backend: "local" or "remote"
+    #[serde(default)]
+    pub backend: WhisperBackend,
+
     /// Model name: tiny, base, small, medium, large-v3, large-v3-turbo
     /// Can also be an absolute path to a .bin file
     pub model: String,
@@ -475,6 +512,25 @@ pub struct WhisperConfig {
     /// Load model on-demand when recording starts (true) or keep loaded (false)
     #[serde(default = "default_on_demand_loading")]
     pub on_demand_loading: bool,
+
+    // --- Remote backend settings ---
+
+    /// Remote server endpoint URL (e.g., "http://192.168.1.100:8080")
+    /// Required when backend = "remote"
+    #[serde(default)]
+    pub remote_endpoint: Option<String>,
+
+    /// Model name to send to remote server (default: "whisper-1")
+    #[serde(default)]
+    pub remote_model: Option<String>,
+
+    /// API key for remote server (optional, can also use VOXTYPE_WHISPER_API_KEY env var)
+    #[serde(default)]
+    pub remote_api_key: Option<String>,
+
+    /// Timeout for remote requests in seconds (default: 30)
+    #[serde(default)]
+    pub remote_timeout_secs: Option<u64>,
 }
 
 /// Text processing configuration
@@ -597,11 +653,16 @@ impl Default for Config {
                 feedback: AudioFeedbackConfig::default(),
             },
             whisper: WhisperConfig {
+                backend: WhisperBackend::default(),
                 model: "base.en".to_string(),
                 language: "en".to_string(),
                 translate: false,
                 threads: None,
                 on_demand_loading: default_on_demand_loading(),
+                remote_endpoint: None,
+                remote_model: None,
+                remote_api_key: None,
+                remote_timeout_secs: None,
             },
             output: OutputConfig {
                 mode: OutputMode::Type,

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,15 @@ pub enum TranscribeError {
 
     #[error("Audio format error: {0}")]
     AudioFormat(String),
+
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+
+    #[error("Network error: {0}")]
+    NetworkError(String),
+
+    #[error("Remote server error: {0}")]
+    RemoteError(String),
 }
 
 /// Errors related to text output

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -1,10 +1,13 @@
 //! Speech-to-text transcription module
 //!
-//! Provides local transcription using whisper.cpp via the whisper-rs crate.
+//! Provides transcription via:
+//! - Local whisper.cpp inference (whisper-rs crate)
+//! - Remote OpenAI-compatible Whisper API (whisper.cpp server, OpenAI, etc.)
 
+pub mod remote;
 pub mod whisper;
 
-use crate::config::WhisperConfig;
+use crate::config::{WhisperBackend, WhisperConfig};
 use crate::error::TranscribeError;
 
 /// Trait for speech-to-text implementations
@@ -14,9 +17,18 @@ pub trait Transcriber: Send + Sync {
     fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError>;
 }
 
-/// Factory function to create transcriber
+/// Factory function to create transcriber based on configured backend
 pub fn create_transcriber(
     config: &WhisperConfig,
 ) -> Result<Box<dyn Transcriber>, TranscribeError> {
-    Ok(Box::new(whisper::WhisperTranscriber::new(config)?))
+    match config.backend {
+        WhisperBackend::Local => {
+            tracing::info!("Using local whisper transcription backend");
+            Ok(Box::new(whisper::WhisperTranscriber::new(config)?))
+        }
+        WhisperBackend::Remote => {
+            tracing::info!("Using remote whisper transcription backend");
+            Ok(Box::new(remote::RemoteTranscriber::new(config)?))
+        }
+    }
 }

--- a/src/transcribe/remote.rs
+++ b/src/transcribe/remote.rs
@@ -1,0 +1,365 @@
+//! Remote speech-to-text transcription via OpenAI-compatible API
+//!
+//! Sends audio to a remote whisper.cpp server or OpenAI-compatible endpoint
+//! for transcription, enabling use of GPU servers for faster inference.
+
+use super::Transcriber;
+use crate::config::WhisperConfig;
+use crate::error::TranscribeError;
+use std::io::Cursor;
+use std::time::Duration;
+use ureq::serde_json;
+
+/// Remote transcriber using OpenAI-compatible Whisper API
+#[derive(Debug)]
+pub struct RemoteTranscriber {
+    /// Base endpoint URL (e.g., "http://192.168.1.100:8080")
+    endpoint: String,
+    /// Model name to send to server
+    model: String,
+    /// Language for transcription
+    language: String,
+    /// Whether to translate to English
+    translate: bool,
+    /// Optional API key for authentication
+    api_key: Option<String>,
+    /// Request timeout
+    timeout: Duration,
+}
+
+impl RemoteTranscriber {
+    /// Create a new remote transcriber from config
+    pub fn new(config: &WhisperConfig) -> Result<Self, TranscribeError> {
+        let endpoint = config
+            .remote_endpoint
+            .as_ref()
+            .ok_or_else(|| {
+                TranscribeError::ConfigError(
+                    "remote_endpoint is required when backend = 'remote'".into(),
+                )
+            })?
+            .clone();
+
+        // Validate endpoint URL format
+        if !endpoint.starts_with("http://") && !endpoint.starts_with("https://") {
+            return Err(TranscribeError::ConfigError(format!(
+                "remote_endpoint must start with http:// or https://, got: {}",
+                endpoint
+            )));
+        }
+
+        // Warn about non-HTTPS for non-localhost endpoints
+        if endpoint.starts_with("http://")
+            && !endpoint.contains("localhost")
+            && !endpoint.contains("127.0.0.1")
+            && !endpoint.contains("[::1]")
+        {
+            tracing::warn!(
+                "Remote endpoint uses HTTP without TLS. Audio data will be transmitted unencrypted!"
+            );
+        }
+
+        // Check for API key in config or environment
+        let api_key = config
+            .remote_api_key
+            .clone()
+            .or_else(|| std::env::var("VOXTYPE_WHISPER_API_KEY").ok());
+
+        let model = config
+            .remote_model
+            .clone()
+            .unwrap_or_else(|| "whisper-1".to_string());
+
+        let timeout = Duration::from_secs(config.remote_timeout_secs.unwrap_or(30));
+
+        tracing::info!(
+            "Configured remote transcriber: endpoint={}, model={}, timeout={}s",
+            endpoint,
+            model,
+            timeout.as_secs()
+        );
+
+        Ok(Self {
+            endpoint,
+            model,
+            language: config.language.clone(),
+            translate: config.translate,
+            api_key,
+            timeout,
+        })
+    }
+
+    /// Encode f32 samples to WAV format
+    fn encode_wav(&self, samples: &[f32]) -> Result<Vec<u8>, TranscribeError> {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+
+        let mut buffer = Cursor::new(Vec::new());
+        let mut writer = hound::WavWriter::new(&mut buffer, spec)
+            .map_err(|e| TranscribeError::AudioFormat(format!("Failed to create WAV writer: {}", e)))?;
+
+        // Convert f32 [-1.0, 1.0] to i16
+        for &sample in samples {
+            let clamped = sample.clamp(-1.0, 1.0);
+            let scaled = (clamped * i16::MAX as f32) as i16;
+            writer
+                .write_sample(scaled)
+                .map_err(|e| TranscribeError::AudioFormat(format!("Failed to write sample: {}", e)))?;
+        }
+
+        writer
+            .finalize()
+            .map_err(|e| TranscribeError::AudioFormat(format!("Failed to finalize WAV: {}", e)))?;
+
+        Ok(buffer.into_inner())
+    }
+
+    /// Build the multipart form body for the API request
+    fn build_multipart_body(
+        &self,
+        wav_data: &[u8],
+    ) -> (String, Vec<u8>) {
+        let boundary = format!("----VoxtypeBoundary{}", std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos());
+
+        let mut body = Vec::new();
+
+        // Add file field
+        body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n");
+        body.extend_from_slice(b"Content-Type: audio/wav\r\n\r\n");
+        body.extend_from_slice(wav_data);
+        body.extend_from_slice(b"\r\n");
+
+        // Add model field
+        body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"model\"\r\n\r\n");
+        body.extend_from_slice(self.model.as_bytes());
+        body.extend_from_slice(b"\r\n");
+
+        // Add language field (if not auto)
+        if self.language != "auto" {
+            body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+            body.extend_from_slice(b"Content-Disposition: form-data; name=\"language\"\r\n\r\n");
+            body.extend_from_slice(self.language.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+
+        // Add response_format field
+        body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"response_format\"\r\n\r\n");
+        body.extend_from_slice(b"json\r\n");
+
+        // End boundary
+        body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+
+        (boundary, body)
+    }
+}
+
+impl Transcriber for RemoteTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat("Empty audio buffer".into()));
+        }
+
+        let duration_secs = samples.len() as f32 / 16000.0;
+        tracing::debug!(
+            "Sending {:.2}s of audio to remote server ({} samples)",
+            duration_secs,
+            samples.len()
+        );
+
+        let start = std::time::Instant::now();
+
+        // Encode audio to WAV
+        let wav_data = self.encode_wav(samples)?;
+        tracing::debug!("Encoded WAV: {} bytes", wav_data.len());
+
+        // Build multipart form
+        let (boundary, body) = self.build_multipart_body(&wav_data);
+
+        // Determine the API path based on whether we're doing transcription or translation
+        let path = if self.translate {
+            "/v1/audio/translations"
+        } else {
+            "/v1/audio/transcriptions"
+        };
+
+        let url = format!("{}{}", self.endpoint.trim_end_matches('/'), path);
+
+        // Build request
+        let mut request = ureq::post(&url)
+            .timeout(self.timeout)
+            .set(
+                "Content-Type",
+                &format!("multipart/form-data; boundary={}", boundary),
+            );
+
+        // Add authorization if API key is configured
+        if let Some(ref key) = self.api_key {
+            request = request.set("Authorization", &format!("Bearer {}", key));
+        }
+
+        // Send request
+        let response = request
+            .send_bytes(&body)
+            .map_err(|e| match e {
+                ureq::Error::Status(code, resp) => {
+                    let body = resp.into_string().unwrap_or_default();
+                    TranscribeError::RemoteError(format!("Server returned {}: {}", code, body))
+                }
+                ureq::Error::Transport(t) => {
+                    TranscribeError::NetworkError(format!("Request failed: {}", t))
+                }
+            })?;
+
+        // Parse JSON response
+        let json: serde_json::Value = response
+            .into_json()
+            .map_err(|e| TranscribeError::RemoteError(format!("Failed to parse response: {}", e)))?;
+
+        // Extract text from response
+        let text = json
+            .get("text")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                TranscribeError::RemoteError(format!(
+                    "Response missing 'text' field: {}",
+                    json
+                ))
+            })?
+            .trim()
+            .to_string();
+
+        tracing::info!(
+            "Remote transcription completed in {:.2}s: {:?}",
+            start.elapsed().as_secs_f32(),
+            if text.chars().count() > 50 {
+                format!("{}...", text.chars().take(50).collect::<String>())
+            } else {
+                text.clone()
+            }
+        );
+
+        Ok(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_wav_basic() {
+        let config = WhisperConfig {
+            backend: crate::config::WhisperBackend::Remote,
+            model: "base.en".to_string(),
+            language: "en".to_string(),
+            translate: false,
+            threads: None,
+            on_demand_loading: false,
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            remote_model: None,
+            remote_api_key: None,
+            remote_timeout_secs: None,
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+
+        // Create a simple sine wave
+        let samples: Vec<f32> = (0..16000)
+            .map(|i| (i as f32 * 440.0 * 2.0 * std::f32::consts::PI / 16000.0).sin() * 0.5)
+            .collect();
+
+        let wav = transcriber.encode_wav(&samples).unwrap();
+
+        // WAV header is 44 bytes, then 16000 samples * 2 bytes = 32000 bytes
+        assert_eq!(wav.len(), 44 + 32000);
+
+        // Check WAV magic
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+    }
+
+    #[test]
+    fn test_config_validation_missing_endpoint() {
+        let config = WhisperConfig {
+            backend: crate::config::WhisperBackend::Remote,
+            model: "base.en".to_string(),
+            language: "en".to_string(),
+            translate: false,
+            threads: None,
+            on_demand_loading: false,
+            remote_endpoint: None, // Missing!
+            remote_model: None,
+            remote_api_key: None,
+            remote_timeout_secs: None,
+        };
+
+        let result = RemoteTranscriber::new(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("remote_endpoint"));
+    }
+
+    #[test]
+    fn test_config_validation_invalid_url() {
+        let config = WhisperConfig {
+            backend: crate::config::WhisperBackend::Remote,
+            model: "base.en".to_string(),
+            language: "en".to_string(),
+            translate: false,
+            threads: None,
+            on_demand_loading: false,
+            remote_endpoint: Some("not-a-url".to_string()),
+            remote_model: None,
+            remote_api_key: None,
+            remote_timeout_secs: None,
+        };
+
+        let result = RemoteTranscriber::new(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("http://"));
+    }
+
+    #[test]
+    fn test_multipart_body_structure() {
+        let config = WhisperConfig {
+            backend: crate::config::WhisperBackend::Remote,
+            model: "base.en".to_string(),
+            language: "en".to_string(),
+            translate: false,
+            threads: None,
+            on_demand_loading: false,
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            remote_model: Some("large-v3".to_string()),
+            remote_api_key: None,
+            remote_timeout_secs: None,
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        let wav_data = vec![0u8; 100]; // Dummy data
+
+        let (boundary, body) = transcriber.build_multipart_body(&wav_data);
+
+        let body_str = String::from_utf8_lossy(&body);
+
+        // Verify boundary is used
+        assert!(body_str.contains(&boundary));
+
+        // Verify required fields
+        assert!(body_str.contains("name=\"file\""));
+        assert!(body_str.contains("filename=\"audio.wav\""));
+        assert!(body_str.contains("name=\"model\""));
+        assert!(body_str.contains("large-v3"));
+        assert!(body_str.contains("name=\"language\""));
+        assert!(body_str.contains("name=\"response_format\""));
+        assert!(body_str.contains("json"));
+    }
+}

--- a/website/index.html
+++ b/website/index.html
@@ -270,6 +270,23 @@
                         vocabulary, or custom workflows. Falls back gracefully on errors.
                     </p>
                 </div>
+
+                <div class="feature-card">
+                    <div class="feature-icon">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <rect x="2" y="2" width="20" height="8" rx="2" ry="2"/>
+                            <rect x="2" y="14" width="20" height="8" rx="2" ry="2"/>
+                            <line x1="6" y1="6" x2="6.01" y2="6"/>
+                            <line x1="6" y1="18" x2="6.01" y2="18"/>
+                        </svg>
+                    </div>
+                    <h3>Remote Whisper Servers</h3>
+                    <p>
+                        Offload transcription to a self-hosted GPU server running whisper.cpp.
+                        Use your laptop while leveraging powerful remote hardware.
+                        <em>Can also connect to cloud APIs for those who choose.</em>
+                    </p>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary

Adds support for offloading transcription to remote whisper.cpp servers or OpenAI-compatible APIs. This feature was requested in #36 by a user who has local hardware too slow for real-time transcription with larger models, but has a separate GPU server running whisper.cpp.

- Add `RemoteTranscriber` implementing the existing `Transcriber` trait
- Add `backend = "local" | "remote"` config option
- Add `remote_endpoint`, `remote_model`, `remote_api_key`, `remote_timeout_secs` config options
- Support `VOXTYPE_WHISPER_API_KEY` environment variable for secure API key handling
- Warn on HTTP for non-localhost endpoints
- Comprehensive documentation with privacy notices

**Key design decisions:**
- Uses `ureq` blocking HTTP client since `Transcriber::transcribe()` is called inside `spawn_blocking`
- Uses `hound` for WAV encoding
- No feature flag needed
- Zero changes to daemon, audio, output, or state machine code

## Privacy Notice

Documentation emphasizes this was **built for self-hosted servers**. Cloud services (OpenAI, etc.) are supported but documentation includes clear caveats about privacy implications.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes
- [ ] Manual test with local whisper.cpp server
- [ ] Manual test with OpenAI API

Closes #36