### PR TITLE
Nemotron streaming transcription (real-time text output)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "parakeet-rs"
-version = "0.2.9"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7667842fd2f3b97b029a30fb9a00138867c6915229f5acd6bd809d08250d2ee"
+checksum = "447e20c2f0ecc35e581aa30da451e4238221a0dfd020c4ee6bdba7cb8c7b52dd"
 dependencies = [
  "eyre",
  "hound",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rodio = { version = "0.19", default-features = false, features = ["wav"] }
 whisper-rs = "0.15.1"
 
 # Parakeet speech-to-text (optional, ONNX-based)
-parakeet-rs = { version = "0.2.9", optional = true }
+parakeet-rs = { version = "0.3.1", optional = true }
 
 
 # CPU count for thread detection
@@ -89,7 +89,7 @@ gpu-hipblas = ["whisper-rs/hipblas"]
 parakeet = ["dep:parakeet-rs"]
 parakeet-cuda = ["parakeet", "parakeet-rs/cuda"]
 parakeet-tensorrt = ["parakeet", "parakeet-rs/tensorrt"]
-parakeet-rocm = ["parakeet", "parakeet-rs/rocm"]
+parakeet-rocm = ["parakeet", "parakeet-rs/migraphx"]
 # Dynamic loading for system ONNX Runtime (used by Nix builds)
 parakeet-load-dynamic = ["parakeet", "parakeet-rs/load-dynamic"]
 

--- a/contrib/nemotron-streaming-test-config.toml
+++ b/contrib/nemotron-streaming-test-config.toml
@@ -1,0 +1,46 @@
+# Voxtype test config: Nemotron streaming transcription
+#
+# Setup:
+#   1. Build with parakeet support:
+#      cargo build --features parakeet
+#
+#   2. Download the Nemotron model:
+#      voxtype setup model
+#      (select "nemotron-speech-streaming-en-0.6b")
+#
+#   3. Run the daemon:
+#      voxtype -c contrib/nemotron-streaming-test-config.toml daemon
+
+engine = "parakeet"
+
+[hotkey]
+key = "Super_R"
+enabled = true
+mode = "push-to-talk"
+
+[audio]
+device = "default"
+max_duration_secs = 30
+
+[audio.feedback]
+enabled = true
+
+[parakeet]
+# Downloaded via: voxtype setup model
+model = "nemotron-speech-streaming-en-0.6b"
+
+# Auto-detected from model files, but you can force it:
+# model_type = "nemotron"
+
+# Streaming is auto-enabled for Nemotron models.
+# Set to false to use batch transcription instead:
+# streaming = false
+
+[output]
+mode = "type"
+state_file = "auto"
+
+[output.notification]
+on_recording_start = true
+on_recording_stop = true
+on_transcription = true

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,6 +61,8 @@ The main key to hold for recording. Must be a valid Linux evdev key name.
 - `PAUSE` - Pause/Break key
 - `RIGHTALT` - Right Alt key
 - `F13` through `F24` - Extended function keys
+- `MEDIA` - Media key (often a dedicated button on multimedia keyboards)
+- `RECORD` - Record key
 - `INSERT` - Insert key
 - `HOME` - Home key
 - `END` - End key
@@ -74,10 +76,25 @@ The main key to hold for recording. Must be a valid Linux evdev key name.
 key = "PAUSE"
 ```
 
+**Numeric keycodes:**
+
+You can also specify keys by their numeric keycode if the key name isn't in the built-in list. Use a prefix to indicate the source tool, since different tools report different numbers for the same key:
+
+- `WEV_234` or `X11_234` or `XEV_234` - XKB keycode as shown by `wev` or `xev` (offset by 8 from the kernel value)
+- `EVTEST_226` - kernel keycode as shown by `evtest`
+- Hex values are also accepted: `WEV_0xEA`, `EVTEST_0xE2`
+
+Bare numeric values (e.g. `226`) are not accepted because `wev`/`xev` and `evtest` report different numbers for the same key.
+
 **Finding key names:**
 ```bash
+# Using evtest (shows kernel keycodes):
 sudo evtest
 # Select keyboard, press desired key, note KEY_XXXX name
+
+# Using wev on Wayland (shows XKB keycodes):
+wev
+# Press the key, note the keycode number — use with WEV_ prefix
 ```
 
 ### modifiers

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1004,12 +1004,49 @@ The model architecture type. Usually auto-detected based on files present in the
 **Values:**
 - `tdt` - Token-Duration-Transducer (recommended, proper punctuation)
 - `ctc` - Connectionist Temporal Classification (faster, character-level)
+- `nemotron` - Nemotron streaming transducer (supports real-time streaming output)
 
 **Example:**
 ```toml
 [parakeet]
 model = "parakeet-tdt-0.6b-v3"
 model_type = "tdt"
+```
+
+**Auto-detection:**
+
+The model type is detected from the files in the model directory:
+
+| Model Type | Required Files |
+|-----------|---------------|
+| TDT | `encoder-model.onnx`, `decoder_joint-model.onnx`, `vocab.txt` |
+| CTC | `model.onnx` (or `model_int8.onnx`), `tokenizer.json` |
+| Nemotron | `encoder.onnx`, `decoder_joint.onnx`, `tokenizer.model` |
+
+### streaming
+
+**Type:** Boolean
+**Default:** Auto (enabled for Nemotron, disabled for TDT/CTC)
+**Required:** No
+
+When enabled, text is typed live during recording as the model produces output. Each audio chunk (560ms) is processed incrementally, and the resulting text is typed immediately at the cursor position.
+
+Streaming is automatically enabled when using a Nemotron model and can be explicitly overridden.
+
+**Example:**
+```toml
+[parakeet]
+model = "/path/to/nemotron-model"
+model_type = "nemotron"
+streaming = true  # This is the default for Nemotron
+```
+
+**To disable streaming for a Nemotron model (batch mode instead):**
+```toml
+[parakeet]
+model = "/path/to/nemotron-model"
+model_type = "nemotron"
+streaming = false  # Wait until recording stops, then transcribe all at once
 ```
 
 ### on_demand_loading
@@ -1027,14 +1064,25 @@ model = "parakeet-tdt-0.6b-v3"
 on_demand_loading = true  # Free memory when not transcribing
 ```
 
-### Complete Example
+### Complete Examples
 
+**TDT model (recommended for batch transcription):**
 ```toml
 engine = "parakeet"
 
 [parakeet]
 model = "parakeet-tdt-0.6b-v3"
 on_demand_loading = false  # Keep model loaded for fast response
+```
+
+**Nemotron model (streaming transcription):**
+```toml
+engine = "parakeet"
+
+[parakeet]
+model = "/path/to/nemotron-0.6b"
+model_type = "nemotron"
+# streaming = true is the default for Nemotron
 ```
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -593,6 +593,100 @@ voxtype --whisper-context-optimization daemon
 
 **Note:** This setting only applies when using the local whisper backend (`backend = "local"`). It has no effect with remote transcription.
 
+### eager_processing
+
+**Type:** Boolean
+**Default:** `false`
+**Required:** No
+
+Enable eager input processing. When enabled, audio is split into chunks and transcribed in parallel with continued recording, reducing perceived latency on slower machines.
+
+**Values:**
+- `false` (default) - Traditional mode: record all audio, then transcribe
+- `true` - Eager mode: transcribe chunks while recording continues
+
+**How it works:**
+
+1. While recording, audio is split into fixed-size chunks (default 5 seconds)
+2. Each chunk is sent for transcription as soon as it's ready
+3. Recording continues while earlier chunks are being transcribed
+4. When recording stops, all chunk results are combined
+
+**When to use eager processing:**
+- You have a slower CPU where transcription takes several seconds
+- You regularly dictate longer passages (10+ seconds)
+- You want to minimize the delay between speaking and text output
+
+**When to keep default (`false`):**
+- You have a fast CPU or GPU acceleration
+- Your recordings are typically short (under 5 seconds)
+- You want maximum transcription accuracy (single-pass is more consistent)
+
+**Example:**
+```toml
+[whisper]
+model = "base.en"
+eager_processing = true
+eager_chunk_secs = 5.0    # 5 second chunks
+eager_overlap_secs = 0.5  # 0.5 second overlap
+```
+
+**CLI override:**
+```bash
+voxtype --eager-processing daemon
+```
+
+**Note:** Eager processing is experimental. There may be occasional word duplications or omissions at chunk boundaries.
+
+### eager_chunk_secs
+
+**Type:** Float
+**Default:** `5.0`
+**Required:** No
+
+Duration of each audio chunk in seconds when eager processing is enabled.
+
+**Example:**
+```toml
+[whisper]
+eager_processing = true
+eager_chunk_secs = 3.0  # Shorter chunks for faster feedback
+```
+
+**CLI override:**
+```bash
+voxtype --eager-processing --eager-chunk-secs 3.0 daemon
+```
+
+**Trade-offs:**
+- Shorter chunks: Faster feedback, but more boundary artifacts
+- Longer chunks: Better accuracy, but less parallelism benefit
+
+### eager_overlap_secs
+
+**Type:** Float
+**Default:** `0.5`
+**Required:** No
+
+Overlap duration in seconds between adjacent chunks when eager processing is enabled. Overlap helps catch words that span chunk boundaries.
+
+**Example:**
+```toml
+[whisper]
+eager_processing = true
+eager_chunk_secs = 5.0
+eager_overlap_secs = 1.0  # More overlap for better boundary handling
+```
+
+**CLI override:**
+```bash
+voxtype --eager-processing --eager-overlap-secs 1.0 daemon
+```
+
+**Trade-offs:**
+- More overlap: Better word boundary handling, slightly more processing
+- Less overlap: Faster processing, but may miss words at boundaries
+
 ### initial_prompt
 
 **Type:** String

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1016,20 +1016,21 @@ fallback_to_clipboard = true  # Use clipboard if typing drivers fail
 ### driver_order
 
 **Type:** Array of strings
-**Default:** `["wtype", "dotool", "ydotool", "clipboard", "xclip"]`
+**Default:** `["wtype", "eitype", "dotool", "ydotool", "clipboard", "xclip"]`
 **Required:** No
 
 Custom order of output drivers to try when `mode = "type"`. Each driver is tried in sequence until one succeeds. This allows you to prefer specific drivers or exclude others entirely.
 
 **Available drivers:**
-- `wtype` - Wayland virtual keyboard (best CJK/Unicode support, wlroots compositors only)
+- `wtype` - Wayland virtual keyboard protocol (best CJK/Unicode support, wlroots compositors only)
+- `eitype` - Wayland via libei/EI protocol (works on GNOME, KDE, and compositors with libei support)
 - `dotool` - uinput-based typing (supports keyboard layouts, works on X11/Wayland/TTY)
 - `ydotool` - uinput-based typing (requires daemon, X11/Wayland/TTY)
 - `clipboard` - Wayland clipboard via wl-copy
 - `xclip` - X11 clipboard via xclip
 
 **Default behavior (no driver_order set):**
-The default chain is: wtype → dotool → ydotool → clipboard → xclip
+The default chain is: wtype → eitype → dotool → ydotool → clipboard → xclip
 
 **Examples:**
 
@@ -1046,8 +1047,8 @@ driver_order = ["dotool", "ydotool", "xclip"]
 # Force single driver (no fallback)
 driver_order = ["ydotool"]
 
-# KDE/GNOME Wayland (wtype doesn't work)
-driver_order = ["dotool", "ydotool", "clipboard"]
+# GNOME/KDE Wayland (prefer eitype, wtype doesn't work)
+driver_order = ["eitype", "dotool", "clipboard"]
 ```
 
 **CLI override:**

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -334,6 +334,8 @@ Any key supported by the Linux evdev system can be used as a hotkey:
 | Right Alt | `RIGHTALT` |
 | Right Ctrl | `RIGHTCTRL` |
 | F13-F24 | `F13`, `F14`, ... `F24` |
+| Media | `MEDIA` |
+| Record | `RECORD` |
 | Insert | `INSERT` |
 | Home | `HOME` |
 | End | `END` |
@@ -354,6 +356,19 @@ sudo evtest
 # Press the key you want to use
 # Look for "KEY_XXXXX" - use the part after KEY_
 ```
+
+### Numeric Keycodes
+
+If your key isn't in the built-in list, you can specify it by numeric keycode. Use a prefix to indicate which tool you got the number from, since `wev`/`xev` and `evtest` report different numbers for the same key (XKB keycodes are offset by 8 from kernel keycodes):
+
+```toml
+[hotkey]
+key = "WEV_234"      # XKB keycode from wev/xev (KEY_MEDIA)
+key = "EVTEST_226"   # Kernel keycode from evtest (KEY_MEDIA)
+key = "WEV_0xEA"     # Hex also works
+```
+
+Prefixes: `WEV_`, `X11_`, `XEV_` (XKB keycode), `EVTEST_` (kernel keycode).
 
 ### Using Modifier Keys
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -973,16 +973,23 @@ systemctl --user enable --now ydotool
 
 **Compositor Compatibility:**
 
-wtype does not work on all Wayland compositors. KDE Plasma and GNOME do not support the virtual keyboard protocol that wtype requires.
+wtype does not work on all Wayland compositors. KDE Plasma and GNOME do not support the virtual keyboard protocol that wtype requires. However, eitype uses the libei/EI protocol which is supported by GNOME and KDE.
 
-| Desktop | wtype | dotool | ydotool | clipboard | Notes |
-|---------|-------|--------|---------|-----------|-------|
-| Hyprland, Sway, River | ✓ | ✓ | ✓ | wl-copy | wtype recommended (best CJK support) |
-| KDE Plasma (Wayland) | ✗ | ✓ | ✓ | wl-copy | dotool recommended (keyboard layout support) |
-| GNOME (Wayland) | ✗ | ✓ | ✓ | wl-copy | dotool recommended (keyboard layout support) |
-| X11 (any) | ✗ | ✓ | ✓ | xclip | dotool or ydotool; xclip for clipboard |
+| Desktop | wtype | eitype | dotool | ydotool | clipboard | Notes |
+|---------|-------|--------|--------|---------|-----------|-------|
+| Hyprland, Sway, River | ✓ | * | ✓ | ✓ | wl-copy | wtype recommended (best CJK support) |
+| KDE Plasma (Wayland) | ✗ | ✓ | ✓ | ✓ | wl-copy | eitype recommended (native EI protocol) |
+| GNOME (Wayland) | ✗ | ✓ | ✓ | ✓ | wl-copy | eitype recommended (native EI protocol) |
+| X11 (any) | ✗ | ✗ | ✓ | ✓ | xclip | dotool or ydotool; xclip for clipboard |
 
-**KDE Plasma and GNOME users:** Install dotool (recommended) or set up ydotool for type mode to work.
+\* eitype works on wlroots compositors with libei support.
+
+**KDE Plasma and GNOME users:** Install eitype (recommended) or dotool for type mode to work.
+
+For eitype (recommended for GNOME/KDE):
+```bash
+cargo install eitype
+```
 
 For dotool (recommended for non-US keyboards):
 ```bash
@@ -1054,7 +1061,7 @@ mode = "paste"
 
 ### Fallback Behavior
 
-Voxtype uses a fallback chain: wtype → dotool → ydotool → clipboard (wl-copy) → xclip
+Voxtype uses a fallback chain: wtype → eitype → dotool → ydotool → clipboard (wl-copy) → xclip
 
 ```toml
 [output]
@@ -1062,7 +1069,7 @@ mode = "type"
 fallback_to_clipboard = true  # Falls back to clipboard if typing fails
 ```
 
-On Wayland, wtype is tried first (best CJK support), then dotool (supports keyboard layouts), then ydotool, then wl-copy (Wayland clipboard). On X11, xclip is available as an additional clipboard fallback.
+On Wayland, wtype is tried first (best CJK support), then eitype (libei protocol, works on GNOME/KDE), then dotool (supports keyboard layouts), then ydotool, then wl-copy (Wayland clipboard). On X11, xclip is available as an additional clipboard fallback.
 
 ### Custom Driver Order
 
@@ -1075,7 +1082,7 @@ mode = "type"
 driver_order = ["ydotool", "wtype", "clipboard"]
 ```
 
-**Available drivers:** `wtype`, `dotool`, `ydotool`, `clipboard` (wl-copy), `xclip` (X11)
+**Available drivers:** `wtype`, `eitype`, `dotool`, `ydotool`, `clipboard` (wl-copy), `xclip` (X11)
 
 **Examples:**
 
@@ -1086,8 +1093,8 @@ driver_order = ["ydotool", "xclip"]
 # Force ydotool only (no fallback)
 driver_order = ["ydotool"]
 
-# KDE/GNOME Wayland (wtype doesn't work)
-driver_order = ["dotool", "ydotool", "clipboard"]
+# GNOME/KDE Wayland (prefer eitype, wtype doesn't work)
+driver_order = ["eitype", "dotool", "clipboard"]
 ```
 
 **CLI override:**

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -592,6 +592,36 @@ Parakeet is NVIDIA's FastConformer-based ASR model. It offers:
 
 See [PARAKEET.md](PARAKEET.md) for detailed setup instructions.
 
+### Nemotron Streaming (Experimental)
+
+Nemotron is a streaming variant of the Parakeet architecture. Unlike TDT and CTC models that transcribe after you stop recording, Nemotron types text live as you speak.
+
+**How it works:**
+- Audio is split into 560ms chunks during recording
+- Each chunk is fed to the Nemotron model immediately
+- Recognized text is typed at the cursor in real-time
+- When you release the hotkey, any remaining audio is flushed
+
+**Setup:**
+1. Download a Nemotron ONNX model (contains `encoder.onnx`, `decoder_joint.onnx`, `tokenizer.model`)
+2. Configure voxtype to use it:
+
+```toml
+engine = "parakeet"
+
+[parakeet]
+model = "/path/to/nemotron-model"
+# model_type = "nemotron" is auto-detected from model files
+```
+
+3. Start the daemon. Text will appear live as you speak.
+
+**Notes:**
+- Streaming mode is automatically enabled when a Nemotron model is detected
+- Set `streaming = false` in `[parakeet]` to disable streaming and use batch mode instead
+- Post-processing commands are not applied during streaming (text is output raw)
+- Requires a Parakeet-enabled binary (`voxtype-*-parakeet-*`)
+
 ---
 
 ## Multi-Model Support

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -17,6 +17,7 @@ Voxtype is a push-to-talk voice-to-text tool for Linux. Optimized for Wayland, w
 - [Whisper Models](#whisper-models)
 - [Remote Whisper Servers](#remote-whisper-servers)
 - [CLI Backend (whisper-cli)](#cli-backend-whisper-cli)
+- [Eager Processing](#eager-processing)
 - [Output Modes](#output-modes)
 - [Post-Processing with LLMs](#post-processing-with-llms)
 - [Profiles](#profiles)
@@ -935,6 +936,107 @@ This adds minimal overhead compared to the FFI approach since file I/O is fast o
 - Slightly higher latency than FFI (file I/O overhead)
 - Requires separate whisper-cli installation
 - No GPU isolation mode (whisper-cli manages its own GPU memory)
+
+---
+
+## Eager Processing
+
+Eager processing transcribes audio in chunks while you're still recording. Instead of waiting until you release the hotkey to start transcription, voxtype begins processing audio in the background as you speak. When you stop recording, the final chunk is transcribed and all results are combined.
+
+### When to Use Eager Processing
+
+Eager processing is most valuable when:
+
+1. **You have slow transcription hardware**: On machines where transcription takes longer than the recording itself, eager processing parallelizes the work to reduce overall wait time.
+
+2. **You make long recordings**: For recordings over 15-30 seconds, starting transcription early means less waiting when you're done speaking.
+
+3. **You use large models**: Larger Whisper models (medium, large-v3) are slower. Eager processing helps hide some of that latency.
+
+**Not recommended when:**
+- You use fast models (tiny, base) on modern hardware with GPU acceleration
+- Your recordings are typically short (under 5 seconds)
+- You're on a laptop and want to minimize battery usage
+
+### How It Works
+
+With eager processing enabled:
+
+1. Audio accumulates as you record
+2. Every `eager_chunk_secs` (default: 5 seconds), a chunk is extracted and sent for transcription
+3. Chunks overlap by `eager_overlap_secs` (default: 0.5 seconds) to avoid missing words at boundaries
+4. When you stop recording, all chunk results are combined and deduplicated
+5. The final text is output
+
+The overlap region helps catch words that might be split across chunk boundaries. The deduplication logic matches overlapping text to produce a clean result.
+
+### Configuration
+
+Enable eager processing in `~/.config/voxtype/config.toml`:
+
+```toml
+[whisper]
+model = "medium.en"
+
+# Enable eager input processing
+eager_processing = true
+
+# Chunk duration (default: 5.0 seconds)
+eager_chunk_secs = 5.0
+
+# Overlap between chunks (default: 0.5 seconds)
+eager_overlap_secs = 0.5
+```
+
+Or via CLI flags:
+
+```bash
+voxtype --eager-processing --eager-chunk-secs 5.0 daemon
+```
+
+### Tuning Chunk Size
+
+The chunk duration affects the trade-off between parallelization and overhead:
+
+| Chunk Size | Pros | Cons |
+|------------|------|------|
+| 3 seconds | More parallelization, faster for slow models | More boundary handling, slightly higher CPU |
+| 5 seconds | Good balance for most cases | - |
+| 10 seconds | Fewer chunks to combine | Less parallelization benefit |
+
+For testing, try `eager_chunk_secs = 3.0` to see more chunk messages in the logs.
+
+### Trade-offs
+
+**Benefits:**
+- Reduced perceived latency on slow hardware
+- Better experience for long recordings
+- Parallelizes transcription work across recording time
+
+**Limitations:**
+- Boundary handling may occasionally produce artifacts (repeated or dropped words at chunk edges)
+- Slightly higher CPU usage during recording
+- Adds complexity to the transcription pipeline
+
+For most users with modern hardware and GPU acceleration, the default (disabled) provides the cleanest results. Enable eager processing when latency is a problem that outweighs the small risk of boundary artifacts.
+
+### Verifying It Works
+
+Run voxtype with verbose logging:
+
+```bash
+voxtype -vv
+```
+
+Then record for 10+ seconds. You should see log messages like:
+
+```
+[DEBUG] Spawning eager transcription for chunk 0
+[DEBUG] Spawning eager transcription for chunk 1
+[DEBUG] Chunk 0 completed: "This is the first part of my recording"
+[DEBUG] Chunk 1 completed: "the first part of my recording and here is more"
+[DEBUG] Combined eager chunks with deduplication
+```
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,18 @@ pub struct Cli {
     #[arg(long, value_name = "PROMPT")]
     pub initial_prompt: Option<String>,
 
+    /// Enable eager input processing (transcribe chunks while recording continues)
+    #[arg(long)]
+    pub eager_processing: bool,
+
+    /// Chunk duration in seconds for eager processing (default: 5.0)
+    #[arg(long, value_name = "SECS")]
+    pub eager_chunk_secs: Option<f32>,
+
+    /// Overlap between chunks in seconds for eager processing (default: 0.5)
+    #[arg(long, value_name = "SECS")]
+    pub eager_overlap_secs: Option<f32>,
+
     /// Override transcription engine: "whisper" (default) or "parakeet" (EXPERIMENTAL)
     #[arg(long, value_name = "ENGINE")]
     pub engine: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,7 @@ pub struct Cli {
     #[arg(long, value_name = "ENGINE")]
     pub engine: Option<String>,
 
-    /// Override hotkey (e.g., SCROLLLOCK, PAUSE, F13)
+    /// Override hotkey (e.g., SCROLLLOCK, PAUSE, F13, MEDIA, WEV_234, EVTEST_226)
     #[arg(long, value_name = "KEY")]
     pub hotkey: Option<String>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,18 @@ translate = false
 # Default: 300 (5 minutes). Only applies when gpu_isolation = false.
 # cold_model_timeout_secs = 300
 
+# --- Eager processing settings ---
+#
+# Enable eager input processing (transcribe chunks while recording continues)
+# Reduces perceived latency on slower machines by processing audio in parallel.
+# eager_processing = false
+#
+# Duration of each audio chunk in seconds (default: 5.0)
+# eager_chunk_secs = 5.0
+#
+# Overlap between chunks in seconds (helps catch words at boundaries, default: 0.5)
+# eager_overlap_secs = 0.5
+
 # --- Remote backend settings (used when backend = "remote") ---
 #
 # Remote server endpoint URL (required for remote backend)
@@ -388,6 +400,14 @@ fn default_max_loaded_models() -> usize {
 
 fn default_cold_model_timeout() -> u64 {
     300 // 5 minutes
+}
+
+fn default_eager_chunk_secs() -> f32 {
+    5.0
+}
+
+fn default_eager_overlap_secs() -> f32 {
+    0.5
 }
 
 fn default_whisper_model() -> String {
@@ -710,6 +730,22 @@ pub struct WhisperConfig {
     #[serde(default = "default_context_window_optimization")]
     pub context_window_optimization: bool,
 
+    // --- Eager processing settings ---
+    /// Enable eager input processing (transcribe chunks while recording continues)
+    /// When enabled, audio is split into chunks and transcribed in parallel with
+    /// continued recording. This reduces perceived latency on slower machines.
+    #[serde(default)]
+    pub eager_processing: bool,
+
+    /// Duration of each audio chunk in seconds for eager processing
+    #[serde(default = "default_eager_chunk_secs")]
+    pub eager_chunk_secs: f32,
+
+    /// Overlap between adjacent chunks in seconds for eager processing
+    /// Overlap helps catch words at chunk boundaries
+    #[serde(default = "default_eager_overlap_secs")]
+    pub eager_overlap_secs: f32,
+
     /// Initial prompt to provide context for transcription
     /// Use this to hint at terminology, proper nouns, or formatting conventions.
     /// Example: "Technical discussion about Rust, TypeScript, and Kubernetes."
@@ -808,6 +844,9 @@ impl Default for WhisperConfig {
             on_demand_loading: default_on_demand_loading(),
             gpu_isolation: false,
             context_window_optimization: default_context_window_optimization(),
+            eager_processing: false,
+            eager_chunk_secs: default_eager_chunk_secs(),
+            eager_overlap_secs: default_eager_overlap_secs(),
             initial_prompt: None,
             secondary_model: None,
             available_models: vec![],
@@ -1184,6 +1223,9 @@ impl Default for Config {
                 on_demand_loading: default_on_demand_loading(),
                 gpu_isolation: false,
                 context_window_optimization: default_context_window_optimization(),
+                eager_processing: false,
+                eager_chunk_secs: default_eager_chunk_secs(),
+                eager_overlap_secs: default_eager_overlap_secs(),
                 initial_prompt: None,
                 secondary_model: None,
                 available_models: vec![],

--- a/src/config.rs
+++ b/src/config.rs
@@ -1100,8 +1100,10 @@ pub enum OutputMode {
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputDriver {
-    /// wtype - Wayland-native, best Unicode/CJK support
+    /// wtype - Wayland-native via virtual-keyboard protocol, best Unicode/CJK support
     Wtype,
+    /// eitype - Wayland via libei/EI protocol, works on GNOME/KDE
+    Eitype,
     /// dotool - Works on X11/Wayland/TTY, supports keyboard layouts
     Dotool,
     /// ydotool - Works on X11/Wayland/TTY, requires daemon
@@ -1116,6 +1118,7 @@ impl std::fmt::Display for OutputDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             OutputDriver::Wtype => write!(f, "wtype"),
+            OutputDriver::Eitype => write!(f, "eitype"),
             OutputDriver::Dotool => write!(f, "dotool"),
             OutputDriver::Ydotool => write!(f, "ydotool"),
             OutputDriver::Clipboard => write!(f, "clipboard"),
@@ -1130,12 +1133,13 @@ impl std::str::FromStr for OutputDriver {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "wtype" => Ok(OutputDriver::Wtype),
+            "eitype" => Ok(OutputDriver::Eitype),
             "dotool" => Ok(OutputDriver::Dotool),
             "ydotool" => Ok(OutputDriver::Ydotool),
             "clipboard" => Ok(OutputDriver::Clipboard),
             "xclip" => Ok(OutputDriver::Xclip),
             _ => Err(format!(
-                "Unknown driver '{}'. Valid options: wtype, dotool, ydotool, clipboard, xclip",
+                "Unknown driver '{}'. Valid options: wtype, eitype, dotool, ydotool, clipboard, xclip",
                 s
             )),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -753,7 +753,6 @@ pub struct WhisperConfig {
     pub initial_prompt: Option<String>,
 
     // --- Multi-model settings ---
-
     /// Secondary model to use when hotkey.model_modifier is held
     /// Example: "large-v3-turbo" for difficult audio
     #[serde(default)]
@@ -810,9 +809,7 @@ impl WhisperConfig {
         }
         // Fall back to deprecated `backend` with warning
         if let Some(backend) = self.backend {
-            tracing::warn!(
-                "DEPRECATED: [whisper] backend is deprecated, use 'mode' instead"
-            );
+            tracing::warn!("DEPRECATED: [whisper] backend is deprecated, use 'mode' instead");
             tracing::warn!(
                 "  Change 'backend = \"{}\"' to 'mode = \"{}\"' in config.toml",
                 match backend {
@@ -913,7 +910,8 @@ impl Default for ParakeetConfig {
 impl ParakeetConfig {
     /// Check if streaming is enabled (auto-detects based on model type)
     pub fn streaming_enabled(&self, detected_model_type: ParakeetModelType) -> bool {
-        self.streaming.unwrap_or(matches!(detected_model_type, ParakeetModelType::Nemotron))
+        self.streaming
+            .unwrap_or(matches!(detected_model_type, ParakeetModelType::Nemotron))
     }
 }
 
@@ -2037,7 +2035,10 @@ mod tests {
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.engine, TranscriptionEngine::Parakeet);
         assert!(config.parakeet.is_some());
-        assert_eq!(config.parakeet.as_ref().unwrap().model, "parakeet-tdt-0.6b-v3");
+        assert_eq!(
+            config.parakeet.as_ref().unwrap().model,
+            "parakeet-tdt-0.6b-v3"
+        );
     }
 
     #[test]
@@ -2065,15 +2066,39 @@ mod tests {
 
     #[test]
     fn test_output_driver_from_str() {
-        assert_eq!("wtype".parse::<OutputDriver>().unwrap(), OutputDriver::Wtype);
-        assert_eq!("dotool".parse::<OutputDriver>().unwrap(), OutputDriver::Dotool);
-        assert_eq!("ydotool".parse::<OutputDriver>().unwrap(), OutputDriver::Ydotool);
-        assert_eq!("clipboard".parse::<OutputDriver>().unwrap(), OutputDriver::Clipboard);
-        assert_eq!("xclip".parse::<OutputDriver>().unwrap(), OutputDriver::Xclip);
+        assert_eq!(
+            "wtype".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Wtype
+        );
+        assert_eq!(
+            "dotool".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Dotool
+        );
+        assert_eq!(
+            "ydotool".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Ydotool
+        );
+        assert_eq!(
+            "clipboard".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Clipboard
+        );
+        assert_eq!(
+            "xclip".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Xclip
+        );
         // Case insensitive
-        assert_eq!("WTYPE".parse::<OutputDriver>().unwrap(), OutputDriver::Wtype);
-        assert_eq!("Ydotool".parse::<OutputDriver>().unwrap(), OutputDriver::Ydotool);
-        assert_eq!("XCLIP".parse::<OutputDriver>().unwrap(), OutputDriver::Xclip);
+        assert_eq!(
+            "WTYPE".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Wtype
+        );
+        assert_eq!(
+            "Ydotool".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Ydotool
+        );
+        assert_eq!(
+            "XCLIP".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Xclip
+        );
         // Invalid
         assert!("invalid".parse::<OutputDriver>().is_err());
     }
@@ -2467,11 +2492,17 @@ mod tests {
         assert_eq!(config.profiles.len(), 2);
 
         let slack = config.get_profile("slack").unwrap();
-        assert_eq!(slack.post_process_command, Some("cleanup-for-slack.sh".to_string()));
+        assert_eq!(
+            slack.post_process_command,
+            Some("cleanup-for-slack.sh".to_string())
+        );
         assert!(slack.output_mode.is_none());
 
         let code = config.get_profile("code").unwrap();
-        assert_eq!(code.post_process_command, Some("cleanup-for-code.sh".to_string()));
+        assert_eq!(
+            code.post_process_command,
+            Some("cleanup-for-code.sh".to_string())
+        );
         assert_eq!(code.output_mode, Some(OutputMode::Clipboard));
     }
 
@@ -2500,7 +2531,10 @@ mod tests {
 
         let config: Config = toml::from_str(toml_str).unwrap();
         let slow = config.get_profile("slow").unwrap();
-        assert_eq!(slow.post_process_command, Some("slow-llm-command".to_string()));
+        assert_eq!(
+            slow.post_process_command,
+            Some("slow-llm-command".to_string())
+        );
         assert_eq!(slow.post_process_timeout_ms, Some(60000));
     }
 

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -1,0 +1,385 @@
+//! Eager input processing module
+//!
+//! Handles chunking audio during recording and processing chunks in parallel
+//! with continued recording. This reduces perceived latency on slower machines.
+//!
+//! The basic approach:
+//! 1. During recording, split audio into fixed-size chunks with small overlaps
+//! 2. As each chunk is ready, spawn a transcription task for it
+//! 3. Continue recording while transcription runs in parallel
+//! 4. At the end, combine all chunk results, deduplicating at boundaries
+
+use crate::state::ChunkResult;
+
+/// Configuration for eager processing
+#[derive(Debug, Clone)]
+pub struct EagerConfig {
+    /// Duration of each chunk in seconds
+    pub chunk_secs: f32,
+    /// Overlap between adjacent chunks in seconds
+    pub overlap_secs: f32,
+    /// Sample rate (assumed 16kHz for whisper)
+    pub sample_rate: u32,
+}
+
+impl EagerConfig {
+    /// Create config from whisper config settings
+    pub fn from_whisper_config(config: &crate::config::WhisperConfig) -> Self {
+        Self {
+            chunk_secs: config.eager_chunk_secs,
+            overlap_secs: config.eager_overlap_secs,
+            sample_rate: 16000, // Whisper expects 16kHz
+        }
+    }
+
+    /// Get chunk size in samples
+    pub fn chunk_samples(&self) -> usize {
+        (self.chunk_secs * self.sample_rate as f32) as usize
+    }
+
+    /// Get overlap size in samples
+    pub fn overlap_samples(&self) -> usize {
+        (self.overlap_secs * self.sample_rate as f32) as usize
+    }
+
+    /// Get the stride between chunk starts (chunk - overlap)
+    pub fn stride_samples(&self) -> usize {
+        self.chunk_samples().saturating_sub(self.overlap_samples())
+    }
+}
+
+/// Extract a chunk from accumulated audio for transcription.
+/// Returns None if there isn't enough audio for the requested chunk yet.
+///
+/// # Arguments
+/// * `accumulated` - All audio samples collected so far
+/// * `chunk_index` - Which chunk to extract (0-based)
+/// * `config` - Eager processing configuration
+///
+/// # Returns
+/// * `Some(Vec<f32>)` - The audio chunk to transcribe
+/// * `None` - Not enough audio yet for this chunk
+pub fn extract_chunk(
+    accumulated: &[f32],
+    chunk_index: usize,
+    config: &EagerConfig,
+) -> Option<Vec<f32>> {
+    let chunk_size = config.chunk_samples();
+    let stride = config.stride_samples();
+
+    // Calculate chunk boundaries
+    let start = chunk_index * stride;
+    let end = start + chunk_size;
+
+    // Check if we have enough samples
+    if end > accumulated.len() {
+        return None;
+    }
+
+    Some(accumulated[start..end].to_vec())
+}
+
+/// Check how many complete chunks are available in the accumulated audio.
+/// A chunk is "complete" when we have enough samples to extract it plus
+/// the overlap for the next chunk (so we don't cut off mid-word).
+///
+/// # Arguments
+/// * `accumulated_len` - Number of samples accumulated so far
+/// * `config` - Eager processing configuration
+///
+/// # Returns
+/// Number of complete chunks available
+pub fn count_complete_chunks(accumulated_len: usize, config: &EagerConfig) -> usize {
+    let stride = config.stride_samples();
+    let chunk_size = config.chunk_samples();
+
+    if accumulated_len < chunk_size {
+        return 0;
+    }
+
+    // Number of chunks where we have the full chunk + overlap for boundary handling
+    let available_after_first = accumulated_len.saturating_sub(chunk_size);
+    1 + available_after_first / stride
+}
+
+/// Combine transcription results from multiple chunks, handling duplicates
+/// at chunk boundaries.
+///
+/// # Arguments
+/// * `results` - Vector of chunk results (may be in any order)
+///
+/// # Returns
+/// Combined transcription text with duplicates at boundaries removed
+pub fn combine_chunk_results(mut results: Vec<ChunkResult>) -> String {
+    if results.is_empty() {
+        return String::new();
+    }
+
+    // Sort by chunk index to ensure correct order
+    results.sort_by_key(|r| r.chunk_index);
+
+    if results.len() == 1 {
+        return results[0].text.clone();
+    }
+
+    let mut combined = String::new();
+
+    for (i, result) in results.iter().enumerate() {
+        if i == 0 {
+            // First chunk: use full text
+            combined = result.text.clone();
+        } else {
+            // Subsequent chunks: deduplicate at boundary
+            let new_text = deduplicate_boundary(&combined, &result.text);
+            if !new_text.is_empty() {
+                if !combined.is_empty() && !combined.ends_with(' ') && !new_text.starts_with(' ') {
+                    combined.push(' ');
+                }
+                combined.push_str(&new_text);
+            }
+        }
+    }
+
+    combined.trim().to_string()
+}
+
+/// Remove duplicate text at the boundary between previous and new transcription.
+///
+/// This uses a simple approach: look for the longest suffix of `previous` that
+/// matches a prefix of `new_text`, and return `new_text` with that prefix removed.
+///
+/// # Arguments
+/// * `previous` - Text transcribed so far (from earlier chunks)
+/// * `new_text` - Text from the new chunk
+///
+/// # Returns
+/// The portion of `new_text` that isn't a duplicate of `previous`
+fn deduplicate_boundary(previous: &str, new_text: &str) -> String {
+    let previous_words: Vec<&str> = previous.split_whitespace().collect();
+    let new_words: Vec<&str> = new_text.split_whitespace().collect();
+
+    if previous_words.is_empty() || new_words.is_empty() {
+        return new_text.to_string();
+    }
+
+    // Look for overlap: find the longest suffix of previous that matches
+    // a prefix of new_text
+    let max_overlap = previous_words.len().min(new_words.len());
+
+    let mut best_overlap = 0;
+    for overlap_len in 1..=max_overlap {
+        let prev_suffix = &previous_words[previous_words.len() - overlap_len..];
+        let new_prefix = &new_words[..overlap_len];
+
+        // Case-insensitive comparison for robustness
+        if prev_suffix
+            .iter()
+            .zip(new_prefix.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b))
+        {
+            best_overlap = overlap_len;
+        }
+    }
+
+    if best_overlap > 0 {
+        // Remove the overlapping prefix from new_text
+        new_words[best_overlap..].join(" ")
+    } else {
+        new_text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> EagerConfig {
+        EagerConfig {
+            chunk_secs: 5.0,
+            overlap_secs: 0.5,
+            sample_rate: 16000,
+        }
+    }
+
+    #[test]
+    fn test_chunk_samples() {
+        let config = test_config();
+        assert_eq!(config.chunk_samples(), 80000); // 5 seconds * 16000 Hz
+        assert_eq!(config.overlap_samples(), 8000); // 0.5 seconds * 16000 Hz
+        assert_eq!(config.stride_samples(), 72000); // chunk - overlap
+    }
+
+    #[test]
+    fn test_count_complete_chunks_empty() {
+        let config = test_config();
+        assert_eq!(count_complete_chunks(0, &config), 0);
+    }
+
+    #[test]
+    fn test_count_complete_chunks_less_than_one() {
+        let config = test_config();
+        // Less than one chunk
+        assert_eq!(count_complete_chunks(40000, &config), 0);
+    }
+
+    #[test]
+    fn test_count_complete_chunks_one() {
+        let config = test_config();
+        // Exactly one chunk
+        assert_eq!(count_complete_chunks(80000, &config), 1);
+    }
+
+    #[test]
+    fn test_count_complete_chunks_multiple() {
+        let config = test_config();
+        // First chunk (80000) + stride for second (72000) = 152000
+        assert_eq!(count_complete_chunks(152000, &config), 2);
+        // First chunk + 2 strides = 224000
+        assert_eq!(count_complete_chunks(224000, &config), 3);
+    }
+
+    #[test]
+    fn test_extract_chunk_insufficient_data() {
+        let config = test_config();
+        let audio = vec![0.0; 40000]; // Less than one chunk
+        assert!(extract_chunk(&audio, 0, &config).is_none());
+    }
+
+    #[test]
+    fn test_extract_chunk_first() {
+        let config = test_config();
+        let audio: Vec<f32> = (0..100000).map(|i| i as f32).collect();
+        let chunk = extract_chunk(&audio, 0, &config).unwrap();
+        assert_eq!(chunk.len(), 80000);
+        assert_eq!(chunk[0], 0.0);
+    }
+
+    #[test]
+    fn test_extract_chunk_second() {
+        let config = test_config();
+        let audio: Vec<f32> = (0..200000).map(|i| i as f32).collect();
+        let chunk = extract_chunk(&audio, 1, &config).unwrap();
+        assert_eq!(chunk.len(), 80000);
+        // Second chunk starts at stride (72000)
+        assert_eq!(chunk[0], 72000.0);
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_no_overlap() {
+        let result = deduplicate_boundary("hello world", "foo bar");
+        assert_eq!(result, "foo bar");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_single_word_overlap() {
+        let result = deduplicate_boundary("hello world", "world foo bar");
+        assert_eq!(result, "foo bar");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_multi_word_overlap() {
+        let result = deduplicate_boundary("hello world foo", "world foo bar baz");
+        assert_eq!(result, "bar baz");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_case_insensitive() {
+        let result = deduplicate_boundary("Hello World", "world foo");
+        assert_eq!(result, "foo");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_empty_previous() {
+        let result = deduplicate_boundary("", "hello world");
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_deduplicate_boundary_empty_new() {
+        let result = deduplicate_boundary("hello world", "");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_empty() {
+        let results: Vec<ChunkResult> = vec![];
+        assert_eq!(combine_chunk_results(results), "");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_single() {
+        let results = vec![ChunkResult {
+            text: "hello world".to_string(),
+            chunk_index: 0,
+        }];
+        assert_eq!(combine_chunk_results(results), "hello world");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_multiple_no_overlap() {
+        let results = vec![
+            ChunkResult {
+                text: "hello world".to_string(),
+                chunk_index: 0,
+            },
+            ChunkResult {
+                text: "foo bar".to_string(),
+                chunk_index: 1,
+            },
+        ];
+        assert_eq!(combine_chunk_results(results), "hello world foo bar");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_with_overlap() {
+        let results = vec![
+            ChunkResult {
+                text: "hello world foo".to_string(),
+                chunk_index: 0,
+            },
+            ChunkResult {
+                text: "foo bar baz".to_string(),
+                chunk_index: 1,
+            },
+        ];
+        assert_eq!(combine_chunk_results(results), "hello world foo bar baz");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_out_of_order() {
+        // Results can arrive out of order; they should be sorted by chunk_index
+        let results = vec![
+            ChunkResult {
+                text: "bar baz".to_string(),
+                chunk_index: 1,
+            },
+            ChunkResult {
+                text: "hello world bar".to_string(),
+                chunk_index: 0,
+            },
+        ];
+        assert_eq!(combine_chunk_results(results), "hello world bar baz");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_three_chunks() {
+        let results = vec![
+            ChunkResult {
+                text: "one two three".to_string(),
+                chunk_index: 0,
+            },
+            ChunkResult {
+                text: "three four five".to_string(),
+                chunk_index: 1,
+            },
+            ChunkResult {
+                text: "five six seven".to_string(),
+                chunk_index: 2,
+            },
+        ];
+        assert_eq!(
+            combine_chunk_results(results),
+            "one two three four five six seven"
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -108,6 +108,9 @@ pub enum OutputError {
     #[error("wtype not found in PATH. Install via your package manager.")]
     WtypeNotFound,
 
+    #[error("eitype not found in PATH. Install via: cargo install eitype")]
+    EitypeNotFound,
+
     #[error("wl-copy not found in PATH. Install wl-clipboard via your package manager.")]
     WlCopyNotFound,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub mod cli;
 pub mod config;
 pub mod cpu;
 pub mod daemon;
+pub mod eager;
 pub mod error;
 pub mod hotkey;
 pub mod model_manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,15 @@ async fn main() -> anyhow::Result<()> {
     if let Some(prompt) = cli.initial_prompt {
         config.whisper.initial_prompt = Some(prompt);
     }
+    if cli.eager_processing {
+        config.whisper.eager_processing = true;
+    }
+    if let Some(secs) = cli.eager_chunk_secs {
+        config.whisper.eager_chunk_secs = secs;
+    }
+    if let Some(secs) = cli.eager_overlap_secs {
+        config.whisper.eager_overlap_secs = secs;
+    }
     if let Some(ref driver_str) = cli.driver {
         match parse_driver_order(driver_str) {
             Ok(drivers) => {

--- a/src/output/eitype.rs
+++ b/src/output/eitype.rs
@@ -1,0 +1,231 @@
+//! eitype-based text output
+//!
+//! Uses eitype to simulate keyboard input via the Emulated Input (EI) protocol.
+//! This works on compositors that support libei, including GNOME/Mutter and KDE,
+//! which do not support the virtual-keyboard protocol used by wtype.
+//!
+//! Requires:
+//! - eitype installed
+//! - Compositor with EI protocol support (GNOME, KDE, Sway with libei)
+
+use super::TextOutput;
+use crate::error::OutputError;
+use std::process::Stdio;
+use tokio::process::Command;
+
+/// eitype-based text output
+pub struct EitypeOutput {
+    /// Whether to send Enter key after output
+    auto_submit: bool,
+    /// Delay between key events in milliseconds
+    type_delay_ms: u32,
+    /// Delay before typing starts (ms)
+    pre_type_delay_ms: u32,
+    /// Convert newlines to Shift+Enter (for apps where Enter submits)
+    shift_enter_newlines: bool,
+}
+
+impl EitypeOutput {
+    /// Create a new eitype output
+    pub fn new(
+        auto_submit: bool,
+        type_delay_ms: u32,
+        pre_type_delay_ms: u32,
+        shift_enter_newlines: bool,
+    ) -> Self {
+        Self {
+            auto_submit,
+            type_delay_ms,
+            pre_type_delay_ms,
+            shift_enter_newlines,
+        }
+    }
+
+    /// Type a string of text using eitype
+    async fn type_text(&self, text: &str) -> Result<(), OutputError> {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        // eitype doesn't have a pre-type delay flag, so sleep if needed
+        if self.pre_type_delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(self.pre_type_delay_ms as u64))
+                .await;
+        }
+
+        let mut cmd = Command::new("eitype");
+        let mut debug_args = vec!["eitype".to_string()];
+
+        // Add inter-keystroke delay if configured
+        if self.type_delay_ms > 0 {
+            cmd.arg("-d").arg(self.type_delay_ms.to_string());
+            debug_args.push(format!("-d {}", self.type_delay_ms));
+        }
+
+        debug_args.push(format!(
+            "\"{}\"",
+            text.chars().take(20).collect::<String>()
+        ));
+        tracing::debug!("Running: {}", debug_args.join(" "));
+
+        let output = cmd
+            .arg(text)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    OutputError::EitypeNotFound
+                } else {
+                    OutputError::InjectionFailed(e.to_string())
+                }
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(OutputError::InjectionFailed(format!(
+                "eitype failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Send Shift+Enter key combination using eitype
+    async fn send_shift_enter(&self) -> Result<(), OutputError> {
+        let output = Command::new("eitype")
+            .args(["-M", "shift", "-k", "return"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| {
+                OutputError::InjectionFailed(format!("eitype Shift+Enter failed: {}", e))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!("Failed to send Shift+Enter: {}", stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Send Enter key using eitype
+    async fn send_enter(&self) -> Result<(), OutputError> {
+        let output = Command::new("eitype")
+            .args(["-k", "return"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| OutputError::InjectionFailed(format!("eitype Enter failed: {}", e)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!("Failed to send Enter key: {}", stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Output text with newlines converted to Shift+Enter
+    async fn output_with_shift_enter_newlines(&self, text: &str) -> Result<(), OutputError> {
+        let segments: Vec<&str> = text.split('\n').collect();
+
+        for (i, segment) in segments.iter().enumerate() {
+            // Type the text segment
+            if !segment.is_empty() {
+                self.type_text(segment).await?;
+            }
+
+            // Send Shift+Enter between segments (not after the last one)
+            if i < segments.len() - 1 {
+                self.send_shift_enter().await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl TextOutput for EitypeOutput {
+    async fn output(&self, text: &str) -> Result<(), OutputError> {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        // If shift_enter_newlines is enabled, process text with Shift+Enter for newlines
+        if self.shift_enter_newlines && text.contains('\n') {
+            self.output_with_shift_enter_newlines(text).await?;
+        } else {
+            self.type_text(text).await?;
+        }
+
+        // Send Enter key if auto_submit is configured
+        if self.auto_submit {
+            self.send_enter().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn is_available(&self) -> bool {
+        // Check if eitype exists in PATH
+        Command::new("which")
+            .arg("eitype")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn name(&self) -> &'static str {
+        "eitype"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let output = EitypeOutput::new(false, 0, 0, false);
+        assert!(!output.auto_submit);
+        assert_eq!(output.type_delay_ms, 0);
+        assert_eq!(output.pre_type_delay_ms, 0);
+        assert!(!output.shift_enter_newlines);
+    }
+
+    #[test]
+    fn test_new_with_enter() {
+        let output = EitypeOutput::new(true, 0, 0, false);
+        assert!(output.auto_submit);
+    }
+
+    #[test]
+    fn test_new_with_type_delay() {
+        let output = EitypeOutput::new(false, 50, 0, false);
+        assert_eq!(output.type_delay_ms, 50);
+        assert_eq!(output.pre_type_delay_ms, 0);
+    }
+
+    #[test]
+    fn test_new_with_pre_type_delay() {
+        let output = EitypeOutput::new(false, 0, 200, false);
+        assert_eq!(output.type_delay_ms, 0);
+        assert_eq!(output.pre_type_delay_ms, 200);
+    }
+
+    #[test]
+    fn test_new_with_shift_enter_newlines() {
+        let output = EitypeOutput::new(false, 0, 0, true);
+        assert!(output.shift_enter_newlines);
+    }
+}

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -139,6 +139,30 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
         huggingface_repo: "altunenes/parakeet-rs",
         huggingface_path: Some("nemotron-speech-streaming-en-0.6b"),
     },
+    ParakeetModelInfo {
+        name: "nemotron-speech-streaming-en-0.6b-int8",
+        size_mb: 670,
+        description: "Nemotron streaming, quantized int8 (faster CPU)",
+        files: &[
+            ("encoder.onnx", 0),
+            ("decoder_joint.onnx", 0),
+            ("tokenizer.model", 257_151),
+        ],
+        huggingface_repo: "lokkju/nemotron-speech-streaming-en-0.6b-int8",
+        huggingface_path: None,
+    },
+    ParakeetModelInfo {
+        name: "nemotron-speech-streaming-en-0.6b-int4",
+        size_mb: 400,
+        description: "Nemotron streaming, quantized int4 (smallest/fastest CPU)",
+        files: &[
+            ("encoder.onnx", 0),
+            ("decoder_joint.onnx", 0),
+            ("tokenizer.model", 257_151),
+        ],
+        huggingface_repo: "lokkju/nemotron-speech-streaming-en-0.6b-int4",
+        huggingface_path: None,
+    },
 ];
 
 // =============================================================================
@@ -1056,6 +1080,9 @@ language = "en"
         let model_names: Vec<&str> = PARAKEET_MODELS.iter().map(|m| m.name).collect();
         assert!(model_names.contains(&"parakeet-tdt-0.6b-v3"));
         assert!(model_names.contains(&"parakeet-tdt-0.6b-v3-int8"));
+        assert!(model_names.contains(&"nemotron-speech-streaming-en-0.6b"));
+        assert!(model_names.contains(&"nemotron-speech-streaming-en-0.6b-int8"));
+        assert!(model_names.contains(&"nemotron-speech-streaming-en-0.6b-int4"));
     }
 
     #[test]
@@ -1099,6 +1126,8 @@ language = "en"
         assert!(is_parakeet_model("parakeet-tdt-0.6b-v3"));
         assert!(is_parakeet_model("parakeet-tdt-0.6b-v3-int8"));
         assert!(is_parakeet_model("nemotron-speech-streaming-en-0.6b"));
+        assert!(is_parakeet_model("nemotron-speech-streaming-en-0.6b-int8"));
+        assert!(is_parakeet_model("nemotron-speech-streaming-en-0.6b-int4"));
 
         // Invalid models
         assert!(!is_parakeet_model("base.en"));

--- a/src/state.rs
+++ b/src/state.rs
@@ -88,7 +88,9 @@ impl State {
     pub fn is_recording(&self) -> bool {
         matches!(
             self,
-            State::Recording { .. } | State::EagerRecording { .. } | State::StreamingRecording { .. }
+            State::Recording { .. }
+                | State::EagerRecording { .. }
+                | State::StreamingRecording { .. }
         )
     }
 
@@ -123,7 +125,9 @@ impl State {
     /// Get the number of transcription tasks currently in flight (eager mode only)
     pub fn eager_tasks_in_flight(&self) -> Option<usize> {
         match self {
-            State::EagerRecording { tasks_in_flight, .. } => Some(*tasks_in_flight),
+            State::EagerRecording {
+                tasks_in_flight, ..
+            } => Some(*tasks_in_flight),
             _ => None,
         }
     }

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -72,7 +72,9 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
                     "Parakeet engine selected but [parakeet] config section is missing".to_string(),
                 )
             })?;
-            Ok(Box::new(parakeet::ParakeetTranscriber::new(parakeet_config)?))
+            Ok(Box::new(parakeet::ParakeetTranscriber::new(
+                parakeet_config,
+            )?))
         }
         #[cfg(not(feature = "parakeet"))]
         TranscriptionEngine::Parakeet => Err(TranscribeError::InitFailed(
@@ -121,7 +123,10 @@ pub fn create_transcriber_with_config_path(
     // Apply GPU selection from VOXTYPE_VULKAN_DEVICE environment variable
     // This sets VK_LOADER_DRIVERS_SELECT to filter Vulkan drivers
     if let Some(vendor) = gpu::apply_gpu_selection() {
-        tracing::info!("GPU selection: {} (via VOXTYPE_VULKAN_DEVICE)", vendor.display_name());
+        tracing::info!(
+            "GPU selection: {} (via VOXTYPE_VULKAN_DEVICE)",
+            vendor.display_name()
+        );
     }
 
     match config.effective_mode() {

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -7,21 +7,25 @@
 //! - CTC (Connectionist Temporal Classification): faster, character-level output
 //! - TDT (Token-Duration-Transducer): recommended, proper punctuation and word boundaries
 
-use super::Transcriber;
+use super::{StreamingTranscriber, Transcriber};
 use crate::config::{ParakeetConfig, ParakeetModelType};
 use crate::error::TranscribeError;
 #[cfg(any(feature = "parakeet-cuda", feature = "parakeet-rocm", feature = "parakeet-tensorrt"))]
 use parakeet_rs::ExecutionProvider;
-use parakeet_rs::{ExecutionConfig, Parakeet, ParakeetTDT, Transcriber as ParakeetTranscriberTrait};
+use parakeet_rs::{
+    ExecutionConfig, Nemotron, Parakeet, ParakeetTDT, Transcriber as ParakeetTranscriberTrait,
+};
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-/// Internal enum to hold either CTC or TDT model instance
+/// Internal enum to hold CTC, TDT, or Nemotron model instance
 enum ParakeetModel {
     /// CTC model (character-level, faster)
     Ctc(Mutex<Parakeet>),
     /// TDT model (token-level, better quality output)
     Tdt(Mutex<ParakeetTDT>),
+    /// Nemotron model (streaming transducer)
+    Nemotron(Mutex<Nemotron>),
 }
 
 /// Parakeet-based transcriber using ONNX Runtime
@@ -66,6 +70,13 @@ impl ParakeetTranscriber {
                         TranscribeError::InitFailed(format!("Parakeet TDT init failed: {}", e))
                     })?;
                 ParakeetModel::Tdt(Mutex::new(parakeet))
+            }
+            ParakeetModelType::Nemotron => {
+                let nemotron = Nemotron::from_pretrained(&model_path, exec_config)
+                    .map_err(|e| {
+                        TranscribeError::InitFailed(format!("Nemotron init failed: {}", e))
+                    })?;
+                ParakeetModel::Nemotron(Mutex::new(nemotron))
             }
         };
 
@@ -132,6 +143,20 @@ impl Transcriber for ParakeetTranscriber {
 
                 result.text.trim().to_string()
             }
+            ParakeetModel::Nemotron(nemotron) => {
+                let mut nemotron = nemotron.lock().map_err(|e| {
+                    TranscribeError::InferenceFailed(format!("Failed to lock Nemotron mutex: {}", e))
+                })?;
+
+                nemotron.reset();
+                let text = nemotron
+                    .transcribe_audio(samples)
+                    .map_err(|e| {
+                        TranscribeError::InferenceFailed(format!("Nemotron inference failed: {}", e))
+                    })?;
+
+                text.trim().to_string()
+            }
         };
 
         tracing::info!(
@@ -147,6 +172,88 @@ impl Transcriber for ParakeetTranscriber {
 
         Ok(text)
     }
+}
+
+/// Nemotron streaming transcriber for real-time output during recording
+pub struct NemotronStreamingTranscriber {
+    model: Nemotron,
+    /// Text already returned to the caller (for computing deltas)
+    last_transcript_len: usize,
+}
+
+impl NemotronStreamingTranscriber {
+    pub fn new(config: &ParakeetConfig) -> Result<Self, TranscribeError> {
+        let model_path = resolve_model_path(&config.model)?;
+
+        tracing::info!("Loading Nemotron streaming model from {:?}", model_path);
+        let start = std::time::Instant::now();
+
+        let exec_config = build_execution_config();
+
+        let model = Nemotron::from_pretrained(&model_path, exec_config).map_err(|e| {
+            TranscribeError::InitFailed(format!("Nemotron init failed: {}", e))
+        })?;
+
+        tracing::info!(
+            "Nemotron streaming model loaded in {:.2}s",
+            start.elapsed().as_secs_f32()
+        );
+
+        Ok(Self {
+            model,
+            last_transcript_len: 0,
+        })
+    }
+}
+
+impl StreamingTranscriber for NemotronStreamingTranscriber {
+    fn transcribe_chunk(&mut self, chunk: &[f32]) -> Result<String, TranscribeError> {
+        let full_text = self.model.transcribe_chunk(chunk).map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Nemotron chunk inference failed: {}", e))
+        })?;
+
+        // Return only the new text (delta)
+        let delta = if full_text.len() > self.last_transcript_len {
+            full_text[self.last_transcript_len..].to_string()
+        } else {
+            String::new()
+        };
+        self.last_transcript_len = full_text.len();
+
+        Ok(delta)
+    }
+
+    fn flush(&mut self) -> Result<String, TranscribeError> {
+        // Feed 3 silence chunks to drain the decoder
+        let silence = vec![0.0f32; self.chunk_size()];
+        let mut flushed = String::new();
+        for _ in 0..3 {
+            let delta = self.transcribe_chunk(&silence)?;
+            flushed.push_str(&delta);
+        }
+        Ok(flushed)
+    }
+
+    fn reset(&mut self) {
+        self.model.reset();
+        self.last_transcript_len = 0;
+    }
+
+    fn get_transcript(&self) -> String {
+        self.model.get_transcript()
+    }
+
+    fn chunk_size(&self) -> usize {
+        // 560ms at 16kHz = 8960 samples
+        8960
+    }
+}
+
+/// Factory function to create a Nemotron streaming transcriber
+pub fn create_nemotron_streaming(
+    config: &ParakeetConfig,
+) -> Result<Box<dyn StreamingTranscriber>, TranscribeError> {
+    Ok(Box::new(NemotronStreamingTranscriber::new(config)?))
 }
 
 /// Build execution config based on compile-time feature flags
@@ -177,10 +284,25 @@ fn build_execution_config() -> Option<ExecutionConfig> {
 
 /// Auto-detect model type from directory structure
 ///
+/// Nemotron models have: encoder.onnx, encoder.onnx.data, decoder_joint.onnx, tokenizer.model
 /// TDT models have: encoder-model.onnx, decoder_joint-model.onnx, vocab.txt
 /// CTC models have: model.onnx (or model_int8.onnx), tokenizer.json
 fn detect_model_type(path: &PathBuf) -> ParakeetModelType {
-    // Check for TDT model structure
+    // Check for Nemotron model structure (must come before TDT since both have encoder/decoder)
+    // Nemotron uses non-hyphenated names: encoder.onnx (not encoder-model.onnx)
+    let has_nemotron_encoder = path.join("encoder.onnx").exists()
+        || path.join("encoder.onnx.data").exists();
+    let has_nemotron_decoder = path.join("decoder_joint.onnx").exists();
+    let has_sentencepiece = path.join("tokenizer.model").exists();
+
+    if has_nemotron_encoder && has_nemotron_decoder && has_sentencepiece {
+        tracing::debug!(
+            "Auto-detected Nemotron model (found encoder.onnx + decoder_joint.onnx + tokenizer.model)"
+        );
+        return ParakeetModelType::Nemotron;
+    }
+
+    // Check for TDT model structure (hyphenated names: encoder-model.onnx)
     let has_encoder = path.join("encoder-model.onnx").exists()
         || path.join("encoder-model.onnx.data").exists();
     let has_decoder = path.join("decoder_joint-model.onnx").exists();
@@ -305,6 +427,49 @@ mod tests {
 
         let detected = detect_model_type(&model_path);
         assert_eq!(detected, ParakeetModelType::Ctc);
+    }
+
+    #[test]
+    fn test_detect_model_type_nemotron() {
+        let temp_dir = TempDir::new().unwrap();
+        let model_path = temp_dir.path().to_path_buf();
+
+        // Create Nemotron model structure (non-hyphenated encoder.onnx)
+        fs::write(model_path.join("encoder.onnx"), b"dummy").unwrap();
+        fs::write(model_path.join("encoder.onnx.data"), b"dummy").unwrap();
+        fs::write(model_path.join("decoder_joint.onnx"), b"dummy").unwrap();
+        fs::write(model_path.join("tokenizer.model"), b"dummy").unwrap();
+
+        let detected = detect_model_type(&model_path);
+        assert_eq!(detected, ParakeetModelType::Nemotron);
+    }
+
+    #[test]
+    fn test_detect_model_type_nemotron_without_data_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let model_path = temp_dir.path().to_path_buf();
+
+        // Nemotron with encoder.onnx (no .data file) + decoder + tokenizer.model
+        fs::write(model_path.join("encoder.onnx"), b"dummy").unwrap();
+        fs::write(model_path.join("decoder_joint.onnx"), b"dummy").unwrap();
+        fs::write(model_path.join("tokenizer.model"), b"dummy").unwrap();
+
+        let detected = detect_model_type(&model_path);
+        assert_eq!(detected, ParakeetModelType::Nemotron);
+    }
+
+    #[test]
+    fn test_detect_model_type_tdt_not_confused_with_nemotron() {
+        let temp_dir = TempDir::new().unwrap();
+        let model_path = temp_dir.path().to_path_buf();
+
+        // TDT uses hyphenated names - should NOT match Nemotron
+        fs::write(model_path.join("encoder-model.onnx"), b"dummy").unwrap();
+        fs::write(model_path.join("decoder_joint-model.onnx"), b"dummy").unwrap();
+        fs::write(model_path.join("vocab.txt"), b"dummy").unwrap();
+
+        let detected = detect_model_type(&model_path);
+        assert_eq!(detected, ParakeetModelType::Tdt);
     }
 
     #[test]

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -382,8 +382,10 @@ fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
 
     Err(TranscribeError::ModelNotFound(format!(
         "Parakeet model '{}' not found. Looked in:\n  - {}\n  - {}\n  - {}\n\n\
+        Run: voxtype setup model\n\n\
         Download TDT (recommended): https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx\n\
-        Download CTC: https://huggingface.co/nvidia/parakeet-ctc-0.6b",
+        Download CTC: https://huggingface.co/nvidia/parakeet-ctc-0.6b\n\
+        Download Nemotron (streaming): https://huggingface.co/altunenes/parakeet-rs/tree/main/nemotron-speech-streaming-en-0.6b",
         model,
         model_path.display(),
         cwd_path.display(),

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -276,8 +276,8 @@ fn build_execution_config() -> Option<ExecutionConfig> {
 
     #[cfg(feature = "parakeet-rocm")]
     {
-        tracing::info!("Configuring ROCm execution provider for AMD GPU acceleration");
-        return Some(ExecutionConfig::new().with_execution_provider(ExecutionProvider::ROCm));
+        tracing::info!("Configuring MIGraphX execution provider for AMD GPU acceleration");
+        return Some(ExecutionConfig::new().with_execution_provider(ExecutionProvider::MIGraphX));
     }
 
     #[cfg(not(any(

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -309,7 +309,7 @@ fn build_execution_config() -> Option<ExecutionConfig> {
 /// Nemotron models have: encoder.onnx, encoder.onnx.data, decoder_joint.onnx, tokenizer.model
 /// TDT models have: encoder-model.onnx, decoder_joint-model.onnx, vocab.txt
 /// CTC models have: model.onnx (or model_int8.onnx), tokenizer.json
-fn detect_model_type(path: &PathBuf) -> ParakeetModelType {
+pub fn detect_model_type(path: &PathBuf) -> ParakeetModelType {
     // Check for Nemotron model structure (must come before TDT since both have encoder/decoder)
     // Nemotron uses non-hyphenated names: encoder.onnx (not encoder-model.onnx)
     let has_nemotron_encoder =
@@ -353,7 +353,7 @@ fn detect_model_type(path: &PathBuf) -> ParakeetModelType {
 }
 
 /// Resolve model name to directory path
-fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
+pub fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
     // If it's already an absolute path, use it directly
     let path = PathBuf::from(model);
     if path.is_absolute() && path.exists() {


### PR DESCRIPTION
## Summary

Adds Nemotron Speech Streaming EN 0.6B support (issue #47) to the Parakeet engine, enabling real-time text output during recording. Text is typed incrementally as you speak rather than waiting until recording stops.

- **New model type**: `ParakeetModelType::Nemotron`, auto-detected from model files
- **New trait**: `StreamingTranscriber` for incremental chunk-based transcription
- **New state**: `State::StreamingRecording` with live text output during recording
- **Persistent model**: loaded once at daemon startup, reused across recordings
- **Model download**: available via `voxtype setup model` (option 13)
- **parakeet-rs bump**: 0.2.9 → 0.3.1 (adds Nemotron API, renames `rocm` → `migraphx`)

### How it works

Audio chunks (560ms / 8960 samples at 16kHz) are fed to the Nemotron model via a persistent blocking task. Text deltas are sent back through a channel and typed immediately via the output chain. On recording stop, remaining audio is flushed through silence padding.

### Config

```toml
engine = "parakeet"

[parakeet]
model = "nemotron-speech-streaming-en-0.6b"
# streaming is auto-enabled for Nemotron models
# streaming = false  # to force batch mode instead
```

## Status: Not Ready

This branch is functional but has a significant limitation:

**Inference speed on CPU is too slow for real-time use.** The 0.6B fp32 model takes longer than 560ms to process each chunk on CPU, so text output lags behind speech. It works, but with noticeable delay.

### Path forward

- **int8/int4 quantized models** are being worked on. Dynamic int8 quantization should bring the model from ~2.6 GB to ~670 MB with proportionally faster inference. int4 would be even smaller/faster. This is the most likely fix for CPU users.
- **CUDA acceleration** (`--features parakeet,parakeet-cuda`) would make this real-time on NVIDIA GPUs but hasn't been tested yet.
- **MIGraphX** (`--features parakeet,parakeet-rocm`) for AMD discrete GPUs — compiles but untested.

## Test plan

- [x] `cargo build --features parakeet` compiles
- [x] `cargo build` without parakeet compiles (no regressions)
- [x] `cargo test` — 282 tests pass
- [x] Manual: Nemotron model appears in `voxtype setup model`
- [x] Manual: text appears live during recording
- [x] Manual: second recording works without errors
- [x] Manual: batch transcription still works for CTC/TDT models
- [ ] Performance: real-time streaming on CPU with quantized model
- [ ] Test CUDA acceleration