### PR TITLE
Add configurable paste keystroke (paste_keys option)

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -86,9 +86,9 @@ on_demand_loading = false
 
 [output]
 # Primary output mode: "type", "clipboard", or "paste"
-# - type: Simulates keyboard input at cursor position (requires ydotool)
+# - type: Simulates keyboard input at cursor position (requires wtype or ydotool)
 # - clipboard: Copies text to clipboard (requires wl-copy)
-# - paste: Copies to clipboard then pastes with Ctrl+V (requires wl-copy and ydotool)
+# - paste: Copies to clipboard then simulates paste keystroke (requires wl-copy and wtype or ydotool)
 mode = "type"
 
 # Fall back to clipboard if typing fails
@@ -106,6 +106,14 @@ type_delay_ms = 0
 # had success with Escape bound by increasing this delay, but the most
 # consistent fix is to use F12 or another key instead.
 wtype_delay_ms = 0
+
+# Keystroke for paste mode (when mode = "paste")
+# Default is "ctrl+v". Change for environments with different paste shortcuts.
+# Examples:
+#   paste_keys = "ctrl+v"        # Standard (default)
+#   paste_keys = "shift+insert"  # Hyprland/Omarchy universal paste
+#   paste_keys = "ctrl+shift+v"  # Some terminal emulators
+# paste_keys = "ctrl+v"
 
 # Compositor integration hooks
 # Use `voxtype setup compositor hyprland|sway|river` for automatic setup.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -558,9 +558,9 @@ Controls how transcribed text is delivered.
 Primary output method.
 
 **Values:**
-- `type` - Simulate keyboard input at cursor position (requires ydotool)
+- `type` - Simulate keyboard input at cursor position (requires wtype or ydotool)
 - `clipboard` - Copy text to clipboard (requires wl-copy)
-- `paste` - Copy to clipboard then paste with Ctrl+V (requires wl-copy and ydotool)
+- `paste` - Copy to clipboard then simulate paste keystroke (requires wl-copy, and wtype or ydotool)
 
 **Example:**
 ```toml
@@ -569,7 +569,34 @@ mode = "paste"
 ```
 
 **Note about paste mode:**
-The `paste` mode is designed to work around non-US keyboard layout issues. Instead of typing characters directly (which assumes US keyboard layout), it copies text to the clipboard and then simulates Ctrl+V to paste it. This works regardless of keyboard layout but requires both wl-copy (for clipboard access) and ydotool (for Ctrl+V simulation).
+The `paste` mode is designed to work around non-US keyboard layout issues. Instead of typing characters directly (which assumes US keyboard layout), it copies text to the clipboard and then simulates a paste keystroke. This works regardless of keyboard layout. Requires wl-copy for clipboard access, plus wtype (preferred, no daemon needed) or ydotool (requires ydotoold daemon) for keystroke simulation.
+
+### paste_keys
+
+**Type:** String
+**Default:** `"ctrl+v"`
+**Required:** No
+
+Keystroke to simulate for paste mode. Change this if your environment uses a different paste shortcut.
+
+**Format:** `"modifier+key"` or `"modifier+modifier+key"` (case-insensitive)
+
+**Common values:**
+- `"ctrl+v"` - Standard paste (default)
+- `"shift+insert"` - Universal paste for Hyprland/Omarchy
+- `"ctrl+shift+v"` - Some terminal emulators
+
+**Example:**
+```toml
+[output]
+mode = "paste"
+paste_keys = "shift+insert"  # For Hyprland/Omarchy
+```
+
+**Supported keys:**
+- Modifiers: `ctrl`, `shift`, `alt`, `super` (also `leftctrl`, `rightctrl`, etc.)
+- Letters: `a-z`
+- Special: `insert`, `enter`
 
 ### fallback_to_clipboard
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -661,6 +661,11 @@ pub struct OutputConfig {
     /// Pipes transcribed text through an external command before output
     #[serde(default)]
     pub post_process: Option<PostProcessConfig>,
+
+    /// Keystroke to simulate for paste mode (e.g., "ctrl+v", "shift+insert", "ctrl+shift+v")
+    /// Defaults to "ctrl+v" if not specified
+    #[serde(default)]
+    pub paste_keys: Option<String>,
 }
 
 /// Output mode selection
@@ -719,6 +724,7 @@ impl Default for Config {
                 pre_output_command: None,
                 post_output_command: None,
                 post_process: None,
+                paste_keys: None,
             },
             text: TextConfig::default(),
             status: StatusConfig::default(),

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -69,6 +69,7 @@ pub fn create_output_chain(config: &OutputConfig) -> Vec<Box<dyn TextOutput>> {
             chain.push(Box::new(paste::PasteOutput::new(
                 config.notification.on_transcription,
                 config.auto_submit,
+                config.paste_keys.clone(),
             )));
         }
     }

--- a/src/output/paste.rs
+++ b/src/output/paste.rs
@@ -1,12 +1,13 @@
 //! Paste-based text output
 //!
-//! Uses wl-copy to copy text to clipboard, then simulates Ctrl+V with ydotool.
+//! Uses wl-copy to copy text to clipboard, then simulates a paste keystroke.
 //! This works around non-US keyboard layout issues by avoiding direct typing.
 //!
 //! Requires:
 //! - wl-copy installed (for clipboard access)
-//! - ydotool installed (for Ctrl+V simulation)
-//! - ydotoold daemon running (systemctl --user start ydotool)
+//! - wtype OR ydotool installed (for keystroke simulation)
+//!   - wtype: Wayland-native, no daemon needed (preferred)
+//!   - ydotool: Works on X11/Wayland/TTY, requires ydotoold daemon
 
 use super::TextOutput;
 use crate::error::OutputError;
@@ -14,20 +15,172 @@ use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
-/// Paste-based text output (clipboard + Ctrl+V)
+/// Parsed paste keystroke (modifiers + key)
+#[derive(Debug, Clone)]
+struct ParsedKeystroke {
+    /// Modifier keys (e.g., ["ctrl"], ["shift"], ["ctrl", "shift"])
+    modifiers: Vec<String>,
+    /// The main key (e.g., "v", "insert")
+    key: String,
+}
+
+impl ParsedKeystroke {
+    /// Parse a keystroke string like "ctrl+v" or "shift+insert"
+    fn parse(s: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = s.split('+').map(|p| p.trim()).collect();
+
+        if parts.is_empty() || parts.iter().any(|p| p.is_empty()) {
+            return Err("Invalid keystroke format".to_string());
+        }
+
+        if parts.len() == 1 {
+            // Just a key, no modifiers
+            return Ok(Self {
+                modifiers: vec![],
+                key: parts[0].to_lowercase(),
+            });
+        }
+
+        // Last part is the key, rest are modifiers
+        let key = parts.last().unwrap().to_lowercase();
+        let modifiers: Vec<String> = parts[..parts.len() - 1]
+            .iter()
+            .map(|s| s.to_lowercase())
+            .collect();
+
+        Ok(Self { modifiers, key })
+    }
+
+    /// Convert to wtype arguments
+    /// e.g., "ctrl+v" -> ["-M", "ctrl", "-k", "v", "-m", "ctrl"]
+    fn to_wtype_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        // Press modifiers
+        for modifier in &self.modifiers {
+            args.push("-M".to_string());
+            args.push(modifier.clone());
+        }
+
+        // Tap the key
+        args.push("-k".to_string());
+        args.push(self.key.clone());
+
+        // Release modifiers (reverse order)
+        for modifier in self.modifiers.iter().rev() {
+            args.push("-m".to_string());
+            args.push(modifier.clone());
+        }
+
+        args
+    }
+
+    /// Convert to ydotool key arguments using evdev codes
+    /// e.g., "ctrl+v" -> ["29:1", "47:1", "47:0", "29:0"]
+    fn to_ydotool_args(&self) -> Result<Vec<String>, String> {
+        let mut args = Vec::new();
+
+        // Get evdev codes for modifiers
+        let modifier_codes: Vec<u16> = self
+            .modifiers
+            .iter()
+            .map(|m| key_name_to_evdev(m))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Get evdev code for main key
+        let key_code = key_name_to_evdev(&self.key)?;
+
+        // Press modifiers
+        for code in &modifier_codes {
+            args.push(format!("{}:1", code));
+        }
+
+        // Press and release the key
+        args.push(format!("{}:1", key_code));
+        args.push(format!("{}:0", key_code));
+
+        // Release modifiers (reverse order)
+        for code in modifier_codes.iter().rev() {
+            args.push(format!("{}:0", code));
+        }
+
+        Ok(args)
+    }
+}
+
+/// Convert a key name to its evdev code
+fn key_name_to_evdev(name: &str) -> Result<u16, String> {
+    match name.to_lowercase().as_str() {
+        // Modifiers
+        "ctrl" | "control" | "leftctrl" => Ok(29),  // KEY_LEFTCTRL
+        "rightctrl" => Ok(97),                       // KEY_RIGHTCTRL
+        "shift" | "leftshift" => Ok(42),            // KEY_LEFTSHIFT
+        "rightshift" => Ok(54),                      // KEY_RIGHTSHIFT
+        "alt" | "leftalt" => Ok(56),                // KEY_LEFTALT
+        "rightalt" | "altgr" => Ok(100),            // KEY_RIGHTALT
+        "super" | "meta" | "leftmeta" | "win" => Ok(125), // KEY_LEFTMETA
+
+        // Common keys
+        "v" => Ok(47),                               // KEY_V
+        "insert" | "ins" => Ok(110),                // KEY_INSERT
+        "enter" | "return" => Ok(28),               // KEY_ENTER
+
+        // Letters (for completeness)
+        "a" => Ok(30),
+        "b" => Ok(48),
+        "c" => Ok(46),
+        "d" => Ok(32),
+        "e" => Ok(18),
+        "f" => Ok(33),
+        "g" => Ok(34),
+        "h" => Ok(35),
+        "i" => Ok(23),
+        "j" => Ok(36),
+        "k" => Ok(37),
+        "l" => Ok(38),
+        "m" => Ok(50),
+        "n" => Ok(49),
+        "o" => Ok(24),
+        "p" => Ok(25),
+        "q" => Ok(16),
+        "r" => Ok(19),
+        "s" => Ok(31),
+        "t" => Ok(20),
+        "u" => Ok(22),
+        "w" => Ok(17),
+        "x" => Ok(45),
+        "y" => Ok(21),
+        "z" => Ok(44),
+
+        other => Err(format!("Unknown key: {}", other)),
+    }
+}
+
+/// Paste-based text output (clipboard + paste keystroke)
 pub struct PasteOutput {
     /// Whether to show a desktop notification
     notify: bool,
     /// Whether to send Enter key after output
     auto_submit: bool,
+    /// Parsed paste keystroke
+    keystroke: ParsedKeystroke,
 }
 
 impl PasteOutput {
     /// Create a new paste output
-    pub fn new(notify: bool, auto_submit: bool) -> Self {
+    pub fn new(notify: bool, auto_submit: bool, paste_keys: Option<String>) -> Self {
+        let keystroke_str = paste_keys.as_deref().unwrap_or("ctrl+v");
+        let keystroke = ParsedKeystroke::parse(keystroke_str).unwrap_or_else(|e| {
+            tracing::warn!("Invalid paste_keys '{}': {}, using ctrl+v", keystroke_str, e);
+            ParsedKeystroke::parse("ctrl+v").unwrap()
+        });
+
+        tracing::debug!("Paste keystroke configured: {:?}", keystroke);
+
         Self {
             notify,
             auto_submit,
+            keystroke,
         }
     }
 
@@ -96,13 +249,91 @@ impl PasteOutput {
         Ok(())
     }
 
-    /// Simulate Ctrl+V key combination using ydotool
-    async fn simulate_ctrl_v(&self) -> Result<(), OutputError> {
-        // Use ydotool to press Ctrl+V (Left Ctrl + V)
-        // 29 = KEY_LEFTCTRL, 47 = KEY_V
-        // Format: key_code:1 (press) then key_code:0 (release)
+    /// Check if wtype is available
+    async fn is_wtype_available(&self) -> bool {
+        // Check if wtype exists
+        let wtype_installed = Command::new("which")
+            .arg("wtype")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if !wtype_installed {
+            return false;
+        }
+
+        // Check if we're on Wayland
+        std::env::var("WAYLAND_DISPLAY").is_ok()
+    }
+
+    /// Check if ydotool is available (installed and daemon running)
+    async fn is_ydotool_available(&self) -> bool {
+        // Check if ydotool exists
+        let ydotool_installed = Command::new("which")
+            .arg("ydotool")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if !ydotool_installed {
+            return false;
+        }
+
+        // Check if ydotoold is running by trying a no-op
+        Command::new("ydotool")
+            .args(["type", ""])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Simulate paste keystroke using wtype
+    async fn simulate_paste_wtype(&self) -> Result<(), OutputError> {
+        let args = self.keystroke.to_wtype_args();
+        tracing::debug!("Running: wtype {}", args.join(" "));
+
+        let output = Command::new("wtype")
+            .args(&args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    OutputError::WtypeNotFound
+                } else {
+                    OutputError::CtrlVFailed(e.to_string())
+                }
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(OutputError::CtrlVFailed(format!("wtype failed: {}", stderr)));
+        }
+
+        Ok(())
+    }
+
+    /// Simulate paste keystroke using ydotool
+    async fn simulate_paste_ydotool(&self) -> Result<(), OutputError> {
+        let args = self.keystroke.to_ydotool_args().map_err(|e| {
+            OutputError::CtrlVFailed(format!("Cannot convert keystroke for ydotool: {}", e))
+        })?;
+
+        tracing::debug!("Running: ydotool key {}", args.join(" "));
+
         let output = Command::new("ydotool")
-            .args(["key", "29:1", "47:1", "47:0", "29:0"])
+            .arg("key")
+            .args(&args)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .output()
@@ -129,6 +360,79 @@ impl PasteOutput {
 
         Ok(())
     }
+
+    /// Simulate paste keystroke, trying wtype first then ydotool
+    async fn simulate_paste_keystroke(&self) -> Result<(), OutputError> {
+        // Try wtype first (preferred - no daemon needed)
+        if self.is_wtype_available().await {
+            match self.simulate_paste_wtype().await {
+                Ok(()) => {
+                    tracing::debug!("Paste keystroke sent via wtype");
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::debug!("wtype paste failed: {}, trying ydotool", e);
+                }
+            }
+        }
+
+        // Fall back to ydotool
+        if self.is_ydotool_available().await {
+            match self.simulate_paste_ydotool().await {
+                Ok(()) => {
+                    tracing::debug!("Paste keystroke sent via ydotool");
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::debug!("ydotool paste failed: {}", e);
+                    return Err(e);
+                }
+            }
+        }
+
+        Err(OutputError::CtrlVFailed(
+            "Neither wtype nor ydotool available for paste keystroke".to_string(),
+        ))
+    }
+
+    /// Send Enter key after paste
+    async fn send_enter(&self) -> Result<(), OutputError> {
+        // Try wtype first
+        if self.is_wtype_available().await {
+            let output = Command::new("wtype")
+                .args(["-k", "Return"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .output()
+                .await;
+
+            if let Ok(out) = output {
+                if out.status.success() {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Fall back to ydotool
+        if self.is_ydotool_available().await {
+            let output = Command::new("ydotool")
+                .args(["key", "28:1", "28:0"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .output()
+                .await;
+
+            if let Ok(out) = output {
+                if out.status.success() {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Best effort - don't fail the whole operation for Enter
+        tracing::warn!("Failed to send Enter key");
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -144,27 +448,12 @@ impl TextOutput for PasteOutput {
         // Small delay to ensure clipboard is set before pasting
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-        // Step 2: Simulate Ctrl+V
-        self.simulate_ctrl_v().await?;
+        // Step 2: Simulate paste keystroke
+        self.simulate_paste_keystroke().await?;
 
         // Send Enter key if configured
-        // ydotool key uses evdev key codes: 28 is KEY_ENTER
-        // Format: keycode:press (1) then keycode:release (0)
         if self.auto_submit {
-            let enter_output = Command::new("ydotool")
-                .args(["key", "28:1", "28:0"])
-                .stdout(Stdio::null())
-                .stderr(Stdio::piped())
-                .output()
-                .await
-                .map_err(|e| {
-                    OutputError::InjectionFailed(format!("ydotool Enter failed: {}", e))
-                })?;
-
-            if !enter_output.status.success() {
-                let stderr = String::from_utf8_lossy(&enter_output.stderr);
-                tracing::warn!("Failed to send Enter key: {}", stderr);
-            }
+            self.send_enter().await?;
         }
 
         // Send notification if enabled
@@ -172,12 +461,18 @@ impl TextOutput for PasteOutput {
             self.send_notification(text).await;
         }
 
-        tracing::info!("Text pasted via clipboard + Ctrl+V ({} chars)", text.len());
+        tracing::info!(
+            "Text pasted via clipboard + {} ({} chars)",
+            self.keystroke.modifiers.join("+")
+                + if !self.keystroke.modifiers.is_empty() { "+" } else { "" }
+                + &self.keystroke.key,
+            text.len()
+        );
         Ok(())
     }
 
     async fn is_available(&self) -> bool {
-        // Check if wl-copy exists
+        // Check if wl-copy exists (required for clipboard)
         let wl_copy_available = Command::new("which")
             .arg("wl-copy")
             .stdout(Stdio::null())
@@ -188,36 +483,31 @@ impl TextOutput for PasteOutput {
             .unwrap_or(false);
 
         if !wl_copy_available {
+            tracing::debug!("paste mode unavailable: wl-copy not found");
             return false;
         }
 
-        // Check if ydotool exists
-        let ydotool_available = Command::new("which")
-            .arg("ydotool")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-            .map(|s| s.success())
-            .unwrap_or(false);
+        // Check if EITHER wtype OR ydotool is available for keystroke simulation
+        let wtype_available = self.is_wtype_available().await;
+        let ydotool_available = self.is_ydotool_available().await;
 
-        if !ydotool_available {
+        if !wtype_available && !ydotool_available {
+            tracing::debug!(
+                "paste mode unavailable: neither wtype nor ydotool available \
+                (wtype needs WAYLAND_DISPLAY, ydotool needs daemon running)"
+            );
             return false;
         }
 
-        // Check if ydotoold is running by trying a no-op
-        // ydotool type "" should succeed quickly if daemon is running
-        Command::new("ydotool")
-            .args(["type", ""])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-            .map(|s| s.success())
-            .unwrap_or(false)
+        tracing::debug!(
+            "paste mode available (wtype: {}, ydotool: {})",
+            wtype_available,
+            ydotool_available
+        );
+        true
     }
 
     fn name(&self) -> &'static str {
-        "paste (clipboard + Ctrl+V)"
+        "paste (clipboard + keystroke)"
     }
 }


### PR DESCRIPTION
## Summary
- Adds `paste_keys` config option for customizing the paste keystroke in paste mode
- Uses wtype as primary method (no daemon required), ydotool as fallback
- Fixes paste mode availability check to pass if either wtype or ydotool is available

## Problem
Paste mode hardcoded Ctrl+V, which doesn't work on systems using different paste shortcuts (e.g., Shift+Insert on Hyprland/Omarchy, Ctrl+Shift+V in terminals). Also required ydotoold daemon even when wtype was available.

## Solution
```toml
[output]
mode = "paste"
paste_keys = "shift+insert"  # or "ctrl+v" (default), "ctrl+shift+v"
```

**Why use it:** Users on Hyprland/Omarchy or other environments with non-standard paste shortcuts can now use paste mode.

## Test plan
- [x] Test paste mode with ctrl+v (default)
- [x] Test paste mode with shift+f6 (custom keystroke)
- [x] Verify wtype is used when available
- [x] Verify ydotool fallback works
- [x] Verify is_available() passes with only wtype installed

Closes #73