### PR TITLE
Disable context_window_optimization by default

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -94,10 +94,11 @@ on_demand_loading = false
 # Enable on laptops with hybrid graphics to let dGPU sleep between transcriptions.
 # gpu_isolation = true
 
-# Context window optimization for short recordings (enabled by default)
-# Speeds up transcription for clips under 22.5 seconds. Disable only if you
-# experience accuracy issues with short recordings (rare).
-# context_window_optimization = false
+# Context window optimization for short recordings (disabled by default)
+# Speeds up transcription for clips under 22.5 seconds. Disabled by default
+# because some models (especially large-v3/turbo) may experience repetition
+# loops. Enable if you want faster transcription and don't experience issues.
+# context_window_optimization = true
 
 # --- Remote mode settings (used when mode = "remote") ---
 # remote_endpoint = "http://192.168.1.100:8080"  # Required

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -539,14 +539,14 @@ gpu_isolation = true  # Release GPU memory between transcriptions
 ### context_window_optimization
 
 **Type:** Boolean
-**Default:** `true`
+**Default:** `false`
 **Required:** No
 
-Optimizes Whisper's context window size for short recordings. When enabled, clips under 22.5 seconds use a smaller context window proportional to their length, significantly speeding up transcription.
+Optimizes Whisper's context window size for short recordings. When enabled, clips under 22.5 seconds use a smaller context window proportional to their length, speeding up transcription. Also sets `no_context=true` to prevent phrase repetition.
 
 **Values:**
-- `true` (default) - Use optimized context window for short clips. Faster transcription.
-- `false` - Always use Whisper's full 30-second context window (1500 tokens).
+- `false` (default) - Use Whisper's full 30-second context window (1500 tokens). Most compatible.
+- `true` - Use optimized context window for short clips. Faster but may cause issues with some models.
 
 **Performance impact:**
 
@@ -557,23 +557,26 @@ Optimizes Whisper's context window size for short recordings. When enabled, clip
 
 The optimization provides roughly 1.6-1.9x speedup for short recordings on both CPU and GPU.
 
-**When to disable (`false`):**
-- You experience transcription quality issues with short clips (rare)
-- Debugging transcription problems and want to rule out this optimization
-- Testing or benchmarking against default Whisper behavior
+**When to enable (`true`):**
+- You want faster transcription for short clips
+- Your model doesn't exhibit repetition issues (test before enabling)
+- You're using smaller models (tiny, base, small) which are more stable
 
-Most users should leave this enabled. The optimization has been tested extensively and should not affect transcription quality.
+**When to keep disabled (`false`):**
+- You use large-v3 or large-v3-turbo models (known repetition issues)
+- You experience phrase repetition like "word word word"
+- You want maximum compatibility across all models
 
 **Example:**
 ```toml
 [whisper]
-model = "large-v3-turbo"
-context_window_optimization = false  # Use full context window (not recommended)
+model = "base.en"
+context_window_optimization = true  # Enable for faster transcription
 ```
 
 **CLI override:**
 ```bash
-voxtype --no-whisper-context-optimization daemon
+voxtype --whisper-context-optimization daemon
 ```
 
 **Note:** This setting only applies when using the local whisper backend (`backend = "local"`). It has no effect with remote transcription.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -251,21 +251,23 @@ model = "base.en"  # For English
 language = "en"
 ```
 
-#### 4. Context window optimization (rare)
+#### 4. Context window optimization
 
-If you experience accuracy issues specifically with short recordings, try disabling context window optimization:
+Context window optimization is disabled by default because it can cause phrase repetition with some models (especially large-v3 and large-v3-turbo).
+
+If you want faster transcription and your model works well with it, you can enable it:
 
 ```toml
 [whisper]
-context_window_optimization = false
+context_window_optimization = true
 ```
 
 Or via command line:
 ```bash
-voxtype --no-whisper-context-optimization daemon
+voxtype --whisper-context-optimization daemon
 ```
 
-This is rarely needed. The optimization speeds up transcription for short clips and should not affect quality. Only try this if other solutions don't help and the issue is specific to short recordings.
+If you experience phrase repetition (e.g., "word word word"), make sure this setting is disabled (the default).
 
 ### Transcription includes "[BLANK_AUDIO]" or similar
 
@@ -284,6 +286,21 @@ This is rarely needed. The optimization speeds up transcription for short clips 
 1. Use a larger model for better accuracy
 2. Avoid recording ambient noise
 3. Keep recordings short and speech-focused
+
+### Phrase repetition (same words repeated multiple times)
+
+**Cause:** Known issue with Whisper large-v3 models, especially when context window optimization is enabled.
+
+**Example:** Saying "increase the limit" produces "increase the limit increase the limit increase the limit"
+
+**Solutions:**
+1. Ensure `context_window_optimization` is disabled (the default):
+   ```toml
+   [whisper]
+   context_window_optimization = false
+   ```
+2. Try a different model (large-v3-turbo and large-v3 are most affected)
+3. If using context optimization and experiencing issues, disable it
 
 ---
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -378,7 +378,7 @@ fn default_on_demand_loading() -> bool {
 }
 
 fn default_context_window_optimization() -> bool {
-    true
+    false
 }
 
 fn default_max_loaded_models() -> usize {
@@ -1750,14 +1750,15 @@ mod tests {
     }
 
     #[test]
-    fn test_context_window_optimization_default_true() {
-        // Default config should have context_window_optimization enabled
+    fn test_context_window_optimization_default_false() {
+        // Default config should have context_window_optimization disabled
+        // (disabled by default due to repetition issues with some models)
         let config = Config::default();
-        assert!(config.whisper.context_window_optimization);
+        assert!(!config.whisper.context_window_optimization);
     }
 
     #[test]
-    fn test_context_window_optimization_can_be_disabled() {
+    fn test_context_window_optimization_can_be_enabled() {
         let toml_str = r#"
             [hotkey]
             key = "SCROLLLOCK"
@@ -1770,7 +1771,32 @@ mod tests {
             [whisper]
             model = "base.en"
             language = "en"
-            context_window_optimization = false
+            context_window_optimization = true
+
+            [output]
+            mode = "type"
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.whisper.context_window_optimization);
+    }
+
+    #[test]
+    fn test_context_window_optimization_defaults_when_omitted() {
+        // When not specified in config, should default to false
+        // (disabled by default due to repetition issues with some models)
+        let toml_str = r#"
+            [hotkey]
+            key = "SCROLLLOCK"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = "en"
 
             [output]
             mode = "type"
@@ -1778,30 +1804,6 @@ mod tests {
 
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(!config.whisper.context_window_optimization);
-    }
-
-    #[test]
-    fn test_context_window_optimization_defaults_when_omitted() {
-        // When not specified in config, should default to true
-        let toml_str = r#"
-            [hotkey]
-            key = "SCROLLLOCK"
-
-            [audio]
-            device = "default"
-            sample_rate = 16000
-            max_duration_secs = 60
-
-            [whisper]
-            model = "base.en"
-            language = "en"
-
-            [output]
-            mode = "type"
-        "#;
-
-        let config: Config = toml::from_str(toml_str).unwrap();
-        assert!(config.whisper.context_window_optimization);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Disable `context_window_optimization` by default to prevent phrase repetition
- Add `no_context=true` when optimization is enabled (fix from PR #116)
- Use more conservative formula with minimum threshold and GPU alignment

## Problem
Some Whisper models (especially large-v3 and large-v3-turbo) experience phrase repetition loops when context window optimization is enabled. Users report output like "word word word" when saying something once.

## Solution
1. **Default to disabled** - Maximum compatibility out of the box
2. **Safer when enabled** - When users opt-in, the optimization now includes:
   - `no_context=true` to prevent text conditioning loops
   - Minimum 384 frame threshold (~7.7s context) to avoid instability
   - Alignment to multiple of 8 for GPU backend compatibility (Metal, Vulkan)
   - Increased padding (128 vs 64 frames)

## Test plan
- [x] All 232 tests pass
- [x] Verified new default behavior in config tests
- [x] Verified audio_ctx calculations with new formula
- [x] Verified alignment to multiple of 8

Closes #124

Co-authored-by: Christopher Albert <albert@alumni.tugraz.at>