### PR TITLE
Add parakeet builds to nix flake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1093,6 +1093,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1573,7 @@ version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
 dependencies = [
+ "libloading 0.9.0",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,8 @@ parakeet = ["dep:parakeet-rs"]
 parakeet-cuda = ["parakeet", "parakeet-rs/cuda"]
 parakeet-tensorrt = ["parakeet", "parakeet-rs/tensorrt"]
 parakeet-rocm = ["parakeet", "parakeet-rs/rocm"]
+# Dynamic loading for system ONNX Runtime (used by Nix builds)
+parakeet-load-dynamic = ["parakeet", "parakeet-rs/load-dynamic"]
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Add `parakeet`, `parakeet-cuda`, and `parakeet-rocm` package variants to flake.nix
- Add `parakeet-load-dynamic` feature to Cargo.toml for nix builds
- Update flake version to 0.5.0

## Implementation

Uses the `load-dynamic` feature from `parakeet-rs` to load system ONNX Runtime at runtime via `ORT_DYLIB_PATH` environment variable. This avoids bundling ONNX Runtime binaries that may contain incompatible CPU instructions.

The wrapper sets:
```nix
--set ORT_DYLIB_PATH "${pkgs.onnxruntime}/lib/libonnxruntime.so"
```

## New packages

| Package | Description |
|---------|-------------|
| `parakeet` | CPU-only parakeet using system ONNX Runtime |
| `parakeet-cuda` | NVIDIA GPU acceleration via CUDA |
| `parakeet-rocm` | AMD GPU acceleration via ROCm |

## Usage

```bash
# Install parakeet variant
nix profile install github:peteonrails/voxtype#parakeet

# Or with CUDA
nix profile install github:peteonrails/voxtype#parakeet-cuda
```

## Test plan
- [x] `cargo check --features parakeet-load-dynamic` compiles
- [x] All 234 tests pass
- [ ] Build tested on NixOS (needs NixOS user to verify)

Closes #125