### PR TITLE
Fix `state_file` option in README example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ mode = "toggle"
 Config file location: `~/.config/voxtype/config.toml`
 
 ```toml
+# State file for Waybar/polybar integration (enabled by default)
+state_file = "auto"  # Or custom path, or "disabled" to turn off
+
 [hotkey]
 key = "SCROLLLOCK"  # Or: PAUSE, F13-F24, RIGHTALT, etc.
 modifiers = []      # Optional: ["LEFTCTRL", "LEFTALT"]
@@ -144,9 +147,6 @@ on_transcription = true     # Show transcribed text
 # [text]
 # spoken_punctuation = true  # Say "period" → ".", "open paren" → "("
 # replacements = { "vox type" = "voxtype", "oh marky" = "Omarchy" }
-
-# State file for Waybar/polybar integration (enabled by default)
-state_file = "auto"  # Or custom path, or "disabled" to turn off
 ```
 
 ### Audio Feedback


### PR DESCRIPTION
## Description

I just ran into issue https://github.com/peteonrails/voxtype/issues/18 because I copied the example config from the README, where the `state_file` option is at the bottom.

I moved it to the top in this PR. Although this is not exactly a robust solution as future modifications might only update one of them again.

In my opinion, a better fix would be to link to the default config in the repo (`config/default.toml`) as this is most likely more up to date.

What I find kind of weird/surprising is that the option states that `enabled` (or I guess `auto`) is supposed the default.
But when I remove the option completely from my config or put it at the bottom (which I guess might be equivalent), `voxtype status` gives me `Error: state_file is no configured`

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Testing

- [ ] I have tested these changes locally
- [ ] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy` with no warnings
- [ ] I have run `cargo fmt`

## Documentation

- [X] I have updated documentation as needed
- [ ] No documentation changes are needed

## Additional Notes

Any additional information reviewers should know.
