### PR TITLE
Bump version to 0.4.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "voxtype"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voxtype"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 authors = ["Peter Jackson", "Jean-Paul van Tillo", "Máté Rémiás", "Rob Zolkos"]
 description = "Push-to-talk voice-to-text for Wayland"


### PR DESCRIPTION
## Summary
- Bump version to 0.4.10 for release
- Includes compositor integration features from #54

## Test plan
- Version verified in Cargo.toml and Cargo.lock