### PR TITLE
Bump version to 0.4.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,7 +1803,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "voxtype"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "voxtype"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 authors = ["Peter Jackson", "Jean-Paul van Tillo", "Máté Rémiás", "Rob Zolkos"]
 description = "Push-to-talk voice-to-text for Wayland"


### PR DESCRIPTION
## Summary
- Bump version in Cargo.toml to 0.4.13
- Update Cargo.lock to match

Required for AUR source package builds which use `--locked`.