### PR TITLE
Add v0.4.14 news article

### DIFF
--- a/website/news/index.html
+++ b/website/news/index.html
@@ -9,16 +9,16 @@
     <!-- Open Graph / Social Media -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://voxtype.io/news/">
-    <meta property="og:title" content="Voxtype 0.4.13: GPU Isolation for Laptop Battery Life">
-    <meta property="og:description" content="New gpu_isolation mode lets your discrete GPU sleep between transcriptions, saving battery on hybrid graphics laptops.">
+    <meta property="og:title" content="Voxtype 0.4.14: Configurable Paste Keystroke">
+    <meta property="og:description" content="Paste mode now supports custom keystrokes and uses wtype as the primary backend, eliminating the need for ydotoold.">
     <meta property="og:image" content="https://voxtype.io/images/gpu-isolation.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Voxtype 0.4.13: GPU Isolation for Laptop Battery Life">
-    <meta name="twitter:description" content="New gpu_isolation mode lets your discrete GPU sleep between transcriptions, saving battery on hybrid graphics laptops.">
+    <meta name="twitter:title" content="Voxtype 0.4.14: Configurable Paste Keystroke">
+    <meta name="twitter:description" content="Paste mode now supports custom keystrokes and uses wtype as the primary backend, eliminating the need for ydotoold.">
     <meta name="twitter:image" content="https://voxtype.io/images/gpu-isolation.png">
 
     <title>News & Updates | Voxtype</title>
@@ -76,6 +76,37 @@
         <div class="container">
 
             <!-- v0.4.x Era Posts -->
+
+            <article class="news-article" id="v0414">
+                <div class="article-meta">
+                    <time datetime="2026-01-14">January 14, 2026</time>
+                    <span class="article-tag">Release</span>
+                </div>
+                <h2>v0.4.14: Configurable Paste Keystroke</h2>
+                <div class="article-body">
+                    <p>Voxtype 0.4.14 adds configurable paste keystrokes and switches to wtype as the primary backend for keystroke simulation.</p>
+
+                    <h3>Configurable Paste Keystroke</h3>
+                    <p>Paste mode now supports custom keystrokes via the <code>paste_keys</code> config option. The default remains <code>ctrl+v</code>, but you can configure alternatives like <code>shift+insert</code> for environments where that works better.</p>
+
+                    <p><strong>Why use it:</strong> Some desktop environments use universal paste shortcuts that differ from the standard Ctrl+V. Hyprland and Omarchy users often prefer Shift+Insert. This lets you match your system's paste behavior.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>config.toml</span></div>
+                        <pre><code>[output]
+mode = "paste"
+paste_keys = "shift+insert"  # Or "ctrl+shift+v" for terminals</code></pre>
+                    </div>
+
+                    <h3>wtype as Primary Keystroke Backend</h3>
+                    <p>Paste mode now prefers wtype over ydotool for simulating keystrokes. This means you no longer need ydotoold running as a daemon for paste mode to work.</p>
+
+                    <p><strong>Why it matters:</strong> ydotool requires its daemon (ydotoold) to be running, which adds complexity. wtype works without a daemon and handles the keystroke simulation directly. If wtype isn't available, Voxtype falls back to ydotool automatically.</p>
+
+                    <h3>Contributors</h3>
+                    <p>This release adds contributor credits to the project for those who have contributed code via co-authored commits: Dan Heuckeroth, Igor Warzocha, Julian Kaiser, Kevin Miller, konnsim, and reisset.</p>
+                </div>
+            </article>
 
             <article class="news-article" id="v0413">
                 <div class="article-meta">


### PR DESCRIPTION
## Summary
- Add news article for v0.4.14 release
- Update Open Graph meta tags for social sharing

## Changes
Documents the new features in v0.4.14:
- Configurable paste keystroke (`paste_keys` config option)
- wtype as primary keystroke backend for paste mode
- New contributor credits