### PR TITLE
Fix first character dropped when using compositor submap

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -95,8 +95,12 @@ fallback_to_clipboard = true
 type_delay_ms = 0
 
 # Delay before wtype starts typing (ms)
-# Allows virtual keyboard to initialize, helps prevent first character drop
-# on some compositors. Try 100-200ms if first character is dropped.
+# Allows virtual keyboard to initialize. Some users report this helps prevent
+# the first character from being dropped on text insertion. Try 100-200ms.
+# Note: When using compositor integration (via `voxtype setup compositor`),
+# best results come from not binding Escape in the submap. Some users have
+# had success with Escape bound by increasing this delay, but the most
+# consistent fix is to use F12 or another key instead.
 wtype_delay_ms = 0
 
 # Output hooks for compositor integration (fixes modifier key interference)

--- a/config/default.toml
+++ b/config/default.toml
@@ -94,6 +94,11 @@ fallback_to_clipboard = true
 # 0 = fastest possible, increase if characters are dropped
 type_delay_ms = 0
 
+# Delay before wtype starts typing (ms)
+# Allows virtual keyboard to initialize, helps prevent first character drop
+# on some compositors. Try 100-200ms if first character is dropped.
+wtype_delay_ms = 0
+
 # Output hooks for compositor integration (fixes modifier key interference)
 # When using compositor keybindings with modifiers (e.g., SUPER+CTRL+X),
 # these hooks switch to a submap/mode that blocks modifiers during typing.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,10 @@ pub struct Cli {
     #[arg(long)]
     pub toggle: bool,
 
+    /// Delay before wtype starts typing (ms), helps prevent first character drop
+    #[arg(long, value_name = "MS")]
+    pub wtype_delay: Option<u32>,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -622,6 +622,11 @@ pub struct OutputConfig {
     #[serde(default)]
     pub type_delay_ms: u32,
 
+    /// Delay before wtype starts typing (ms), allows virtual keyboard to initialize
+    /// Helps prevent first character from being dropped on some compositors
+    #[serde(default)]
+    pub wtype_delay_ms: u32,
+
     /// Automatically submit (send Enter key) after outputting transcribed text
     /// Useful for chat applications, command lines, or forms where you want
     /// to auto-submit after dictation
@@ -693,6 +698,7 @@ impl Default for Config {
                 fallback_to_clipboard: true,
                 notification: NotificationConfig::default(),
                 type_delay_ms: 0,
+                wtype_delay_ms: 0,
                 auto_submit: false,
                 pre_output_command: None,
                 post_output_command: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,9 @@ async fn main() -> anyhow::Result<()> {
     if cli.toggle {
         config.hotkey.mode = config::ActivationMode::Toggle;
     }
+    if let Some(delay) = cli.wtype_delay {
+        config.output.wtype_delay_ms = delay;
+    }
 
     // Run the appropriate command
     match cli.command.unwrap_or(Commands::Daemon) {
@@ -585,6 +588,7 @@ async fn show_config(config: &config::Config) -> anyhow::Result<()> {
         config.output.fallback_to_clipboard
     );
     println!("  type_delay_ms = {}", config.output.type_delay_ms);
+    println!("  wtype_delay_ms = {}", config.output.wtype_delay_ms);
 
     println!("\n[output.notification]");
     println!(

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -43,6 +43,7 @@ pub fn create_output_chain(config: &OutputConfig) -> Vec<Box<dyn TextOutput>> {
             chain.push(Box::new(wtype::WtypeOutput::new(
                 config.notification.on_transcription,
                 config.auto_submit,
+                config.wtype_delay_ms,
             )));
 
             // Fallback: ydotool (works on X11/TTY, requires daemon)

--- a/src/setup/compositor.rs
+++ b/src/setup/compositor.rs
@@ -26,6 +26,11 @@ const HYPRLAND_CONFIG: &str = r#"# Voxtype compositor integration
 # When using keybindings with modifiers (e.g., SUPER+CTRL+X), if keys are
 # released slowly, voxtype may start typing while modifier keys are still
 # held down. This submap temporarily blocks modifiers during text output.
+#
+# NOTE: Escape must NOT be bound here. Binding Escape causes wtype's first
+# character to be dropped. Escape appears to clear compositor state during
+# submap transitions; binding it to a no-op prevents this.
+# See: https://github.com/hyprwm/Hyprland/issues/3165
 
 # Modifier suppression submap
 submap = voxtype_suppress
@@ -37,9 +42,8 @@ bind = , Alt_L, exec, true
 bind = , Alt_R, exec, true
 bind = , Shift_L, exec, true
 bind = , Shift_R, exec, true
-bind = , Escape, exec, voxtype record cancel  # Cancel recording/transcription
-bind = , Escape, submap, reset
-bind = , F12, submap, reset  # Emergency escape if voxtype crashes
+bind = , F12, exec, voxtype record cancel  # Cancel recording/transcription
+bind = , F12, submap, reset
 submap = reset
 "#;
 
@@ -51,6 +55,11 @@ const SWAY_CONFIG: &str = r#"# Voxtype compositor integration
 # When using keybindings with modifiers (e.g., $mod+Ctrl+x), if keys are
 # released slowly, voxtype may start typing while modifier keys are still
 # held down. This mode temporarily blocks modifiers during text output.
+#
+# NOTE: Escape must NOT be bound here. Binding Escape causes wtype's first
+# character to be dropped. Escape appears to clear compositor state during
+# mode transitions; binding it to a no-op prevents this.
+# See: https://github.com/hyprwm/Hyprland/issues/3165
 
 # Modifier suppression mode
 mode "voxtype_suppress" {
@@ -62,8 +71,7 @@ mode "voxtype_suppress" {
     bindsym Alt_R nop
     bindsym Shift_L nop
     bindsym Shift_R nop
-    bindsym Escape exec voxtype record cancel; mode "default"  # Cancel recording/transcription
-    bindsym F12 mode "default"  # Emergency escape if voxtype crashes
+    bindsym F12 exec voxtype record cancel; mode "default"  # Cancel recording/transcription
 }
 "#;
 
@@ -84,6 +92,11 @@ const RIVER_CONFIG: &str = r#"#!/bin/sh
 # When using keybindings with modifiers (e.g., Super+Control+X), if keys are
 # released slowly, voxtype may start typing while modifier keys are still
 # held down. This mode temporarily blocks modifiers during text output.
+#
+# NOTE: Escape must NOT be bound here. Binding Escape causes wtype's first
+# character to be dropped. Escape appears to clear compositor state during
+# mode transitions; binding it to a no-op prevents this.
+# See: https://github.com/hyprwm/Hyprland/issues/3165
 
 # Declare the modifier suppression mode
 riverctl declare-mode voxtype_suppress
@@ -98,11 +111,8 @@ riverctl map voxtype_suppress None Alt_R spawn true
 riverctl map voxtype_suppress None Shift_L spawn true
 riverctl map voxtype_suppress None Shift_R spawn true
 
-# Cancel recording/transcription with Escape
-riverctl map voxtype_suppress None Escape spawn "voxtype record cancel"
-riverctl map voxtype_suppress None Escape enter-mode normal
-
-# Emergency escape if voxtype crashes
+# Cancel recording/transcription with F12 (NOT Escape - see note above)
+riverctl map voxtype_suppress None F12 spawn "voxtype record cancel"
 riverctl map voxtype_suppress None F12 enter-mode normal
 "#;
 


### PR DESCRIPTION
## Summary

Fixes the first character being dropped when using compositor submap/mode integration for modifier key suppression. This PR includes two solutions.

### Solution 1: Remove Escape binding from submaps (recommended)

**Observed behavior:**
- Binding Escape in the submap causes wtype's first character to be dropped
- This occurs even when no modifier keys are held (e.g., using HOME as the hotkey)
- Not binding Escape in the submap resolves the issue consistently

**Best theory:** [Hyprland issue #3165](https://github.com/hyprwm/Hyprland/issues/3165) documents that Escape clears compositor state during submap transitions. Binding Escape to a no-op may prevent this state-clearing from occurring. However, that issue specifically discusses modifier key accumulation, which doesn't fully explain why the problem occurs with non-modifier hotkeys.

**Solution:** Remove Escape bindings from all compositor configs (Hyprland, Sway, River). Use F12 for cancel functionality instead.

### Solution 2: Configurable wtype delay (alternative)

Adds `wtype_delay_ms` config option and `--wtype-delay` CLI flag. This adds a delay before wtype starts typing, allowing the virtual keyboard to fully initialize.

**Usage:**
```toml
[output]
wtype_delay_ms = 200
```

Or via CLI:
```bash
voxtype --wtype-delay 200
```

This is based on [PR #63](https://github.com/peteonrails/voxtype/pull/63) but makes the delay configurable instead of hardcoded.

**Note:** Some users have reported success with this delay. However, our testing found that when Escape is bound in the submap, the first character is still dropped even with delays up to 1000ms. This suggests the Escape issue is not timing-related. Removing Escape from the submap (Solution 1) is the most consistent fix.

## Changes

- Hyprland: Removed `bind = , Escape, ...` bindings, use F12 for cancel
- Sway: Removed `bindsym Escape ...` binding, use F12 for cancel  
- River: Removed `riverctl map ... Escape ...` bindings, use F12 for cancel
- Added `wtype_delay_ms` config option and `--wtype-delay` CLI flag
- Updated default.toml with documentation for new option

## Test plan

- [x] Verified transcription with Hyprland submap no longer drops first character
- [x] Verified adding Escape binding back causes first character to drop
- [x] Verified wtype_delay_ms (200ms, 1000ms) does NOT fix the issue when Escape is bound
- [x] Verified F12 cancel works during recording
- [x] All tests pass (115 passed)

Closes #61

Co-authored-by: Julian194 <Julian194@users.noreply.github.com>
Co-authored-by: Julian Kaiser <julian.kaiser.mail@gmail.com>