### PR TITLE
Add single-instance safeguard using pidlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pidlock"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df53bd1a4f9f7d54dc8e604c09aa3d06988d052ac35db5b34d7423272f8046a8"
+dependencies = [
+ "libc",
+ "log",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,6 +1829,7 @@ dependencies = [
  "nix 0.29.0",
  "notify",
  "num_cpus",
+ "pidlock",
  "regex",
  "rodio",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ num_cpus = "1.16"
 # File watching for status --follow
 notify = "6"
 
+# Single instance check
+pidlock = "0.1"
+
 [features]
 default = []
 gpu-vulkan = ["whisper-rs/vulkan"]


### PR DESCRIPTION
## Summary
Prevents multiple voxtype daemon instances from running simultaneously by acquiring a PID lock at startup. If another instance is already running, the daemon exits gracefully with a clear error message.

The lock is maintained for the entire daemon lifetime and automatically released on shutdown, preventing conflicts with audio capture, hotkey binding, and output handling.

## Changes
- Added `pidlock` dependency to Cargo.toml
- Imported `Pidlock` in daemon.rs
- Added single-instance check in `Daemon::run()` method that acquires a lock at `$XDG_RUNTIME_DIR/voxtype/voxtype.lock`

## Test plan
- [x] Code compiles without errors
- [x] All existing tests pass (124 tests)
- [x] Verify lock file is created at startup and released on shutdown
