### PR TITLE
Add --model option to setup command for non-interactive installs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,10 @@ pub enum Commands {
         #[arg(long)]
         download: bool,
 
+        /// Specify which model to download (use with --download)
+        #[arg(long, value_name = "NAME")]
+        model: Option<String>,
+
         /// Suppress all output (for scripting/automation)
         #[arg(long)]
         quiet: bool,
@@ -302,6 +306,45 @@ mod tests {
                 assert!(restart, "should have restart=true");
             }
             _ => panic!("Expected Setup Model command"),
+        }
+    }
+
+    #[test]
+    fn test_setup_download_with_model() {
+        let cli = Cli::parse_from(["voxtype", "setup", "--download", "--model", "large-v3-turbo"]);
+        match cli.command {
+            Some(Commands::Setup { download, model, .. }) => {
+                assert!(download, "should have download=true");
+                assert_eq!(model, Some("large-v3-turbo".to_string()));
+            }
+            _ => panic!("Expected Setup command"),
+        }
+    }
+
+    #[test]
+    fn test_setup_model_without_download() {
+        // --model can be specified without --download (for validation/config update of existing model)
+        let cli = Cli::parse_from(["voxtype", "setup", "--model", "small.en"]);
+        match cli.command {
+            Some(Commands::Setup { download, model, .. }) => {
+                assert!(!download, "download should be false");
+                assert_eq!(model, Some("small.en".to_string()));
+            }
+            _ => panic!("Expected Setup command"),
+        }
+    }
+
+    #[test]
+    fn test_setup_download_model_quiet() {
+        // Full non-interactive setup command
+        let cli = Cli::parse_from(["voxtype", "setup", "--download", "--model", "large-v3-turbo", "--quiet"]);
+        match cli.command {
+            Some(Commands::Setup { download, model, quiet, .. }) => {
+                assert!(download, "should have download=true");
+                assert_eq!(model, Some("large-v3-turbo".to_string()));
+                assert!(quiet, "should have quiet=true");
+            }
+            _ => panic!("Expected Setup command"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
             transcribe_file(&config, &file)?;
         }
 
-        Commands::Setup { action, download, quiet, no_post_install } => {
+        Commands::Setup { action, download, model, quiet, no_post_install } => {
             match action {
                 Some(SetupAction::Check) => {
                     setup::run_checks(&config).await?;
@@ -122,7 +122,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 None => {
                     // Default: run setup (non-blocking)
-                    setup::run_setup(&config, download, quiet, no_post_install).await?;
+                    setup::run_setup(&config, download, model.as_deref(), quiet, no_post_install).await?;
                 }
             }
         }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -345,9 +345,17 @@ fn print_tool_status(tool: &OutputToolStatus, is_relevant: bool) {
 /// Run setup tasks (non-blocking, no red X errors)
 ///
 /// Flags:
+/// - `download`: Download model if missing
+/// - `model_override`: Specific model to download (use with `download`)
 /// - `quiet`: Suppress ALL output (for scripting/automation)
 /// - `no_post_install`: Suppress only "Next steps" instructions
-pub async fn run_setup(config: &Config, download: bool, quiet: bool, no_post_install: bool) -> anyhow::Result<()> {
+pub async fn run_setup(
+    config: &Config,
+    download: bool,
+    model_override: Option<&str>,
+    quiet: bool,
+    no_post_install: bool,
+) -> anyhow::Result<()> {
     if !quiet {
         println!("Voxtype Setup\n");
         println!("=============\n");
@@ -384,7 +392,24 @@ pub async fn run_setup(config: &Config, download: bool, quiet: bool, no_post_ins
         println!("\nWhisper model...");
     }
     let models_dir = Config::models_dir();
-    let model_name = &config.whisper.model;
+
+    // Use model_override if provided, otherwise use config default
+    let model_name: &str = match model_override {
+        Some(name) => {
+            // Validate the model name
+            if !model::is_valid_model(name) {
+                let valid = model::valid_model_names().join(", ");
+                anyhow::bail!(
+                    "Unknown model '{}'. Valid models are: {}",
+                    name,
+                    valid
+                );
+            }
+            name
+        }
+        None => &config.whisper.model,
+    };
+
     let model_filename = crate::transcribe::whisper::get_model_filename(model_name);
     let model_path = models_dir.join(&model_filename);
 
@@ -398,11 +423,25 @@ pub async fn run_setup(config: &Config, download: bool, quiet: bool, no_post_ins
                 model_name, size
             ));
         }
+        // If user explicitly requested this model, update config even if already downloaded
+        if model_override.is_some() {
+            model::set_model_config(model_name)?;
+            if !quiet {
+                print_success(&format!("Config updated to use '{}'", model_name));
+            }
+        }
     } else if download {
         if !quiet {
             println!("  Downloading {}...", model_name);
         }
         model::download_model(model_name)?;
+        // Update config to use the downloaded model
+        if model_override.is_some() {
+            model::set_model_config(model_name)?;
+            if !quiet {
+                print_success(&format!("Config updated to use '{}'", model_name));
+            }
+        }
     } else if !quiet {
         print_info(&format!("Model '{}' not downloaded yet", model_name));
         println!("       Run: voxtype setup --download");


### PR DESCRIPTION
Allows specifying which whisper model to download during automated setup scripts. Addresses GitHub issue #48.

Usage: voxtype setup --download --model large-v3-turbo --quiet

The model name is validated against known models and the config is automatically updated when a specific model is requested.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] I have tested these changes locally
- [ ] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy` with no warnings
- [ ] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [ ] No documentation changes are needed

## Additional Notes

Any additional information reviewers should know.
