### PR TITLE
Add Native backend variant for source-built binaries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -526,7 +526,8 @@ impl ExtendedStatusInfo {
     fn from_config(config: &config::Config) -> Self {
         let backend = setup::gpu::detect_current_backend()
             .map(|b| match b {
-                setup::gpu::Backend::Cpu => "CPU (native)",
+                setup::gpu::Backend::Cpu => "CPU (legacy)",
+                setup::gpu::Backend::Native => "CPU (native)",
                 setup::gpu::Backend::Avx2 => "CPU (AVX2)",
                 setup::gpu::Backend::Avx512 => "CPU (AVX-512)",
                 setup::gpu::Backend::Vulkan => "GPU (Vulkan)",


### PR DESCRIPTION
## Summary

- Adds `Backend::Native` enum variant to recognize source-built binaries (`voxtype-native`)
- Updates GPU status detection to properly identify and display native binaries
- Updates enable/disable GPU commands to work with the new symlink-based layout

## Context

This is a follow-up fix to #148 which added the `voxtype-native` binary naming for source packages. The GPU setup code wasn't updated to recognize this new binary name, causing `voxtype setup gpu --status` to show "Active backend: Unknown (symlink may be broken)" when the symlink pointed to `voxtype-native`.

## Test plan

- [x] `voxtype setup gpu --status` correctly shows "CPU (native) - installed" when `voxtype-native` exists
- [x] Switching to CPU mode correctly identifies the native backend
- [x] Switching to GPU mode and back works correctly
- [x] Code compiles without warnings (except pre-existing unused variable warning)

Fixes #145 (continued)