### PR TITLE
Add eager input processing (#70)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -593,6 +593,100 @@ voxtype --whisper-context-optimization daemon
 
 **Note:** This setting only applies when using the local whisper backend (`backend = "local"`). It has no effect with remote transcription.
 
+### eager_processing
+
+**Type:** Boolean
+**Default:** `false`
+**Required:** No
+
+Enable eager input processing. When enabled, audio is split into chunks and transcribed in parallel with continued recording, reducing perceived latency on slower machines.
+
+**Values:**
+- `false` (default) - Traditional mode: record all audio, then transcribe
+- `true` - Eager mode: transcribe chunks while recording continues
+
+**How it works:**
+
+1. While recording, audio is split into fixed-size chunks (default 5 seconds)
+2. Each chunk is sent for transcription as soon as it's ready
+3. Recording continues while earlier chunks are being transcribed
+4. When recording stops, all chunk results are combined
+
+**When to use eager processing:**
+- You have a slower CPU where transcription takes several seconds
+- You regularly dictate longer passages (10+ seconds)
+- You want to minimize the delay between speaking and text output
+
+**When to keep default (`false`):**
+- You have a fast CPU or GPU acceleration
+- Your recordings are typically short (under 5 seconds)
+- You want maximum transcription accuracy (single-pass is more consistent)
+
+**Example:**
+```toml
+[whisper]
+model = "base.en"
+eager_processing = true
+eager_chunk_secs = 5.0    # 5 second chunks
+eager_overlap_secs = 0.5  # 0.5 second overlap
+```
+
+**CLI override:**
+```bash
+voxtype --eager-processing daemon
+```
+
+**Note:** Eager processing is experimental. There may be occasional word duplications or omissions at chunk boundaries.
+
+### eager_chunk_secs
+
+**Type:** Float
+**Default:** `5.0`
+**Required:** No
+
+Duration of each audio chunk in seconds when eager processing is enabled.
+
+**Example:**
+```toml
+[whisper]
+eager_processing = true
+eager_chunk_secs = 3.0  # Shorter chunks for faster feedback
+```
+
+**CLI override:**
+```bash
+voxtype --eager-processing --eager-chunk-secs 3.0 daemon
+```
+
+**Trade-offs:**
+- Shorter chunks: Faster feedback, but more boundary artifacts
+- Longer chunks: Better accuracy, but less parallelism benefit
+
+### eager_overlap_secs
+
+**Type:** Float
+**Default:** `0.5`
+**Required:** No
+
+Overlap duration in seconds between adjacent chunks when eager processing is enabled. Overlap helps catch words that span chunk boundaries.
+
+**Example:**
+```toml
+[whisper]
+eager_processing = true
+eager_chunk_secs = 5.0
+eager_overlap_secs = 1.0  # More overlap for better boundary handling
+```
+
+**CLI override:**
+```bash
+voxtype --eager-processing --eager-overlap-secs 1.0 daemon
+```
+
+**Trade-offs:**
+- More overlap: Better word boundary handling, slightly more processing
+- Less overlap: Faster processing, but may miss words at boundaries
+
 ### initial_prompt
 
 **Type:** String

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -17,6 +17,7 @@ Voxtype is a push-to-talk voice-to-text tool for Linux. Optimized for Wayland, w
 - [Whisper Models](#whisper-models)
 - [Remote Whisper Servers](#remote-whisper-servers)
 - [CLI Backend (whisper-cli)](#cli-backend-whisper-cli)
+- [Eager Processing](#eager-processing)
 - [Output Modes](#output-modes)
 - [Post-Processing with LLMs](#post-processing-with-llms)
 - [Profiles](#profiles)
@@ -935,6 +936,107 @@ This adds minimal overhead compared to the FFI approach since file I/O is fast o
 - Slightly higher latency than FFI (file I/O overhead)
 - Requires separate whisper-cli installation
 - No GPU isolation mode (whisper-cli manages its own GPU memory)
+
+---
+
+## Eager Processing
+
+Eager processing transcribes audio in chunks while you're still recording. Instead of waiting until you release the hotkey to start transcription, voxtype begins processing audio in the background as you speak. When you stop recording, the final chunk is transcribed and all results are combined.
+
+### When to Use Eager Processing
+
+Eager processing is most valuable when:
+
+1. **You have slow transcription hardware**: On machines where transcription takes longer than the recording itself, eager processing parallelizes the work to reduce overall wait time.
+
+2. **You make long recordings**: For recordings over 15-30 seconds, starting transcription early means less waiting when you're done speaking.
+
+3. **You use large models**: Larger Whisper models (medium, large-v3) are slower. Eager processing helps hide some of that latency.
+
+**Not recommended when:**
+- You use fast models (tiny, base) on modern hardware with GPU acceleration
+- Your recordings are typically short (under 5 seconds)
+- You're on a laptop and want to minimize battery usage
+
+### How It Works
+
+With eager processing enabled:
+
+1. Audio accumulates as you record
+2. Every `eager_chunk_secs` (default: 5 seconds), a chunk is extracted and sent for transcription
+3. Chunks overlap by `eager_overlap_secs` (default: 0.5 seconds) to avoid missing words at boundaries
+4. When you stop recording, all chunk results are combined and deduplicated
+5. The final text is output
+
+The overlap region helps catch words that might be split across chunk boundaries. The deduplication logic matches overlapping text to produce a clean result.
+
+### Configuration
+
+Enable eager processing in `~/.config/voxtype/config.toml`:
+
+```toml
+[whisper]
+model = "medium.en"
+
+# Enable eager input processing
+eager_processing = true
+
+# Chunk duration (default: 5.0 seconds)
+eager_chunk_secs = 5.0
+
+# Overlap between chunks (default: 0.5 seconds)
+eager_overlap_secs = 0.5
+```
+
+Or via CLI flags:
+
+```bash
+voxtype --eager-processing --eager-chunk-secs 5.0 daemon
+```
+
+### Tuning Chunk Size
+
+The chunk duration affects the trade-off between parallelization and overhead:
+
+| Chunk Size | Pros | Cons |
+|------------|------|------|
+| 3 seconds | More parallelization, faster for slow models | More boundary handling, slightly higher CPU |
+| 5 seconds | Good balance for most cases | - |
+| 10 seconds | Fewer chunks to combine | Less parallelization benefit |
+
+For testing, try `eager_chunk_secs = 3.0` to see more chunk messages in the logs.
+
+### Trade-offs
+
+**Benefits:**
+- Reduced perceived latency on slow hardware
+- Better experience for long recordings
+- Parallelizes transcription work across recording time
+
+**Limitations:**
+- Boundary handling may occasionally produce artifacts (repeated or dropped words at chunk edges)
+- Slightly higher CPU usage during recording
+- Adds complexity to the transcription pipeline
+
+For most users with modern hardware and GPU acceleration, the default (disabled) provides the cleanest results. Enable eager processing when latency is a problem that outweighs the small risk of boundary artifacts.
+
+### Verifying It Works
+
+Run voxtype with verbose logging:
+
+```bash
+voxtype -vv
+```
+
+Then record for 10+ seconds. You should see log messages like:
+
+```
+[DEBUG] Spawning eager transcription for chunk 0
+[DEBUG] Spawning eager transcription for chunk 1
+[DEBUG] Chunk 0 completed: "This is the first part of my recording"
+[DEBUG] Chunk 1 completed: "the first part of my recording and here is more"
+[DEBUG] Combined eager chunks with deduplication
+```
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,18 @@ pub struct Cli {
     #[arg(long, value_name = "PROMPT")]
     pub initial_prompt: Option<String>,
 
+    /// Enable eager input processing (transcribe chunks while recording continues)
+    #[arg(long)]
+    pub eager_processing: bool,
+
+    /// Chunk duration in seconds for eager processing (default: 5.0)
+    #[arg(long, value_name = "SECS")]
+    pub eager_chunk_secs: Option<f32>,
+
+    /// Overlap between chunks in seconds for eager processing (default: 0.5)
+    #[arg(long, value_name = "SECS")]
+    pub eager_overlap_secs: Option<f32>,
+
     /// Override transcription engine: "whisper" (default) or "parakeet" (EXPERIMENTAL)
     #[arg(long, value_name = "ENGINE")]
     pub engine: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,18 @@ translate = false
 # Default: 300 (5 minutes). Only applies when gpu_isolation = false.
 # cold_model_timeout_secs = 300
 
+# --- Eager processing settings ---
+#
+# Enable eager input processing (transcribe chunks while recording continues)
+# Reduces perceived latency on slower machines by processing audio in parallel.
+# eager_processing = false
+#
+# Duration of each audio chunk in seconds (default: 5.0)
+# eager_chunk_secs = 5.0
+#
+# Overlap between chunks in seconds (helps catch words at boundaries, default: 0.5)
+# eager_overlap_secs = 0.5
+
 # --- Remote backend settings (used when backend = "remote") ---
 #
 # Remote server endpoint URL (required for remote backend)
@@ -388,6 +400,14 @@ fn default_max_loaded_models() -> usize {
 
 fn default_cold_model_timeout() -> u64 {
     300 // 5 minutes
+}
+
+fn default_eager_chunk_secs() -> f32 {
+    5.0
+}
+
+fn default_eager_overlap_secs() -> f32 {
+    0.5
 }
 
 fn default_whisper_model() -> String {
@@ -710,6 +730,22 @@ pub struct WhisperConfig {
     #[serde(default = "default_context_window_optimization")]
     pub context_window_optimization: bool,
 
+    // --- Eager processing settings ---
+    /// Enable eager input processing (transcribe chunks while recording continues)
+    /// When enabled, audio is split into chunks and transcribed in parallel with
+    /// continued recording. This reduces perceived latency on slower machines.
+    #[serde(default)]
+    pub eager_processing: bool,
+
+    /// Duration of each audio chunk in seconds for eager processing
+    #[serde(default = "default_eager_chunk_secs")]
+    pub eager_chunk_secs: f32,
+
+    /// Overlap between adjacent chunks in seconds for eager processing
+    /// Overlap helps catch words at chunk boundaries
+    #[serde(default = "default_eager_overlap_secs")]
+    pub eager_overlap_secs: f32,
+
     /// Initial prompt to provide context for transcription
     /// Use this to hint at terminology, proper nouns, or formatting conventions.
     /// Example: "Technical discussion about Rust, TypeScript, and Kubernetes."
@@ -808,6 +844,9 @@ impl Default for WhisperConfig {
             on_demand_loading: default_on_demand_loading(),
             gpu_isolation: false,
             context_window_optimization: default_context_window_optimization(),
+            eager_processing: false,
+            eager_chunk_secs: default_eager_chunk_secs(),
+            eager_overlap_secs: default_eager_overlap_secs(),
             initial_prompt: None,
             secondary_model: None,
             available_models: vec![],
@@ -1184,6 +1223,9 @@ impl Default for Config {
                 on_demand_loading: default_on_demand_loading(),
                 gpu_isolation: false,
                 context_window_optimization: default_context_window_optimization(),
+                eager_processing: false,
+                eager_chunk_secs: default_eager_chunk_secs(),
+                eager_overlap_secs: default_eager_overlap_secs(),
                 initial_prompt: None,
                 secondary_model: None,
                 available_models: vec![],

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -1,0 +1,385 @@
+//! Eager input processing module
+//!
+//! Handles chunking audio during recording and processing chunks in parallel
+//! with continued recording. This reduces perceived latency on slower machines.
+//!
+//! The basic approach:
+//! 1. During recording, split audio into fixed-size chunks with small overlaps
+//! 2. As each chunk is ready, spawn a transcription task for it
+//! 3. Continue recording while transcription runs in parallel
+//! 4. At the end, combine all chunk results, deduplicating at boundaries
+
+use crate::state::ChunkResult;
+
+/// Configuration for eager processing
+#[derive(Debug, Clone)]
+pub struct EagerConfig {
+    /// Duration of each chunk in seconds
+    pub chunk_secs: f32,
+    /// Overlap between adjacent chunks in seconds
+    pub overlap_secs: f32,
+    /// Sample rate (assumed 16kHz for whisper)
+    pub sample_rate: u32,
+}
+
+impl EagerConfig {
+    /// Create config from whisper config settings
+    pub fn from_whisper_config(config: &crate::config::WhisperConfig) -> Self {
+        Self {
+            chunk_secs: config.eager_chunk_secs,
+            overlap_secs: config.eager_overlap_secs,
+            sample_rate: 16000, // Whisper expects 16kHz
+        }
+    }
+
+    /// Get chunk size in samples
+    pub fn chunk_samples(&self) -> usize {
+        (self.chunk_secs * self.sample_rate as f32) as usize
+    }
+
+    /// Get overlap size in samples
+    pub fn overlap_samples(&self) -> usize {
+        (self.overlap_secs * self.sample_rate as f32) as usize
+    }
+
+    /// Get the stride between chunk starts (chunk - overlap)
+    pub fn stride_samples(&self) -> usize {
+        self.chunk_samples().saturating_sub(self.overlap_samples())
+    }
+}
+
+/// Extract a chunk from accumulated audio for transcription.
+/// Returns None if there isn't enough audio for the requested chunk yet.
+///
+/// # Arguments
+/// * `accumulated` - All audio samples collected so far
+/// * `chunk_index` - Which chunk to extract (0-based)
+/// * `config` - Eager processing configuration
+///
+/// # Returns
+/// * `Some(Vec<f32>)` - The audio chunk to transcribe
+/// * `None` - Not enough audio yet for this chunk
+pub fn extract_chunk(
+    accumulated: &[f32],
+    chunk_index: usize,
+    config: &EagerConfig,
+) -> Option<Vec<f32>> {
+    let chunk_size = config.chunk_samples();
+    let stride = config.stride_samples();
+
+    // Calculate chunk boundaries
+    let start = chunk_index * stride;
+    let end = start + chunk_size;
+
+    // Check if we have enough samples
+    if end > accumulated.len() {
+        return None;
+    }
+
+    Some(accumulated[start..end].to_vec())
+}
+
+/// Check how many complete chunks are available in the accumulated audio.
+/// A chunk is "complete" when we have enough samples to extract it plus
+/// the overlap for the next chunk (so we don't cut off mid-word).
+///
+/// # Arguments
+/// * `accumulated_len` - Number of samples accumulated so far
+/// * `config` - Eager processing configuration
+///
+/// # Returns
+/// Number of complete chunks available
+pub fn count_complete_chunks(accumulated_len: usize, config: &EagerConfig) -> usize {
+    let stride = config.stride_samples();
+    let chunk_size = config.chunk_samples();
+
+    if accumulated_len < chunk_size {
+        return 0;
+    }
+
+    // Number of chunks where we have the full chunk + overlap for boundary handling
+    let available_after_first = accumulated_len.saturating_sub(chunk_size);
+    1 + available_after_first / stride
+}
+
+/// Combine transcription results from multiple chunks, handling duplicates
+/// at chunk boundaries.
+///
+/// # Arguments
+/// * `results` - Vector of chunk results (may be in any order)
+///
+/// # Returns
+/// Combined transcription text with duplicates at boundaries removed
+pub fn combine_chunk_results(mut results: Vec<ChunkResult>) -> String {
+    if results.is_empty() {
+        return String::new();
+    }
+
+    // Sort by chunk index to ensure correct order
+    results.sort_by_key(|r| r.chunk_index);
+
+    if results.len() == 1 {
+        return results[0].text.clone();
+    }
+
+    let mut combined = String::new();
+
+    for (i, result) in results.iter().enumerate() {
+        if i == 0 {
+            // First chunk: use full text
+            combined = result.text.clone();
+        } else {
+            // Subsequent chunks: deduplicate at boundary
+            let new_text = deduplicate_boundary(&combined, &result.text);
+            if !new_text.is_empty() {
+                if !combined.is_empty() && !combined.ends_with(' ') && !new_text.starts_with(' ') {
+                    combined.push(' ');
+                }
+                combined.push_str(&new_text);
+            }
+        }
+    }
+
+    combined.trim().to_string()
+}
+
+/// Remove duplicate text at the boundary between previous and new transcription.
+///
+/// This uses a simple approach: look for the longest suffix of `previous` that
+/// matches a prefix of `new_text`, and return `new_text` with that prefix removed.
+///
+/// # Arguments
+/// * `previous` - Text transcribed so far (from earlier chunks)
+/// * `new_text` - Text from the new chunk
+///
+/// # Returns
+/// The portion of `new_text` that isn't a duplicate of `previous`
+fn deduplicate_boundary(previous: &str, new_text: &str) -> String {
+    let previous_words: Vec<&str> = previous.split_whitespace().collect();
+    let new_words: Vec<&str> = new_text.split_whitespace().collect();
+
+    if previous_words.is_empty() || new_words.is_empty() {
+        return new_text.to_string();
+    }
+
+    // Look for overlap: find the longest suffix of previous that matches
+    // a prefix of new_text
+    let max_overlap = previous_words.len().min(new_words.len());
+
+    let mut best_overlap = 0;
+    for overlap_len in 1..=max_overlap {
+        let prev_suffix = &previous_words[previous_words.len() - overlap_len..];
+        let new_prefix = &new_words[..overlap_len];
+
+        // Case-insensitive comparison for robustness
+        if prev_suffix
+            .iter()
+            .zip(new_prefix.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b))
+        {
+            best_overlap = overlap_len;
+        }
+    }
+
+    if best_overlap > 0 {
+        // Remove the overlapping prefix from new_text
+        new_words[best_overlap..].join(" ")
+    } else {
+        new_text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> EagerConfig {
+        EagerConfig {
+            chunk_secs: 5.0,
+            overlap_secs: 0.5,
+            sample_rate: 16000,
+        }
+    }
+
+    #[test]
+    fn test_chunk_samples() {
+        let config = test_config();
+        assert_eq!(config.chunk_samples(), 80000); // 5 seconds * 16000 Hz
+        assert_eq!(config.overlap_samples(), 8000); // 0.5 seconds * 16000 Hz
+        assert_eq!(config.stride_samples(), 72000); // chunk - overlap
+    }
+
+    #[test]
+    fn test_count_complete_chunks_empty() {
+        let config = test_config();
+        assert_eq!(count_complete_chunks(0, &config), 0);
+    }
+
+    #[test]
+    fn test_count_complete_chunks_less_than_one() {
+        let config = test_config();
+        // Less than one chunk
+        assert_eq!(count_complete_chunks(40000, &config), 0);
+    }
+
+    #[test]
+    fn test_count_complete_chunks_one() {
+        let config = test_config();
+        // Exactly one chunk
+        assert_eq!(count_complete_chunks(80000, &config), 1);
+    }
+
+    #[test]
+    fn test_count_complete_chunks_multiple() {
+        let config = test_config();
+        // First chunk (80000) + stride for second (72000) = 152000
+        assert_eq!(count_complete_chunks(152000, &config), 2);
+        // First chunk + 2 strides = 224000
+        assert_eq!(count_complete_chunks(224000, &config), 3);
+    }
+
+    #[test]
+    fn test_extract_chunk_insufficient_data() {
+        let config = test_config();
+        let audio = vec![0.0; 40000]; // Less than one chunk
+        assert!(extract_chunk(&audio, 0, &config).is_none());
+    }
+
+    #[test]
+    fn test_extract_chunk_first() {
+        let config = test_config();
+        let audio: Vec<f32> = (0..100000).map(|i| i as f32).collect();
+        let chunk = extract_chunk(&audio, 0, &config).unwrap();
+        assert_eq!(chunk.len(), 80000);
+        assert_eq!(chunk[0], 0.0);
+    }
+
+    #[test]
+    fn test_extract_chunk_second() {
+        let config = test_config();
+        let audio: Vec<f32> = (0..200000).map(|i| i as f32).collect();
+        let chunk = extract_chunk(&audio, 1, &config).unwrap();
+        assert_eq!(chunk.len(), 80000);
+        // Second chunk starts at stride (72000)
+        assert_eq!(chunk[0], 72000.0);
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_no_overlap() {
+        let result = deduplicate_boundary("hello world", "foo bar");
+        assert_eq!(result, "foo bar");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_single_word_overlap() {
+        let result = deduplicate_boundary("hello world", "world foo bar");
+        assert_eq!(result, "foo bar");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_multi_word_overlap() {
+        let result = deduplicate_boundary("hello world foo", "world foo bar baz");
+        assert_eq!(result, "bar baz");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_case_insensitive() {
+        let result = deduplicate_boundary("Hello World", "world foo");
+        assert_eq!(result, "foo");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_empty_previous() {
+        let result = deduplicate_boundary("", "hello world");
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_empty_new() {
+        let result = deduplicate_boundary("hello world", "");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_empty() {
+        let results: Vec<ChunkResult> = vec![];
+        assert_eq!(combine_chunk_results(results), "");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_single() {
+        let results = vec![ChunkResult {
+            text: "hello world".to_string(),
+            chunk_index: 0,
+        }];
+        assert_eq!(combine_chunk_results(results), "hello world");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_multiple_no_overlap() {
+        let results = vec![
+            ChunkResult {
+                text: "hello world".to_string(),
+                chunk_index: 0,
+            },
+            ChunkResult {
+                text: "foo bar".to_string(),
+                chunk_index: 1,
+            },
+        ];
+        assert_eq!(combine_chunk_results(results), "hello world foo bar");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_with_overlap() {
+        let results = vec![
+            ChunkResult {
+                text: "hello world foo".to_string(),
+                chunk_index: 0,
+            },
+            ChunkResult {
+                text: "foo bar baz".to_string(),
+                chunk_index: 1,
+            },
+        ];
+        assert_eq!(combine_chunk_results(results), "hello world foo bar baz");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_out_of_order() {
+        // Results can arrive out of order; they should be sorted by chunk_index
+        let results = vec![
+            ChunkResult {
+                text: "bar baz".to_string(),
+                chunk_index: 1,
+            },
+            ChunkResult {
+                text: "hello world bar".to_string(),
+                chunk_index: 0,
+            },
+        ];
+        assert_eq!(combine_chunk_results(results), "hello world bar baz");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_three_chunks() {
+        let results = vec![
+            ChunkResult {
+                text: "one two three".to_string(),
+                chunk_index: 0,
+            },
+            ChunkResult {
+                text: "three four five".to_string(),
+                chunk_index: 1,
+            },
+            ChunkResult {
+                text: "five six seven".to_string(),
+                chunk_index: 2,
+            },
+        ];
+        assert_eq!(
+            combine_chunk_results(results),
+            "one two three four five six seven"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub mod cli;
 pub mod config;
 pub mod cpu;
 pub mod daemon;
+pub mod eager;
 pub mod error;
 pub mod hotkey;
 pub mod model_manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,15 @@ async fn main() -> anyhow::Result<()> {
     if let Some(prompt) = cli.initial_prompt {
         config.whisper.initial_prompt = Some(prompt);
     }
+    if cli.eager_processing {
+        config.whisper.eager_processing = true;
+    }
+    if let Some(secs) = cli.eager_chunk_secs {
+        config.whisper.eager_chunk_secs = secs;
+    }
+    if let Some(secs) = cli.eager_overlap_secs {
+        config.whisper.eager_overlap_secs = secs;
+    }
     if let Some(ref driver_str) = cli.driver {
         match parse_driver_order(driver_str) {
             Ok(drivers) => {


### PR DESCRIPTION
## Summary

Implements eager input processing (issue #70), which transcribes audio chunks in parallel while recording continues. This reduces perceived latency on slower machines or for long recordings.

- Adds `src/eager.rs` module with chunking logic and word-level deduplication at chunk boundaries
- Adds `EagerRecording` state variant to track in-progress chunk transcriptions
- Integrates eager processing into daemon event loop for all recording triggers (hotkey, toggle, external)
- Adds config options: `eager_processing`, `eager_chunk_secs`, `eager_overlap_secs`
- Adds CLI flags: `--eager-processing`, `--eager-chunk-secs`, `--eager-overlap-secs`
- Documents feature in USER_MANUAL.md, CONFIGURATION.md, and SMOKE_TESTS.md
- 23 new tests for eager processing logic

**Disabled by default** for backwards compatibility.

## Test plan

- [x] `cargo test eager` passes (23 tests)
- [x] `cargo test config::tests` passes
- [x] `cargo build --release` succeeds
- [x] CLI help shows new flags (`voxtype --help | grep eager`)
- [ ] Manual test: enable `eager_processing = true` with short chunks (3s), record 10+ seconds, verify logs show chunk processing
- [ ] Manual test: verify combined output is coherent without obvious word duplication