### PR TITLE
Fix gpu_isolation worker subprocess failing to start

### DIFF
--- a/src/transcribe/subprocess.rs
+++ b/src/transcribe/subprocess.rs
@@ -84,15 +84,17 @@ impl SubprocessTranscriber {
         let exe_path = Self::get_executable_path()?;
 
         let mut cmd = Command::new(&exe_path);
+
+        // Pass config path BEFORE the subcommand — --config is a parent-level
+        // arg in clap, so it must appear before "transcribe-worker"
+        if let Some(ref config_path) = self.config_path {
+            cmd.arg("--config").arg(config_path);
+        }
+
         cmd.arg("transcribe-worker")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-
-        // Pass config path if we have one
-        if let Some(ref config_path) = self.config_path {
-            cmd.arg("--config").arg(config_path);
-        }
 
         // Pass essential config via command-line arguments
         cmd.arg("--model").arg(&self.config.model);

--- a/website/compare/index.html
+++ b/website/compare/index.html
@@ -84,9 +84,9 @@
                             <td>Vocalinux</td>
                             <td>Whisper</td>
                             <td><span class="check">Yes</span></td>
-                            <td><span class="no">No</span></td>
-                            <td><span class="check">Yes</span></td>
-                            <td><span class="no">No (ydotool)</span></td>
+                            <td><span class="check">Vulkan/CUDA</span></td>
+                            <td><span class="check">Native</span></td>
+                            <td><span class="check">Yes (wtype/ydotool)</span></td>
                             <td><span class="check">Yes</span></td>
                             <td>Medium</td>
                         </tr>

--- a/website/compare/vocalinux.html
+++ b/website/compare/vocalinux.html
@@ -64,12 +64,12 @@
             <tr>
                 <td>Text Output</td>
                 <td>wtype (native Wayland)</td>
-                <td>ydotool</td>
+                <td>wtype / ydotool (auto-selected)</td>
             </tr>
             <tr>
                 <td>CJK/Unicode Output</td>
                 <td><strong>Yes</strong></td>
-                <td>No (ydotool limitation)</td>
+                <td>Yes (wtype/ydotool)</td>
             </tr>
             <tr>
                 <td>Recording Feedback</td>
@@ -79,7 +79,7 @@
             <tr>
                 <td>GPU Acceleration</td>
                 <td>Vulkan, CUDA, Metal, ROCm</td>
-                <td>No</td>
+                <td>Vulkan, CUDA</td>
             </tr>
             <tr>
                 <td>Text Processing</td>


### PR DESCRIPTION
## Summary

- Fix regression where `gpu_isolation = true` causes worker subprocess to exit immediately with `Worker failed to load model (got: "")`
- The `--config` flag was placed after the `transcribe-worker` subcommand, but clap only recognizes parent-level args before the subcommand name
- Introduced in v0.5.0 when config_path tracking was added; before that config_path was always None so the flag was never appended

## Test plan

- [ ] Build and run with `gpu_isolation = true` in config.toml
- [ ] Verify transcription completes successfully with gpu_isolation enabled
- [ ] Verify transcription still works with `gpu_isolation = false`
- [ ] Run `cargo test`

Closes #185