### PR TITLE
Add FN/Function/Globe key support for macOS

### DIFF
--- a/src/hotkey_macos.rs
+++ b/src/hotkey_macos.rs
@@ -186,6 +186,7 @@ fn parse_key_name(name: &str) -> Option<Key> {
         "PAUSE" => Some(Key::Pause),
         "SCROLLLOCK" => Some(Key::ScrollLock),
         "PRINTSCREEN" => Some(Key::PrintScreen),
+        "FN" | "FUNCTION" | "GLOBE" => Some(Key::Function),
 
         // Letters (for completeness, though unusual for hotkeys)
         "A" => Some(Key::KeyA),


### PR DESCRIPTION
## Summary
- Add `FN`, `FUNCTION`, and `GLOBE` as recognized key names in the macOS hotkey parser
- Maps to `Key::Function` (keycode 63) via the rdev crate
- Allows users to set `key = "FN"` in their config for the macOS Globe/Function key

## Files changed
- `src/hotkey_macos.rs` - Add key name mapping (1 line)

## Test plan
- [ ] `key = "FN"` in config.toml is recognized without "Unknown key name" error
- [ ] Pressing and holding the FN/Globe key triggers recording
- [ ] Releasing the key starts transcription