### PR TITLE
Add media key names and numeric keycode support

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,6 +61,8 @@ The main key to hold for recording. Must be a valid Linux evdev key name.
 - `PAUSE` - Pause/Break key
 - `RIGHTALT` - Right Alt key
 - `F13` through `F24` - Extended function keys
+- `MEDIA` - Media key (often a dedicated button on multimedia keyboards)
+- `RECORD` - Record key
 - `INSERT` - Insert key
 - `HOME` - Home key
 - `END` - End key
@@ -74,10 +76,25 @@ The main key to hold for recording. Must be a valid Linux evdev key name.
 key = "PAUSE"
 ```
 
+**Numeric keycodes:**
+
+You can also specify keys by their numeric keycode if the key name isn't in the built-in list. Use a prefix to indicate the source tool, since different tools report different numbers for the same key:
+
+- `WEV_234` or `X11_234` or `XEV_234` - XKB keycode as shown by `wev` or `xev` (offset by 8 from the kernel value)
+- `EVTEST_226` - kernel keycode as shown by `evtest`
+- Hex values are also accepted: `WEV_0xEA`, `EVTEST_0xE2`
+
+Bare numeric values (e.g. `226`) are not accepted because `wev`/`xev` and `evtest` report different numbers for the same key.
+
 **Finding key names:**
 ```bash
+# Using evtest (shows kernel keycodes):
 sudo evtest
 # Select keyboard, press desired key, note KEY_XXXX name
+
+# Using wev on Wayland (shows XKB keycodes):
+wev
+# Press the key, note the keycode number — use with WEV_ prefix
 ```
 
 ### modifiers

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -334,6 +334,8 @@ Any key supported by the Linux evdev system can be used as a hotkey:
 | Right Alt | `RIGHTALT` |
 | Right Ctrl | `RIGHTCTRL` |
 | F13-F24 | `F13`, `F14`, ... `F24` |
+| Media | `MEDIA` |
+| Record | `RECORD` |
 | Insert | `INSERT` |
 | Home | `HOME` |
 | End | `END` |
@@ -354,6 +356,19 @@ sudo evtest
 # Press the key you want to use
 # Look for "KEY_XXXXX" - use the part after KEY_
 ```
+
+### Numeric Keycodes
+
+If your key isn't in the built-in list, you can specify it by numeric keycode. Use a prefix to indicate which tool you got the number from, since `wev`/`xev` and `evtest` report different numbers for the same key (XKB keycodes are offset by 8 from kernel keycodes):
+
+```toml
+[hotkey]
+key = "WEV_234"      # XKB keycode from wev/xev (KEY_MEDIA)
+key = "EVTEST_226"   # Kernel keycode from evtest (KEY_MEDIA)
+key = "WEV_0xEA"     # Hex also works
+```
+
+Prefixes: `WEV_`, `X11_`, `XEV_` (XKB keycode), `EVTEST_` (kernel keycode).
 
 ### Using Modifier Keys
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,7 @@ pub struct Cli {
     #[arg(long, value_name = "ENGINE")]
     pub engine: Option<String>,
 
-    /// Override hotkey (e.g., SCROLLLOCK, PAUSE, F13)
+    /// Override hotkey (e.g., SCROLLLOCK, PAUSE, F13, MEDIA, WEV_234, EVTEST_226)
     #[arg(long, value_name = "KEY")]
     pub hotkey: Option<String>,
 


### PR DESCRIPTION
## Summary

- Add media key names (MEDIA, RECORD, REWIND, FASTFORWARD) to evdev hotkey parser
- Support prefixed numeric keycodes for keys not in the built-in list:
  - `WEV_234`, `X11_234`, `XEV_234` — XKB keycodes (as shown by wev/xev, offset by 8)
  - `EVTEST_226` — kernel keycodes (as shown by evtest)
  - Hex values also accepted: `WEV_0xEA`, `EVTEST_0xE2`
- Bare numeric keycodes are rejected with a helpful error explaining the ambiguity between XKB and kernel numbering
- Update docs (CONFIGURATION.md, USER_MANUAL.md) and CLI help text

## Test plan

- [ ] `cargo test hotkey` passes (8 tests covering named keys, prefixed decimal, prefixed hex, and bare numeric rejection)
- [ ] Verify `key = "MEDIA"` in config works for devices with a media key
- [ ] Verify `key = "WEV_234"` works (equivalent to KEY_MEDIA via XKB keycode)
- [ ] Verify `key = "EVTEST_226"` works (equivalent to KEY_MEDIA via kernel keycode)
- [ ] Verify bare `key = "226"` produces a clear error message