### PR TITLE
Auto-update systemd service when switching GPU backends

### DIFF
--- a/src/setup/gpu.rs
+++ b/src/setup/gpu.rs
@@ -398,6 +398,11 @@ pub fn enable() -> anyhow::Result<()> {
         enable_simple_mode()?;
     }
 
+    // Regenerate systemd service if it exists
+    if super::systemd::regenerate_service_file()? {
+        println!("Updated systemd service to use GPU backend.");
+    }
+
     println!("Switched to GPU (Vulkan) backend.");
     println!();
     println!("Restart voxtype to use GPU acceleration:");
@@ -416,6 +421,11 @@ pub fn disable() -> anyhow::Result<()> {
     } else {
         disable_simple_mode()?;
         println!("Switched to CPU (native) backend.");
+    }
+
+    // Regenerate systemd service if it exists
+    if super::systemd::regenerate_service_file()? {
+        println!("Updated systemd service to use CPU backend.");
     }
 
     println!();

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -73,6 +73,26 @@ pub fn get_voxtype_path() -> String {
         .unwrap_or_else(|_| "voxtype".to_string())
 }
 
+/// Get the voxtype binary path for service files
+///
+/// In tiered mode (DEB/RPM packages), returns /usr/bin/voxtype (the symlink)
+/// so backend switching only requires a service restart rather than regenerating
+/// the service file.
+pub fn get_voxtype_service_path() -> String {
+    const VOXTYPE_BIN: &str = "/usr/bin/voxtype";
+
+    // If /usr/bin/voxtype exists (either as symlink or binary), use it
+    // This allows backend switching to work with just a service restart
+    if std::path::Path::new(VOXTYPE_BIN).exists()
+        || std::fs::symlink_metadata(VOXTYPE_BIN).is_ok()
+    {
+        return VOXTYPE_BIN.to_string();
+    }
+
+    // Fallback to current exe (for non-standard installations)
+    get_voxtype_path()
+}
+
 /// Print a success message
 pub fn print_success(msg: &str) {
     println!("  \x1b[32m✓\x1b[0m {}", msg);

--- a/src/setup/systemd.rs
+++ b/src/setup/systemd.rs
@@ -1,6 +1,6 @@
 //! Systemd user service management for voxtype
 
-use super::{get_voxtype_path, print_failure, print_info, print_success};
+use super::{get_voxtype_service_path, print_failure, print_info, print_success};
 use std::path::PathBuf;
 use tokio::process::Command;
 
@@ -20,7 +20,7 @@ fn service_path() -> PathBuf {
 
 /// Generate the systemd service file content
 fn generate_service_file() -> String {
-    let voxtype_path = get_voxtype_path();
+    let voxtype_path = get_voxtype_service_path();
 
     format!(
         r#"[Unit]
@@ -170,4 +170,19 @@ pub async fn status() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Regenerate the service file content (used after backend switches)
+///
+/// Returns true if the service file was updated, false if no service was installed.
+pub fn regenerate_service_file() -> anyhow::Result<bool> {
+    let service_path = service_path();
+
+    if !service_path.exists() {
+        return Ok(false); // No service installed, nothing to update
+    }
+
+    let content = generate_service_file();
+    std::fs::write(&service_path, &content)?;
+    Ok(true)
 }


### PR DESCRIPTION
## Summary

- Fixes the bug where `voxtype setup gpu --enable` didn't update the systemd service file
- Service file now uses `/usr/bin/voxtype` (the symlink) instead of resolved binary paths
- Backend switches automatically regenerate the service file if one exists

## Changes

- Added `get_voxtype_service_path()` in `src/setup/mod.rs` - returns `/usr/bin/voxtype` when available
- Updated `src/setup/systemd.rs` to use the new path function and added `regenerate_service_file()`
- Modified `src/setup/gpu.rs` to call `regenerate_service_file()` in both `enable()` and `disable()`

## Before

```bash
sudo voxtype setup gpu --enable
# Switched to GPU (Vulkan) backend.
# But service file still points to old binary!

cat ~/.config/systemd/user/voxtype.service | grep ExecStart
# ExecStart=/usr/lib/voxtype/voxtype-avx512 daemon  <-- wrong!

voxtype setup systemd  # Manual step required
systemctl --user restart voxtype
```

## After

```bash
sudo voxtype setup gpu --enable
# Updated systemd service to use GPU backend.
# Switched to GPU (Vulkan) backend.

cat ~/.config/systemd/user/voxtype.service | grep ExecStart
# ExecStart=/usr/bin/voxtype daemon  <-- uses symlink, automatically updated

systemctl --user restart voxtype  # Just restart, no manual regeneration needed
```

## Test plan

- [ ] Run `voxtype setup systemd` and verify ExecStart uses `/usr/bin/voxtype`
- [ ] Run `sudo voxtype setup gpu --enable` and verify service file is updated
- [ ] Run `sudo voxtype setup gpu --disable` and verify service file is updated
- [ ] Verify `systemctl --user restart voxtype` picks up the new backend

Closes #69