### PR TITLE
Simplify NixOS packaging based on community feedback

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,15 +162,16 @@
 
       in {
         packages = {
-          # Unwrapped packages (for Home Manager module which does its own wrapping)
-          voxtype-unwrapped = mkVoxtypeUnwrapped {};
-          voxtype-vulkan-unwrapped = vulkanUnwrapped;
-          voxtype-rocm-unwrapped = rocmUnwrapped;
-
           # Wrapped packages (ready to use, runtime deps in PATH)
+          # Use these for Home Manager module and direct installation
           default = wrapVoxtype (mkVoxtypeUnwrapped {});
           vulkan = wrapVoxtype vulkanUnwrapped;
           rocm = wrapVoxtype rocmUnwrapped;
+
+          # Unwrapped packages (for custom wrapping scenarios)
+          voxtype-unwrapped = mkVoxtypeUnwrapped {};
+          voxtype-vulkan-unwrapped = vulkanUnwrapped;
+          voxtype-rocm-unwrapped = rocmUnwrapped;
         };
 
         # Development shell with all dependencies

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -6,10 +6,16 @@
 #
 #   programs.voxtype = {
 #     enable = true;
-#     package = voxtype.packages.${system}.vulkan;  # or .default for CPU
+#     package = voxtype.packages.${system}.vulkan;
 #     model.name = "base.en";
-#     hotkey.enable = true;
 #     service.enable = true;
+#
+#     # All config options go in settings (converted to config.toml)
+#     settings = {
+#       hotkey.enabled = false;  # Use compositor keybindings instead
+#       output.mode = "type";
+#       whisper.language = "en";
+#     };
 #   };
 #
 { config, lib, pkgs, ... }:
@@ -32,89 +38,15 @@ let
   resolvedModelPath =
     if cfg.model.path != null then cfg.model.path
     else if cfg.model.name != null then fetchedModel
-    else throw "programs.voxtype: either model.name or model.path must be set";
+    else null;
 
-  # Runtime dependencies to wrap into PATH
-  runtimeDeps = with pkgs; [
-    # Wayland typing
-    wtype
-    wl-clipboard
-    # Alternative typing backend (works on X11 and Wayland)
-    ydotool
-    # X11 fallback
-    xdotool
-    xclip
-    # Common utilities
-    libnotify
-    pciutils
-  ];
-
-  # Wrap the package with runtime dependencies
-  wrappedPackage = pkgs.symlinkJoin {
-    name = "voxtype-wrapped-${cfg.package.version or "unknown"}";
-    paths = [ cfg.package ];
-    buildInputs = [ pkgs.makeWrapper ];
-    postBuild = ''
-      wrapProgram $out/bin/voxtype \
-        --prefix PATH : ${lib.makeBinPath runtimeDeps}
-    '';
-  };
-
-  # Build the config TOML from options
+  # Build the config TOML from settings, injecting model path
   configFile = tomlFormat.generate "voxtype-config.toml" (
-    lib.recursiveUpdate {
-      state_file = cfg.stateFile;
-
-      hotkey = {
-        enabled = cfg.hotkey.enable;
-        key = cfg.hotkey.key;
-        modifiers = cfg.hotkey.modifiers;
-        mode = cfg.hotkey.mode;
-      };
-
-      audio = {
-        device = cfg.audio.device;
-        sample_rate = cfg.audio.sampleRate;
-        max_duration_secs = cfg.audio.maxDurationSecs;
-      } // lib.optionalAttrs cfg.audio.feedback.enable {
-        feedback = {
-          enabled = true;
-          theme = cfg.audio.feedback.theme;
-          volume = cfg.audio.feedback.volume;
-        };
-      };
-
-      whisper = {
-        model = toString resolvedModelPath;
-        language = cfg.whisper.language;
-        translate = cfg.whisper.translate;
-        on_demand_loading = cfg.whisper.onDemandLoading;
-      } // lib.optionalAttrs (cfg.whisper.threads != null) {
-        threads = cfg.whisper.threads;
-      };
-
-      output = {
-        mode = cfg.output.mode;
-        fallback_to_clipboard = cfg.output.fallbackToClipboard;
-        type_delay_ms = cfg.output.typeDelayMs;
-        notification = {
-          on_recording_start = cfg.output.notification.onRecordingStart;
-          on_recording_stop = cfg.output.notification.onRecordingStop;
-          on_transcription = cfg.output.notification.onTranscription;
-        };
-      } // lib.optionalAttrs (cfg.output.postProcess.command != null) {
-        post_process = {
-          command = cfg.output.postProcess.command;
-          timeout_ms = cfg.output.postProcess.timeoutMs;
-        };
-      };
-
-      status = {
-        icon_theme = cfg.status.iconTheme;
-      } // lib.optionalAttrs (cfg.status.icons != { }) {
-        icons = cfg.status.icons;
-      };
-    } cfg.settings
+    lib.recursiveUpdate
+      (lib.optionalAttrs (resolvedModelPath != null) {
+        whisper.model = toString resolvedModelPath;
+      })
+      cfg.settings
   );
 
 in {
@@ -124,289 +56,60 @@ in {
     package = lib.mkOption {
       type = lib.types.package;
       description = ''
-        The VoxType package to use. Use the flake's packages.default for CPU
-        or packages.vulkan for GPU acceleration.
+        The VoxType package to use. Use the flake's wrapped packages:
+        - packages.default: CPU-only (works everywhere)
+        - packages.vulkan: Vulkan GPU acceleration (AMD/NVIDIA/Intel)
+        - packages.rocm: ROCm/HIP acceleration (AMD only)
+
+        These packages include all runtime dependencies (wtype, ydotool, etc.)
+        in their PATH.
       '';
       example = lib.literalExpression "voxtype.packages.\${system}.vulkan";
     };
 
-    # Model configuration
     model = {
       name = lib.mkOption {
         type = lib.types.nullOr (lib.types.enum (builtins.attrNames modelDefs));
         default = "base.en";
         description = ''
-          Whisper model to use. The model will be downloaded from HuggingFace
-          and stored in the Nix store. Set to null if using model.path instead.
+          Whisper model to download from HuggingFace. Set to null to manage
+          the model yourself via model.path or let voxtype download on first run.
 
-          Available models:
-          - tiny, tiny.en (75 MB) - Fastest, lowest quality
-          - base, base.en (142 MB) - Good balance for most users
-          - small, small.en (466 MB) - Better accuracy
-          - medium, medium.en (1.5 GB) - High accuracy
-          - large-v3 (3.1 GB) - Best accuracy
-          - large-v3-turbo (1.6 GB) - Fast + high accuracy
-
-          The .en variants are English-only but faster and more accurate for English.
+          Available: tiny, tiny.en, base, base.en, small, small.en,
+          medium, medium.en, large-v3, large-v3-turbo
         '';
       };
 
       path = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
-        description = ''
-          Path to a custom whisper model file. Use this instead of model.name
-          if you want to manage the model yourself or use a custom model.
-        '';
+        description = "Path to a custom whisper model file (overrides model.name).";
         example = "/home/user/.local/share/voxtype/models/ggml-custom.bin";
       };
     };
 
-    # Hotkey configuration
-    hotkey = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Enable the built-in evdev hotkey.
-
-          RECOMMENDED: Most users should leave this DISABLED and use compositor
-          keybindings instead (Hyprland bind/bindr, Sway bindsym, River riverctl).
-          Compositor bindings are more secure and work without special permissions.
-
-          Only enable this if you:
-          - Are on X11 without a compositor that supports key-release events
-          - Need a dedicated key like ScrollLock that your compositor can't bind
-          - Understand the security implications of the 'input' group
-
-          SECURITY WARNING: This requires membership in the 'input' group, which
-          grants read access to ALL input devices including keyboards. This means
-          any process running as your user could potentially act as a keylogger.
-          Only add yourself to the 'input' group if you understand and accept this
-          risk. On a single-user system with trusted software this is generally fine,
-          but on shared systems or with untrusted software it's a security concern.
-        '';
-      };
-
-      key = lib.mkOption {
-        type = lib.types.str;
-        default = "SCROLLLOCK";
-        description = ''
-          Key to hold for push-to-talk (when hotkey.enable is true).
-          Common choices: SCROLLLOCK, PAUSE, RIGHTALT, F13-F24.
-          Use `evtest` to find key names for your keyboard.
-        '';
-        example = "F13";
-      };
-
-      modifiers = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        description = "Modifier keys that must also be held.";
-        example = [ "LEFTCTRL" "LEFTALT" ];
-      };
-
-      mode = lib.mkOption {
-        type = lib.types.enum [ "push_to_talk" "toggle" ];
-        default = "push_to_talk";
-        description = ''
-          Activation mode:
-          - push_to_talk: Hold hotkey to record, release to transcribe
-          - toggle: Press once to start recording, press again to stop
-        '';
-      };
-    };
-
-    # Audio configuration
-    audio = {
-      device = lib.mkOption {
-        type = lib.types.str;
-        default = "default";
-        description = ''
-          Audio input device. Use "default" for system default.
-          List devices with: pactl list sources short
-        '';
-      };
-
-      sampleRate = lib.mkOption {
-        type = lib.types.int;
-        default = 16000;
-        description = "Sample rate in Hz (whisper expects 16000).";
-      };
-
-      maxDurationSecs = lib.mkOption {
-        type = lib.types.int;
-        default = 60;
-        description = "Maximum recording duration in seconds (safety limit).";
-      };
-
-      feedback = {
-        enable = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = "Enable audio feedback sounds (beeps when recording starts/stops).";
-        };
-
-        theme = lib.mkOption {
-          type = lib.types.str;
-          default = "default";
-          description = ''
-            Sound theme: "default", "subtle", "mechanical", or path to custom theme.
-          '';
-        };
-
-        volume = lib.mkOption {
-          type = lib.types.float;
-          default = 0.7;
-          description = "Volume level (0.0 to 1.0).";
-        };
-      };
-    };
-
-    # Whisper configuration
-    whisper = {
-      language = lib.mkOption {
-        type = lib.types.str;
-        default = "en";
-        description = ''
-          Language for transcription. Use "en" for English, "auto" for auto-detection.
-        '';
-      };
-
-      translate = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Translate non-English speech to English.";
-      };
-
-      threads = lib.mkOption {
-        type = lib.types.nullOr lib.types.int;
-        default = null;
-        description = "Number of CPU threads for inference (null for auto-detection).";
-      };
-
-      onDemandLoading = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Load model on-demand when recording starts (true) or keep loaded (false).
-          When true, model is loaded when recording starts and unloaded after.
-          When false, model is kept in memory for faster response times.
-        '';
-      };
-    };
-
-    # Output configuration
-    output = {
-      mode = lib.mkOption {
-        type = lib.types.enum [ "type" "clipboard" "paste" ];
-        default = "type";
-        description = ''
-          Primary output mode:
-          - type: Simulates keyboard input at cursor position
-          - clipboard: Copies text to clipboard
-          - paste: Copies to clipboard then pastes with Ctrl+V
-        '';
-      };
-
-      fallbackToClipboard = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Fall back to clipboard if typing fails.";
-      };
-
-      typeDelayMs = lib.mkOption {
-        type = lib.types.int;
-        default = 0;
-        description = ''
-          Delay between typed characters in milliseconds.
-          0 = fastest, increase if characters are dropped.
-        '';
-      };
-
-      notification = {
-        onRecordingStart = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = "Show notification when recording starts.";
-        };
-
-        onRecordingStop = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = "Show notification when recording stops.";
-        };
-
-        onTranscription = lib.mkOption {
-          type = lib.types.bool;
-          default = true;
-          description = "Show notification with transcribed text.";
-        };
-      };
-
-      postProcess = {
-        command = lib.mkOption {
-          type = lib.types.nullOr lib.types.str;
-          default = null;
-          description = ''
-            Pipe transcribed text through an external command for cleanup.
-            The command receives text on stdin and outputs processed text on stdout.
-          '';
-          example = "ollama run llama3.2:1b 'Clean up this dictation...'";
-        };
-
-        timeoutMs = lib.mkOption {
-          type = lib.types.int;
-          default = 30000;
-          description = "Timeout for post-processing command in milliseconds.";
-        };
-      };
-    };
-
-    # Status/tray configuration
-    status = {
-      iconTheme = lib.mkOption {
-        type = lib.types.str;
-        default = "emoji";
-        description = ''
-          Icon theme for status display. Options:
-          - Font-based: "emoji", "nerd-font", "material", "phosphor", "codicons", "omarchy"
-          - Universal: "minimal", "dots", "arrows", "text"
-        '';
-      };
-
-      icons = lib.mkOption {
-        type = lib.types.attrsOf lib.types.str;
-        default = { };
-        description = "Per-state icon overrides.";
-        example = {
-          idle = "...";
-          recording = "...";
-          transcribing = "...";
-        };
-      };
-    };
-
-    # State file location
-    stateFile = lib.mkOption {
-      type = lib.types.str;
-      default = "auto";
-      description = ''
-        State file for external integrations (Waybar, polybar, etc.).
-        Use "auto" for default location, a custom path, or "disabled".
-      '';
-    };
-
-    # Raw settings override (escape hatch)
     settings = lib.mkOption {
       type = tomlFormat.type;
       default = { };
       description = ''
-        Additional settings to merge into the config file.
-        These override any settings defined by other options.
+        Configuration for voxtype. These settings are written to
+        ~/.config/voxtype/config.toml. See the voxtype documentation
+        for available options.
       '';
       example = lib.literalExpression ''
         {
+          hotkey = {
+            enabled = false;  # Use compositor keybindings
+            key = "SCROLLLOCK";
+          };
+          whisper = {
+            language = "en";
+            translate = false;
+          };
+          output = {
+            mode = "type";
+            fallback_to_clipboard = true;
+          };
           text = {
             spoken_punctuation = true;
             replacements = { "vox type" = "voxtype"; };
@@ -415,32 +118,22 @@ in {
       '';
     };
 
-    # Systemd service
-    service = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Enable the systemd user service for VoxType.
-          The service runs `voxtype daemon` and starts with your graphical session.
-        '';
-      };
+    service.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable the systemd user service for VoxType.";
     };
   };
 
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.model.name != null || cfg.model.path != null;
-        message = "programs.voxtype: either model.name or model.path must be set";
-      }
-      {
         assertion = !(cfg.model.name != null && cfg.model.path != null);
         message = "programs.voxtype: cannot set both model.name and model.path";
       }
     ];
 
-    home.packages = [ wrappedPackage ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."voxtype/config.toml".source = configFile;
 
@@ -454,7 +147,7 @@ in {
 
       Service = {
         Type = "simple";
-        ExecStart = "${wrappedPackage}/bin/voxtype daemon";
+        ExecStart = "${cfg.package}/bin/voxtype daemon";
         Restart = "on-failure";
         RestartSec = 5;
       };

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -10,8 +10,13 @@
 #   programs.voxtype = {
 #     enable = true;
 #     package = voxtype.packages.${system}.vulkan;
-#     typingBackend = "wtype";
 #   };
+#
+# For evdev hotkey support, add your user to the input group:
+#   users.users.yourname.extraGroups = [ "input" ];
+#
+# For ydotool backend, enable the NixOS ydotool module:
+#   programs.ydotool.enable = true;
 #
 { config, lib, pkgs, ... }:
 
@@ -24,104 +29,20 @@ in {
     package = lib.mkOption {
       type = lib.types.package;
       description = ''
-        The VoxType package to install.
-        This should be set to one of the voxtype flake packages.
+        The VoxType package to install. Use the flake's wrapped packages:
+        - packages.default: CPU-only
+        - packages.vulkan: Vulkan GPU acceleration
+        - packages.rocm: ROCm/HIP acceleration (AMD)
+
+        These packages include all runtime dependencies (wtype, ydotool, etc.)
+        in their PATH.
       '';
       example = lib.literalExpression "voxtype.packages.\${system}.vulkan";
-    };
-
-    # Runtime dependency configuration
-    typingBackend = lib.mkOption {
-      type = lib.types.enum [ "wtype" "ydotool" "both" ];
-      default = "wtype";
-      description = ''
-        Backend for simulating keyboard input:
-
-        - wtype: Wayland virtual keyboard protocol (recommended for Wayland)
-          Works with most Wayland compositors, best Unicode/emoji support.
-
-        - ydotool: Uses uinput kernel module, works on both X11 and Wayland.
-          Requires ydotoold daemon. May need 'input' group membership.
-
-        - both: Install both backends, let VoxType choose based on session.
-      '';
-    };
-
-    # Input group for evdev hotkey (with security warning)
-    inputGroupUsers = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      example = [ "alice" "bob" ];
-      description = ''
-        Users to add to the 'input' group for evdev hotkey access.
-
-        SECURITY WARNING: The 'input' group grants read access to ALL input
-        devices, including keyboards. This means any process running as these
-        users could potentially act as a keylogger. Only use this if:
-
-        - You need the built-in evdev hotkey (most users should use compositor
-          keybindings instead, which don't require special permissions)
-        - You understand and accept the security implications
-        - You're on a single-user system with trusted software
-
-        Leave empty (default) if using compositor keybindings for push-to-talk.
-      '';
-    };
-
-    # ydotool daemon management
-    ydotool = {
-      enableDaemon = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Enable the ydotoold systemd user service.
-          Required when using ydotool as the typing backend.
-          The daemon will start automatically with the graphical session.
-        '';
-      };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    # Install VoxType and selected typing backends
-    environment.systemPackages = [ cfg.package ]
-      ++ lib.optional (cfg.typingBackend == "wtype" || cfg.typingBackend == "both") pkgs.wtype
-      ++ lib.optional (cfg.typingBackend == "ydotool" || cfg.typingBackend == "both") pkgs.ydotool
-      ++ [ pkgs.wl-clipboard ];  # Always useful for clipboard fallback
-
-    # Enable uinput for ydotool (required for ydotool to work)
-    hardware.uinput.enable = lib.mkIf
-      (cfg.typingBackend == "ydotool" || cfg.typingBackend == "both" || cfg.ydotool.enableDaemon)
-      true;
-
-    # Add specified users to input group (with assertion for awareness)
-    users.users = lib.mkIf (cfg.inputGroupUsers != [ ]) (
-      lib.genAttrs cfg.inputGroupUsers (user: {
-        extraGroups = [ "input" ];
-      })
-    );
-
-    # Warn if input group is used
-    warnings = lib.optional (cfg.inputGroupUsers != [ ]) ''
-      VoxType: You have added users to the 'input' group via programs.voxtype.inputGroupUsers.
-      This grants read access to ALL input devices (keyboards, mice, etc.) which has
-      security implications. Ensure this is intentional. Consider using compositor
-      keybindings instead, which don't require special permissions.
-    '';
-
-    # ydotool daemon as a systemd user service
-    systemd.user.services.ydotoold = lib.mkIf cfg.ydotool.enableDaemon {
-      description = "ydotool daemon for virtual input";
-      documentation = [ "man:ydotool(1)" ];
-      wantedBy = [ "graphical-session.target" ];
-      partOf = [ "graphical-session.target" ];
-      after = [ "graphical-session.target" ];
-
-      serviceConfig = {
-        ExecStart = "${pkgs.ydotool}/bin/ydotoold";
-        Restart = "on-failure";
-        RestartSec = 5;
-      };
-    };
+    # Install VoxType (runtime deps are already in the wrapped package's PATH)
+    environment.systemPackages = [ cfg.package ];
   };
 }


### PR DESCRIPTION
## Summary

Addresses feedback from @danheuck on PR #43 to simplify and align the NixOS packaging with standard conventions.

### Changes

**Home Manager Module** 
- Replaced all typed options with a single `settings` attrset 
- Now uses pre-wrapped packages from the flake
- Kept valuable features: model downloading from HuggingFace, systemd service

**NixOS Module**
- Now just installs the package
- Runtime deps are in the wrapped package's PATH
- Documents how to enable ydotool and input group access in header comments

**flake.nix**
- Reordered packages to list wrapped packages first
- Updated comments

### Before/After

**Before:**
```nix
programs.voxtype = {
  enable = true;
  package = voxtype.packages.${system}.vulkan;
  model.name = "base.en";
  hotkey.enable = false;
  hotkey.key = "SCROLLLOCK";
  whisper.language = "en";
  output.mode = "type";
  output.fallbackToClipboard = true;
  service.enable = true;
};
```

**After:**
```nix
programs.voxtype = {
  enable = true;
  package = voxtype.packages.${system}.vulkan;
  model.name = "base.en";
  service.enable = true;
  settings = {
    hotkey.enabled = false;
    whisper.language = "en";
    output.mode = "type";
    output.fallback_to_clipboard = true;
  };
};
```

### Migration

Users of the previous NixOS module:

```nix
# Input group access (was inputGroupUsers)
users.users.yourname.extraGroups = [ "input" ];

# ydotool (was ydotool.enableDaemon)
programs.ydotool.enable = true;
```

Users of the previous Home Manager module:
- Move all typed options into `settings` attrset
- Use snake_case keys (matching config.toml)