### PR TITLE
Replace inotify with notify crate for device hotplug detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,12 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,19 +942,6 @@ dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
  "libc",
-]
-
-[[package]]
-name = "inotify"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
-dependencies = [
- "bitflags 1.3.2",
- "futures-core",
- "inotify-sys",
- "libc",
- "tokio",
 ]
 
 [[package]]
@@ -1356,7 +1337,7 @@ dependencies = [
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
- "inotify 0.9.6",
+ "inotify",
  "kqueue",
  "libc",
  "log",
@@ -2617,7 +2598,6 @@ dependencies = [
  "directories",
  "evdev",
  "hound",
- "inotify 0.10.2",
  "libc",
  "nix 0.29.0",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ async-trait = "0.1"
 # Input handling (evdev for kernel-level key events)
 evdev = "0.12"
 libc = "0.2"
-inotify = "0.10"  # Watch /dev/input for device hotplug
 nix = { version = "0.29", features = ["signal", "process"] }  # Unix signals for IPC
 
 # Audio capture
@@ -64,7 +63,7 @@ parakeet-rs = { version = "0.2.9", optional = true }
 # CPU count for thread detection
 num_cpus = "1.16"
 
-# File watching for status --follow
+# File and device watching (status --follow, device hotplug)
 notify = "6"
 
 # Single instance check


### PR DESCRIPTION
## Summary
- Switch device hotplug detection from inotify to notify crate
- notify is already used for status --follow, so this consolidates dependencies
- The notify crate uses inotify internally on Linux, so behavior is unchanged

## Test plan
- [ ] Verify device hotplug detection still works when plugging/unplugging keyboards
- [ ] Verify `voxtype status --follow` still works
- [ ] Run `cargo test` on Linux