### PR TITLE
Fix CLI Description of recording commands 

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,9 +15,9 @@ Optimized for Wayland, works on X11 too.
 COMMANDS:
   voxtype                  Start the daemon (with evdev hotkey detection)
   voxtype daemon           Same as above
-  voxtype record-toggle    Toggle recording (for compositor keybindings)
-  voxtype record-start     Start recording
-  voxtype record-stop      Stop recording and transcribe
+  voxtype record toggle    Toggle recording (for compositor keybindings)
+  voxtype record start     Start recording
+  voxtype record stop      Stop recording and transcribe
   voxtype status           Show daemon status (integrates with Waybar)
   voxtype setup            Check dependencies and download models
   voxtype config           Show current configuration


### PR DESCRIPTION
The help text showed hyphenated commands (record-toggle) but the CLI uses subcommands with spaces (record toggle) - simple update the cli to reflect this..