### PR TITLE
Add CLI backend for whisper-cli subprocess transcription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,6 +2633,7 @@ dependencies = [
  "regex",
  "rodio",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2634,6 +2641,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq 2.12.1",
+ "which",
  "whisper-rs",
 ]
 
@@ -2755,6 +2763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -3141,6 +3161,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,15 @@ hound = "3"  # WAV file reading/writing
 # HTTP client for remote transcription
 ureq = { version = "2", features = ["json"] }
 
+# JSON parsing (for CLI backend)
+serde_json = "1"
+
+# CLI path resolution (for CLI backend)
+which = "7"
+
+# Temp files (for CLI backend audio)
+tempfile = "3"
+
 # Audio playback (for feedback sounds)
 rodio = { version = "0.19", default-features = false, features = ["wav"] }
 
@@ -87,7 +96,6 @@ clap = { version = "4", features = ["derive"] }
 clap_mangen = "0.2"
 
 [dev-dependencies]
-tempfile = "3"
 
 [profile.release]
 lto = true

--- a/config/default.toml
+++ b/config/default.toml
@@ -105,6 +105,12 @@ on_demand_loading = false
 # remote_api_key = "sk-..."                       # Or use VOXTYPE_WHISPER_API_KEY env var
 # remote_timeout_secs = 30
 
+# --- CLI mode settings (used when mode = "cli") ---
+# Uses whisper-cli subprocess instead of whisper-rs FFI bindings.
+# Fallback for systems where whisper-rs crashes (e.g., glibc 2.42+ on Ubuntu 25.10).
+# Requires whisper-cli from whisper.cpp: https://github.com/ggerganov/whisper.cpp
+# whisper_cli_path = "/usr/local/bin/whisper-cli"  # Optional, searches PATH if not set
+
 # [parakeet]
 # Parakeet configuration (only used when engine = "parakeet")
 # Requires: cargo build --features parakeet

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -343,16 +343,28 @@ Controls the Whisper speech-to-text engine.
 Selects the transcription backend.
 
 **Values:**
-- `local` - Use whisper.cpp locally on your machine (default, fully offline)
+- `local` - Use whisper.cpp locally via FFI bindings (default, fully offline)
 - `remote` - Send audio to a remote server for transcription
+- `cli` - Use whisper-cli subprocess (fallback for systems where FFI crashes)
 
 > **Privacy Notice**: When using `remote` backend, audio is transmitted over the network. See [User Manual - Remote Whisper Servers](USER_MANUAL.md#remote-whisper-servers) for privacy considerations.
 
-**Example:**
+**When to use `cli` backend:**
+The `cli` backend is a workaround for systems where the whisper-rs FFI bindings crash due to C++ exceptions crossing the FFI boundary. This affects some systems with glibc 2.42+ (e.g., Ubuntu 25.10). If voxtype crashes during transcription, try the `cli` backend.
+
+Requires `whisper-cli` from [whisper.cpp](https://github.com/ggerganov/whisper.cpp).
+
+**Examples:**
 ```toml
 [whisper]
 backend = "remote"
 remote_endpoint = "http://192.168.1.100:8080"
+```
+
+```toml
+[whisper]
+backend = "cli"
+whisper_cli_path = "/usr/local/bin/whisper-cli"  # Optional
 ```
 
 ### model
@@ -804,6 +816,39 @@ Maximum time in seconds to wait for the remote server to respond. Increase for s
 backend = "remote"
 remote_endpoint = "http://192.168.1.100:8080"
 remote_timeout_secs = 60  # 60 second timeout for long recordings
+```
+
+### whisper_cli_path
+
+**Type:** String
+**Default:** Auto-detected from PATH
+**Required:** No
+
+Path to the `whisper-cli` binary. Only used when `backend = "cli"`.
+
+If not specified, voxtype searches for `whisper-cli` or `whisper` in:
+1. Your `$PATH`
+2. Common system locations (`/usr/local/bin`, `/usr/bin`)
+3. Current directory
+4. `~/.local/bin`
+
+**Example:**
+```toml
+[whisper]
+backend = "cli"
+whisper_cli_path = "/opt/whisper.cpp/build/bin/whisper-cli"
+```
+
+**Installing whisper-cli:**
+
+Build from source at [github.com/ggerganov/whisper.cpp](https://github.com/ggerganov/whisper.cpp):
+
+```bash
+git clone https://github.com/ggerganov/whisper.cpp
+cd whisper.cpp
+cmake -B build
+cmake --build build --config Release
+sudo cp build/bin/whisper-cli /usr/local/bin/
 ```
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -231,6 +231,29 @@ curl -L -o ~/.local/share/voxtype/models/ggml-base.en.bin \
     https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
 ```
 
+### Voxtype crashes during transcription
+
+**Cause:** On some systems (particularly with glibc 2.42+ like Ubuntu 25.10), the whisper-rs FFI bindings crash due to C++ exceptions crossing the FFI boundary.
+
+**Solution:** Use the CLI backend which runs whisper-cli as a subprocess:
+
+```toml
+[whisper]
+backend = "cli"
+```
+
+This requires `whisper-cli` to be installed. Build it from [whisper.cpp](https://github.com/ggerganov/whisper.cpp):
+
+```bash
+git clone https://github.com/ggerganov/whisper.cpp
+cd whisper.cpp
+cmake -B build
+cmake --build build --config Release
+sudo cp build/bin/whisper-cli /usr/local/bin/
+```
+
+See [CLI Backend](USER_MANUAL.md#cli-backend-whisper-cli) in the User Manual for details.
+
 ### Poor transcription accuracy
 
 **Possible causes:**

--- a/src/config.rs
+++ b/src/config.rs
@@ -592,7 +592,9 @@ pub enum WhisperMode {
     Local,
     /// Remote transcription via OpenAI-compatible API
     Remote,
-    // Future: Cli variant for whisper-cli subprocess (PR #77)
+    /// CLI transcription using whisper-cli subprocess
+    /// Fallback for systems where whisper-rs FFI doesn't work (e.g., glibc 2.42+)
+    Cli,
 }
 
 /// Language configuration supporting single language or array of allowed languages
@@ -754,6 +756,12 @@ pub struct WhisperConfig {
     /// Timeout for remote requests in seconds (default: 30)
     #[serde(default)]
     pub remote_timeout_secs: Option<u64>,
+
+    // --- CLI backend settings ---
+    /// Path to whisper-cli binary (optional, searches PATH if not set)
+    /// Used when mode = "cli"
+    #[serde(default)]
+    pub whisper_cli_path: Option<String>,
 }
 
 impl WhisperConfig {
@@ -773,10 +781,12 @@ impl WhisperConfig {
                 match backend {
                     WhisperMode::Local => "local",
                     WhisperMode::Remote => "remote",
+                    WhisperMode::Cli => "cli",
                 },
                 match backend {
                     WhisperMode::Local => "local",
                     WhisperMode::Remote => "remote",
+                    WhisperMode::Cli => "cli",
                 }
             );
             return backend;
@@ -806,6 +816,7 @@ impl Default for WhisperConfig {
             remote_model: None,
             remote_api_key: None,
             remote_timeout_secs: None,
+            whisper_cli_path: None,
         }
     }
 }
@@ -1181,6 +1192,7 @@ impl Default for Config {
                 remote_model: None,
                 remote_api_key: None,
                 remote_timeout_secs: None,
+                whisper_cli_path: None,
             },
             output: OutputConfig {
                 mode: OutputMode::Type,

--- a/src/transcribe/cli.rs
+++ b/src/transcribe/cli.rs
@@ -1,0 +1,355 @@
+//! CLI-based speech-to-text transcription
+//!
+//! Uses whisper-cli (from whisper.cpp) as an external process for transcription.
+//! This is a fallback for systems where the whisper-rs FFI bindings don't work
+//! (e.g., Ubuntu 25.10 with glibc 2.42+).
+//!
+//! The whisper-cli binary must be installed separately or built from whisper.cpp.
+
+use super::Transcriber;
+use crate::config::{Config, WhisperConfig};
+use crate::error::TranscribeError;
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// CLI-based transcriber using whisper-cli subprocess
+pub struct CliTranscriber {
+    /// Path to whisper-cli binary
+    cli_path: PathBuf,
+    /// Path to model file
+    model_path: PathBuf,
+    /// Language for transcription
+    language: String,
+    /// Whether to translate to English
+    translate: bool,
+    /// Number of threads to use
+    threads: usize,
+    /// Initial prompt for context
+    initial_prompt: Option<String>,
+}
+
+/// JSON output structure from whisper-cli
+#[derive(Debug, Deserialize)]
+struct WhisperCliOutput {
+    transcription: Vec<Segment>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Segment {
+    text: String,
+}
+
+impl CliTranscriber {
+    /// Create a new CLI-based transcriber
+    pub fn new(config: &WhisperConfig) -> Result<Self, TranscribeError> {
+        let cli_path = resolve_cli_path(config.whisper_cli_path.as_deref())?;
+        let model_path = resolve_model_path(&config.model)?;
+
+        tracing::info!(
+            "Using whisper-cli backend: {:?} with model {:?}",
+            cli_path,
+            model_path
+        );
+
+        // Verify cli exists and is executable
+        if !cli_path.exists() {
+            return Err(TranscribeError::InitFailed(format!(
+                "whisper-cli not found at {:?}",
+                cli_path
+            )));
+        }
+
+        // threads = 0 or None means auto-detect, use a sensible default
+        let threads = match config.threads {
+            Some(0) | None => num_cpus::get().min(4),
+            Some(n) => n,
+        };
+
+        // Get language - use primary language from config
+        let language = config.language.primary().to_string();
+
+        Ok(Self {
+            cli_path,
+            model_path,
+            language,
+            translate: config.translate,
+            threads,
+            initial_prompt: config.initial_prompt.clone(),
+        })
+    }
+
+    /// Write audio samples to a temporary WAV file
+    fn write_temp_wav(&self, samples: &[f32]) -> Result<tempfile::NamedTempFile, TranscribeError> {
+        let temp_file = tempfile::Builder::new()
+            .prefix("voxtype_")
+            .suffix(".wav")
+            .tempfile()
+            .map_err(|e| {
+                TranscribeError::AudioFormat(format!("Failed to create temp file: {}", e))
+            })?;
+
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+
+        let mut writer = hound::WavWriter::create(temp_file.path(), spec).map_err(|e| {
+            TranscribeError::AudioFormat(format!("Failed to create WAV writer: {}", e))
+        })?;
+
+        for &sample in samples {
+            // Convert f32 [-1.0, 1.0] to i16
+            let clamped = sample.clamp(-1.0, 1.0);
+            let scaled = (clamped * 32767.0) as i16;
+            writer.write_sample(scaled).map_err(|e| {
+                TranscribeError::AudioFormat(format!("Failed to write sample: {}", e))
+            })?;
+        }
+
+        writer
+            .finalize()
+            .map_err(|e| TranscribeError::AudioFormat(format!("Failed to finalize WAV: {}", e)))?;
+
+        Ok(temp_file)
+    }
+}
+
+impl Transcriber for CliTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat(
+                "Empty audio buffer".to_string(),
+            ));
+        }
+
+        let duration_secs = samples.len() as f32 / 16000.0;
+        tracing::debug!(
+            "Transcribing {:.2}s of audio ({} samples) via whisper-cli",
+            duration_secs,
+            samples.len()
+        );
+
+        let start = std::time::Instant::now();
+
+        // Write audio to temp WAV file
+        let temp_wav = self.write_temp_wav(samples)?;
+
+        // Create temp file for JSON output
+        let temp_json = tempfile::Builder::new()
+            .prefix("voxtype_out_")
+            .suffix("") // whisper-cli adds .json
+            .tempfile()
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Failed to create temp file: {}", e))
+            })?;
+
+        let output_base = temp_json
+            .path()
+            .to_str()
+            .ok_or_else(|| TranscribeError::InferenceFailed("Invalid temp path".to_string()))?;
+
+        // Build command
+        let mut cmd = Command::new(&self.cli_path);
+        cmd.arg("--model")
+            .arg(&self.model_path)
+            .arg("--file")
+            .arg(temp_wav.path())
+            .arg("--output-json")
+            .arg("--output-file")
+            .arg(output_base)
+            .arg("--threads")
+            .arg(self.threads.to_string())
+            .arg("--no-prints"); // Suppress progress output
+
+        // Set language (skip if auto-detect)
+        if self.language != "auto" {
+            cmd.arg("--language").arg(&self.language);
+        }
+
+        // Translation
+        if self.translate {
+            cmd.arg("--translate");
+        }
+
+        // Initial prompt
+        if let Some(prompt) = &self.initial_prompt {
+            cmd.arg("--prompt").arg(prompt);
+        }
+
+        tracing::debug!("Running whisper-cli: {:?}", cmd);
+
+        // Run whisper-cli
+        let output = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Failed to run whisper-cli: {}", e))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(TranscribeError::InferenceFailed(format!(
+                "whisper-cli failed: {}",
+                stderr
+            )));
+        }
+
+        // Read JSON output
+        let json_path = format!("{}.json", output_base);
+        let json_content = std::fs::read_to_string(&json_path).map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Failed to read output: {}", e))
+        })?;
+
+        // Clean up JSON file
+        let _ = std::fs::remove_file(&json_path);
+
+        // Parse JSON
+        let result: WhisperCliOutput = serde_json::from_str(&json_content).map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Failed to parse JSON output: {}", e))
+        })?;
+
+        // Combine all segments
+        let text: String = result
+            .transcription
+            .iter()
+            .map(|s| s.text.trim())
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_string();
+
+        tracing::info!(
+            "Transcription completed in {:.2}s: {:?}",
+            start.elapsed().as_secs_f32(),
+            if text.chars().count() > 50 {
+                format!("{}...", text.chars().take(50).collect::<String>())
+            } else {
+                text.clone()
+            }
+        );
+
+        Ok(text)
+    }
+}
+
+/// Resolve whisper-cli path
+fn resolve_cli_path(configured_path: Option<&str>) -> Result<PathBuf, TranscribeError> {
+    // If explicitly configured, use that
+    if let Some(path) = configured_path {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Ok(p);
+        }
+        return Err(TranscribeError::InitFailed(format!(
+            "Configured whisper-cli path not found: {}",
+            path
+        )));
+    }
+
+    // Check common locations
+    let candidates = [
+        // In PATH
+        which::which("whisper-cli").ok(),
+        which::which("whisper").ok(),
+        // Local builds
+        Some(PathBuf::from("./whisper-cli")),
+        Some(PathBuf::from("./build/bin/whisper-cli")),
+        // System locations
+        Some(PathBuf::from("/usr/local/bin/whisper-cli")),
+        Some(PathBuf::from("/usr/bin/whisper-cli")),
+        // Home directory
+        directories::BaseDirs::new().map(|d| d.home_dir().join(".local/bin/whisper-cli")),
+    ];
+
+    for candidate in candidates.into_iter().flatten() {
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(TranscribeError::InitFailed(
+        "whisper-cli not found. Install from https://github.com/ggerganov/whisper.cpp or set whisper_cli_path in config.".to_string()
+    ))
+}
+
+/// Resolve model name to file path
+fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
+    // If it's already an absolute path, use it directly
+    let path = PathBuf::from(model);
+    if path.is_absolute() && path.exists() {
+        return Ok(path);
+    }
+
+    // Map model names to file names
+    let model_filename = match model {
+        "tiny" => "ggml-tiny.bin",
+        "tiny.en" => "ggml-tiny.en.bin",
+        "base" => "ggml-base.bin",
+        "base.en" => "ggml-base.en.bin",
+        "small" => "ggml-small.bin",
+        "small.en" => "ggml-small.en.bin",
+        "medium" => "ggml-medium.bin",
+        "medium.en" => "ggml-medium.en.bin",
+        "large" | "large-v1" => "ggml-large-v1.bin",
+        "large-v2" => "ggml-large-v2.bin",
+        "large-v3" => "ggml-large-v3.bin",
+        "large-v3-turbo" => "ggml-large-v3-turbo.bin",
+        other if other.ends_with(".bin") => other,
+        other => {
+            return Err(TranscribeError::ModelNotFound(format!(
+                "Unknown model: '{}'. Valid models: tiny, base, small, medium, large-v3, large-v3-turbo",
+                other
+            )));
+        }
+    };
+
+    // Look in the data directory
+    let models_dir = Config::models_dir();
+    let model_path = models_dir.join(model_filename);
+
+    if model_path.exists() {
+        return Ok(model_path);
+    }
+
+    // Also check current directory
+    let cwd_path = PathBuf::from(model_filename);
+    if cwd_path.exists() {
+        return Ok(cwd_path);
+    }
+
+    // Also check ./models/
+    let local_models_path = PathBuf::from("models").join(model_filename);
+    if local_models_path.exists() {
+        return Ok(local_models_path);
+    }
+
+    Err(TranscribeError::ModelNotFound(format!(
+        "Model '{}' not found. Looked in:\n  - {}\n  - {}\n  - {}",
+        model,
+        model_path.display(),
+        cwd_path.display(),
+        local_models_path.display()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_cli_not_found() {
+        // Should fail gracefully when whisper-cli is not installed
+        let result = resolve_cli_path(Some("/nonexistent/whisper-cli"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_model_path_unknown() {
+        let result = resolve_model_path("nonexistent-model");
+        assert!(result.is_err());
+    }
+}

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -3,9 +3,11 @@
 //! Provides transcription via:
 //! - Local whisper.cpp inference (whisper-rs crate)
 //! - Remote OpenAI-compatible Whisper API (whisper.cpp server, OpenAI, etc.)
+//! - CLI subprocess using whisper-cli (fallback for glibc 2.42+ compatibility)
 //! - Subprocess isolation for GPU memory release
 //! - Optionally NVIDIA Parakeet via ONNX Runtime (when `parakeet` feature is enabled)
 
+pub mod cli;
 pub mod remote;
 pub mod subprocess;
 pub mod whisper;
@@ -88,6 +90,10 @@ pub fn create_transcriber_with_config_path(
         WhisperMode::Remote => {
             tracing::info!("Using remote whisper transcription mode");
             Ok(Box::new(remote::RemoteTranscriber::new(config)?))
+        }
+        WhisperMode::Cli => {
+            tracing::info!("Using whisper-cli subprocess backend");
+            Ok(Box::new(cli::CliTranscriber::new(config)?))
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `cli` backend option that uses `whisper-cli` (from whisper.cpp) as a subprocess for transcription. This is a workaround for systems where the whisper-rs FFI bindings crash due to C++ exceptions crossing the FFI boundary.

- New `WhisperMode::Cli` variant
- New `whisper_cli_path` config option
- New `CliTranscriber` implementation that writes audio to temp WAV, runs whisper-cli with `--output-json`, and parses results
- Handles `threads = 0` as auto-detect

Fixes #30

## Configuration

```toml
[whisper]
backend = "cli"
whisper_cli_path = "/path/to/whisper-cli"  # optional, searches PATH
```

## Why use CLI backend?

- **glibc 2.42+ systems**: Ubuntu 25.10 and similar distros experience crashes due to C++ exceptions crossing the FFI boundary. whisper.cpp works fine when run as a standalone binary.
- **Custom whisper.cpp builds**: Use a whisper-cli compiled with specific optimizations
- **Debugging**: Easier to isolate transcription issues

## Test plan

- [x] `cargo test` passes (233 tests)
- [x] `cargo clippy` clean (no new warnings)
- [ ] Manual test with whisper-cli installed
- [ ] Test on system with glibc 2.42+

## Credits

Based on PR #77 by @ayoahha - thank you for the original implementation!