### PR TITLE
Fix NixOS systemd service path issue

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,11 @@
               export CMAKE_BUILD_PARALLEL_LEVEL=$NIX_BUILD_CORES
             '';
 
-            # Install shell completions and systemd service
+            # Install shell completions and default config
+            # Note: systemd service is NOT installed here because it contains
+            # hardcoded FHS paths (/usr/bin/voxtype) that don't work on NixOS.
+            # Use the Home Manager module with service.enable = true instead,
+            # which generates a service with the correct Nix store path.
             postInstall = ''
               # Shell completions
               install -Dm644 packaging/completions/voxtype.bash \
@@ -85,10 +89,6 @@
                 $out/share/zsh/site-functions/_voxtype
               install -Dm644 packaging/completions/voxtype.fish \
                 $out/share/fish/vendor_completions.d/voxtype.fish
-
-              # Systemd user service
-              install -Dm644 packaging/systemd/voxtype.service \
-                $out/lib/systemd/user/voxtype.service
 
               # Default config
               install -Dm644 config/default.toml \

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,7 +1,7 @@
 # NixOS module for VoxType
 #
-# This module provides system-level configuration for VoxType.
-# For user-level configuration with full options, use the Home Manager module.
+# This module installs the VoxType package system-wide.
+# For the systemd user service and full configuration, use the Home Manager module.
 #
 # Usage in your configuration.nix or flake:
 #
@@ -10,6 +10,16 @@
 #   programs.voxtype = {
 #     enable = true;
 #     package = voxtype.packages.${system}.vulkan;
+#   };
+#
+# For the systemd service, use the Home Manager module with service.enable = true:
+#
+#   imports = [ voxtype.homeManagerModules.default ];
+#
+#   programs.voxtype = {
+#     enable = true;
+#     package = voxtype.packages.${system}.vulkan;
+#     service.enable = true;  # Creates systemd user service with correct Nix store path
 #   };
 #
 # For evdev hotkey support, add your user to the input group:


### PR DESCRIPTION
## Summary
- Fix systemd service failing with exit code 203/EXEC on NixOS due to hardcoded `/usr/bin/voxtype` path
- Remove stock systemd service from Nix package build (it's for FHS distros, not NixOS)
- Update NixOS module docs to direct users to Home Manager module for systemd service

## Details

The stock `packaging/systemd/voxtype.service` file has `ExecStart=/usr/bin/voxtype daemon` hardcoded, which doesn't work on NixOS where binaries live in the Nix store.

The Home Manager module already generates the correct service with `${cfg.package}/bin/voxtype`, so users should use that instead:

```nix
programs.voxtype = {
  enable = true;
  package = voxtype.packages.${system}.vulkan;
  service.enable = true;  # Creates systemd service with correct Nix store path
};
```

Fixes #103

## Test plan
- [ ] Verify NixOS flake build succeeds without the systemd service file
- [ ] Verify Home Manager module with `service.enable = true` creates working systemd service