### PR TITLE
v0.5.1: ROCm support, CLI backend fix, smoke tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxtype"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "voxtype"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Peter Jackson", "Jean-Paul van Tillo", "Máté Rémiás", "Rob Zolkos", "Dan Heuckeroth", "Igor Warzocha", "Julian Kaiser", "Kevin Miller", "konnsim", "reisset", "Zubair"]
 description = "Push-to-talk voice-to-text for Wayland"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ COMMANDS:
 EXAMPLES:
   voxtype setup model      Interactive model selection (Whisper or Parakeet)
   voxtype setup waybar     Show Waybar integration config
-  voxtype setup gpu        Manage GPU acceleration (Vulkan)
+  voxtype setup gpu        Manage GPU acceleration (Vulkan/CUDA/ROCm)
   voxtype setup parakeet   Switch between Whisper and Parakeet engines
   voxtype status --follow --format json   Waybar integration
 
@@ -405,9 +405,9 @@ pub enum SetupAction {
         restart: bool,
     },
 
-    /// Manage GPU acceleration (switch between CPU and Vulkan backends)
+    /// Manage GPU acceleration (Vulkan for Whisper, CUDA/ROCm for Parakeet)
     Gpu {
-        /// Enable GPU (Vulkan) acceleration
+        /// Enable GPU acceleration (auto-detects best backend)
         #[arg(long)]
         enable: bool,
 


### PR DESCRIPTION
## Summary

- **ROCm GPU support for Parakeet** - Auto-detects AMD GPUs and enables ROCm acceleration
- **CLI backend fix** - `mode = "cli"` now correctly skips model preloading
- **Dual symlink location support** - GPU setup works with both `/usr/bin/voxtype` and `/usr/local/bin/voxtype`
- **Smoke tests for v0.5.1 features** - Added test procedures for Parakeet engine switching
- **README updates** - Architecture diagram shows multiple backends, added recent contributors

## Commits

- Add ROCm support and dual symlink locations to GPU setup
- Update README architecture diagram and contributors
- Fix CLI backend: skip model preload and use CLI transcriber
- Add smoke tests for v0.5.1 features
- Bump version to 0.5.1
- Merge PR #139: fix parakeet transcription when on-demand loading is disabled
- Fix Nix flake CUDA build for consumer flakes

## Test plan

- [x] `voxtype setup gpu` shows correct status for Whisper backends
- [x] `voxtype setup gpu` shows correct status for Parakeet backends (AVX2, AVX-512, CUDA, ROCm)
- [x] `voxtype setup gpu --enable` switches to Vulkan for Whisper
- [x] `voxtype setup gpu --enable` switches to ROCm for Parakeet on AMD GPU
- [x] `voxtype setup gpu --disable` switches back to best CPU backend
- [x] Parakeet ROCm transcription works (0.07s for 2.9s audio)
- [x] CLI backend mode skips model preloading