### PR TITLE
Add language array support for constrained auto-detection

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -327,26 +327,50 @@ model = "/home/user/models/custom-whisper.bin"
 
 ### language
 
-**Type:** String
+**Type:** String or Array of Strings
 **Default:** `"en"`
 **Required:** No
 
-Language code for transcription.
+Language code for transcription. Supports three modes:
+
+1. **Single language** - Use a specific language for all transcriptions
+2. **Auto-detect** - Let Whisper detect from all ~99 supported languages
+3. **Constrained auto-detect** - Detect from a specific set of allowed languages
 
 **Common values:**
-- `en` - English
-- `auto` - Auto-detect language
-- `es` - Spanish
-- `fr` - French
-- `de` - German
-- `ja` - Japanese
-- `zh` - Chinese
+- `"en"` - English
+- `"auto"` - Auto-detect from all languages
+- `"es"` - Spanish
+- `"fr"` - French
+- `"de"` - German
+- `"ja"` - Japanese
+- `"zh"` - Chinese
+- `["en", "fr"]` - Auto-detect between English and French only
 
-**Example:**
+**Examples:**
 ```toml
 [whisper]
-language = "auto"  # Auto-detect spoken language
+# Single language (fastest, most accurate for monolingual use)
+language = "en"
+
+# Auto-detect from all languages
+language = "auto"
+
+# Constrained auto-detect (recommended for multilingual users)
+# Whisper sometimes misdetects language for short sentences.
+# This limits detection to your known languages for better accuracy.
+language = ["en", "fr"]
+
+# Works with any number of languages
+language = ["en", "fr", "de", "es"]
 ```
+
+**When to use constrained auto-detect:**
+- You regularly speak in 2-3 languages
+- Whisper misdetects language for short sentences
+- You want faster detection than full auto-detect
+
+**Note:** Remote backends (OpenAI API) don't support language arrays. When using remote backend with an array, the first language is used.
 
 ### translate
 

--- a/src/audio/feedback.rs
+++ b/src/audio/feedback.rs
@@ -77,8 +77,7 @@ impl AudioFeedback {
 
     fn play_wav(&self, data: &[u8]) -> Result<(), String> {
         let cursor = Cursor::new(data.to_vec());
-        let source = Decoder::new(cursor)
-            .map_err(|e| format!("Failed to decode audio: {}", e))?;
+        let source = Decoder::new(cursor).map_err(|e| format!("Failed to decode audio: {}", e))?;
 
         // Apply volume control
         let source = source.amplify(self.config.volume);
@@ -152,12 +151,7 @@ fn generate_tone_wav(frequency: f32, duration_ms: u32, fade_ms: u32) -> Vec<u8> 
 }
 
 /// Generate a two-tone sound (rising or falling)
-fn generate_two_tone_wav(
-    freq1: f32,
-    freq2: f32,
-    duration_ms: u32,
-    fade_ms: u32,
-) -> Vec<u8> {
+fn generate_two_tone_wav(freq1: f32, freq2: f32, duration_ms: u32, fade_ms: u32) -> Vec<u8> {
     let sample_rate = 44100u32;
     let num_samples = (sample_rate * duration_ms / 1000) as usize;
     let fade_samples = (sample_rate * fade_ms / 1000) as usize;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -223,9 +223,21 @@ impl RecordAction {
     /// Extract the output mode override from the action flags
     pub fn output_mode_override(&self) -> Option<OutputModeOverride> {
         let (type_mode, clipboard, paste) = match self {
-            RecordAction::Start { type_mode, clipboard, paste } => (*type_mode, *clipboard, *paste),
-            RecordAction::Stop { type_mode, clipboard, paste } => (*type_mode, *clipboard, *paste),
-            RecordAction::Toggle { type_mode, clipboard, paste } => (*type_mode, *clipboard, *paste),
+            RecordAction::Start {
+                type_mode,
+                clipboard,
+                paste,
+            } => (*type_mode, *clipboard, *paste),
+            RecordAction::Stop {
+                type_mode,
+                clipboard,
+                paste,
+            } => (*type_mode, *clipboard, *paste),
+            RecordAction::Toggle {
+                type_mode,
+                clipboard,
+                paste,
+            } => (*type_mode, *clipboard, *paste),
             RecordAction::Cancel => return None,
         };
 
@@ -379,8 +391,15 @@ mod tests {
     fn test_setup_no_post_install_flag() {
         let cli = Cli::parse_from(["voxtype", "setup", "--no-post-install"]);
         match cli.command {
-            Some(Commands::Setup { no_post_install, quiet, .. }) => {
-                assert!(no_post_install, "setup --no-post-install should set no_post_install=true");
+            Some(Commands::Setup {
+                no_post_install,
+                quiet,
+                ..
+            }) => {
+                assert!(
+                    no_post_install,
+                    "setup --no-post-install should set no_post_install=true"
+                );
                 assert!(!quiet, "quiet should be false");
             }
             _ => panic!("Expected Setup command"),
@@ -391,9 +410,16 @@ mod tests {
     fn test_setup_without_flags() {
         let cli = Cli::parse_from(["voxtype", "setup"]);
         match cli.command {
-            Some(Commands::Setup { quiet, no_post_install, .. }) => {
+            Some(Commands::Setup {
+                quiet,
+                no_post_install,
+                ..
+            }) => {
                 assert!(!quiet, "setup without --quiet should have quiet=false");
-                assert!(!no_post_install, "setup without --no-post-install should have no_post_install=false");
+                assert!(
+                    !no_post_install,
+                    "setup without --no-post-install should have no_post_install=false"
+                );
             }
             _ => panic!("Expected Setup command"),
         }
@@ -403,7 +429,9 @@ mod tests {
     fn test_setup_quiet_with_download() {
         let cli = Cli::parse_from(["voxtype", "setup", "--quiet", "--download"]);
         match cli.command {
-            Some(Commands::Setup { quiet, download, .. }) => {
+            Some(Commands::Setup {
+                quiet, download, ..
+            }) => {
                 assert!(quiet, "should have quiet=true");
                 assert!(download, "should have download=true");
             }
@@ -416,7 +444,11 @@ mod tests {
         // Both flags can be used together (quiet takes precedence)
         let cli = Cli::parse_from(["voxtype", "setup", "--quiet", "--no-post-install"]);
         match cli.command {
-            Some(Commands::Setup { quiet, no_post_install, .. }) => {
+            Some(Commands::Setup {
+                quiet,
+                no_post_install,
+                ..
+            }) => {
                 assert!(quiet, "should have quiet=true");
                 assert!(no_post_install, "should have no_post_install=true");
             }
@@ -428,7 +460,12 @@ mod tests {
     fn test_setup_no_post_install_with_download() {
         let cli = Cli::parse_from(["voxtype", "setup", "--no-post-install", "--download"]);
         match cli.command {
-            Some(Commands::Setup { quiet, no_post_install, download, .. }) => {
+            Some(Commands::Setup {
+                quiet,
+                no_post_install,
+                download,
+                ..
+            }) => {
                 assert!(!quiet, "quiet should be false");
                 assert!(no_post_install, "should have no_post_install=true");
                 assert!(download, "should have download=true");
@@ -439,9 +476,20 @@ mod tests {
 
     #[test]
     fn test_setup_all_flags() {
-        let cli = Cli::parse_from(["voxtype", "setup", "--quiet", "--no-post-install", "--download"]);
+        let cli = Cli::parse_from([
+            "voxtype",
+            "setup",
+            "--quiet",
+            "--no-post-install",
+            "--download",
+        ]);
         match cli.command {
-            Some(Commands::Setup { quiet, no_post_install, download, .. }) => {
+            Some(Commands::Setup {
+                quiet,
+                no_post_install,
+                download,
+                ..
+            }) => {
                 assert!(quiet, "should have quiet=true");
                 assert!(no_post_install, "should have no_post_install=true");
                 assert!(download, "should have download=true");
@@ -452,9 +500,19 @@ mod tests {
 
     #[test]
     fn test_model_set_restart_flags() {
-        let cli = Cli::parse_from(["voxtype", "setup", "model", "--set", "large-v3", "--restart"]);
+        let cli = Cli::parse_from([
+            "voxtype",
+            "setup",
+            "model",
+            "--set",
+            "large-v3",
+            "--restart",
+        ]);
         match cli.command {
-            Some(Commands::Setup { action: Some(SetupAction::Model { set, restart, .. }), .. }) => {
+            Some(Commands::Setup {
+                action: Some(SetupAction::Model { set, restart, .. }),
+                ..
+            }) => {
                 assert_eq!(set, Some("large-v3".to_string()));
                 assert!(restart, "should have restart=true");
             }
@@ -464,9 +522,17 @@ mod tests {
 
     #[test]
     fn test_setup_download_with_model() {
-        let cli = Cli::parse_from(["voxtype", "setup", "--download", "--model", "large-v3-turbo"]);
+        let cli = Cli::parse_from([
+            "voxtype",
+            "setup",
+            "--download",
+            "--model",
+            "large-v3-turbo",
+        ]);
         match cli.command {
-            Some(Commands::Setup { download, model, .. }) => {
+            Some(Commands::Setup {
+                download, model, ..
+            }) => {
                 assert!(download, "should have download=true");
                 assert_eq!(model, Some("large-v3-turbo".to_string()));
             }
@@ -479,7 +545,9 @@ mod tests {
         // --model can be specified without --download (for validation/config update of existing model)
         let cli = Cli::parse_from(["voxtype", "setup", "--model", "small.en"]);
         match cli.command {
-            Some(Commands::Setup { download, model, .. }) => {
+            Some(Commands::Setup {
+                download, model, ..
+            }) => {
                 assert!(!download, "download should be false");
                 assert_eq!(model, Some("small.en".to_string()));
             }
@@ -490,9 +558,21 @@ mod tests {
     #[test]
     fn test_setup_download_model_quiet() {
         // Full non-interactive setup command
-        let cli = Cli::parse_from(["voxtype", "setup", "--download", "--model", "large-v3-turbo", "--quiet"]);
+        let cli = Cli::parse_from([
+            "voxtype",
+            "setup",
+            "--download",
+            "--model",
+            "large-v3-turbo",
+            "--quiet",
+        ]);
         match cli.command {
-            Some(Commands::Setup { download, model, quiet, .. }) => {
+            Some(Commands::Setup {
+                download,
+                model,
+                quiet,
+                ..
+            }) => {
                 assert!(download, "should have download=true");
                 assert_eq!(model, Some("large-v3-turbo".to_string()));
                 assert!(quiet, "should have quiet=true");
@@ -505,7 +585,9 @@ mod tests {
     fn test_record_cancel() {
         let cli = Cli::parse_from(["voxtype", "record", "cancel"]);
         match cli.command {
-            Some(Commands::Record { action: RecordAction::Cancel }) => {
+            Some(Commands::Record {
+                action: RecordAction::Cancel,
+            }) => {
                 // Success - cancel action parsed correctly
             }
             _ => panic!("Expected Record Cancel command"),
@@ -528,7 +610,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "start", "--paste"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::Paste));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::Paste)
+                );
             }
             _ => panic!("Expected Record command"),
         }
@@ -539,7 +624,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "start", "--clipboard"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::Clipboard));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::Clipboard)
+                );
             }
             _ => panic!("Expected Record command"),
         }
@@ -550,7 +638,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "start", "--type"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::Type));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::Type)
+                );
             }
             _ => panic!("Expected Record command"),
         }
@@ -561,7 +652,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "stop", "--paste"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::Paste));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::Paste)
+                );
             }
             _ => panic!("Expected Record command"),
         }
@@ -572,7 +666,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "toggle", "--paste"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::Paste));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::Paste)
+                );
             }
             _ => panic!("Expected Record command"),
         }

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -50,9 +50,8 @@ impl EvdevListener {
             .transpose()?;
 
         // Verify we can access /dev/input (permission check)
-        std::fs::read_dir("/dev/input").map_err(|e| {
-            HotkeyError::DeviceAccess(format!("/dev/input: {}", e))
-        })?;
+        std::fs::read_dir("/dev/input")
+            .map_err(|e| HotkeyError::DeviceAccess(format!("/dev/input: {}", e)))?;
 
         Ok(Self {
             target_key,
@@ -76,7 +75,8 @@ impl HotkeyListener for EvdevListener {
 
         // Spawn the listener task
         tokio::task::spawn_blocking(move || {
-            if let Err(e) = evdev_listener_loop(target_key, modifier_keys, cancel_key, tx, stop_rx) {
+            if let Err(e) = evdev_listener_loop(target_key, modifier_keys, cancel_key, tx, stop_rx)
+            {
                 tracing::error!("Hotkey listener error: {}", e);
             }
         });
@@ -115,9 +115,7 @@ impl DeviceManager {
         inotify
             .watches()
             .add("/dev/input", WatchMask::CREATE | WatchMask::DELETE)
-            .map_err(|e| {
-                HotkeyError::DeviceAccess(format!("Failed to watch /dev/input: {}", e))
-            })?;
+            .map_err(|e| HotkeyError::DeviceAccess(format!("Failed to watch /dev/input: {}", e)))?;
 
         let mut manager = Self {
             devices: HashMap::new(),
@@ -138,9 +136,8 @@ impl DeviceManager {
 
     /// Enumerate all keyboard devices and open them
     fn enumerate_devices(&mut self) -> Result<(), HotkeyError> {
-        let input_dir = std::fs::read_dir("/dev/input").map_err(|e| {
-            HotkeyError::DeviceAccess(format!("/dev/input: {}", e))
-        })?;
+        let input_dir = std::fs::read_dir("/dev/input")
+            .map_err(|e| HotkeyError::DeviceAccess(format!("/dev/input: {}", e)))?;
 
         for entry in input_dir.flatten() {
             let path = entry.path();
@@ -264,10 +261,7 @@ impl DeviceManager {
             tracing::warn!("Device enumeration failed: {}", e);
         }
 
-        tracing::info!(
-            "Devices updated: {} keyboard(s) active",
-            self.devices.len()
-        );
+        tracing::info!("Devices updated: {} keyboard(s) active", self.devices.len());
     }
 
     /// Validate that all devices are still accessible
@@ -439,9 +433,8 @@ fn evdev_listener_loop(
 
             // Check target key
             if key == target_key {
-                let modifiers_satisfied = modifier_keys
-                    .iter()
-                    .all(|m| active_modifiers.contains(m));
+                let modifiers_satisfied =
+                    modifier_keys.iter().all(|m| active_modifiers.contains(m));
 
                 if modifiers_satisfied {
                     match value {

--- a/src/output/clipboard.rs
+++ b/src/output/clipboard.rs
@@ -74,7 +74,7 @@ impl TextOutput for ClipboardOutput {
                 .write_all(text.as_bytes())
                 .await
                 .map_err(|e| OutputError::InjectionFailed(e.to_string()))?;
-            
+
             // Close stdin to signal EOF
             drop(stdin);
         }

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -109,7 +109,10 @@ impl TextOutput for DotoolOutput {
 
         // Pre-typing delay if configured
         if self.pre_type_delay_ms > 0 {
-            tracing::debug!("dotool: sleeping {}ms before typing", self.pre_type_delay_ms);
+            tracing::debug!(
+                "dotool: sleeping {}ms before typing",
+                self.pre_type_delay_ms
+            );
             tokio::time::sleep(Duration::from_millis(self.pre_type_delay_ms as u64)).await;
         }
 
@@ -143,10 +146,9 @@ impl TextOutput for DotoolOutput {
 
         // Write commands to stdin
         if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(commands.as_bytes())
-                .await
-                .map_err(|e| OutputError::InjectionFailed(format!("Failed to write to dotool stdin: {}", e)))?;
+            stdin.write_all(commands.as_bytes()).await.map_err(|e| {
+                OutputError::InjectionFailed(format!("Failed to write to dotool stdin: {}", e))
+            })?;
             // Close stdin to signal end of input
             drop(stdin);
         }

--- a/src/output/paste.rs
+++ b/src/output/paste.rs
@@ -112,18 +112,18 @@ impl ParsedKeystroke {
 fn key_name_to_evdev(name: &str) -> Result<u16, String> {
     match name.to_lowercase().as_str() {
         // Modifiers
-        "ctrl" | "control" | "leftctrl" => Ok(29),  // KEY_LEFTCTRL
-        "rightctrl" => Ok(97),                       // KEY_RIGHTCTRL
-        "shift" | "leftshift" => Ok(42),            // KEY_LEFTSHIFT
-        "rightshift" => Ok(54),                      // KEY_RIGHTSHIFT
-        "alt" | "leftalt" => Ok(56),                // KEY_LEFTALT
-        "rightalt" | "altgr" => Ok(100),            // KEY_RIGHTALT
+        "ctrl" | "control" | "leftctrl" => Ok(29), // KEY_LEFTCTRL
+        "rightctrl" => Ok(97),                     // KEY_RIGHTCTRL
+        "shift" | "leftshift" => Ok(42),           // KEY_LEFTSHIFT
+        "rightshift" => Ok(54),                    // KEY_RIGHTSHIFT
+        "alt" | "leftalt" => Ok(56),               // KEY_LEFTALT
+        "rightalt" | "altgr" => Ok(100),           // KEY_RIGHTALT
         "super" | "meta" | "leftmeta" | "win" => Ok(125), // KEY_LEFTMETA
 
         // Common keys
-        "v" => Ok(47),                               // KEY_V
-        "insert" | "ins" => Ok(110),                // KEY_INSERT
-        "enter" | "return" => Ok(28),               // KEY_ENTER
+        "v" => Ok(47),                // KEY_V
+        "insert" | "ins" => Ok(110),  // KEY_INSERT
+        "enter" | "return" => Ok(28), // KEY_ENTER
 
         // Letters (for completeness)
         "a" => Ok(30),
@@ -181,7 +181,11 @@ impl PasteOutput {
     ) -> Self {
         let keystroke_str = paste_keys.as_deref().unwrap_or("ctrl+v");
         let keystroke = ParsedKeystroke::parse(keystroke_str).unwrap_or_else(|e| {
-            tracing::warn!("Invalid paste_keys '{}': {}, using ctrl+v", keystroke_str, e);
+            tracing::warn!(
+                "Invalid paste_keys '{}': {}, using ctrl+v",
+                keystroke_str,
+                e
+            );
             ParsedKeystroke::parse("ctrl+v").unwrap()
         });
 
@@ -329,7 +333,10 @@ impl PasteOutput {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(OutputError::CtrlVFailed(format!("wtype failed: {}", stderr)));
+            return Err(OutputError::CtrlVFailed(format!(
+                "wtype failed: {}",
+                stderr
+            )));
         }
 
         Ok(())
@@ -341,7 +348,11 @@ impl PasteOutput {
             OutputError::CtrlVFailed(format!("Cannot convert keystroke for ydotool: {}", e))
         })?;
 
-        tracing::debug!("Running: ydotool key {}, {}ms", args.join(" "), self.type_delay_ms);
+        tracing::debug!(
+            "Running: ydotool key {}, {}ms",
+            args.join(" "),
+            self.type_delay_ms
+        );
 
         let mut cmd = Command::new("ydotool");
         cmd.arg("key");
@@ -489,7 +500,11 @@ impl TextOutput for PasteOutput {
         tracing::info!(
             "Text pasted via clipboard + {} ({} chars)",
             self.keystroke.modifiers.join("+")
-                + if !self.keystroke.modifiers.is_empty() { "+" } else { "" }
+                + if !self.keystroke.modifiers.is_empty() {
+                    "+"
+                } else {
+                    ""
+                }
                 + &self.keystroke.key,
             text.len()
         );

--- a/src/output/wtype.rs
+++ b/src/output/wtype.rs
@@ -28,7 +28,12 @@ pub struct WtypeOutput {
 
 impl WtypeOutput {
     /// Create a new wtype output
-    pub fn new(notify: bool, auto_submit: bool, type_delay_ms: u32, pre_type_delay_ms: u32) -> Self {
+    pub fn new(
+        notify: bool,
+        auto_submit: bool,
+        type_delay_ms: u32,
+        pre_type_delay_ms: u32,
+    ) -> Self {
         Self {
             notify,
             auto_submit,

--- a/src/output/ydotool.rs
+++ b/src/output/ydotool.rs
@@ -32,7 +32,12 @@ impl YdotoolOutput {
     /// Create a new ydotool output
     ///
     /// Detects ydotool capabilities at construction time.
-    pub fn new(type_delay_ms: u32, pre_type_delay_ms: u32, notify: bool, auto_submit: bool) -> Self {
+    pub fn new(
+        type_delay_ms: u32,
+        pre_type_delay_ms: u32,
+        notify: bool,
+        auto_submit: bool,
+    ) -> Self {
         let supports_key_hold = Self::detect_key_hold_support();
         if supports_key_hold {
             tracing::debug!("ydotool supports --key-hold flag");
@@ -97,7 +102,10 @@ impl TextOutput for YdotoolOutput {
 
         // Pre-typing delay if configured
         if self.pre_type_delay_ms > 0 {
-            tracing::debug!("ydotool: sleeping {}ms before typing", self.pre_type_delay_ms);
+            tracing::debug!(
+                "ydotool: sleeping {}ms before typing",
+                self.pre_type_delay_ms
+            );
             tokio::time::sleep(Duration::from_millis(self.pre_type_delay_ms as u64)).await;
         }
 
@@ -118,7 +126,11 @@ impl TextOutput for YdotoolOutput {
         tracing::debug!(
             "Running: ydotool type --key-delay {} {} -- \"{}\"",
             self.type_delay_ms,
-            if self.supports_key_hold { format!("--key-hold {}", self.type_delay_ms) } else { String::new() },
+            if self.supports_key_hold {
+                format!("--key-hold {}", self.type_delay_ms)
+            } else {
+                String::new()
+            },
             text.chars().take(20).collect::<String>()
         );
 

--- a/src/setup/compositor.rs
+++ b/src/setup/compositor.rs
@@ -170,7 +170,9 @@ fn add_hooks_to_config(content: &str, hooks: &str) -> String {
         // or after a blank line following [output]
         if found_output_section && !hooks_inserted {
             let trimmed = line.trim();
-            if trimmed.is_empty() || (!trimmed.starts_with('#') && !trimmed.starts_with('[') && trimmed.contains('=')) {
+            if trimmed.is_empty()
+                || (!trimmed.starts_with('#') && !trimmed.starts_with('[') && trimmed.contains('='))
+            {
                 // Found a good place to insert - after this line
                 result.push('\n');
                 result.push_str("# Compositor integration hooks (modifier key fix)\n");
@@ -198,7 +200,11 @@ fn add_hooks_to_config(content: &str, hooks: &str) -> String {
 /// Run compositor setup command
 pub async fn run(compositor: &CompositorType) -> anyhow::Result<()> {
     match compositor {
-        CompositorType::Hyprland { uninstall, status, show } => {
+        CompositorType::Hyprland {
+            uninstall,
+            status,
+            show,
+        } => {
             if *show {
                 print_hyprland_config();
             } else if *status {
@@ -209,7 +215,11 @@ pub async fn run(compositor: &CompositorType) -> anyhow::Result<()> {
                 hyprland_install()?;
             }
         }
-        CompositorType::Sway { uninstall, status, show } => {
+        CompositorType::Sway {
+            uninstall,
+            status,
+            show,
+        } => {
             if *show {
                 print_sway_config();
             } else if *status {
@@ -220,7 +230,11 @@ pub async fn run(compositor: &CompositorType) -> anyhow::Result<()> {
                 sway_install()?;
             }
         }
-        CompositorType::River { uninstall, status, show } => {
+        CompositorType::River {
+            uninstall,
+            status,
+            show,
+        } => {
             if *show {
                 print_river_config();
             } else if *status {
@@ -350,9 +364,13 @@ fn hyprland_status() {
             if content.contains("pre_recording_command") && content.contains("hyprctl") {
                 print_success("Voxtype hooks: configured for Hyprland (with recording hook)");
             } else if content.contains("pre_output_command") && content.contains("hyprctl") {
-                print_warning("Voxtype hooks: configured for Hyprland (missing pre_recording_command)");
+                print_warning(
+                    "Voxtype hooks: configured for Hyprland (missing pre_recording_command)",
+                );
                 println!("       Add to [output] section:\n");
-                println!("       pre_recording_command = \"hyprctl dispatch submap voxtype_recording\"");
+                println!(
+                    "       pre_recording_command = \"hyprctl dispatch submap voxtype_recording\""
+                );
             } else if content.contains("pre_output_command") {
                 print_warning("Voxtype hooks: configured (but not for Hyprland)");
             } else {
@@ -663,9 +681,13 @@ fn river_status() {
             if content.contains("pre_recording_command") && content.contains("riverctl") {
                 print_success("Voxtype hooks: configured for River (with recording hook)");
             } else if content.contains("pre_output_command") && content.contains("riverctl") {
-                print_warning("Voxtype hooks: configured for River (missing pre_recording_command)");
+                print_warning(
+                    "Voxtype hooks: configured for River (missing pre_recording_command)",
+                );
                 println!("       Add to [output] section:\n");
-                println!("       pre_recording_command = \"riverctl enter-mode voxtype_recording\"");
+                println!(
+                    "       pre_recording_command = \"riverctl enter-mode voxtype_recording\""
+                );
             } else if content.contains("pre_output_command") {
                 print_warning("Voxtype hooks: configured (but not for River)");
             } else {

--- a/src/setup/gpu.rs
+++ b/src/setup/gpu.rs
@@ -83,7 +83,11 @@ pub fn detect_available_backends() -> Vec<Backend> {
         }
     } else {
         // Simple mode: CPU binary at /usr/bin/voxtype or backed up
-        if Path::new(VOXTYPE_BIN).is_file() && !fs::symlink_metadata(VOXTYPE_BIN).map(|m| m.file_type().is_symlink()).unwrap_or(false) {
+        if Path::new(VOXTYPE_BIN).is_file()
+            && !fs::symlink_metadata(VOXTYPE_BIN)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+        {
             available.push(Backend::Cpu);
         } else if Path::new(VOXTYPE_CPU_BACKUP).exists() {
             available.push(Backend::Cpu);
@@ -208,9 +212,8 @@ fn enable_simple_mode() -> anyhow::Result<()> {
     }
 
     // Ensure lib dir exists
-    fs::create_dir_all(VOXTYPE_LIB_DIR).map_err(|e| {
-        anyhow::anyhow!("Failed to create {}: {}", VOXTYPE_LIB_DIR, e)
-    })?;
+    fs::create_dir_all(VOXTYPE_LIB_DIR)
+        .map_err(|e| anyhow::anyhow!("Failed to create {}: {}", VOXTYPE_LIB_DIR, e))?;
 
     // Backup the CPU binary
     if Path::new(VOXTYPE_BIN).exists() {
@@ -290,7 +293,9 @@ pub fn show_status() {
             if backend == Backend::Vulkan || (tiered && backend != Backend::Cpu) {
                 println!(
                     "  Binary: {}",
-                    Path::new(VOXTYPE_LIB_DIR).join(backend.binary_name()).display()
+                    Path::new(VOXTYPE_LIB_DIR)
+                        .join(backend.binary_name())
+                        .display()
                 );
             } else {
                 println!("  Binary: {}", VOXTYPE_BIN);
@@ -304,7 +309,11 @@ pub fn show_status() {
     // Installation mode
     println!(
         "\nInstallation mode: {}",
-        if tiered { "tiered (pre-built)" } else { "simple (source build)" }
+        if tiered {
+            "tiered (pre-built)"
+        } else {
+            "simple (source build)"
+        }
     );
 
     // Available backends

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -83,8 +83,7 @@ pub fn get_voxtype_service_path() -> String {
 
     // If /usr/bin/voxtype exists (either as symlink or binary), use it
     // This allows backend switching to work with just a service restart
-    if std::path::Path::new(VOXTYPE_BIN).exists()
-        || std::fs::symlink_metadata(VOXTYPE_BIN).is_ok()
+    if std::path::Path::new(VOXTYPE_BIN).exists() || std::fs::symlink_metadata(VOXTYPE_BIN).is_ok()
     {
         return VOXTYPE_BIN.to_string();
     }
@@ -128,11 +127,7 @@ pub fn detect_display_server() -> DisplayServer {
 
 /// Get the path to a command if it exists
 pub async fn get_command_path(cmd: &str) -> Option<String> {
-    let output = Command::new("which")
-        .arg(cmd)
-        .output()
-        .await
-        .ok()?;
+    let output = Command::new("which").arg(cmd).output().await.ok()?;
 
     if output.status.success() {
         Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -280,7 +275,10 @@ pub fn print_output_chain_status(status: &OutputChainStatus) {
     println!("  Display server:  {}", ds_info);
 
     // wtype
-    print_tool_status(&status.wtype, status.display_server == DisplayServer::Wayland);
+    print_tool_status(
+        &status.wtype,
+        status.display_server == DisplayServer::Wayland,
+    );
 
     // ydotool
     if status.ydotool.installed {
@@ -291,9 +289,15 @@ pub fn print_output_chain_status(status: &OutputChainStatus) {
         };
         if let Some(ref path) = status.ydotool.path {
             if status.ydotool.available {
-                println!("  ydotool:         \x1b[32m✓\x1b[0m installed ({}), {}", path, daemon_status);
+                println!(
+                    "  ydotool:         \x1b[32m✓\x1b[0m installed ({}), {}",
+                    path, daemon_status
+                );
             } else {
-                println!("  ydotool:         \x1b[33m⚠\x1b[0m installed ({}), {}", path, daemon_status);
+                println!(
+                    "  ydotool:         \x1b[33m⚠\x1b[0m installed ({}), {}",
+                    path, daemon_status
+                );
             }
         }
     } else {
@@ -301,7 +305,10 @@ pub fn print_output_chain_status(status: &OutputChainStatus) {
     }
 
     // wl-copy
-    print_tool_status(&status.wl_copy, status.display_server == DisplayServer::Wayland);
+    print_tool_status(
+        &status.wl_copy,
+        status.display_server == DisplayServer::Wayland,
+    );
 
     // xclip (only show on X11 or if installed)
     if status.display_server == DisplayServer::X11 || status.xclip.installed {
@@ -327,24 +334,31 @@ pub fn print_output_chain_status(status: &OutputChainStatus) {
 fn print_tool_status(tool: &OutputToolStatus, is_relevant: bool) {
     if tool.installed {
         let path = tool.path.as_deref().unwrap_or("?");
-        let note = tool.note.as_deref().map(|n| format!(" ({})", n)).unwrap_or_default();
+        let note = tool
+            .note
+            .as_deref()
+            .map(|n| format!(" ({})", n))
+            .unwrap_or_default();
 
         if tool.available {
-            println!("  {}:{}  \x1b[32m✓\x1b[0m installed ({}){}",
+            println!(
+                "  {}:{}  \x1b[32m✓\x1b[0m installed ({}){}",
                 tool.name,
                 " ".repeat(14 - tool.name.len()),
                 path,
                 note
             );
         } else if is_relevant {
-            println!("  {}:{}  \x1b[33m⚠\x1b[0m installed ({}){}",
+            println!(
+                "  {}:{}  \x1b[33m⚠\x1b[0m installed ({}){}",
                 tool.name,
                 " ".repeat(14 - tool.name.len()),
                 path,
                 note
             );
         } else {
-            println!("  {}:{}  \x1b[90m✓ installed ({}){}\x1b[0m",
+            println!(
+                "  {}:{}  \x1b[90m✓ installed ({}){}\x1b[0m",
                 tool.name,
                 " ".repeat(14 - tool.name.len()),
                 path,
@@ -352,12 +366,14 @@ fn print_tool_status(tool: &OutputToolStatus, is_relevant: bool) {
             );
         }
     } else if is_relevant {
-        println!("  {}:{}  \x1b[31m✗\x1b[0m not installed",
+        println!(
+            "  {}:{}  \x1b[31m✗\x1b[0m not installed",
             tool.name,
             " ".repeat(14 - tool.name.len())
         );
     } else {
-        println!("  {}:{}  \x1b[90m- not installed\x1b[0m",
+        println!(
+            "  {}:{}  \x1b[90m- not installed\x1b[0m",
             tool.name,
             " ".repeat(14 - tool.name.len())
         );
@@ -421,11 +437,7 @@ pub async fn run_setup(
             // Validate the model name
             if !model::is_valid_model(name) {
                 let valid = model::valid_model_names().join(", ");
-                anyhow::bail!(
-                    "Unknown model '{}'. Valid models are: {}",
-                    name,
-                    valid
-                );
+                anyhow::bail!("Unknown model '{}'. Valid models are: {}", name, valid);
             }
             name
         }
@@ -440,10 +452,7 @@ pub async fn run_setup(
             let size = std::fs::metadata(&model_path)
                 .map(|m| m.len() as f64 / 1024.0 / 1024.0)
                 .unwrap_or(0.0);
-            print_success(&format!(
-                "Model ready: {} ({:.0} MB)",
-                model_name, size
-            ));
+            print_success(&format!("Model ready: {} ({:.0} MB)", model_name, size));
         }
         // If user explicitly requested this model, update config even if already downloaded
         if model_override.is_some() {
@@ -480,7 +489,9 @@ pub async fn run_setup(
         println!();
         println!("Next steps:");
         println!("  1. Set up a compositor keybinding to trigger recording:");
-        println!("     Example for Hyprland: bind = , XF86AudioRecord, exec, voxtype record-toggle\n");
+        println!(
+            "     Example for Hyprland: bind = , XF86AudioRecord, exec, voxtype record-toggle\n"
+        );
         println!("  2. Start the daemon: voxtype daemon\n");
         println!("Optional:");
         println!("  voxtype setup check      - Verify system configuration");
@@ -584,7 +595,10 @@ pub async fn run_checks(config: &Config) -> anyhow::Result<()> {
         let size = std::fs::metadata(&model_path)
             .map(|m| m.len() as f64 / 1024.0 / 1024.0)
             .unwrap_or(0.0);
-        print_success(&format!("Model '{}' installed ({:.0} MB)", model_name, size));
+        print_success(&format!(
+            "Model '{}' installed ({:.0} MB)",
+            model_name, size
+        ));
     } else {
         print_failure(&format!("Model '{}' not found", model_name));
         println!("       Run: voxtype setup --download");

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -221,7 +221,7 @@ pub fn download_model(model_name: &str) -> anyhow::Result<()> {
     // Use curl for downloading - it handles progress display and redirects
     let status = Command::new("curl")
         .args([
-            "-L",              // Follow redirects
+            "-L",             // Follow redirects
             "--progress-bar", // Show progress bar
             "-o",
             model_path.to_str().unwrap_or("model.bin"),
@@ -286,7 +286,10 @@ pub async fn set_model(model_name: &str, restart: bool) -> anyhow::Result<()> {
         }
     } else {
         print_info("Restart daemon to use new model: systemctl --user restart voxtype");
-        println!("       Or use: voxtype setup model --set {} --restart", model_name);
+        println!(
+            "       Or use: voxtype setup model --set {} --restart",
+            model_name
+        );
     }
 
     Ok(())
@@ -315,10 +318,7 @@ pub fn list_installed() {
                 .map(|m| m.len() as f64 / 1024.0 / 1024.0)
                 .unwrap_or(0.0);
 
-            println!(
-                "  {} ({:.0} MB) - {}",
-                model.name, size, model.description
-            );
+            println!("  {} ({:.0} MB) - {}", model.name, size, model.description);
             found = true;
         }
     }

--- a/src/setup/waybar.rs
+++ b/src/setup/waybar.rs
@@ -52,9 +52,8 @@ pub fn install() -> Result<(), VoxtypeError> {
     };
 
     // Read current config
-    let config_content = fs::read_to_string(&config_path).map_err(|e| {
-        VoxtypeError::Config(format!("Failed to read waybar config: {}", e))
-    })?;
+    let config_content = fs::read_to_string(&config_path)
+        .map_err(|e| VoxtypeError::Config(format!("Failed to read waybar config: {}", e)))?;
 
     // Check if voxtype module already exists
     if config_content.contains("\"custom/voxtype\"") {
@@ -80,16 +79,14 @@ pub fn install() -> Result<(), VoxtypeError> {
 
     // Create backup
     let backup_path = format!("{}.voxtype-backup", config_path.display());
-    fs::copy(&config_path, &backup_path).map_err(|e| {
-        VoxtypeError::Config(format!("Failed to create backup: {}", e))
-    })?;
+    fs::copy(&config_path, &backup_path)
+        .map_err(|e| VoxtypeError::Config(format!("Failed to create backup: {}", e)))?;
     println!("Created backup: {}", backup_path);
 
     // Inject module into config
     let new_config = inject_module_into_config(&config_content)?;
-    fs::write(&config_path, new_config).map_err(|e| {
-        VoxtypeError::Config(format!("Failed to write config: {}", e))
-    })?;
+    fs::write(&config_path, new_config)
+        .map_err(|e| VoxtypeError::Config(format!("Failed to write config: {}", e)))?;
     println!("Added voxtype module to Waybar config.");
 
     // Add CSS if style file exists and doesn't already have voxtype styles
@@ -100,9 +97,8 @@ pub fn install() -> Result<(), VoxtypeError> {
                 .append(true)
                 .open(&style_path)
                 .map_err(|e| VoxtypeError::Config(format!("Failed to open style.css: {}", e)))?;
-            writeln!(file, "\n{}", get_css_config()).map_err(|e| {
-                VoxtypeError::Config(format!("Failed to write CSS: {}", e))
-            })?;
+            writeln!(file, "\n{}", get_css_config())
+                .map_err(|e| VoxtypeError::Config(format!("Failed to write CSS: {}", e)))?;
             println!("Added voxtype styling to Waybar CSS.");
         }
     }
@@ -131,9 +127,8 @@ pub fn uninstall() -> Result<(), VoxtypeError> {
         }
     };
 
-    let config_content = fs::read_to_string(&config_path).map_err(|e| {
-        VoxtypeError::Config(format!("Failed to read waybar config: {}", e))
-    })?;
+    let config_content = fs::read_to_string(&config_path)
+        .map_err(|e| VoxtypeError::Config(format!("Failed to read waybar config: {}", e)))?;
 
     if !config_content.contains("\"custom/voxtype\"") {
         println!("Voxtype module not found in Waybar config.");
@@ -153,9 +148,8 @@ pub fn uninstall() -> Result<(), VoxtypeError> {
 
     // Remove module from config
     let new_config = remove_module_from_config(&config_content);
-    fs::write(&config_path, new_config).map_err(|e| {
-        VoxtypeError::Config(format!("Failed to write config: {}", e))
-    })?;
+    fs::write(&config_path, new_config)
+        .map_err(|e| VoxtypeError::Config(format!("Failed to write config: {}", e)))?;
     println!("Removed voxtype module from Waybar config.");
 
     // Remove CSS
@@ -163,9 +157,8 @@ pub fn uninstall() -> Result<(), VoxtypeError> {
         let style_content = fs::read_to_string(&style_path).unwrap_or_default();
         if style_content.contains("#custom-voxtype") {
             let new_style = remove_css_from_style(&style_content);
-            fs::write(&style_path, new_style).map_err(|e| {
-                VoxtypeError::Config(format!("Failed to write style.css: {}", e))
-            })?;
+            fs::write(&style_path, new_style)
+                .map_err(|e| VoxtypeError::Config(format!("Failed to write style.css: {}", e)))?;
             println!("Removed voxtype styling from Waybar CSS.");
         }
     }
@@ -217,9 +210,7 @@ fn inject_module_into_config(content: &str) -> Result<String, VoxtypeError> {
         // Check if we need to add a comma after the previous module
         // Look backwards from the last brace to find the previous }
         let before_last = &result[..last_brace];
-        let needs_comma = before_last
-            .trim_end()
-            .ends_with('}');
+        let needs_comma = before_last.trim_end().ends_with('}');
 
         let module_def = if needs_comma {
             r#",
@@ -354,7 +345,11 @@ fn remove_css_from_style(content: &str) -> String {
             let trailing_ws = after.chars().take_while(|c| c.is_whitespace()).count();
             // Remove the block including leading whitespace
             let before = &result[..start];
-            let leading_ws = before.chars().rev().take_while(|c| *c == ' ' || *c == '\t' || *c == '\n').count();
+            let leading_ws = before
+                .chars()
+                .rev()
+                .take_while(|c| *c == ' ' || *c == '\t' || *c == '\n')
+                .count();
             let actual_start = start.saturating_sub(leading_ws);
             let actual_end = end + trailing_ws;
             result = format!("{}{}", &result[..actual_start], &result[actual_end..]);
@@ -387,7 +382,11 @@ fn remove_css_from_style(content: &str) -> String {
             let after = &result[end..];
             let trailing_ws = after.chars().take_while(|c| c.is_whitespace()).count();
             let before = &result[..start];
-            let leading_ws = before.chars().rev().take_while(|c| *c == ' ' || *c == '\t' || *c == '\n').count();
+            let leading_ws = before
+                .chars()
+                .rev()
+                .take_while(|c| *c == ' ' || *c == '\t' || *c == '\n')
+                .count();
             let actual_start = start.saturating_sub(leading_ws);
             let actual_end = end + trailing_ws;
             result = format!("{}{}", &result[..actual_start], &result[actual_end..]);
@@ -418,13 +417,15 @@ pub fn print_config() {
     println!("   In the \"modules-right\" (or left/center) array, add: \"custom/voxtype\"\n");
 
     println!("   Then add this module configuration:\n");
-    println!(r#"   "custom/voxtype": {{
+    println!(
+        r#"   "custom/voxtype": {{
        "exec": "voxtype status --follow --format json",
        "return-type": "json",
        "format": "{{}}",
        "tooltip": true,
        "on-click": "systemctl --user restart voxtype"
-   }}"#);
+   }}"#
+    );
 
     println!("\n\n2. Add this to your Waybar style.css:\n");
     println!(
@@ -464,9 +465,12 @@ pub fn print_config() {
     println!("---");
     println!("\nCustomizing Icons:");
     println!("------------------");
-    println!("Voxtype outputs an \"alt\" field in JSON that enables Waybar's format-icons feature.");
+    println!(
+        "Voxtype outputs an \"alt\" field in JSON that enables Waybar's format-icons feature."
+    );
     println!("To use custom icons (e.g., Nerd Fonts), configure your Waybar module like this:\n");
-    println!(r#"   "custom/voxtype": {{
+    println!(
+        r#"   "custom/voxtype": {{
        "exec": "voxtype status --follow --format json",
        "return-type": "json",
        "format": "{{icon}}",
@@ -477,7 +481,8 @@ pub fn print_config() {
            "stopped": "\uf131"
        }},
        "tooltip": true
-   }}"#);
+   }}"#
+    );
     println!("\n   Nerd Font codepoints: U+F130 (mic), U+F111 (dot), U+F110 (spinner), U+F131 (mic-slash)");
     println!("\nAlternatively, configure icons in voxtype's config.toml:\n");
     println!("   [status]");

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -206,10 +206,7 @@ mod tests {
         let processor = TextProcessor::new(&config);
 
         assert_eq!(processor.process("open paren test close paren"), "(test)");
-        assert_eq!(
-            processor.process("hello exclamation mark"),
-            "hello!"
-        );
+        assert_eq!(processor.process("hello exclamation mark"), "hello!");
     }
 
     #[test]
@@ -254,10 +251,7 @@ mod tests {
         let config = make_config(true, &[("voxtype", "Voxtype")]);
         let processor = TextProcessor::new(&config);
 
-        assert_eq!(
-            processor.process("I use voxtype period"),
-            "I use Voxtype."
-        );
+        assert_eq!(processor.process("I use voxtype period"), "I use Voxtype.");
     }
 
     #[test]
@@ -265,8 +259,14 @@ mod tests {
         let config = make_config(true, &[]);
         let processor = TextProcessor::new(&config);
 
-        assert_eq!(processor.process("function open paren close paren"), "function()");
-        assert_eq!(processor.process("array open bracket close bracket"), "array[]");
+        assert_eq!(
+            processor.process("function open paren close paren"),
+            "function()"
+        );
+        assert_eq!(
+            processor.process("array open bracket close bracket"),
+            "array[]"
+        );
         assert_eq!(processor.process("hash include"), "#include");
         assert_eq!(processor.process("user at sign example"), "user@example");
     }
@@ -276,7 +276,10 @@ mod tests {
         let config = make_config(true, &[]);
         let processor = TextProcessor::new(&config);
 
-        assert_eq!(processor.process("line one new line line two"), "line one\nline two");
+        assert_eq!(
+            processor.process("line one new line line two"),
+            "line one\nline two"
+        );
         assert_eq!(processor.process("col one tab col two"), "col one\tcol two");
     }
 }

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -33,9 +33,7 @@ pub trait Transcriber: Send + Sync {
 }
 
 /// Factory function to create transcriber based on configured backend
-pub fn create_transcriber(
-    config: &WhisperConfig,
-) -> Result<Box<dyn Transcriber>, TranscribeError> {
+pub fn create_transcriber(config: &WhisperConfig) -> Result<Box<dyn Transcriber>, TranscribeError> {
     create_transcriber_with_config_path(config, None)
 }
 
@@ -48,7 +46,9 @@ pub fn create_transcriber_with_config_path(
     match config.backend {
         WhisperBackend::Local => {
             if config.gpu_isolation {
-                tracing::info!("Using subprocess-isolated whisper transcription (gpu_isolation=true)");
+                tracing::info!(
+                    "Using subprocess-isolated whisper transcription (gpu_isolation=true)"
+                );
                 Ok(Box::new(subprocess::SubprocessTranscriber::new(
                     config,
                     config_path,

--- a/src/transcribe/remote.rs
+++ b/src/transcribe/remote.rs
@@ -2,9 +2,12 @@
 //!
 //! Sends audio to a remote whisper.cpp server or OpenAI-compatible endpoint
 //! for transcription, enabling use of GPU servers for faster inference.
+//!
+//! Note: Remote APIs don't support language arrays. When a language array is
+//! configured, the first/primary language is used.
 
 use super::Transcriber;
-use crate::config::WhisperConfig;
+use crate::config::{LanguageConfig, WhisperConfig};
 use crate::error::TranscribeError;
 use std::io::Cursor;
 use std::time::Duration;
@@ -17,8 +20,8 @@ pub struct RemoteTranscriber {
     endpoint: String,
     /// Model name to send to server
     model: String,
-    /// Language for transcription
-    language: String,
+    /// Language configuration
+    language: LanguageConfig,
     /// Whether to translate to English
     translate: bool,
     /// Optional API key for authentication
@@ -72,6 +75,15 @@ impl RemoteTranscriber {
 
         let timeout = Duration::from_secs(config.remote_timeout_secs.unwrap_or(30));
 
+        // Warn if language array is configured (remote APIs don't support arrays)
+        if config.language.is_multiple() {
+            tracing::warn!(
+                "Remote backend doesn't support language arrays. Using primary language '{}' from {:?}",
+                config.language.primary(),
+                config.language.as_vec()
+            );
+        }
+
         tracing::info!(
             "Configured remote transcriber: endpoint={}, model={}, timeout={}s",
             endpoint,
@@ -99,16 +111,17 @@ impl RemoteTranscriber {
         };
 
         let mut buffer = Cursor::new(Vec::new());
-        let mut writer = hound::WavWriter::new(&mut buffer, spec)
-            .map_err(|e| TranscribeError::AudioFormat(format!("Failed to create WAV writer: {}", e)))?;
+        let mut writer = hound::WavWriter::new(&mut buffer, spec).map_err(|e| {
+            TranscribeError::AudioFormat(format!("Failed to create WAV writer: {}", e))
+        })?;
 
         // Convert f32 [-1.0, 1.0] to i16
         for &sample in samples {
             let clamped = sample.clamp(-1.0, 1.0);
             let scaled = (clamped * i16::MAX as f32) as i16;
-            writer
-                .write_sample(scaled)
-                .map_err(|e| TranscribeError::AudioFormat(format!("Failed to write sample: {}", e)))?;
+            writer.write_sample(scaled).map_err(|e| {
+                TranscribeError::AudioFormat(format!("Failed to write sample: {}", e))
+            })?;
         }
 
         writer
@@ -119,20 +132,22 @@ impl RemoteTranscriber {
     }
 
     /// Build the multipart form body for the API request
-    fn build_multipart_body(
-        &self,
-        wav_data: &[u8],
-    ) -> (String, Vec<u8>) {
-        let boundary = format!("----VoxtypeBoundary{}", std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos());
+    fn build_multipart_body(&self, wav_data: &[u8]) -> (String, Vec<u8>) {
+        let boundary = format!(
+            "----VoxtypeBoundary{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
 
         let mut body = Vec::new();
 
         // Add file field
         body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
-        body.extend_from_slice(b"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n");
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
+        );
         body.extend_from_slice(b"Content-Type: audio/wav\r\n\r\n");
         body.extend_from_slice(wav_data);
         body.extend_from_slice(b"\r\n");
@@ -143,11 +158,12 @@ impl RemoteTranscriber {
         body.extend_from_slice(self.model.as_bytes());
         body.extend_from_slice(b"\r\n");
 
-        // Add language field (if not auto)
-        if self.language != "auto" {
+        // Add language field (if not auto-detect mode)
+        // For language arrays, use the primary language since remote APIs don't support arrays
+        if !self.language.is_auto() {
             body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
             body.extend_from_slice(b"Content-Disposition: form-data; name=\"language\"\r\n\r\n");
-            body.extend_from_slice(self.language.as_bytes());
+            body.extend_from_slice(self.language.primary().as_bytes());
             body.extend_from_slice(b"\r\n");
         }
 
@@ -195,12 +211,10 @@ impl Transcriber for RemoteTranscriber {
         let url = format!("{}{}", self.endpoint.trim_end_matches('/'), path);
 
         // Build request
-        let mut request = ureq::post(&url)
-            .timeout(self.timeout)
-            .set(
-                "Content-Type",
-                &format!("multipart/form-data; boundary={}", boundary),
-            );
+        let mut request = ureq::post(&url).timeout(self.timeout).set(
+            "Content-Type",
+            &format!("multipart/form-data; boundary={}", boundary),
+        );
 
         // Add authorization if API key is configured
         if let Some(ref key) = self.api_key {
@@ -208,32 +222,27 @@ impl Transcriber for RemoteTranscriber {
         }
 
         // Send request
-        let response = request
-            .send_bytes(&body)
-            .map_err(|e| match e {
-                ureq::Error::Status(code, resp) => {
-                    let body = resp.into_string().unwrap_or_default();
-                    TranscribeError::RemoteError(format!("Server returned {}: {}", code, body))
-                }
-                ureq::Error::Transport(t) => {
-                    TranscribeError::NetworkError(format!("Request failed: {}", t))
-                }
-            })?;
+        let response = request.send_bytes(&body).map_err(|e| match e {
+            ureq::Error::Status(code, resp) => {
+                let body = resp.into_string().unwrap_or_default();
+                TranscribeError::RemoteError(format!("Server returned {}: {}", code, body))
+            }
+            ureq::Error::Transport(t) => {
+                TranscribeError::NetworkError(format!("Request failed: {}", t))
+            }
+        })?;
 
         // Parse JSON response
-        let json: serde_json::Value = response
-            .into_json()
-            .map_err(|e| TranscribeError::RemoteError(format!("Failed to parse response: {}", e)))?;
+        let json: serde_json::Value = response.into_json().map_err(|e| {
+            TranscribeError::RemoteError(format!("Failed to parse response: {}", e))
+        })?;
 
         // Extract text from response
         let text = json
             .get("text")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                TranscribeError::RemoteError(format!(
-                    "Response missing 'text' field: {}",
-                    json
-                ))
+                TranscribeError::RemoteError(format!("Response missing 'text' field: {}", json))
             })?
             .trim()
             .to_string();
@@ -261,7 +270,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "en".to_string(),
+            language: LanguageConfig::Single("en".to_string()),
             translate: false,
             threads: None,
             on_demand_loading: false,
@@ -295,7 +304,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "en".to_string(),
+            language: LanguageConfig::Single("en".to_string()),
             translate: false,
             threads: None,
             on_demand_loading: false,
@@ -317,7 +326,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "en".to_string(),
+            language: LanguageConfig::Single("en".to_string()),
             translate: false,
             threads: None,
             on_demand_loading: false,
@@ -339,7 +348,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "en".to_string(),
+            language: LanguageConfig::Single("en".to_string()),
             translate: false,
             threads: None,
             on_demand_loading: false,
@@ -376,7 +385,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "en".to_string(),
+            language: LanguageConfig::Single("en".to_string()),
             translate: false,
             threads: None,
             on_demand_loading: false,
@@ -407,7 +416,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "auto".to_string(),
+            language: LanguageConfig::Single("auto".to_string()),
             translate: true,
             threads: None,
             on_demand_loading: false,
@@ -438,7 +447,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "en".to_string(),
+            language: LanguageConfig::Single("en".to_string()),
             translate: false,
             threads: None,
             on_demand_loading: false,
@@ -459,7 +468,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "en".to_string(),
+            language: LanguageConfig::Single("en".to_string()),
             translate: false,
             threads: None,
             on_demand_loading: false,
@@ -480,7 +489,7 @@ mod tests {
         let config = WhisperConfig {
             backend: crate::config::WhisperBackend::Remote,
             model: "base.en".to_string(),
-            language: "en".to_string(),
+            language: LanguageConfig::Single("en".to_string()),
             translate: false,
             threads: None,
             on_demand_loading: false,

--- a/src/transcribe/worker.rs
+++ b/src/transcribe/worker.rs
@@ -60,10 +60,10 @@ pub fn run_worker(config: &WhisperConfig) -> anyhow::Result<()> {
         Ok(t) => t,
         Err(e) => {
             // Write error and exit - parent will see no READY signal
-            write_response_to(&mut stdout_lock, WorkerResponse::error(format!(
-                "Failed to load model: {}",
-                e
-            )));
+            write_response_to(
+                &mut stdout_lock,
+                WorkerResponse::error(format!("Failed to load model: {}", e)),
+            );
             return Ok(());
         }
     };
@@ -108,7 +108,10 @@ pub fn run_worker(config: &WhisperConfig) -> anyhow::Result<()> {
     }
 
     if sample_count == 0 {
-        write_response_to(&mut stdout_lock, WorkerResponse::error("Empty audio buffer"));
+        write_response_to(
+            &mut stdout_lock,
+            WorkerResponse::error("Empty audio buffer"),
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Adds support for specifying multiple allowed languages in the language config option
- When multiple languages are configured, Whisper's language detection runs before transcription and picks the highest-probability language from the allowed set
- Helps multilingual users who found that Whisper sometimes misdetects language for short sentences

## Config syntax

```toml
[whisper]
# Single language (existing behavior)
language = "en"

# Auto-detect from all languages (existing behavior)
language = "auto"

# NEW: Constrained auto-detect
language = ["en", "fr"]
```

## Implementation

- New `LanguageConfig` enum with `Single`/`Multiple` variants
- `WhisperTranscriber` runs `lang_detect()` when multiple languages configured
- `RemoteTranscriber` warns and uses first language (APIs don't support arrays)
- Subprocess passes languages as comma-separated string

## Test plan

- [x] All 138 existing tests pass
- [x] New tests for `LanguageConfig` parsing (single, auto, array, single-element array)
- [ ] Manual test with multilingual model and French/English audio
- [ ] Verify remote backend logs warning when array configured

Closes #108