### PR TITLE
Fix CI workflow issues

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Verify binary
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          chmod +x releases/${VERSION}/voxtype-${VERSION}-linux-x86_64-avx2
           releases/${VERSION}/voxtype-${VERSION}-linux-x86_64-avx2 --version
 
       - name: Upload artifact
@@ -71,7 +70,6 @@ jobs:
       - name: Verify binary
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          chmod +x releases/${VERSION}/voxtype-${VERSION}-linux-x86_64-vulkan
           releases/${VERSION}/voxtype-${VERSION}-linux-x86_64-vulkan --version
 
       - name: Upload artifact
@@ -105,7 +103,6 @@ jobs:
       - name: Verify binary
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          chmod +x releases/${VERSION}/voxtype-${VERSION}-linux-x86_64-parakeet-avx2
           releases/${VERSION}/voxtype-${VERSION}-linux-x86_64-parakeet-avx2 --version
 
       - name: Upload artifact
@@ -143,13 +140,14 @@ jobs:
 
       - name: Install Rust
         if: steps.check-avx512.outputs.supported == 'true'
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         if: steps.check-avx512.outputs.supported == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev clang cmake
+          sudo apt-get install -y libasound2-dev libclang-dev cmake \
+            libgtk-3-dev libglib2.0-dev libx11-dev libxi-dev libxtst-dev
 
       - name: Build AVX-512 binary
         if: steps.check-avx512.outputs.supported == 'true'
@@ -203,13 +201,15 @@ jobs:
 
       - name: Install Rust
         if: steps.check-avx512.outputs.supported == 'true'
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         if: steps.check-avx512.outputs.supported == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev clang cmake
+          sudo apt-get install -y libasound2-dev libclang-dev cmake \
+            libgtk-3-dev libglib2.0-dev libx11-dev libxi-dev libxtst-dev \
+            libssl-dev protobuf-compiler libprotobuf-dev
 
       - name: Build Parakeet AVX-512 binary
         if: steps.check-avx512.outputs.supported == 'true'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install Rust targets
         run: |

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -43,7 +43,12 @@ jobs:
             cmake \
             ruby \
             ruby-dev \
-            build-essential
+            build-essential \
+            libgtk-3-dev \
+            libglib2.0-dev \
+            libx11-dev \
+            libxi-dev \
+            libxtst-dev
           sudo gem install fpm
 
       - name: Cache cargo registry

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -80,5 +80,6 @@ RUN echo "=== Verifying AVX2 binary ===" \
 # Output stage - copy binary to /output volume
 CMD mkdir -p /output \
     && cp /tmp/voxtype-avx2 /output/voxtype-${VERSION}-linux-x86_64-avx2 \
+    && chmod 755 /output/voxtype-${VERSION}-linux-x86_64-avx2 \
     && echo "Binary copied to /output:" \
     && ls -la /output/voxtype-*

--- a/Dockerfile.parakeet
+++ b/Dockerfile.parakeet
@@ -89,5 +89,6 @@ RUN echo "=== Verifying Parakeet AVX2 binary ===" \
 # Output stage
 CMD mkdir -p /output \
     && cp /tmp/voxtype-parakeet-avx2 /output/voxtype-${VERSION}-linux-x86_64-parakeet-avx2 \
+    && chmod 755 /output/voxtype-${VERSION}-linux-x86_64-parakeet-avx2 \
     && echo "Binary copied to /output:" \
     && ls -la /output/voxtype-*

--- a/Dockerfile.vulkan
+++ b/Dockerfile.vulkan
@@ -87,5 +87,6 @@ RUN echo "=== Verifying Vulkan binary ===" \
 # Output stage - copy binary to /output volume
 CMD mkdir -p /output \
     && cp /tmp/voxtype-vulkan /output/voxtype-${VERSION}-linux-x86_64-vulkan \
+    && chmod 755 /output/voxtype-${VERSION}-linux-x86_64-vulkan \
     && echo "Binary copied to /output:" \
     && ls -la /output/voxtype-*-vulkan


### PR DESCRIPTION
## Summary
- Fix `dtolnay/rust-action` (non-existent) to `dtolnay/rust-toolchain` in macOS and Linux build workflows
- Add missing GTK/X11 development dependencies (`libgtk-3-dev`, `libglib2.0-dev`, `libx11-dev`, `libxi-dev`, `libxtst-dev`) for non-Docker Linux builds
- Fix Docker build permission errors by adding `chmod 755` in CMD stage for mounted volume outputs

## Files changed
- `.github/workflows/build-macos.yml` - Fix action reference
- `.github/workflows/build-linux.yml` - Fix action reference, add GTK deps
- `.github/workflows/test-packages.yml` - Add GTK/X11 deps
- `Dockerfile.build`, `Dockerfile.vulkan`, `Dockerfile.parakeet` - Fix output permissions

## Test plan
- [ ] macOS CI workflow runs successfully
- [ ] Linux CI workflow (AVX-512 and Parakeet AVX-512) runs successfully
- [ ] Docker builds produce binaries with correct permissions