### PR TITLE
Correct Vocalinux feature claims on comparison page

### DIFF
--- a/website/compare/index.html
+++ b/website/compare/index.html
@@ -84,9 +84,9 @@
                             <td>Vocalinux</td>
                             <td>Whisper</td>
                             <td><span class="check">Yes</span></td>
-                            <td><span class="no">No</span></td>
-                            <td><span class="check">Yes</span></td>
-                            <td><span class="no">No (ydotool)</span></td>
+                            <td><span class="check">Vulkan/CUDA</span></td>
+                            <td><span class="check">Native</span></td>
+                            <td><span class="check">Yes (wtype/ydotool)</span></td>
                             <td><span class="check">Yes</span></td>
                             <td>Medium</td>
                         </tr>

--- a/website/compare/vocalinux.html
+++ b/website/compare/vocalinux.html
@@ -64,12 +64,12 @@
             <tr>
                 <td>Text Output</td>
                 <td>wtype (native Wayland)</td>
-                <td>ydotool</td>
+                <td>wtype / ydotool (auto-selected)</td>
             </tr>
             <tr>
                 <td>CJK/Unicode Output</td>
                 <td><strong>Yes</strong></td>
-                <td>No (ydotool limitation)</td>
+                <td>Yes (wtype/ydotool)</td>
             </tr>
             <tr>
                 <td>Recording Feedback</td>
@@ -79,7 +79,7 @@
             <tr>
                 <td>GPU Acceleration</td>
                 <td>Vulkan, CUDA, Metal, ROCm</td>
-                <td>No</td>
+                <td>Vulkan, CUDA</td>
             </tr>
             <tr>
                 <td>Text Processing</td>


### PR DESCRIPTION
## Summary

- Correct GPU support from "No" to "Vulkan/CUDA" (Vocalinux has CUDA via PyTorch and Vulkan detection with automatic backend selection)
- Correct Wayland support from "Yes" to "Native" (auto-selects between wtype and ydotool)
- Correct CJK output from "No (ydotool)" to "Yes (wtype/ydotool)" (Vocalinux uses wtype, not just ydotool)
- Update text output description to reflect auto-selection of wtype/ydotool

Changes verified against the [Vocalinux source code](https://github.com/jatinkrmalik/vocalinux).

Closes #184

## Test plan

- [ ] Verify comparison matrix on index page renders correctly
- [ ] Verify Vocalinux detail page table renders correctly