### PR TITLE
Add dotool output driver with keyboard layout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Hold a hotkey (default: ScrollLock) while speaking, release to transcribe and ou
 
 - **Works on any Linux desktop** - Uses compositor keybindings (Hyprland, Sway, River) with evdev fallback for X11 and other environments
 - **Fully offline by default** - Uses whisper.cpp for local transcription, with optional remote server support
-- **Fallback chain** - Types via wtype (best CJK support), falls back to ydotool, then clipboard
+- **Fallback chain** - Types via wtype (best CJK support), falls back to dotool (keyboard layout support), ydotool, then clipboard
 - **Push-to-talk or Toggle mode** - Hold to record, or press once to start/stop
 - **Audio feedback** - Optional sound cues when recording starts/stops
 - **Configurable** - Choose your hotkey, model size, output mode, and more
@@ -361,6 +361,7 @@ Results vary by hardware. Example on AMD RX 6800:
 
 - **PipeWire** or **PulseAudio** (for audio capture)
 - **wtype** (for typing output on Wayland) - *recommended, best CJK/Unicode support*
+- **dotool** - *for non-US keyboard layouts (German, French, etc.) - supports XKB layouts*
 - **ydotool** + daemon - *for X11 or as Wayland fallback*
 - **wl-clipboard** (for clipboard fallback on Wayland)
 
@@ -472,18 +473,23 @@ sudo usermod -aG input $USER
 
 ### Text not appearing / typing not working
 
-Voxtype uses wtype (preferred) or ydotool as fallback for typing output:
+Voxtype uses wtype (preferred), dotool, or ydotool for typing output:
 
 ```bash
-# Check if wtype is installed
-which wtype
+# Check available typing backends
+which wtype dotool ydotool
+
+# For non-US keyboard layouts, install dotool and configure:
+# In ~/.config/voxtype/config.toml:
+# [output]
+# dotool_xkb_layout = "de"  # Your layout (de, fr, es, etc.)
 
 # If using ydotool fallback (X11/TTY), start the daemon:
 systemctl --user start ydotool
 systemctl --user enable ydotool  # Start on login
 ```
 
-**KDE Plasma / GNOME users:** wtype does not work on these desktops. You must use ydotool with the daemon running. See [Troubleshooting](docs/TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for setup instructions.
+**KDE Plasma / GNOME users:** wtype does not work on these desktops. Voxtype automatically falls back to dotool (recommended for non-US layouts) or ydotool. See [Troubleshooting](docs/TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for setup instructions.
 
 ### No audio captured
 
@@ -516,7 +522,7 @@ flowchart LR
         Audio --> Whisper["Whisper<br/>(whisper-rs)"]
         Whisper --> PostProcess["Post-Process<br/>(optional)"]
         PostProcess --> PreHook["Pre-Output<br/>Hook"]
-        PreHook --> Output["Output<br/>(wtype/ydotool)"]
+        PreHook --> Output["Output<br/>(wtype/dotool/ydotool)"]
         Output --> PostHook["Post-Output<br/>Hook"]
         PreHook -.-> Compositor["Compositor<br/>(submap/mode)"]
         PostHook -.-> Compositor
@@ -527,7 +533,7 @@ flowchart LR
 
 **Fallback: evdev hotkey.** For X11 or compositors without key-release support, voxtype includes a built-in hotkey using evdev (the Linux input subsystem). This requires the user to be in the `input` group.
 
-**Why wtype + ydotool?** On Wayland, wtype uses the virtual-keyboard protocol for text input, with excellent Unicode/CJK support and no daemon required. On X11 (or as a fallback), ydotool uses uinput for text injection. This combination ensures Voxtype works on any Linux desktop.
+**Why wtype + dotool + ydotool?** On Wayland, wtype uses the virtual-keyboard protocol for text input, with excellent Unicode/CJK support and no daemon required. When wtype fails (KDE/GNOME), dotool provides keyboard layout support via XKB for non-US layouts. As a final fallback, ydotool uses uinput for text injection on X11/TTY. This combination ensures Voxtype works on any Linux desktop with proper keyboard layout support.
 
 **Post-processing.** Transcriptions can optionally be piped through an external command before output. Use this to integrate local LLMs (Ollama, llama.cpp) for grammar correction, text expansion, or domain-specific vocabulary. Any command that reads stdin and writes stdout works.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -600,9 +600,9 @@ Controls how transcribed text is delivered.
 Primary output method.
 
 **Values:**
-- `type` - Simulate keyboard input at cursor position (requires wtype or ydotool)
+- `type` - Simulate keyboard input at cursor position (uses wtype, dotool, or ydotool)
 - `clipboard` - Copy text to clipboard (requires wl-copy)
-- `paste` - Copy to clipboard then simulate paste keystroke (requires wl-copy, and wtype or ydotool)
+- `paste` - Copy to clipboard then simulate paste keystroke (requires wl-copy, and wtype, dotool, or ydotool)
 
 **Example:**
 ```toml
@@ -611,10 +611,13 @@ mode = "paste"
 ```
 
 **Note about wtype compatibility:**
-wtype does not work on KDE Plasma or GNOME Wayland because these compositors don't support the virtual keyboard protocol. On these desktops, voxtype automatically falls back to ydotool, but the ydotool daemon must be running (`systemctl --user enable --now ydotool`). See [Troubleshooting](TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for details.
+wtype does not work on KDE Plasma or GNOME Wayland because these compositors don't support the virtual keyboard protocol. On these desktops, voxtype automatically falls back to dotool (if installed) or ydotool. For ydotool, the daemon must be running (`systemctl --user enable --now ydotool`). See [Troubleshooting](TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for details.
+
+**Note about non-US keyboard layouts:**
+For non-US keyboard layouts (German QWERTZ, French AZERTY, etc.), dotool is recommended over ydotool. Set `dotool_xkb_layout` to your layout code (e.g., `"de"` for German). ydotool does not support keyboard layouts and will produce incorrect characters (e.g., 'y' and 'z' swapped on German layouts).
 
 **Note about paste mode:**
-The `paste` mode is designed to work around non-US keyboard layout issues. Instead of typing characters directly (which assumes US keyboard layout), it copies text to the clipboard and then simulates a paste keystroke. This works regardless of keyboard layout. Requires wl-copy for clipboard access, plus wtype (preferred, no daemon needed) or ydotool (requires ydotoold daemon) for keystroke simulation.
+The `paste` mode is an alternative for non-US keyboard layouts. Instead of typing characters directly, it copies text to the clipboard and simulates a paste keystroke. This works regardless of keyboard layout but overwrites your clipboard. Requires wl-copy for clipboard access.
 
 ### paste_keys
 
@@ -658,6 +661,45 @@ When `true` and `mode = "type"`, falls back to clipboard if typing fails.
 [output]
 mode = "type"
 fallback_to_clipboard = true  # Use clipboard if ydotool fails
+```
+
+### dotool_xkb_layout
+
+**Type:** String (optional)
+**Default:** None
+**Required:** No
+
+Keyboard layout for dotool output driver. Required for non-US keyboard layouts (German, French, etc.) when using dotool as the typing backend.
+
+dotool is automatically used as a fallback when wtype fails (e.g., on GNOME/KDE Wayland). Unlike ydotool, dotool supports keyboard layouts via XKB environment variables.
+
+**Common values:**
+- `"de"` - German (QWERTZ)
+- `"fr"` - French (AZERTY)
+- `"es"` - Spanish
+- `"uk"` - Ukrainian
+- `"ru"` - Russian
+
+**Example:**
+```toml
+[output]
+mode = "type"
+dotool_xkb_layout = "de"  # German keyboard layout
+```
+
+### dotool_xkb_variant
+
+**Type:** String (optional)
+**Default:** None
+**Required:** No
+
+Keyboard layout variant for dotool. Use this for layout variations like `nodeadkeys`.
+
+**Example:**
+```toml
+[output]
+dotool_xkb_layout = "de"
+dotool_xkb_variant = "nodeadkeys"  # German without dead keys
 ```
 
 ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -681,6 +681,15 @@ pub struct OutputConfig {
     /// Defaults to "ctrl+v" if not specified
     #[serde(default)]
     pub paste_keys: Option<String>,
+
+    /// Keyboard layout for dotool (e.g., "de" for German, "fr" for French)
+    /// Required for non-US keyboard layouts when using dotool
+    #[serde(default)]
+    pub dotool_xkb_layout: Option<String>,
+
+    /// Keyboard layout variant for dotool (e.g., "nodeadkeys")
+    #[serde(default)]
+    pub dotool_xkb_variant: Option<String>,
 }
 
 impl OutputConfig {
@@ -767,6 +776,8 @@ impl Default for Config {
                 post_output_command: None,
                 post_process: None,
                 paste_keys: None,
+                dotool_xkb_layout: None,
+                dotool_xkb_variant: None,
             },
             text: TextConfig::default(),
             status: StatusConfig::default(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,9 @@ pub enum OutputError {
     #[error("ydotool not found in PATH. Install via your package manager.")]
     YdotoolNotFound,
 
+    #[error("dotool not found in PATH. Install from https://sr.ht/~geb/dotool/")]
+    DotoolNotFound,
+
     #[error("wtype not found in PATH. Install via your package manager.")]
     WtypeNotFound,
 
@@ -108,7 +111,7 @@ pub enum OutputError {
     #[error("Ctrl+V simulation failed: {0}")]
     CtrlVFailed(String),
 
-    #[error("All output methods failed. Ensure wtype, ydotool, or wl-copy is available.")]
+    #[error("All output methods failed. Ensure wtype, dotool, ydotool, or wl-copy is available.")]
     AllMethodsFailed,
 }
 

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -1,0 +1,239 @@
+//! dotool-based text output
+//!
+//! Uses dotool to simulate keyboard input with proper keyboard layout support.
+//! Unlike ydotool, dotool respects keyboard layouts via DOTOOL_XKB_LAYOUT.
+//!
+//! Requires:
+//! - dotool installed (https://sr.ht/~geb/dotool/)
+//! - User in 'input' group for uinput access
+//! - DOTOOL_XKB_LAYOUT set for non-US layouts
+
+use super::TextOutput;
+use crate::error::OutputError;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+/// dotool-based text output with keyboard layout support
+pub struct DotoolOutput {
+    /// Delay between keypresses in milliseconds
+    type_delay_ms: u32,
+    /// Delay before typing starts in milliseconds
+    pre_type_delay_ms: u32,
+    /// Whether to show a desktop notification
+    notify: bool,
+    /// Whether to send Enter key after output
+    auto_submit: bool,
+    /// Keyboard layout (e.g., "de" for German, "fr" for French)
+    xkb_layout: Option<String>,
+    /// Keyboard layout variant (e.g., "nodeadkeys")
+    xkb_variant: Option<String>,
+}
+
+impl DotoolOutput {
+    /// Create a new dotool output
+    pub fn new(
+        type_delay_ms: u32,
+        pre_type_delay_ms: u32,
+        notify: bool,
+        auto_submit: bool,
+        xkb_layout: Option<String>,
+        xkb_variant: Option<String>,
+    ) -> Self {
+        if let Some(ref layout) = xkb_layout {
+            tracing::debug!("dotool: using keyboard layout '{}'", layout);
+        }
+        Self {
+            type_delay_ms,
+            pre_type_delay_ms,
+            notify,
+            auto_submit,
+            xkb_layout,
+            xkb_variant,
+        }
+    }
+
+    /// Send a desktop notification
+    async fn send_notification(&self, text: &str) {
+        // Truncate preview for notification
+        let preview: String = text.chars().take(100).collect();
+        let preview = if text.len() > 100 {
+            format!("{}...", preview)
+        } else {
+            preview
+        };
+
+        let _ = Command::new("notify-send")
+            .args([
+                "--app-name=Voxtype",
+                "--expire-time=3000",
+                "Transcribed",
+                &preview,
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+    }
+
+    /// Build the dotool command string to send via stdin
+    fn build_commands(&self, text: &str) -> String {
+        let mut commands = String::new();
+
+        // Set delays if configured
+        if self.type_delay_ms > 0 {
+            commands.push_str(&format!("typedelay {}\n", self.type_delay_ms));
+            commands.push_str(&format!("typehold {}\n", self.type_delay_ms));
+        }
+
+        // Type the text
+        // Note: dotool's type command takes text on the same line
+        commands.push_str(&format!("type {}\n", text));
+
+        // Send Enter key if auto_submit is enabled
+        if self.auto_submit {
+            commands.push_str("key enter\n");
+        }
+
+        commands
+    }
+}
+
+#[async_trait::async_trait]
+impl TextOutput for DotoolOutput {
+    async fn output(&self, text: &str) -> Result<(), OutputError> {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        // Pre-typing delay if configured
+        if self.pre_type_delay_ms > 0 {
+            tracing::debug!("dotool: sleeping {}ms before typing", self.pre_type_delay_ms);
+            tokio::time::sleep(Duration::from_millis(self.pre_type_delay_ms as u64)).await;
+        }
+
+        let commands = self.build_commands(text);
+        tracing::debug!(
+            "dotool: sending commands for text: \"{}\"",
+            text.chars().take(20).collect::<String>()
+        );
+
+        // Spawn dotool with stdin pipe
+        let mut cmd = Command::new("dotool");
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+
+        // Set keyboard layout environment variables if configured
+        if let Some(ref layout) = self.xkb_layout {
+            cmd.env("DOTOOL_XKB_LAYOUT", layout);
+        }
+        if let Some(ref variant) = self.xkb_variant {
+            cmd.env("DOTOOL_XKB_VARIANT", variant);
+        }
+
+        let mut child = cmd.spawn().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                OutputError::DotoolNotFound
+            } else {
+                OutputError::InjectionFailed(format!("Failed to spawn dotool: {}", e))
+            }
+        })?;
+
+        // Write commands to stdin
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(commands.as_bytes())
+                .await
+                .map_err(|e| OutputError::InjectionFailed(format!("Failed to write to dotool stdin: {}", e)))?;
+            // Close stdin to signal end of input
+            drop(stdin);
+        }
+
+        // Wait for dotool to complete
+        let output = child.wait_with_output().await.map_err(|e| {
+            OutputError::InjectionFailed(format!("Failed to wait for dotool: {}", e))
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            // Check for common errors
+            if stderr.contains("uinput") || stderr.contains("permission") {
+                return Err(OutputError::InjectionFailed(
+                    "dotool: uinput permission denied. Is user in 'input' group?".to_string(),
+                ));
+            }
+
+            return Err(OutputError::InjectionFailed(format!(
+                "dotool exited with error: {}",
+                stderr
+            )));
+        }
+
+        tracing::info!("Text typed via dotool ({} chars)", text.len());
+
+        // Send notification if enabled
+        if self.notify {
+            self.send_notification(text).await;
+        }
+
+        Ok(())
+    }
+
+    async fn is_available(&self) -> bool {
+        // Check if dotool exists in PATH
+        Command::new("which")
+            .arg("dotool")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn name(&self) -> &'static str {
+        "dotool"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let output = DotoolOutput::new(10, 0, true, false, Some("de".to_string()), None);
+        assert_eq!(output.type_delay_ms, 10);
+        assert_eq!(output.pre_type_delay_ms, 0);
+        assert!(output.notify);
+        assert!(!output.auto_submit);
+        assert_eq!(output.xkb_layout, Some("de".to_string()));
+    }
+
+    #[test]
+    fn test_build_commands_simple() {
+        let output = DotoolOutput::new(0, 0, false, false, None, None);
+        let cmds = output.build_commands("Hello world");
+        assert_eq!(cmds, "type Hello world\n");
+    }
+
+    #[test]
+    fn test_build_commands_with_delay() {
+        let output = DotoolOutput::new(10, 0, false, false, None, None);
+        let cmds = output.build_commands("Test");
+        assert!(cmds.contains("typedelay 10"));
+        assert!(cmds.contains("typehold 10"));
+        assert!(cmds.contains("type Test"));
+    }
+
+    #[test]
+    fn test_build_commands_with_enter() {
+        let output = DotoolOutput::new(0, 0, false, true, None, None);
+        let cmds = output.build_commands("Test");
+        assert!(cmds.contains("type Test"));
+        assert!(cmds.contains("key enter"));
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -4,12 +4,14 @@
 //!
 //! Fallback chain for `mode = "type"`:
 //! 1. wtype - Wayland-native, best Unicode/CJK support, no daemon needed
-//! 2. ydotool - Works on X11/Wayland/TTY, requires daemon
-//! 3. clipboard - Universal fallback via wl-copy
+//! 2. dotool - Works on X11/Wayland/TTY, supports keyboard layouts, no daemon needed
+//! 3. ydotool - Works on X11/Wayland/TTY, requires daemon
+//! 4. clipboard - Universal fallback via wl-copy
 //!
 //! Paste mode (clipboard + Ctrl+V) helps with system with non US keyboard layouts.
 
 pub mod clipboard;
+pub mod dotool;
 pub mod paste;
 pub mod post_process;
 pub mod wtype;
@@ -50,7 +52,17 @@ pub fn create_output_chain(config: &OutputConfig) -> Vec<Box<dyn TextOutput>> {
                 pre_type_delay_ms,
             )));
 
-            // Fallback: ydotool (works on X11/TTY, requires daemon)
+            // Fallback 1: dotool (supports keyboard layouts, no daemon needed)
+            chain.push(Box::new(dotool::DotoolOutput::new(
+                config.type_delay_ms,
+                pre_type_delay_ms,
+                false, // no notification, wtype handles it if available
+                config.auto_submit,
+                config.dotool_xkb_layout.clone(),
+                config.dotool_xkb_variant.clone(),
+            )));
+
+            // Fallback 2: ydotool (works on X11/TTY, requires daemon)
             chain.push(Box::new(ydotool::YdotoolOutput::new(
                 config.type_delay_ms,
                 pre_type_delay_ms,


### PR DESCRIPTION
## Summary

- Adds dotool as a new output driver in the fallback chain
- Solves keyboard layout issues on non-US layouts (German QWERTZ, French AZERTY, etc.)
- Works on GNOME/KDE Wayland where wtype fails

## Problem

ydotool sends raw US keycodes and doesn't support keyboard layouts, causing incorrect characters on non-US layouts (e.g., 'y' and 'z' swapped on German QWERTZ). wtype doesn't work on GNOME/KDE Wayland due to missing virtual keyboard protocol support.

## Solution

dotool supports keyboard layouts via `DOTOOL_XKB_LAYOUT` environment variable. This PR adds dotool to the fallback chain:

```
wtype -> dotool -> ydotool -> clipboard
```

## Changes

- Add `src/output/dotool.rs` implementing `TextOutput` trait
- Add dotool to fallback chain in `src/output/mod.rs`
- Add `DotoolNotFound` error type
- Add `dotool_xkb_layout` and `dotool_xkb_variant` config options
- Update README.md and CONFIGURATION.md

## Configuration

```toml
[output]
mode = "type"
dotool_xkb_layout = "de"  # German keyboard layout
```

## Test plan

- [x] Build with `cargo build --release`
- [x] Test on GNOME Wayland with German keyboard layout
- [x] Verify 'y' and 'z' are typed correctly
- [ ] Test on other non-US layouts (French, Spanish, etc.)