### PR TITLE
Update website download links to v0.5.2 (#146)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -723,9 +723,10 @@ option = "value"</code></pre>
 **Checklist for releases:**
 1. Create GitHub release with notes following the style above
 2. Add matching article to `website/news/index.html`
-3. Update `packaging/arch-bin/voxtype-bin.install` post_upgrade() message with current version highlights
-4. Commit and push website changes
-5. Push AUR package updates
+3. Update download examples in `website/index.html` (deb/rpm URLs with new version)
+4. Update `packaging/arch-bin/voxtype-bin.install` post_upgrade() message with current version highlights
+5. Commit and push website changes
+6. Push AUR package updates
 
 ## Website
 

--- a/website/index.html
+++ b/website/index.html
@@ -625,8 +625,8 @@ sudo pacman -S wtype wl-clipboard</code></pre>
                             <button class="copy-btn">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install (Ubuntu 24.04+, Debian Trixie+)</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.4.1-4/voxtype_0.4.1-4_amd64.deb
-sudo dpkg -i voxtype_0.4.1-4_amd64.deb
+wget https://github.com/peteonrails/voxtype/releases/download/v0.5.2/voxtype_0.5.2-1_amd64.deb
+sudo dpkg -i voxtype_0.5.2-1_amd64.deb
 sudo apt-get install -f
 
 <span class="comment"># Install optional dependencies</span>
@@ -642,8 +642,8 @@ sudo apt install wtype wl-clipboard</code></pre>
                             <button class="copy-btn">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install (Fedora 39+)</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.4.1-4/voxtype-0.4.1-4.x86_64.rpm
-sudo dnf install ./voxtype-0.4.1-4.x86_64.rpm
+wget https://github.com/peteonrails/voxtype/releases/download/v0.5.2/voxtype-0.5.2-1.x86_64.rpm
+sudo dnf install ./voxtype-0.5.2-1.x86_64.rpm
 
 <span class="comment"># Install optional dependencies</span>
 sudo dnf install wtype wl-clipboard</code></pre>


### PR DESCRIPTION
## Summary

Updates the deb and rpm download examples on the website to point to the latest release (v0.5.2) instead of the outdated v0.4.1-4.

Fixes #146

## Test plan

- [ ] Verify links work after merge by visiting voxtype.io