### PR TITLE
Document wtype incompatibility with KDE Plasma and GNOME Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,8 @@ systemctl --user start ydotool
 systemctl --user enable ydotool  # Start on login
 ```
 
+**KDE Plasma / GNOME users:** wtype does not work on these desktops. You must use ydotool with the daemon running. See [Troubleshooting](docs/TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for setup instructions.
+
 ### No audio captured
 
 Check your default audio input:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -610,6 +610,9 @@ Primary output method.
 mode = "paste"
 ```
 
+**Note about wtype compatibility:**
+wtype does not work on KDE Plasma or GNOME Wayland because these compositors don't support the virtual keyboard protocol. On these desktops, voxtype automatically falls back to ydotool, but the ydotool daemon must be running (`systemctl --user enable --now ydotool`). See [Troubleshooting](TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for details.
+
 **Note about paste mode:**
 The `paste` mode is designed to work around non-US keyboard layout issues. Instead of typing characters directly (which assumes US keyboard layout), it copies text to the clipboard and then simulates a paste keystroke. This works regardless of keyboard layout. Requires wl-copy for clipboard access, plus wtype (preferred, no daemon needed) or ydotool (requires ydotoold daemon) for keystroke simulation.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -66,6 +66,19 @@ For **type mode**: Most applications work. Some may have issues:
 
 For **clipboard mode**: Works universally (you just need to paste manually).
 
+### Does wtype work on KDE Plasma or GNOME?
+
+No. KDE Plasma and GNOME (on Wayland) do not support the virtual keyboard protocol that wtype requires. You'll see the error: "Compositor does not support the virtual keyboard protocol."
+
+**Solution:** Use ydotool instead. Voxtype automatically falls back to ydotool when wtype fails, but ydotool requires its daemon to be running:
+
+```bash
+# Install ydotool, then start the daemon
+systemctl --user enable --now ydotool
+```
+
+Without the daemon running, you'll only get clipboard output. See [Troubleshooting](TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for complete setup instructions.
+
 ---
 
 ## Features

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -350,7 +350,15 @@ sudo apt install ydotool
 systemctl --user enable --now ydotool
 ```
 
-Voxtype uses wtype on Wayland (no daemon needed), ydotool on X11, and falls back to clipboard if neither is available.
+**On KDE Plasma or GNOME (Wayland):** wtype does not work on these desktops because they don't support the virtual keyboard protocol. You must use ydotool instead:
+
+```bash
+# Install ydotool (see commands above for your distro)
+# Then enable and start the daemon (required!)
+systemctl --user enable --now ydotool
+```
+
+Voxtype uses wtype on Wayland (no daemon needed), ydotool on X11, and falls back to clipboard if neither is available. On KDE/GNOME Wayland, wtype will fail and voxtype will use ydotool if the daemon is running.
 
 ### 3. Verify audio setup
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -9,6 +9,7 @@ Solutions to common issues when using Voxtype.
 - [Audio Problems](#audio-problems)
 - [Transcription Issues](#transcription-issues)
 - [Output Problems](#output-problems)
+  - [wtype not working on KDE Plasma or GNOME Wayland](#wtype-not-working-on-kde-plasma-or-gnome-wayland)
 - [Performance Issues](#performance-issues)
 - [Systemd Service Issues](#systemd-service-issues)
 - [Debug Mode](#debug-mode)
@@ -287,6 +288,56 @@ This is rarely needed. The optimization speeds up transcription for short clips 
 ---
 
 ## Output Problems
+
+### wtype not working on KDE Plasma or GNOME Wayland
+
+**Symptom:** wtype fails with "Compositor does not support the virtual keyboard protocol"
+
+**Cause:** KDE Plasma and GNOME do not implement the `zwp_virtual_keyboard_v1` Wayland protocol that wtype requires. This is a compositor limitation, not a voxtype bug.
+
+**What happens:** Voxtype detects this failure and automatically falls back to ydotool. If ydotool isn't set up, it falls back to clipboard mode.
+
+**Solution:** Set up ydotool as your typing backend. Unlike wtype, ydotool requires a daemon to be running:
+
+```bash
+# 1. Install ydotool
+# Arch:
+sudo pacman -S ydotool
+# Fedora:
+sudo dnf install ydotool
+# Ubuntu/Debian:
+sudo apt install ydotool
+
+# 2. Enable and start the daemon (required!)
+systemctl --user enable --now ydotool
+
+# 3. Verify it's running
+systemctl --user status ydotool
+```
+
+**Important:** Simply having ydotool installed is not enough. The daemon must be running for the fallback to work. If the daemon isn't running, voxtype will fall back to clipboard-only output.
+
+**Alternative:** Use clipboard or paste mode instead of type mode:
+
+```toml
+[output]
+mode = "clipboard"  # Copies to clipboard, you paste manually
+# or
+mode = "paste"      # Copies to clipboard, then simulates Ctrl+V
+```
+
+**Compositor compatibility:**
+
+| Desktop | wtype | ydotool | Recommended |
+|---------|-------|---------|-------------|
+| Hyprland | ✓ | ✓ | wtype |
+| Sway | ✓ | ✓ | wtype |
+| River | ✓ | ✓ | wtype |
+| KDE Plasma (Wayland) | ✗ | ✓ | ydotool |
+| GNOME (Wayland) | ✗ | ✓ | ydotool |
+| X11 (any desktop) | ✗ | ✓ | ydotool |
+
+---
 
 ### "ydotool daemon not running"
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -690,6 +690,25 @@ systemctl --user enable --now ydotool
 - ydotool requires daemon and cannot output CJK characters
 - May be slow in some applications (increase `type_delay_ms`)
 
+**Compositor Compatibility:**
+
+wtype does not work on all Wayland compositors. KDE Plasma and GNOME do not support the virtual keyboard protocol that wtype requires.
+
+| Desktop | wtype | ydotool | Notes |
+|---------|-------|---------|-------|
+| Hyprland, Sway, River | ✓ | ✓ | wtype recommended (best CJK support) |
+| KDE Plasma (Wayland) | ✗ | ✓ | Use ydotool (daemon required) |
+| GNOME (Wayland) | ✗ | ✓ | Use ydotool (daemon required) |
+| X11 (any) | ✗ | ✓ | Use ydotool (daemon required) |
+
+**KDE Plasma and GNOME users:** You must set up ydotool for type mode to work. Install ydotool and start the daemon:
+
+```bash
+systemctl --user enable --now ydotool
+```
+
+See [Troubleshooting: wtype not working on KDE/GNOME](TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for details.
+
 ### Clipboard Mode
 
 Copies transcribed text to the clipboard.


### PR DESCRIPTION
## Summary

- Documents that wtype does not work on KDE Plasma or GNOME Wayland (they don't support the virtual keyboard protocol)
- Emphasizes that ydotool requires its daemon to be running for the fallback to work
- Adds compatibility tables showing which output methods work on which desktops

## Changes

| File | Changes |
|------|---------|
| `docs/TROUBLESHOOTING.md` | New section with full explanation, ydotool setup instructions, and compositor compatibility table |
| `docs/USER_MANUAL.md` | Added "Compositor Compatibility" section under Type Mode |
| `docs/FAQ.md` | New Q&A "Does wtype work on KDE Plasma or GNOME?" |
| `docs/INSTALL.md` | Added KDE/GNOME-specific guidance in typing backend section |
| `docs/CONFIGURATION.md` | Added note about wtype compatibility under output mode |
| `README.md` | Added brief note for KDE/GNOME users with link to troubleshooting |

## Test plan

- [x] Review documentation for accuracy and clarity
- [x] Verify all internal links work correctly

Closes #85

cc @materemias for review