### PR TITLE
Default state_file to "auto" and link default config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@ mode = "toggle"
 
 Config file location: `~/.config/voxtype/config.toml`
 
+See [`config/default.toml`](config/default.toml) for the full annotated default configuration.
+
 ```toml
+# State file for Waybar/polybar integration (enabled by default)
+state_file = "auto"  # Or custom path, or "disabled" to turn off
+
 [hotkey]
 key = "SCROLLLOCK"  # Or: PAUSE, F13-F24, RIGHTALT, etc.
 modifiers = []      # Optional: ["LEFTCTRL", "LEFTALT"]
@@ -144,9 +149,6 @@ on_transcription = true     # Show transcribed text
 # [text]
 # spoken_punctuation = true  # Say "period" → ".", "open paren" → "("
 # replacements = { "vox type" = "voxtype", "oh marky" = "Omarchy" }
-
-# State file for Waybar/polybar integration (enabled by default)
-state_file = "auto"  # Or custom path, or "disabled" to turn off
 ```
 
 ### Audio Feedback

--- a/src/config.rs
+++ b/src/config.rs
@@ -283,7 +283,7 @@ pub struct Config {
     /// When set, the daemon writes current state ("idle", "recording", "transcribing")
     /// to this file whenever state changes.
     /// Example: "/run/user/1000/voxtype/state" or use "auto" for default location
-    #[serde(default)]
+    #[serde(default = "default_state_file")]
     pub state_file: Option<String>,
 
     /// Named profiles for context-specific settings
@@ -392,6 +392,10 @@ fn default_cold_model_timeout() -> u64 {
 
 fn default_whisper_model() -> String {
     "base.en".to_string()
+}
+
+fn default_state_file() -> Option<String> {
+    Some("auto".to_string())
 }
 
 impl Default for AudioFeedbackConfig {


### PR DESCRIPTION
## Summary

- Fix `state_file` serde default so it actually defaults to `"auto"` during config deserialization, not `None`
- Move `state_file` to the top of the README example config where it's visible as a top-level key
- Link to `config/default.toml` in the README as the canonical configuration reference

The root issue: `#[serde(default)]` on `Option<String>` defaults to `None`, overriding the `Config::default()` value of `Some("auto")`. Users with existing config files that omit `state_file` got `"state_file is not configured"` errors despite the documentation claiming `"auto"` is the default.

## Test plan

- [x] `cargo test config::` -- all 56 tests pass
- [ ] Verify `voxtype status` works without `state_file` in config.toml
- [ ] Verify explicit `state_file = "auto"` still works
- [ ] Verify `state_file = "disabled"` still works

Closes #182