### PR TITLE
Clarify ydotool setup for Fedora (system service)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -346,9 +346,11 @@ sudo pacman -S ydotool
 # Ubuntu:
 sudo apt install ydotool
 
-# Enable and start the daemon
+# Enable and start the daemon (Arch)
 systemctl --user enable --now ydotool
 ```
+
+> **Note (Fedora):** Fedora's ydotool uses a system service that requires additional configuration. See [Troubleshooting - ydotool daemon not running](TROUBLESHOOTING.md#ydotool-daemon-not-running) for Fedora-specific setup.
 
 **On KDE Plasma or GNOME (Wayland):** wtype does not work on these desktops because they don't support the virtual keyboard protocol. Install dotool (recommended) or use ydotool:
 
@@ -364,7 +366,8 @@ For ydotool:
 ```bash
 # Install ydotool (see commands above for your distro)
 # Then enable and start the daemon (required!)
-systemctl --user enable --now ydotool
+systemctl --user enable --now ydotool  # Arch
+# For Fedora, see Troubleshooting guide for system service setup
 ```
 
 Voxtype uses wtype on Wayland (no daemon needed), with dotool and ydotool as fallbacks, and clipboard as the last resort. On KDE/GNOME Wayland, wtype will fail and voxtype will use dotool or ydotool.


### PR DESCRIPTION
## Summary

- Expands ydotool troubleshooting section with distribution-specific instructions
- Documents Fedora's system service setup with socket configuration
- Adds note to INSTALL.md directing Fedora users to troubleshooting guide

## Context

Issue #128 reported that Fedora's ydotool package provides a system-level service (`/usr/lib/systemd/system/ydotool.service`) rather than a user service. This requires additional configuration to allow non-root users to access the socket.

The existing docs assumed `systemctl --user enable --now ydotool` would work everywhere, which is misleading for Fedora users.

## Changes

**TROUBLESHOOTING.md:**
- Added Arch Linux section (user service - existing behavior)
- Added Fedora section with `systemctl edit` instructions for socket configuration
- Added Ubuntu/Debian section with guidance on checking which service type exists
- Added verification step

**INSTALL.md:**
- Added note pointing Fedora users to the troubleshooting guide

## Test plan

- [x] Verify instructions match the reporter's solution in #128

Closes #128