### PR TITLE
fix: add wtype init delay to prevent first character drop

### DIFF
--- a/src/output/wtype.rs
+++ b/src/output/wtype.rs
@@ -63,6 +63,7 @@ impl TextOutput for WtypeOutput {
         }
 
         let output = Command::new("wtype")
+            .args(["-s", "200"]) // delay after init to prevent first char drop
             .arg("--")
             .arg(text)
             .stdout(Stdio::null())


### PR DESCRIPTION
## Summary

Adds a 200ms delay (`-s 200`) after wtype initializes its virtual keyboard before sending the first keystroke. This fixes an issue where the first character of transcriptions was intermittently dropped.

## Root Cause

When wtype starts, it connects to Wayland and creates a virtual keyboard. The first keystroke was being sent before the virtual keyboard was fully ready, causing the first character to be dropped.

## Testing

Tested on Arch Linux with Hyprland. Before this fix, transcriptions like "Hello" would appear as "ello". After the fix, all characters appear correctly.

## Note

This fix works best when combined with disabling the submap integration (commenting out `pre_output_command` and `post_output_command` in config). The submap was also contributing to the issue by consuming virtual keyboard events.

Fixes #61