### PR TITLE
Run cargo fmt across the codebase

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -809,7 +809,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "start", "--file=out.txt"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::File));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::File)
+                );
                 assert_eq!(action.file_path(), Some("out.txt"));
             }
             _ => panic!("Expected Record command"),
@@ -833,7 +836,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "start", "--file"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::File));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::File)
+                );
                 assert_eq!(action.file_path(), Some("")); // Empty string means use config path
             }
             _ => panic!("Expected Record command"),
@@ -842,11 +848,21 @@ mod tests {
 
     #[test]
     fn test_record_start_model_and_output_override() {
-        let cli = Cli::parse_from(["voxtype", "record", "start", "--model", "large-v3-turbo", "--clipboard"]);
+        let cli = Cli::parse_from([
+            "voxtype",
+            "record",
+            "start",
+            "--model",
+            "large-v3-turbo",
+            "--clipboard",
+        ]);
         match cli.command {
             Some(Commands::Record { action }) => {
                 assert_eq!(action.model_override(), Some("large-v3-turbo"));
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::Clipboard));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::Clipboard)
+                );
             }
             _ => panic!("Expected Record command"),
         }
@@ -857,7 +873,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "start", "--file=/tmp/output.txt"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::File));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::File)
+                );
                 assert_eq!(action.file_path(), Some("/tmp/output.txt"));
             }
             _ => panic!("Expected Record command"),
@@ -880,7 +899,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "toggle", "--file=out.txt"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::File));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::File)
+                );
                 assert_eq!(action.file_path(), Some("out.txt"));
             }
             _ => panic!("Expected Record command"),
@@ -892,7 +914,10 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "record", "toggle", "--file"]);
         match cli.command {
             Some(Commands::Record { action }) => {
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::File));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::File)
+                );
                 assert_eq!(action.file_path(), Some("")); // Empty string means use config path
             }
             _ => panic!("Expected Record command"),
@@ -916,17 +941,9 @@ mod tests {
 
     #[test]
     fn test_record_start_file_mutually_exclusive_with_paste() {
-        let result = Cli::try_parse_from([
-            "voxtype",
-            "record",
-            "start",
-            "--file=out.txt",
-            "--paste",
-        ]);
-        assert!(
-            result.is_err(),
-            "Should not allow both --file and --paste"
-        );
+        let result =
+            Cli::try_parse_from(["voxtype", "record", "start", "--file=out.txt", "--paste"]);
+        assert!(result.is_err(), "Should not allow both --file and --paste");
     }
 
     #[test]
@@ -946,17 +963,9 @@ mod tests {
 
     #[test]
     fn test_record_start_file_mutually_exclusive_with_type() {
-        let result = Cli::try_parse_from([
-            "voxtype",
-            "record",
-            "start",
-            "--file=out.txt",
-            "--type",
-        ]);
-        assert!(
-            result.is_err(),
-            "Should not allow both --file and --type"
-        );
+        let result =
+            Cli::try_parse_from(["voxtype", "record", "start", "--file=out.txt", "--type"]);
+        assert!(result.is_err(), "Should not allow both --file and --type");
     }
 
     #[test]
@@ -1076,11 +1085,21 @@ mod tests {
     #[test]
     fn test_record_start_profile_with_output_mode() {
         // Profile can be used together with output mode overrides
-        let cli = Cli::parse_from(["voxtype", "record", "start", "--profile", "slack", "--clipboard"]);
+        let cli = Cli::parse_from([
+            "voxtype",
+            "record",
+            "start",
+            "--profile",
+            "slack",
+            "--clipboard",
+        ]);
         match cli.command {
             Some(Commands::Record { action }) => {
                 assert_eq!(action.profile(), Some("slack"));
-                assert_eq!(action.output_mode_override(), Some(OutputModeOverride::Clipboard));
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::Clipboard)
+                );
             }
             _ => panic!("Expected Record command"),
         }
@@ -1095,7 +1114,12 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "setup", "dms", "--install"]);
         match cli.command {
             Some(Commands::Setup {
-                action: Some(SetupAction::Dms { install, uninstall, qml }),
+                action:
+                    Some(SetupAction::Dms {
+                        install,
+                        uninstall,
+                        qml,
+                    }),
                 ..
             }) => {
                 assert!(install, "should have install=true");
@@ -1111,7 +1135,12 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "setup", "dms", "--uninstall"]);
         match cli.command {
             Some(Commands::Setup {
-                action: Some(SetupAction::Dms { install, uninstall, qml }),
+                action:
+                    Some(SetupAction::Dms {
+                        install,
+                        uninstall,
+                        qml,
+                    }),
                 ..
             }) => {
                 assert!(!install, "should have install=false");
@@ -1127,7 +1156,12 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "setup", "dms", "--qml"]);
         match cli.command {
             Some(Commands::Setup {
-                action: Some(SetupAction::Dms { install, uninstall, qml }),
+                action:
+                    Some(SetupAction::Dms {
+                        install,
+                        uninstall,
+                        qml,
+                    }),
                 ..
             }) => {
                 assert!(!install, "should have install=false");
@@ -1143,7 +1177,12 @@ mod tests {
         let cli = Cli::parse_from(["voxtype", "setup", "dms"]);
         match cli.command {
             Some(Commands::Setup {
-                action: Some(SetupAction::Dms { install, uninstall, qml }),
+                action:
+                    Some(SetupAction::Dms {
+                        install,
+                        uninstall,
+                        qml,
+                    }),
                 ..
             }) => {
                 assert!(!install, "should have install=false");

--- a/src/config.rs
+++ b/src/config.rs
@@ -757,7 +757,6 @@ pub struct WhisperConfig {
     pub initial_prompt: Option<String>,
 
     // --- Multi-model settings ---
-
     /// Secondary model to use when hotkey.model_modifier is held
     /// Example: "large-v3-turbo" for difficult audio
     #[serde(default)]
@@ -814,9 +813,7 @@ impl WhisperConfig {
         }
         // Fall back to deprecated `backend` with warning
         if let Some(backend) = self.backend {
-            tracing::warn!(
-                "DEPRECATED: [whisper] backend is deprecated, use 'mode' instead"
-            );
+            tracing::warn!("DEPRECATED: [whisper] backend is deprecated, use 'mode' instead");
             tracing::warn!(
                 "  Change 'backend = \"{}\"' to 'mode = \"{}\"' in config.toml",
                 match backend {
@@ -2025,7 +2022,10 @@ mod tests {
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.engine, TranscriptionEngine::Parakeet);
         assert!(config.parakeet.is_some());
-        assert_eq!(config.parakeet.as_ref().unwrap().model, "parakeet-tdt-0.6b-v3");
+        assert_eq!(
+            config.parakeet.as_ref().unwrap().model,
+            "parakeet-tdt-0.6b-v3"
+        );
     }
 
     #[test]
@@ -2053,15 +2053,39 @@ mod tests {
 
     #[test]
     fn test_output_driver_from_str() {
-        assert_eq!("wtype".parse::<OutputDriver>().unwrap(), OutputDriver::Wtype);
-        assert_eq!("dotool".parse::<OutputDriver>().unwrap(), OutputDriver::Dotool);
-        assert_eq!("ydotool".parse::<OutputDriver>().unwrap(), OutputDriver::Ydotool);
-        assert_eq!("clipboard".parse::<OutputDriver>().unwrap(), OutputDriver::Clipboard);
-        assert_eq!("xclip".parse::<OutputDriver>().unwrap(), OutputDriver::Xclip);
+        assert_eq!(
+            "wtype".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Wtype
+        );
+        assert_eq!(
+            "dotool".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Dotool
+        );
+        assert_eq!(
+            "ydotool".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Ydotool
+        );
+        assert_eq!(
+            "clipboard".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Clipboard
+        );
+        assert_eq!(
+            "xclip".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Xclip
+        );
         // Case insensitive
-        assert_eq!("WTYPE".parse::<OutputDriver>().unwrap(), OutputDriver::Wtype);
-        assert_eq!("Ydotool".parse::<OutputDriver>().unwrap(), OutputDriver::Ydotool);
-        assert_eq!("XCLIP".parse::<OutputDriver>().unwrap(), OutputDriver::Xclip);
+        assert_eq!(
+            "WTYPE".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Wtype
+        );
+        assert_eq!(
+            "Ydotool".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Ydotool
+        );
+        assert_eq!(
+            "XCLIP".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Xclip
+        );
         // Invalid
         assert!("invalid".parse::<OutputDriver>().is_err());
     }
@@ -2455,11 +2479,17 @@ mod tests {
         assert_eq!(config.profiles.len(), 2);
 
         let slack = config.get_profile("slack").unwrap();
-        assert_eq!(slack.post_process_command, Some("cleanup-for-slack.sh".to_string()));
+        assert_eq!(
+            slack.post_process_command,
+            Some("cleanup-for-slack.sh".to_string())
+        );
         assert!(slack.output_mode.is_none());
 
         let code = config.get_profile("code").unwrap();
-        assert_eq!(code.post_process_command, Some("cleanup-for-code.sh".to_string()));
+        assert_eq!(
+            code.post_process_command,
+            Some("cleanup-for-code.sh".to_string())
+        );
         assert_eq!(code.output_mode, Some(OutputMode::Clipboard));
     }
 
@@ -2488,7 +2518,10 @@ mod tests {
 
         let config: Config = toml::from_str(toml_str).unwrap();
         let slow = config.get_profile("slow").unwrap();
-        assert_eq!(slow.post_process_command, Some("slow-llm-command".to_string()));
+        assert_eq!(
+            slow.post_process_command,
+            Some("slow-llm-command".to_string())
+        );
         assert_eq!(slow.post_process_timeout_ms, Some(60000));
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -123,7 +123,9 @@ pub enum OutputError {
     #[error("Ctrl+V simulation failed: {0}")]
     CtrlVFailed(String),
 
-    #[error("All output methods failed. Ensure wtype, dotool, ydotool, wl-copy, or xclip is available.")]
+    #[error(
+        "All output methods failed. Ensure wtype, dotool, ydotool, wl-copy, or xclip is available."
+    )]
     AllMethodsFailed,
 }
 

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -675,18 +675,17 @@ const XKB_OFFSET: u16 = 8;
 fn parse_prefixed_keycode(s: &str) -> Result<Option<Key>, HotkeyError> {
     let normalized = s.to_ascii_uppercase();
 
-    let (number_str, is_xkb) =
-        if let Some(n) = normalized.strip_prefix("WEV_") {
-            (n, true)
-        } else if let Some(n) = normalized.strip_prefix("X11_") {
-            (n, true)
-        } else if let Some(n) = normalized.strip_prefix("XEV_") {
-            (n, true)
-        } else if let Some(n) = normalized.strip_prefix("EVTEST_") {
-            (n, false)
-        } else {
-            return Ok(None);
-        };
+    let (number_str, is_xkb) = if let Some(n) = normalized.strip_prefix("WEV_") {
+        (n, true)
+    } else if let Some(n) = normalized.strip_prefix("X11_") {
+        (n, true)
+    } else if let Some(n) = normalized.strip_prefix("XEV_") {
+        (n, true)
+    } else if let Some(n) = normalized.strip_prefix("EVTEST_") {
+        (n, false)
+    } else {
+        return Ok(None);
+    };
 
     let code: u16 = if let Some(hex) = number_str.strip_prefix("0X") {
         u16::from_str_radix(hex, 16)

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,10 @@ async fn main() -> anyhow::Result<()> {
             "whisper" => config.engine = config::TranscriptionEngine::Whisper,
             "parakeet" => config.engine = config::TranscriptionEngine::Parakeet,
             _ => {
-                eprintln!("Error: Invalid engine '{}'. Valid options: whisper, parakeet", engine);
+                eprintln!(
+                    "Error: Invalid engine '{}'. Valid options: whisper, parakeet",
+                    engine
+                );
                 std::process::exit(1);
             }
         }
@@ -285,7 +288,11 @@ async fn main() -> anyhow::Result<()> {
                         setup::gpu::show_status();
                     }
                 }
-                Some(SetupAction::Parakeet { enable, disable, status }) => {
+                Some(SetupAction::Parakeet {
+                    enable,
+                    disable,
+                    status,
+                }) => {
                     warn_if_root("parakeet");
                     if status {
                         setup::parakeet::show_status();
@@ -414,7 +421,14 @@ fn send_record_command(config: &config::Config, action: RecordAction) -> anyhow:
             } else {
                 eprintln!("Error: Profile '{}' not found.", profile_name);
                 eprintln!();
-                eprintln!("Available profiles: {}", available.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "));
+                eprintln!(
+                    "Available profiles: {}",
+                    available
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
             }
             std::process::exit(1);
         }
@@ -819,7 +833,10 @@ async fn show_config(config: &config::Config) -> anyhow::Result<()> {
         if let Some(ref model_type) = parakeet_config.model_type {
             println!("  model_type = {:?}", model_type);
         }
-        println!("  on_demand_loading = {}", parakeet_config.on_demand_loading);
+        println!(
+            "  on_demand_loading = {}",
+            parakeet_config.on_demand_loading
+        );
     } else {
         println!("  (not configured)");
     }

--- a/src/model_manager.rs
+++ b/src/model_manager.rs
@@ -6,7 +6,7 @@
 //! - Fresh subprocess per model (when gpu_isolation = true)
 //! - Remote backend model selection
 
-use crate::config::{WhisperMode, WhisperConfig};
+use crate::config::{WhisperConfig, WhisperMode};
 use crate::error::TranscribeError;
 use crate::transcribe::{self, Transcriber};
 use std::collections::HashMap;
@@ -115,10 +115,7 @@ impl ModelManager {
     }
 
     /// Create a CLI transcriber with model override
-    fn create_cli_transcriber(
-        &self,
-        model: &str,
-    ) -> Result<Arc<dyn Transcriber>, TranscribeError> {
+    fn create_cli_transcriber(&self, model: &str) -> Result<Arc<dyn Transcriber>, TranscribeError> {
         let mut config = self.config.clone();
         config.model = model.to_string();
         tracing::info!("Using whisper-cli subprocess backend");

--- a/src/output/eitype.rs
+++ b/src/output/eitype.rs
@@ -49,8 +49,10 @@ impl EitypeOutput {
 
         // eitype doesn't have a pre-type delay flag, so sleep if needed
         if self.pre_type_delay_ms > 0 {
-            tokio::time::sleep(std::time::Duration::from_millis(self.pre_type_delay_ms as u64))
-                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(
+                self.pre_type_delay_ms as u64,
+            ))
+            .await;
         }
 
         let mut cmd = Command::new("eitype");
@@ -62,10 +64,7 @@ impl EitypeOutput {
             debug_args.push(format!("-d {}", self.type_delay_ms));
         }
 
-        debug_args.push(format!(
-            "\"{}\"",
-            text.chars().take(20).collect::<String>()
-        ));
+        debug_args.push(format!("\"{}\"", text.chars().take(20).collect::<String>()));
         tracing::debug!("Running: {}", debug_args.join(" "));
 
         let output = cmd

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -24,8 +24,8 @@ pub mod ydotool;
 use crate::config::{OutputConfig, OutputDriver};
 use crate::error::OutputError;
 use std::borrow::Cow;
-use std::process::Stdio;
 use std::fs;
+use std::process::Stdio;
 use tokio::process::Command;
 
 /// Normalize Unicode curly quotes to ASCII equivalents.
@@ -46,7 +46,7 @@ fn normalize_quotes(text: &str) -> Cow<'_, str> {
             | '\u{201C}'  // LEFT DOUBLE QUOTATION MARK
             | '\u{201D}'  // RIGHT DOUBLE QUOTATION MARK
             | '\u{201F}'  // DOUBLE HIGH-REVERSED-9 QUOTATION MARK
-            | '\u{2033}'  // DOUBLE PRIME
+            | '\u{2033}' // DOUBLE PRIME
         )
     });
 
@@ -100,7 +100,11 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
 }
 
 /// Send a transcription notification with optional engine icon
-pub async fn send_transcription_notification(text: &str, show_engine_icon: bool, engine: crate::config::TranscriptionEngine) {
+pub async fn send_transcription_notification(
+    text: &str,
+    show_engine_icon: bool,
+    engine: crate::config::TranscriptionEngine,
+) {
     // Truncate preview for notification (use chars() to handle multi-byte UTF-8)
     let preview = if text.chars().count() > 80 {
         format!("{}...", text.chars().take(80).collect::<String>())

--- a/src/setup/dms.rs
+++ b/src/setup/dms.rs
@@ -325,7 +325,10 @@ pub fn print_config() {
     println!("   with the following content:\n");
 
     // Print the simplified QML with the actual path substituted
-    println!("{}", QML_SIMPLE_TEMPLATE.replace("VOXTYPE_PATH", &voxtype_path));
+    println!(
+        "{}",
+        QML_SIMPLE_TEMPLATE.replace("VOXTYPE_PATH", &voxtype_path)
+    );
 
     println!("\n\n3. Enable the widget in DankMaterialShell settings.\n");
 

--- a/src/setup/gpu.rs
+++ b/src/setup/gpu.rs
@@ -118,7 +118,12 @@ impl GpuVendor {
     /// Parse vendor from GPU name string
     fn from_name(name: &str) -> Self {
         let lower = name.to_lowercase();
-        if lower.contains("nvidia") || lower.contains("geforce") || lower.contains("quadro") || lower.contains("rtx") || lower.contains("gtx") {
+        if lower.contains("nvidia")
+            || lower.contains("geforce")
+            || lower.contains("quadro")
+            || lower.contains("rtx")
+            || lower.contains("gtx")
+        {
             GpuVendor::Nvidia
         } else if lower.contains("amd") || lower.contains("radeon") || lower.contains("rx ") {
             GpuVendor::Amd
@@ -295,14 +300,14 @@ pub fn detect_gpu() -> Option<String> {
 
 /// Parse VOXTYPE_VULKAN_DEVICE environment variable and return the appropriate vendor
 pub fn get_selected_gpu_vendor() -> Option<GpuVendor> {
-    std::env::var("VOXTYPE_VULKAN_DEVICE").ok().and_then(|val| {
-        match val.to_lowercase().as_str() {
+    std::env::var("VOXTYPE_VULKAN_DEVICE")
+        .ok()
+        .and_then(|val| match val.to_lowercase().as_str() {
             "nvidia" | "nv" => Some(GpuVendor::Nvidia),
             "amd" | "radeon" => Some(GpuVendor::Amd),
             "intel" => Some(GpuVendor::Intel),
             _ => None,
-        }
-    })
+        })
 }
 
 /// Apply GPU selection environment variables based on VOXTYPE_VULKAN_DEVICE
@@ -650,7 +655,10 @@ pub fn show_status() {
         if gpus.len() > 1 {
             println!();
             if let Some(selected) = get_selected_gpu_vendor() {
-                println!("GPU selection: {} (via VOXTYPE_VULKAN_DEVICE)", selected.display_name());
+                println!(
+                    "GPU selection: {} (via VOXTYPE_VULKAN_DEVICE)",
+                    selected.display_name()
+                );
             } else {
                 println!("GPU selection: auto (first available)");
                 println!();
@@ -758,7 +766,10 @@ pub fn enable() -> anyhow::Result<()> {
 
         // Regenerate systemd service if it exists
         if super::systemd::regenerate_service_file()? {
-            println!("Updated systemd service to use Parakeet {} backend.", backend_name);
+            println!(
+                "Updated systemd service to use Parakeet {} backend.",
+                backend_name
+            );
         }
 
         println!("Switched to Parakeet ({}) backend.", backend_name);
@@ -816,7 +827,10 @@ pub fn disable() -> anyhow::Result<()> {
         let best_backend = detect_best_parakeet_cpu_backend();
         if let Some(backend_name) = best_backend {
             switch_backend_tiered_parakeet(backend_name)?;
-            println!("Switched to Parakeet ({}) backend.", backend_name.trim_start_matches("voxtype-parakeet-"));
+            println!(
+                "Switched to Parakeet ({}) backend.",
+                backend_name.trim_start_matches("voxtype-parakeet-")
+            );
         } else {
             anyhow::bail!(
                 "No Parakeet CPU backend found.\n\

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -357,7 +357,9 @@ pub fn print_output_chain_status(status: &OutputChainStatus) {
         println!("  \x1b[32m→\x1b[0m Text will be typed via {}", method_desc);
     } else {
         println!("  \x1b[31m→\x1b[0m No text output method available!");
-        println!("    Install wtype (Wayland), eitype (GNOME/KDE), or ydotool (X11) for typing support");
+        println!(
+            "    Install wtype (Wayland), eitype (GNOME/KDE), or ydotool (X11) for typing support"
+        );
     }
 }
 
@@ -487,7 +489,10 @@ pub async fn run_setup(
         // Check if parakeet feature is enabled
         #[cfg(not(feature = "parakeet"))]
         {
-            print_failure(&format!("Parakeet model '{}' requires the 'parakeet' feature", model_name));
+            print_failure(&format!(
+                "Parakeet model '{}' requires the 'parakeet' feature",
+                model_name
+            ));
             println!("       Rebuild with: cargo build --features parakeet");
             anyhow::bail!("Parakeet feature not enabled");
         }
@@ -495,8 +500,8 @@ pub async fn run_setup(
         #[cfg(feature = "parakeet")]
         {
             let model_path = models_dir.join(model_name);
-            let model_valid = model_path.exists()
-                && model::validate_parakeet_model(&model_path).is_ok();
+            let model_valid =
+                model_path.exists() && model::validate_parakeet_model(&model_path).is_ok();
 
             if model_valid {
                 if !quiet {
@@ -509,10 +514,7 @@ pub async fn run_setup(
                                 .sum::<f64>()
                         })
                         .unwrap_or(0.0);
-                    print_success(&format!(
-                        "Model ready: {} ({:.0} MB)",
-                        model_name, size
-                    ));
+                    print_success(&format!("Model ready: {} ({:.0} MB)", model_name, size));
                 }
                 // Update config to use Parakeet
                 model::set_parakeet_config(model_name)?;
@@ -534,7 +536,10 @@ pub async fn run_setup(
                 }
             } else if !quiet {
                 print_info(&format!("Model '{}' not downloaded yet", model_name));
-                println!("       Run: voxtype setup --download --model {}", model_name);
+                println!(
+                    "       Run: voxtype setup --download --model {}",
+                    model_name
+                );
             }
         }
     } else {
@@ -570,10 +575,7 @@ pub async fn run_setup(
                 let size = std::fs::metadata(&model_path)
                     .map(|m| m.len() as f64 / 1024.0 / 1024.0)
                     .unwrap_or(0.0);
-                print_success(&format!(
-                    "Model ready: {} ({:.0} MB)",
-                    model_name, size
-                ));
+                print_success(&format!("Model ready: {} ({:.0} MB)", model_name, size));
             }
             // If user explicitly requested this model, update config even if already downloaded
             if model_override.is_some() {
@@ -777,9 +779,14 @@ pub async fn run_checks(config: &Config) -> anyhow::Result<()> {
     if config.engine == crate::config::TranscriptionEngine::Parakeet {
         if let Some(ref parakeet_config) = config.parakeet {
             let configured_model = &parakeet_config.model;
-            let model_found = parakeet_models.iter().any(|(name, _)| name == configured_model);
+            let model_found = parakeet_models
+                .iter()
+                .any(|(name, _)| name == configured_model);
             if !model_found {
-                print_failure(&format!("Configured Parakeet model '{}' not found", configured_model));
+                print_failure(&format!(
+                    "Configured Parakeet model '{}' not found",
+                    configured_model
+                ));
                 println!("       Download the model or change config to use an available model");
                 all_ok = false;
             }

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -156,7 +156,12 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let parakeet_available = cfg!(feature = "parakeet");
     let whisper_count = MODELS.len();
     let parakeet_count = PARAKEET_MODELS.len();
-    let total_count = whisper_count + if parakeet_available { parakeet_count } else { 0 };
+    let total_count = whisper_count
+        + if parakeet_available {
+            parakeet_count
+        } else {
+            0
+        };
 
     // --- Whisper Section ---
     println!("--- Whisper (OpenAI, 99+ languages) ---\n");
@@ -704,7 +709,10 @@ fn download_parakeet_model_by_info(model: &ParakeetModelInfo) -> anyhow::Result<
 
     // Validate all files are present
     validate_parakeet_model(&model_path)?;
-    print_success(&format!("Model '{}' downloaded to {:?}", model.name, model_path));
+    print_success(&format!(
+        "Model '{}' downloaded to {:?}",
+        model.name, model_path
+    ));
 
     Ok(())
 }
@@ -811,10 +819,7 @@ fn update_parakeet_in_config(config: &str, model_name: &str) -> String {
 
     // Add [parakeet] section if not present
     if !has_parakeet_section {
-        result.push_str(&format!(
-            "\n[parakeet]\nmodel = \"{}\"\n",
-            model_name
-        ));
+        result.push_str(&format!("\n[parakeet]\nmodel = \"{}\"\n", model_name));
     }
 
     // Remove trailing newline if original didn't have one
@@ -853,10 +858,7 @@ pub fn list_installed_parakeet() {
                 })
                 .unwrap_or(0.0);
 
-            println!(
-                "  {} ({:.0} MB) - {}",
-                model.name, size, model.description
-            );
+            println!("  {} ({:.0} MB) - {}", model.name, size, model.description);
             found = true;
         }
     }
@@ -1181,16 +1183,23 @@ translate = false
         use crate::config::TranscriptionEngine;
 
         // Simulate: engine=Whisper, current model="base.en"
-        let is_whisper_engine = matches!(TranscriptionEngine::Whisper, TranscriptionEngine::Whisper);
+        let is_whisper_engine =
+            matches!(TranscriptionEngine::Whisper, TranscriptionEngine::Whisper);
         let current_whisper_model = "base.en";
 
         // "base.en" should have star
         let is_current = is_whisper_engine && "base.en" == current_whisper_model;
-        assert!(is_current, "base.en should show star when it's the current Whisper model");
+        assert!(
+            is_current,
+            "base.en should show star when it's the current Whisper model"
+        );
 
         // "small.en" should NOT have star
         let is_current = is_whisper_engine && "small.en" == current_whisper_model;
-        assert!(!is_current, "small.en should not show star when base.en is current");
+        assert!(
+            !is_current,
+            "small.en should not show star when base.en is current"
+        );
     }
 
     #[test]
@@ -1198,16 +1207,25 @@ translate = false
         use crate::config::TranscriptionEngine;
 
         // Simulate: engine=Parakeet, current model="parakeet-tdt-0.6b-v3"
-        let is_parakeet_engine = matches!(TranscriptionEngine::Parakeet, TranscriptionEngine::Parakeet);
+        let is_parakeet_engine =
+            matches!(TranscriptionEngine::Parakeet, TranscriptionEngine::Parakeet);
         let current_parakeet_model: Option<&str> = Some("parakeet-tdt-0.6b-v3");
 
         // "parakeet-tdt-0.6b-v3" should have star
-        let is_current = is_parakeet_engine && current_parakeet_model == Some("parakeet-tdt-0.6b-v3");
-        assert!(is_current, "parakeet-tdt-0.6b-v3 should show star when it's the current Parakeet model");
+        let is_current =
+            is_parakeet_engine && current_parakeet_model == Some("parakeet-tdt-0.6b-v3");
+        assert!(
+            is_current,
+            "parakeet-tdt-0.6b-v3 should show star when it's the current Parakeet model"
+        );
 
         // "parakeet-tdt-0.6b-v3-int8" should NOT have star
-        let is_current = is_parakeet_engine && current_parakeet_model == Some("parakeet-tdt-0.6b-v3-int8");
-        assert!(!is_current, "parakeet-tdt-0.6b-v3-int8 should not show star when other model is current");
+        let is_current =
+            is_parakeet_engine && current_parakeet_model == Some("parakeet-tdt-0.6b-v3-int8");
+        assert!(
+            !is_current,
+            "parakeet-tdt-0.6b-v3-int8 should not show star when other model is current"
+        );
     }
 
     #[test]
@@ -1215,18 +1233,27 @@ translate = false
         use crate::config::TranscriptionEngine;
 
         // When engine is Parakeet, Whisper models should NOT show star
-        let is_whisper_engine = matches!(TranscriptionEngine::Parakeet, TranscriptionEngine::Whisper);
+        let is_whisper_engine =
+            matches!(TranscriptionEngine::Parakeet, TranscriptionEngine::Whisper);
         let current_whisper_model = "base.en";
 
         let is_current = is_whisper_engine && "base.en" == current_whisper_model;
-        assert!(!is_current, "Whisper models should not show star when engine is Parakeet");
+        assert!(
+            !is_current,
+            "Whisper models should not show star when engine is Parakeet"
+        );
 
         // When engine is Whisper, Parakeet models should NOT show star
-        let is_parakeet_engine = matches!(TranscriptionEngine::Whisper, TranscriptionEngine::Parakeet);
+        let is_parakeet_engine =
+            matches!(TranscriptionEngine::Whisper, TranscriptionEngine::Parakeet);
         let current_parakeet_model: Option<&str> = Some("parakeet-tdt-0.6b-v3");
 
-        let is_current = is_parakeet_engine && current_parakeet_model == Some("parakeet-tdt-0.6b-v3");
-        assert!(!is_current, "Parakeet models should not show star when engine is Whisper");
+        let is_current =
+            is_parakeet_engine && current_parakeet_model == Some("parakeet-tdt-0.6b-v3");
+        assert!(
+            !is_current,
+            "Parakeet models should not show star when engine is Whisper"
+        );
     }
 
     #[test]
@@ -1234,11 +1261,16 @@ translate = false
         use crate::config::TranscriptionEngine;
 
         // When parakeet config is None (not configured)
-        let is_parakeet_engine = matches!(TranscriptionEngine::Parakeet, TranscriptionEngine::Parakeet);
+        let is_parakeet_engine =
+            matches!(TranscriptionEngine::Parakeet, TranscriptionEngine::Parakeet);
         let current_parakeet_model: Option<&str> = None;
 
         // No model should show star when no parakeet config exists
-        let is_current = is_parakeet_engine && current_parakeet_model == Some("parakeet-tdt-0.6b-v3");
-        assert!(!is_current, "No star should show when parakeet config is not set");
+        let is_current =
+            is_parakeet_engine && current_parakeet_model == Some("parakeet-tdt-0.6b-v3");
+        assert!(
+            !is_current,
+            "No star should show when parakeet config is not set"
+        );
     }
 }

--- a/src/setup/parakeet.rs
+++ b/src/setup/parakeet.rs
@@ -161,7 +161,11 @@ fn detect_best_parakeet_backend() -> Option<ParakeetBackend> {
 /// Detect if NVIDIA GPU is present
 fn detect_nvidia_gpu() -> bool {
     // Check for nvidia-smi
-    if let Ok(output) = Command::new("nvidia-smi").arg("--query-gpu=name").arg("--format=csv,noheader").output() {
+    if let Ok(output) = Command::new("nvidia-smi")
+        .arg("--query-gpu=name")
+        .arg("--format=csv,noheader")
+        .output()
+    {
         return output.status.success() && !output.stdout.is_empty();
     }
 
@@ -188,7 +192,10 @@ fn detect_amd_gpu() -> bool {
                 if name.starts_with("renderD") {
                     // Check if it's an AMD device via sysfs
                     let card_num = name.trim_start_matches("renderD");
-                    let vendor_path = format!("/sys/class/drm/card{}/device/vendor", card_num.parse::<i32>().unwrap_or(0) - 128);
+                    let vendor_path = format!(
+                        "/sys/class/drm/card{}/device/vendor",
+                        card_num.parse::<i32>().unwrap_or(0) - 128
+                    );
                     if let Ok(vendor) = fs::read_to_string(&vendor_path) {
                         // AMD vendor ID is 0x1002
                         if vendor.trim() == "0x1002" {
@@ -252,13 +259,18 @@ pub fn show_status() {
             println!("  Backend: {}", backend.display_name());
             println!(
                 "  Binary: {}",
-                Path::new(VOXTYPE_LIB_DIR).join(backend.binary_name()).display()
+                Path::new(VOXTYPE_LIB_DIR)
+                    .join(backend.binary_name())
+                    .display()
             );
         }
     } else {
         println!("Active engine: Whisper");
         if let Some(backend) = detect_current_whisper_backend() {
-            println!("  Binary: {}", Path::new(VOXTYPE_LIB_DIR).join(backend).display());
+            println!(
+                "  Binary: {}",
+                Path::new(VOXTYPE_LIB_DIR).join(backend).display()
+            );
         }
     }
 
@@ -376,18 +388,31 @@ pub fn disable() -> anyhow::Result<()> {
         whisper_backend
     } else {
         // Try to find any available Whisper backend
-        for fallback in ["voxtype-avx512", "voxtype-avx2", "voxtype-vulkan", "voxtype-native"] {
+        for fallback in [
+            "voxtype-avx512",
+            "voxtype-avx2",
+            "voxtype-vulkan",
+            "voxtype-native",
+        ] {
             if Path::new(VOXTYPE_LIB_DIR).join(fallback).exists() {
-                eprintln!("Note: {} not found, using {} instead", whisper_backend, fallback);
+                eprintln!(
+                    "Note: {} not found, using {} instead",
+                    whisper_backend, fallback
+                );
                 break;
             }
         }
         // Find first available
-        ["voxtype-avx512", "voxtype-avx2", "voxtype-vulkan", "voxtype-native"]
-            .iter()
-            .find(|b| Path::new(VOXTYPE_LIB_DIR).join(b).exists())
-            .copied()
-            .ok_or_else(|| anyhow::anyhow!("No Whisper backend found to switch to"))?
+        [
+            "voxtype-avx512",
+            "voxtype-avx2",
+            "voxtype-vulkan",
+            "voxtype-native",
+        ]
+        .iter()
+        .find(|b| Path::new(VOXTYPE_LIB_DIR).join(b).exists())
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("No Whisper backend found to switch to"))?
     };
 
     switch_binary(final_backend)?;
@@ -397,7 +422,10 @@ pub fn disable() -> anyhow::Result<()> {
         println!("Updated systemd service to use Whisper backend.");
     }
 
-    println!("Switched to Whisper ({}) backend.", final_backend.trim_start_matches("voxtype-"));
+    println!(
+        "Switched to Whisper ({}) backend.",
+        final_backend.trim_start_matches("voxtype-")
+    );
     println!();
     println!("Restart voxtype to use Whisper:");
     println!("  systemctl --user restart voxtype");
@@ -412,7 +440,10 @@ mod tests {
     #[test]
     fn test_parakeet_backend_binary_names() {
         assert_eq!(ParakeetBackend::Avx2.binary_name(), "voxtype-parakeet-avx2");
-        assert_eq!(ParakeetBackend::Avx512.binary_name(), "voxtype-parakeet-avx512");
+        assert_eq!(
+            ParakeetBackend::Avx512.binary_name(),
+            "voxtype-parakeet-avx512"
+        );
         assert_eq!(ParakeetBackend::Cuda.binary_name(), "voxtype-parakeet-cuda");
         assert_eq!(ParakeetBackend::Rocm.binary_name(), "voxtype-parakeet-rocm");
         assert_eq!(ParakeetBackend::Custom.binary_name(), "voxtype-parakeet");
@@ -430,10 +461,16 @@ mod tests {
     #[test]
     fn test_parakeet_whisper_equivalents() {
         assert_eq!(ParakeetBackend::Avx2.whisper_equivalent(), "voxtype-avx2");
-        assert_eq!(ParakeetBackend::Avx512.whisper_equivalent(), "voxtype-avx512");
+        assert_eq!(
+            ParakeetBackend::Avx512.whisper_equivalent(),
+            "voxtype-avx512"
+        );
         assert_eq!(ParakeetBackend::Cuda.whisper_equivalent(), "voxtype-vulkan");
         assert_eq!(ParakeetBackend::Rocm.whisper_equivalent(), "voxtype-vulkan");
-        assert_eq!(ParakeetBackend::Custom.whisper_equivalent(), "voxtype-native");
+        assert_eq!(
+            ParakeetBackend::Custom.whisper_equivalent(),
+            "voxtype-native"
+        );
     }
 
     #[test]

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -50,7 +50,9 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
                     "Parakeet engine selected but [parakeet] config section is missing".to_string(),
                 )
             })?;
-            Ok(Box::new(parakeet::ParakeetTranscriber::new(parakeet_config)?))
+            Ok(Box::new(parakeet::ParakeetTranscriber::new(
+                parakeet_config,
+            )?))
         }
         #[cfg(not(feature = "parakeet"))]
         TranscriptionEngine::Parakeet => Err(TranscribeError::InitFailed(
@@ -76,7 +78,10 @@ pub fn create_transcriber_with_config_path(
     // Apply GPU selection from VOXTYPE_VULKAN_DEVICE environment variable
     // This sets VK_LOADER_DRIVERS_SELECT to filter Vulkan drivers
     if let Some(vendor) = gpu::apply_gpu_selection() {
-        tracing::info!("GPU selection: {} (via VOXTYPE_VULKAN_DEVICE)", vendor.display_name());
+        tracing::info!(
+            "GPU selection: {} (via VOXTYPE_VULKAN_DEVICE)",
+            vendor.display_name()
+        );
     }
 
     match config.effective_mode() {

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -10,9 +10,15 @@
 use super::Transcriber;
 use crate::config::{ParakeetConfig, ParakeetModelType};
 use crate::error::TranscribeError;
-#[cfg(any(feature = "parakeet-cuda", feature = "parakeet-rocm", feature = "parakeet-tensorrt"))]
+#[cfg(any(
+    feature = "parakeet-cuda",
+    feature = "parakeet-rocm",
+    feature = "parakeet-tensorrt"
+))]
 use parakeet_rs::ExecutionProvider;
-use parakeet_rs::{ExecutionConfig, Parakeet, ParakeetTDT, Transcriber as ParakeetTranscriberTrait};
+use parakeet_rs::{
+    ExecutionConfig, Parakeet, ParakeetTDT, Transcriber as ParakeetTranscriberTrait,
+};
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -54,15 +60,15 @@ impl ParakeetTranscriber {
 
         let model = match model_type {
             ParakeetModelType::Ctc => {
-                let parakeet = Parakeet::from_pretrained(&model_path, exec_config)
-                    .map_err(|e| {
+                let parakeet =
+                    Parakeet::from_pretrained(&model_path, exec_config).map_err(|e| {
                         TranscribeError::InitFailed(format!("Parakeet CTC init failed: {}", e))
                     })?;
                 ParakeetModel::Ctc(Mutex::new(parakeet))
             }
             ParakeetModelType::Tdt => {
-                let parakeet = ParakeetTDT::from_pretrained(&model_path, exec_config)
-                    .map_err(|e| {
+                let parakeet =
+                    ParakeetTDT::from_pretrained(&model_path, exec_config).map_err(|e| {
                         TranscribeError::InitFailed(format!("Parakeet TDT init failed: {}", e))
                     })?;
                 ParakeetModel::Tdt(Mutex::new(parakeet))
@@ -82,7 +88,9 @@ impl ParakeetTranscriber {
 impl Transcriber for ParakeetTranscriber {
     fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
         if samples.is_empty() {
-            return Err(TranscribeError::AudioFormat("Empty audio buffer".to_string()));
+            return Err(TranscribeError::AudioFormat(
+                "Empty audio buffer".to_string(),
+            ));
         }
 
         let duration_secs = samples.len() as f32 / 16000.0;
@@ -98,7 +106,10 @@ impl Transcriber for ParakeetTranscriber {
         let text = match &self.model {
             ParakeetModel::Ctc(parakeet) => {
                 let mut parakeet = parakeet.lock().map_err(|e| {
-                    TranscribeError::InferenceFailed(format!("Failed to lock Parakeet mutex: {}", e))
+                    TranscribeError::InferenceFailed(format!(
+                        "Failed to lock Parakeet mutex: {}",
+                        e
+                    ))
                 })?;
 
                 let result = parakeet
@@ -109,14 +120,20 @@ impl Transcriber for ParakeetTranscriber {
                         None,  // default timestamp mode
                     )
                     .map_err(|e| {
-                        TranscribeError::InferenceFailed(format!("Parakeet CTC inference failed: {}", e))
+                        TranscribeError::InferenceFailed(format!(
+                            "Parakeet CTC inference failed: {}",
+                            e
+                        ))
                     })?;
 
                 result.text.trim().to_string()
             }
             ParakeetModel::Tdt(parakeet) => {
                 let mut parakeet = parakeet.lock().map_err(|e| {
-                    TranscribeError::InferenceFailed(format!("Failed to lock Parakeet mutex: {}", e))
+                    TranscribeError::InferenceFailed(format!(
+                        "Failed to lock Parakeet mutex: {}",
+                        e
+                    ))
                 })?;
 
                 let result = parakeet
@@ -127,7 +144,10 @@ impl Transcriber for ParakeetTranscriber {
                         None,  // default timestamp mode
                     )
                     .map_err(|e| {
-                        TranscribeError::InferenceFailed(format!("Parakeet TDT inference failed: {}", e))
+                        TranscribeError::InferenceFailed(format!(
+                            "Parakeet TDT inference failed: {}",
+                            e
+                        ))
                     })?;
 
                 result.text.trim().to_string()
@@ -169,7 +189,11 @@ fn build_execution_config() -> Option<ExecutionConfig> {
         return Some(ExecutionConfig::new().with_execution_provider(ExecutionProvider::ROCm));
     }
 
-    #[cfg(not(any(feature = "parakeet-cuda", feature = "parakeet-tensorrt", feature = "parakeet-rocm")))]
+    #[cfg(not(any(
+        feature = "parakeet-cuda",
+        feature = "parakeet-tensorrt",
+        feature = "parakeet-rocm"
+    )))]
     {
         None
     }
@@ -181,8 +205,8 @@ fn build_execution_config() -> Option<ExecutionConfig> {
 /// CTC models have: model.onnx (or model_int8.onnx), tokenizer.json
 fn detect_model_type(path: &PathBuf) -> ParakeetModelType {
     // Check for TDT model structure
-    let has_encoder = path.join("encoder-model.onnx").exists()
-        || path.join("encoder-model.onnx.data").exists();
+    let has_encoder =
+        path.join("encoder-model.onnx").exists() || path.join("encoder-model.onnx.data").exists();
     let has_decoder = path.join("decoder_joint-model.onnx").exists();
 
     if has_encoder && has_decoder {
@@ -191,8 +215,7 @@ fn detect_model_type(path: &PathBuf) -> ParakeetModelType {
     }
 
     // Check for CTC model structure
-    let has_ctc_model = path.join("model.onnx").exists()
-        || path.join("model_int8.onnx").exists();
+    let has_ctc_model = path.join("model.onnx").exists() || path.join("model_int8.onnx").exists();
     let has_tokenizer = path.join("tokenizer.json").exists();
 
     if has_ctc_model && has_tokenizer {


### PR DESCRIPTION
## Summary

- Applies `cargo fmt` to 16 files with 95 formatting inconsistencies
- No functional changes, formatting only
- Cleans up formatting debt so future PRs (like #176) don't carry unrelated formatting diffs

## Context

While evaluating PR #176, we noticed that most of its 766 additions were `cargo fmt` reformatting rather than functional changes. Running `cargo fmt --check` on main confirmed 95 formatting diffs across 16 files. This commit resolves that debt separately so it doesn't muddy feature PRs.

## Test plan

- [x] `cargo fmt --check` passes (no remaining diffs)
- [ ] `cargo test` passes (no functional changes)
- [ ] `cargo clippy` passes