### PR TITLE
feat: add CLI backend for whisper-cli subprocess transcription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1827,7 @@ dependencies = [
  "regex",
  "rodio",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1828,6 +1835,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "which",
  "whisper-rs",
 ]
 
@@ -1940,6 +1948,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -2304,6 +2324,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,15 @@ hound = "3"  # WAV file reading/writing
 # HTTP client for remote transcription
 ureq = { version = "2", features = ["json"] }
 
+# JSON parsing (for CLI backend)
+serde_json = "1"
+
+# CLI path resolution (for CLI backend)
+which = "7"
+
+# Temp files (for CLI backend audio)
+tempfile = "3"
+
 # Audio playback (for feedback sounds)
 rodio = { version = "0.19", default-features = false, features = ["wav"] }
 

--- a/src/transcribe/cli.rs
+++ b/src/transcribe/cli.rs
@@ -1,0 +1,336 @@
+//! CLI-based speech-to-text transcription
+//!
+//! Uses whisper-cli (from whisper.cpp) as an external process for transcription.
+//! This is a fallback for systems where the whisper-rs FFI bindings don't work
+//! (e.g., Ubuntu 25.10 with glibc 2.42).
+//!
+//! The whisper-cli binary must be installed separately or built from whisper.cpp.
+
+use super::Transcriber;
+use crate::config::{Config, WhisperConfig};
+use crate::error::TranscribeError;
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// CLI-based transcriber using whisper-cli subprocess
+pub struct CliTranscriber {
+    /// Path to whisper-cli binary
+    cli_path: PathBuf,
+    /// Path to model file
+    model_path: PathBuf,
+    /// Language for transcription
+    language: String,
+    /// Whether to translate to English
+    translate: bool,
+    /// Number of threads to use
+    threads: usize,
+}
+
+/// JSON output structure from whisper-cli
+#[derive(Debug, Deserialize)]
+struct WhisperCliOutput {
+    transcription: Vec<Segment>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Segment {
+    text: String,
+}
+
+impl CliTranscriber {
+    /// Create a new CLI-based transcriber
+    pub fn new(config: &WhisperConfig) -> Result<Self, TranscribeError> {
+        let cli_path = resolve_cli_path(config.whisper_cli_path.as_deref())?;
+        let model_path = resolve_model_path(&config.model)?;
+
+        tracing::info!(
+            "Using whisper-cli backend: {:?} with model {:?}",
+            cli_path,
+            model_path
+        );
+
+        // Verify cli exists and is executable
+        if !cli_path.exists() {
+            return Err(TranscribeError::InitFailed(format!(
+                "whisper-cli not found at {:?}",
+                cli_path
+            )));
+        }
+
+        // threads = 0 means auto-detect, use a sensible default
+        let threads = match config.threads {
+            Some(0) | None => num_cpus::get().min(4),
+            Some(n) => n,
+        };
+
+        Ok(Self {
+            cli_path,
+            model_path,
+            language: config.language.clone(),
+            translate: config.translate,
+            threads,
+        })
+    }
+
+    /// Write audio samples to a temporary WAV file
+    fn write_temp_wav(&self, samples: &[f32]) -> Result<tempfile::NamedTempFile, TranscribeError> {
+        let temp_file = tempfile::Builder::new()
+            .prefix("voxtype_")
+            .suffix(".wav")
+            .tempfile()
+            .map_err(|e| {
+                TranscribeError::AudioFormat(format!("Failed to create temp file: {}", e))
+            })?;
+
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+
+        let mut writer = hound::WavWriter::create(temp_file.path(), spec).map_err(|e| {
+            TranscribeError::AudioFormat(format!("Failed to create WAV writer: {}", e))
+        })?;
+
+        for &sample in samples {
+            // Convert f32 [-1.0, 1.0] to i16
+            let clamped = sample.clamp(-1.0, 1.0);
+            let scaled = (clamped * 32767.0) as i16;
+            writer.write_sample(scaled).map_err(|e| {
+                TranscribeError::AudioFormat(format!("Failed to write sample: {}", e))
+            })?;
+        }
+
+        writer
+            .finalize()
+            .map_err(|e| TranscribeError::AudioFormat(format!("Failed to finalize WAV: {}", e)))?;
+
+        Ok(temp_file)
+    }
+}
+
+impl Transcriber for CliTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat(
+                "Empty audio buffer".to_string(),
+            ));
+        }
+
+        let duration_secs = samples.len() as f32 / 16000.0;
+        tracing::debug!(
+            "Transcribing {:.2}s of audio ({} samples) via whisper-cli",
+            duration_secs,
+            samples.len()
+        );
+
+        let start = std::time::Instant::now();
+
+        // Write audio to temp WAV file
+        let temp_wav = self.write_temp_wav(samples)?;
+
+        // Create temp file for JSON output
+        let temp_json = tempfile::Builder::new()
+            .prefix("voxtype_out_")
+            .suffix("") // whisper-cli adds .json
+            .tempfile()
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Failed to create temp file: {}", e))
+            })?;
+
+        let output_base = temp_json
+            .path()
+            .to_str()
+            .ok_or_else(|| TranscribeError::InferenceFailed("Invalid temp path".to_string()))?;
+
+        // Build command
+        let mut cmd = Command::new(&self.cli_path);
+        cmd.arg("--model")
+            .arg(&self.model_path)
+            .arg("--file")
+            .arg(temp_wav.path())
+            .arg("--output-json")
+            .arg("--output-file")
+            .arg(output_base)
+            .arg("--threads")
+            .arg(self.threads.to_string())
+            .arg("--no-prints"); // Suppress progress output
+
+        // Set language
+        if self.language != "auto" {
+            cmd.arg("--language").arg(&self.language);
+        }
+
+        // Translation
+        if self.translate {
+            cmd.arg("--translate");
+        }
+
+        // Run whisper-cli
+        let output = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Failed to run whisper-cli: {}", e))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(TranscribeError::InferenceFailed(format!(
+                "whisper-cli failed: {}",
+                stderr
+            )));
+        }
+
+        // Read JSON output
+        let json_path = format!("{}.json", output_base);
+        let json_content = std::fs::read_to_string(&json_path).map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Failed to read output: {}", e))
+        })?;
+
+        // Clean up JSON file
+        let _ = std::fs::remove_file(&json_path);
+
+        // Parse JSON
+        let result: WhisperCliOutput = serde_json::from_str(&json_content).map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Failed to parse JSON output: {}", e))
+        })?;
+
+        // Combine all segments
+        let text: String = result
+            .transcription
+            .iter()
+            .map(|s| s.text.trim())
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_string();
+
+        tracing::info!(
+            "Transcription completed in {:.2}s: {:?}",
+            start.elapsed().as_secs_f32(),
+            if text.chars().count() > 50 {
+                format!("{}...", text.chars().take(50).collect::<String>())
+            } else {
+                text.clone()
+            }
+        );
+
+        Ok(text)
+    }
+}
+
+/// Resolve whisper-cli path
+fn resolve_cli_path(configured_path: Option<&str>) -> Result<PathBuf, TranscribeError> {
+    // If explicitly configured, use that
+    if let Some(path) = configured_path {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Ok(p);
+        }
+        return Err(TranscribeError::InitFailed(format!(
+            "Configured whisper-cli path not found: {}",
+            path
+        )));
+    }
+
+    // Check common locations
+    let candidates = [
+        // In PATH
+        which::which("whisper-cli").ok(),
+        which::which("whisper").ok(),
+        // Local builds
+        Some(PathBuf::from("./whisper-cli")),
+        Some(PathBuf::from("./build/bin/whisper-cli")),
+        // System locations
+        Some(PathBuf::from("/usr/local/bin/whisper-cli")),
+        Some(PathBuf::from("/usr/bin/whisper-cli")),
+        // Home directory
+        directories::BaseDirs::new().map(|d| d.home_dir().join(".local/bin/whisper-cli")),
+    ];
+
+    for candidate in candidates.into_iter().flatten() {
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(TranscribeError::InitFailed(
+        "whisper-cli not found. Install from https://github.com/ggerganov/whisper.cpp or set whisper_cli_path in config.".to_string()
+    ))
+}
+
+/// Resolve model name to file path (reused from whisper.rs)
+fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
+    // If it's already an absolute path, use it directly
+    let path = PathBuf::from(model);
+    if path.is_absolute() && path.exists() {
+        return Ok(path);
+    }
+
+    // Map model names to file names
+    let model_filename = match model {
+        "tiny" => "ggml-tiny.bin",
+        "tiny.en" => "ggml-tiny.en.bin",
+        "base" => "ggml-base.bin",
+        "base.en" => "ggml-base.en.bin",
+        "small" => "ggml-small.bin",
+        "small.en" => "ggml-small.en.bin",
+        "medium" => "ggml-medium.bin",
+        "medium.en" => "ggml-medium.en.bin",
+        "large" | "large-v1" => "ggml-large-v1.bin",
+        "large-v2" => "ggml-large-v2.bin",
+        "large-v3" => "ggml-large-v3.bin",
+        "large-v3-turbo" => "ggml-large-v3-turbo.bin",
+        other if other.ends_with(".bin") => other,
+        other => {
+            return Err(TranscribeError::ModelNotFound(format!(
+                "Unknown model: '{}'. Valid models: tiny, base, small, medium, large-v3, large-v3-turbo",
+                other
+            )));
+        }
+    };
+
+    // Look in the data directory
+    let models_dir = Config::models_dir();
+    let model_path = models_dir.join(model_filename);
+
+    if model_path.exists() {
+        return Ok(model_path);
+    }
+
+    // Also check current directory
+    let cwd_path = PathBuf::from(model_filename);
+    if cwd_path.exists() {
+        return Ok(cwd_path);
+    }
+
+    // Also check ./models/
+    let local_models_path = PathBuf::from("models").join(model_filename);
+    if local_models_path.exists() {
+        return Ok(local_models_path);
+    }
+
+    Err(TranscribeError::ModelNotFound(format!(
+        "Model '{}' not found. Looked in:\n  - {}\n  - {}\n  - {}",
+        model,
+        model_path.display(),
+        cwd_path.display(),
+        local_models_path.display()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_cli_not_found() {
+        // Should fail gracefully when whisper-cli is not installed
+        let result = resolve_cli_path(Some("/nonexistent/whisper-cli"));
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a `cli` backend option that uses `whisper-cli` (from whisper.cpp) as a subprocess for transcription. This is a workaround for issue #30 where the whisper-rs FFI bindings crash on systems with glibc 2.42+ (e.g., Ubuntu 25.10).

**Root cause**: The crash is a C++ exception crossing the Rust FFI boundary. Interestingly, whisper.cpp works perfectly when run natively - only the Rust FFI bindings fail.

## Key Changes

- New `WhisperBackend::Cli` variant in config
- New `whisper_cli_path` config option to specify custom binary location
- New `CliTranscriber` implementation that:
  - Writes audio to temporary WAV file
  - Calls whisper-cli with `--output-json`
  - Parses JSON output for transcription text
- Handles `threads = 0` config as "auto-detect" (prevents whisper-cli crash)

## Configuration

```toml
[whisper]
backend = "cli"
whisper_cli_path = "/path/to/whisper-cli"  # optional, searches PATH if not set
model = "small"
language = "fr"
```

Fixes #30