### PR TITLE
Add Parakeet support to Home Manager module

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -258,6 +258,7 @@ pub enum ActivationMode {
 pub struct Config {
     pub hotkey: HotkeyConfig,
     pub audio: AudioConfig,
+    #[serde(default)]
     pub whisper: WhisperConfig,
     pub output: OutputConfig,
 
@@ -2323,6 +2324,30 @@ mod tests {
     fn test_parakeet_model_type_enum_default() {
         // ParakeetModelType defaults to Tdt
         assert_eq!(ParakeetModelType::default(), ParakeetModelType::Tdt);
+    }
+
+    #[test]
+    fn test_whisper_section_is_optional() {
+        // The [whisper] section should be optional for Parakeet users
+        // See: https://github.com/peteonrails/voxtype/issues/137
+        //
+        // We test this by deserializing into a struct that mirrors Config
+        // but only has the fields we want to test (avoiding all required fields)
+        #[derive(Debug, Deserialize)]
+        struct PartialConfig {
+            engine: TranscriptionEngine,
+            #[serde(default)]
+            whisper: WhisperConfig,
+        }
+
+        let toml = r#"
+            engine = "parakeet"
+        "#;
+
+        let config: PartialConfig =
+            toml::from_str(toml).expect("whisper section should be optional");
+        assert_eq!(config.engine, TranscriptionEngine::Parakeet);
+        assert_eq!(config.whisper.model, "base.en"); // Default value
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `engine` option to select `whisper` or `parakeet`
- Make `model.name` default to `null` (was `"base.en"`)
- Generate config with engine-appropriate section (`[whisper]` or `[parakeet]`)
- Add assertion preventing `model.name` with parakeet engine
- Make `[whisper]` config section optional via `#[serde(default)]`
- Update package descriptions to include Parakeet variants

## Problem

The Home Manager module only supported Whisper:
1. `model.name` defaulted to `"base.en"` (a Whisper model)
2. Config always generated `whisper.model = ...`
3. The Rust config required a `[whisper]` section even when using Parakeet

This caused errors like:
```
missing field `whisper`
```

## Solution

Add an `engine` option and make the module engine-aware:

```nix
programs.voxtype = {
  enable = true;
  engine = "parakeet";
  package = voxtype.packages.${system}.parakeet-cuda;
  model.path = "/path/to/parakeet-tdt-1.1b";
  service.enable = true;
};
```

The Rust config change (`#[serde(default)]` on `whisper` field) allows configs without a `[whisper]` section to parse successfully.

Fixes #137

## Test plan

- [x] `cargo test` passes (including new test for optional whisper section)
- [ ] Test Parakeet config generation on NixOS
- [ ] Verify Whisper configs still work (backwards compatible)