### PR TITLE
use migraphx instead of rocm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,9 +1723,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "libloading 0.9.0",
  "ndarray 0.17.1",
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
@@ -1748,15 +1748,15 @@ dependencies = [
 
 [[package]]
 name = "parakeet-rs"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbd5310b3d9a1d8ab59369a2e6dd20511f46a81de08f5aaca0ba811059c2c93"
+checksum = "ac2c29bb70e3b63ddfa9af7cbb66f87a200550a5f6a5ac82fabf527b270c6615"
 dependencies = [
  "eyre",
  "hound",
  "ndarray 0.17.1",
  "ort",
- "rustfft",
+ "realfft",
  "serde",
  "serde_json",
  "tokenizers 0.22.2",
@@ -2025,6 +2025,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,10 +67,10 @@ rodio = { version = "0.19", default-features = false, features = ["wav"] }
 whisper-rs = "0.16.0"
 
 # Parakeet speech-to-text (optional, ONNX-based)
-parakeet-rs = { version = "0.3", optional = true }
+parakeet-rs = { version = "^0.3.4", optional = true }
 
 # ONNX-based ASR engines (Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual)
-ort = { version = "2.0.0-rc.11", optional = true }
+ort = { version = "2.0.0-rc.12", optional = true }
 ndarray = { version = "0.16", optional = true }
 tokenizers = { version = "0.20", optional = true, default-features = false, features = ["onig"] }
 rustfft = { version = "6", optional = true }
@@ -101,7 +101,7 @@ ml-diarization = ["dep:ort", "dep:ndarray"]
 parakeet = ["dep:parakeet-rs"]
 parakeet-cuda = ["parakeet", "parakeet-rs/cuda"]
 parakeet-tensorrt = ["parakeet", "parakeet-rs/tensorrt"]
-parakeet-rocm = ["parakeet", "parakeet-rs/rocm"]
+parakeet-rocm = ["parakeet", "parakeet-rs/migraphx"]
 # Dynamic loading for system ONNX Runtime (used by Nix builds)
 parakeet-load-dynamic = ["parakeet", "parakeet-rs/load-dynamic"]
 # Shared ONNX dependencies for engines using fbank/CTC preprocessing

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767767207,
-        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
         # Wrap an ONNX package with runtime dependencies and ORT_DYLIB_PATH
         # ONNX engines need ONNX Runtime at runtime for inference
         libExt = if pkgs.stdenv.isDarwin then "dylib" else "so";
-        wrapOnnx = { onnxruntime ? pkgs.onnxruntime, pkg }: pkgs.symlinkJoin {
+        wrapOnnx = { onnxruntime ? pkgs.onnxruntime, pkg, extraWrapperArgs ? "" }: pkgs.symlinkJoin {
           name = "${pkg.pname or "voxtype"}-wrapped-${pkg.version}";
           paths = [ pkg ];
           buildInputs = [ pkgs.makeWrapper ];
@@ -101,10 +101,20 @@
             wrapProgram $out/bin/voxtype \
               --prefix PATH : ${pkgs.lib.makeBinPath runtimeDeps} \
               --set ORT_DYLIB_PATH "${onnxruntime}/lib/libonnxruntime.${libExt}" \
-              --prefix LD_LIBRARY_PATH : "${onnxruntime}/lib"
+              --prefix LD_LIBRARY_PATH : "${onnxruntime}/lib" \
+              ${extraWrapperArgs}
           '';
           inherit (pkg) meta;
         };
+
+        # Extra wrapper args for MIGraphX (ROCm) to set cache directory
+        migraphxWrapperArgs = ''
+          --run '
+            : "''${ORT_MIGRAPHX_MODEL_CACHE_PATH:=''${XDG_CACHE_HOME:-$HOME/.cache}/voxtype/migraphx}"
+            export ORT_MIGRAPHX_MODEL_CACHE_PATH
+            mkdir -p "$ORT_MIGRAPHX_MODEL_CACHE_PATH"
+          '
+        '';
 
         # ONNX Runtime variants for different GPU backends
         onnxruntimeCuda = pkgsUnfree.onnxruntime.override { cudaSupport = true; };
@@ -284,12 +294,12 @@
           # Paraformer, Dolphin, Omnilingual)
           onnx = wrapOnnx { pkg = onnxUnwrapped; };
           onnx-cuda = wrapOnnx { onnxruntime = onnxruntimeCuda; pkg = onnxCudaUnwrapped; };
-          onnx-rocm = wrapOnnx { onnxruntime = onnxruntimeRocm; pkg = onnxRocmUnwrapped; };
+          onnx-rocm = wrapOnnx { onnxruntime = onnxruntimeRocm; pkg = onnxRocmUnwrapped; extraWrapperArgs = migraphxWrapperArgs; };
 
           # Backwards-compatible aliases (parakeet → onnx)
           parakeet = wrapOnnx { pkg = onnxUnwrapped; };
           parakeet-cuda = wrapOnnx { onnxruntime = onnxruntimeCuda; pkg = onnxCudaUnwrapped; };
-          parakeet-rocm = wrapOnnx { onnxruntime = onnxruntimeRocm; pkg = onnxRocmUnwrapped; };
+          parakeet-rocm = wrapOnnx { onnxruntime = onnxruntimeRocm; pkg = onnxRocmUnwrapped; extraWrapperArgs = migraphxWrapperArgs; };
 
           # Unwrapped packages (for custom wrapping scenarios)
           voxtype-unwrapped = mkVoxtypeUnwrapped {};

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -196,7 +196,7 @@ fn build_execution_config() -> Option<ExecutionConfig> {
     #[cfg(feature = "parakeet-rocm")]
     {
         tracing::info!("Configuring ROCm execution provider for AMD GPU acceleration");
-        return Some(ExecutionConfig::new().with_execution_provider(ExecutionProvider::ROCm));
+        return Some(ExecutionConfig::new().with_execution_provider(ExecutionProvider::MIGraphX));
     }
 
     #[cfg(not(any(

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -195,7 +195,7 @@ fn build_execution_config() -> Option<ExecutionConfig> {
 
     #[cfg(feature = "parakeet-rocm")]
     {
-        tracing::info!("Configuring ROCm execution provider for AMD GPU acceleration");
+        tracing::info!("Configuring MIGraphX execution provider for AMD GPU acceleration");
         return Some(ExecutionConfig::new().with_execution_provider(ExecutionProvider::MIGraphX));
     }
 


### PR DESCRIPTION
Uses the latest unreleased `parakeet-rs` to replace deprecated rocm with migraphx. The `voxtype` codebase still refers to rocm rather than migraphx. Unfortunately I couldn't get this to work:

```
❯ ./result/bin/voxtype daemon
2026-01-28T14:33:38.479248Z  INFO Starting voxtype daemon
2026-01-28T14:33:38.479301Z  WARN Removing stale pid file at /run/user/1000/voxtype/voxtype.lock
2026-01-28T14:33:38.479318Z  INFO Output mode: Type
2026-01-28T14:33:38.479321Z  INFO State file: "/run/user/1000/voxtype/state"
2026-01-28T14:33:38.479323Z  INFO Built-in hotkey disabled, use 'voxtype record' commands or compositor keybindings
2026-01-28T14:33:38.479693Z  INFO Loading transcription model: parakeet-tdt-0.6b-v3
2026-01-28T14:33:38.479729Z  INFO Loading Parakeet Tdt model from "/home/user/.local/share/voxtype/models/parakeet-tdt-0.6b-v3"
2026-01-28T14:33:38.479736Z  INFO Configuring ROCm execution provider for AMD GPU acceleration
2026-01-28T14:33:38.537252Z ERROR An error occurred when attempting to register `MIGraphXExecutionProvider`: /build/source/include/onnxruntime/core/framework/provider_options_utils.h:41 std::string onnxruntime::EnumToName(EnumNameMapping<TEnum>&, TEnum) [with TEnum = ArenaExtendStrategy; std::string = std::__cxx11::basic_string<char>; EnumNameMapping<TEnum> = std::vector<std::pair<ArenaExtendStrategy, std::__cxx11::basic_string<char> >, std::allocator<std::pair<ArenaExtendStrategy, std::__cxx11::basic_string<char> > > >] [ONNXRuntimeError] : 1 : FAIL : provider_options_utils.h:31 EnumToName Failed to map enum value to name: 1084772928
 source=session options
2026-01-28T14:33:39.514144Z ERROR An error occurred when attempting to register `MIGraphXExecutionProvider`: /build/source/include/onnxruntime/core/framework/provider_options_utils.h:41 std::string onnxruntime::EnumToName(EnumNameMapping<TEnum>&, TEnum) [with TEnum = ArenaExtendStrategy; std::string = std::__cxx11::basic_string<char>; EnumNameMapping<TEnum> = std::vector<std::pair<ArenaExtendStrategy, std::__cxx11::basic_string<char> >, std::allocator<std::pair<ArenaExtendStrategy, std::__cxx11::basic_string<char> > > >] [ONNXRuntimeError] : 1 : FAIL : provider_options_utils.h:31 EnumToName Failed to map enum value to name: 1084772928
 source=session options
2026-01-28T14:33:39.549346Z  INFO Parakeet Tdt model loaded in 1.07s
2026-01-28T14:33:39.549361Z  INFO Model loaded, ready for voice input
```