### PR TITLE
Add append_text config option for post-transcription text

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1335,6 +1335,31 @@ auto_submit = true  # Press Enter after transcription
 
 **Note:** This works with all output modes (`type`, `paste`) but has no effect in `clipboard` mode since clipboard-only output doesn't simulate keypresses.
 
+### append_text
+
+**Type:** String
+**Default:** None (disabled)
+**Required:** No
+**Environment Variable:** `VOXTYPE_APPEND_TEXT`
+
+Text to append after each transcription. Appended after the main transcription but before `auto_submit` (if enabled). Useful for separating sentences when dictating paragraphs incrementally.
+
+**Common use case:** When transcribing a paragraph sentence by sentence, there are no spaces between each sentence. Setting `append_text = " "` adds a space after each transcription, creating proper sentence separation.
+
+**Example:**
+```toml
+[output]
+append_text = " "  # Add a space after each transcription
+```
+
+**How it works:**
+- In `type` mode: Types the text after the main transcription
+- In `paste` mode: Includes the text in the clipboard before pasting
+- In `clipboard` mode: Includes the text in the clipboard
+- With `auto_submit = true`: The append_text is typed/pasted first, then Enter is sent
+
+**Note:** You can append any text, not just spaces. For example, `append_text = "\n"` would add a newline after each transcription.
+
 ### shift_enter_newlines
 
 **Type:** Boolean

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -115,6 +115,7 @@ Check dependencies and optionally download models.
 voxtype setup              # Check dependencies only
 voxtype setup --download   # Download default model (base.en)
 voxtype setup model        # Interactive model selection
+voxtype setup vad          # Download the Silero VAD model
 ```
 
 ### `voxtype config`
@@ -254,7 +255,7 @@ device = "default"
 sample_rate = 16000
 
 # Maximum recording duration in seconds (safety limit)
-# Recording automatically stops after this time
+# Recording automatically stops and transcribes after this time
 max_duration_secs = 60
 
 [whisper]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,6 +100,11 @@ pub struct Cli {
     #[arg(long, value_name = "MS", hide = true)]
     pub wtype_delay: Option<u32>,
 
+    /// Text to append after each transcription (e.g., " " for a trailing space).
+    /// Appended before auto_submit. Useful for separating sentences when dictating incrementally.
+    #[arg(long, value_name = "TEXT")]
+    pub append_text: Option<String>,
+
     /// Output driver order for type mode (comma-separated)
     /// Overrides config driver_order. Available: wtype, dotool, ydotool, clipboard
     /// Example: --driver=ydotool,wtype,clipboard

--- a/src/config.rs
+++ b/src/config.rs
@@ -1134,6 +1134,12 @@ pub struct OutputConfig {
     #[serde(default)]
     pub auto_submit: bool,
 
+    /// Text to append after each transcription (e.g., " " for a space)
+    /// Appended after the transcription but before auto_submit
+    /// Useful for separating sentences when dictating paragraphs incrementally
+    #[serde(default)]
+    pub append_text: Option<String>,
+
     /// Convert newlines to Shift+Enter instead of regular Enter
     /// Useful for applications where Enter submits (e.g., Cursor IDE, Slack, Discord)
     #[serde(default)]
@@ -1337,6 +1343,7 @@ impl Default for Config {
                 pre_type_delay_ms: 0,
                 wtype_delay_ms: 0,
                 auto_submit: false,
+                append_text: None,
                 shift_enter_newlines: false,
                 pre_recording_command: None,
                 pre_output_command: None,
@@ -1494,6 +1501,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
             "paste" => OutputMode::Paste,
             _ => OutputMode::Type,
         };
+    }
+    if let Ok(append_text) = std::env::var("VOXTYPE_APPEND_TEXT") {
+        config.output.append_text = Some(append_text);
     }
 
     Ok(config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,9 @@ fn warn_if_root(command_name: &str) -> bool {
             command_name
         );
         eprintln!("  - Models will download to /root/.local/share/voxtype/ instead of your user directory");
-        eprintln!("  - Config changes will apply to /root/.config/voxtype/ instead of your user config");
+        eprintln!(
+            "  - Config changes will apply to /root/.config/voxtype/ instead of your user config"
+        );
         eprintln!("  - Cannot restart your user's voxtype daemon from root");
         eprintln!();
         eprintln!("Run without sudo: voxtype setup {}", command_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,9 @@ async fn main() -> anyhow::Result<()> {
     if let Some(secs) = cli.eager_overlap_secs {
         config.whisper.eager_overlap_secs = secs;
     }
+    if let Some(append_text) = cli.append_text {
+        config.output.append_text = Some(append_text);
+    }
     if let Some(ref driver_str) = cli.driver {
         match parse_driver_order(driver_str) {
             Ok(drivers) => {

--- a/src/output/eitype.rs
+++ b/src/output/eitype.rs
@@ -17,6 +17,8 @@ use tokio::process::Command;
 pub struct EitypeOutput {
     /// Whether to send Enter key after output
     auto_submit: bool,
+    /// Text to append after transcription (before auto_submit)
+    append_text: Option<String>,
     /// Delay between key events in milliseconds
     type_delay_ms: u32,
     /// Delay before typing starts (ms)
@@ -29,12 +31,14 @@ impl EitypeOutput {
     /// Create a new eitype output
     pub fn new(
         auto_submit: bool,
+        append_text: Option<String>,
         type_delay_ms: u32,
         pre_type_delay_ms: u32,
         shift_enter_newlines: bool,
     ) -> Self {
         Self {
             auto_submit,
+            append_text,
             type_delay_ms,
             pre_type_delay_ms,
             shift_enter_newlines,
@@ -164,6 +168,11 @@ impl TextOutput for EitypeOutput {
             self.type_text(text).await?;
         }
 
+        // Append text if configured (e.g., a space to separate sentences)
+        if let Some(ref append) = self.append_text {
+            self.type_text(append).await?;
+        }
+
         // Send Enter key if auto_submit is configured
         if self.auto_submit {
             self.send_enter().await?;
@@ -195,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = EitypeOutput::new(false, 0, 0, false);
+        let output = EitypeOutput::new(false, None, 0, 0, false);
         assert!(!output.auto_submit);
         assert_eq!(output.type_delay_ms, 0);
         assert_eq!(output.pre_type_delay_ms, 0);
@@ -204,27 +213,27 @@ mod tests {
 
     #[test]
     fn test_new_with_enter() {
-        let output = EitypeOutput::new(true, 0, 0, false);
+        let output = EitypeOutput::new(true, None, 0, 0, false);
         assert!(output.auto_submit);
     }
 
     #[test]
     fn test_new_with_type_delay() {
-        let output = EitypeOutput::new(false, 50, 0, false);
+        let output = EitypeOutput::new(false, None, 50, 0, false);
         assert_eq!(output.type_delay_ms, 50);
         assert_eq!(output.pre_type_delay_ms, 0);
     }
 
     #[test]
     fn test_new_with_pre_type_delay() {
-        let output = EitypeOutput::new(false, 0, 200, false);
+        let output = EitypeOutput::new(false, None, 0, 200, false);
         assert_eq!(output.type_delay_ms, 0);
         assert_eq!(output.pre_type_delay_ms, 200);
     }
 
     #[test]
     fn test_new_with_shift_enter_newlines() {
-        let output = EitypeOutput::new(false, 0, 0, true);
+        let output = EitypeOutput::new(false, None, 0, 0, true);
         assert!(output.shift_enter_newlines);
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -168,12 +168,14 @@ fn create_driver_output(
     match driver {
         OutputDriver::Wtype => Box::new(wtype::WtypeOutput::new(
             config.auto_submit,
+            config.append_text.clone(),
             config.type_delay_ms,
             pre_type_delay_ms,
             config.shift_enter_newlines,
         )),
         OutputDriver::Eitype => Box::new(eitype::EitypeOutput::new(
             config.auto_submit,
+            config.append_text.clone(),
             config.type_delay_ms,
             pre_type_delay_ms,
             config.shift_enter_newlines,
@@ -183,6 +185,7 @@ fn create_driver_output(
             pre_type_delay_ms,
             show_notification,
             config.auto_submit,
+            config.append_text.clone(),
             config.dotool_xkb_layout.clone(),
             config.dotool_xkb_variant.clone(),
         )),
@@ -191,6 +194,7 @@ fn create_driver_output(
             pre_type_delay_ms,
             show_notification,
             config.auto_submit,
+            config.append_text.clone(),
         )),
         OutputDriver::Clipboard => Box::new(clipboard::ClipboardOutput::new(show_notification)),
         OutputDriver::Xclip => Box::new(xclip::XclipOutput::new(show_notification)),
@@ -265,6 +269,7 @@ pub fn create_output_chain_with_override(
             // Only paste mode (no fallback as requested)
             chain.push(Box::new(paste::PasteOutput::new(
                 config.auto_submit,
+                config.append_text.clone(),
                 config.paste_keys.clone(),
                 config.type_delay_ms,
                 pre_type_delay_ms,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -196,8 +196,14 @@ fn create_driver_output(
             config.auto_submit,
             config.append_text.clone(),
         )),
-        OutputDriver::Clipboard => Box::new(clipboard::ClipboardOutput::new(show_notification)),
-        OutputDriver::Xclip => Box::new(xclip::XclipOutput::new(show_notification)),
+        OutputDriver::Clipboard => Box::new(clipboard::ClipboardOutput::new(
+            show_notification,
+            config.append_text.clone(),
+        )),
+        OutputDriver::Xclip => Box::new(xclip::XclipOutput::new(
+            show_notification,
+            config.append_text.clone(),
+        )),
     }
 }
 
@@ -256,13 +262,17 @@ pub fn create_output_chain_with_override(
                 && config.driver_order.is_some()
                 && !driver_order.contains(&OutputDriver::Clipboard)
             {
-                chain.push(Box::new(clipboard::ClipboardOutput::new(false)));
+                chain.push(Box::new(clipboard::ClipboardOutput::new(
+                    false,
+                    config.append_text.clone(),
+                )));
             }
         }
         crate::config::OutputMode::Clipboard => {
             // Only clipboard
             chain.push(Box::new(clipboard::ClipboardOutput::new(
                 config.notification.on_transcription,
+                config.append_text.clone(),
             )));
         }
         crate::config::OutputMode::Paste => {
@@ -283,6 +293,7 @@ pub fn create_output_chain_with_override(
             );
             chain.push(Box::new(clipboard::ClipboardOutput::new(
                 config.notification.on_transcription,
+                config.append_text.clone(),
             )));
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -102,7 +102,9 @@ impl State {
     /// Get the number of transcription tasks currently in flight (eager mode only)
     pub fn eager_tasks_in_flight(&self) -> Option<usize> {
         match self {
-            State::EagerRecording { tasks_in_flight, .. } => Some(*tasks_in_flight),
+            State::EagerRecording {
+                tasks_in_flight, ..
+            } => Some(*tasks_in_flight),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- Adds `append_text` config option to append text (e.g., a trailing space) after each transcription
- Configurable via config file (`[output] append_text = " "`), env var (`VOXTYPE_APPEND_TEXT`), and CLI flag (`--append-text`)
- Implemented across all output drivers: wtype, eitype, dotool, ydotool, paste, clipboard, xclip
- Appended after transcription text but before auto_submit

Closes #187

## Test plan

- [x] `cargo test` passes (268 tests)
- [ ] Manual test: set `append_text = " "`, dictate multiple sentences, verify spaces between them
- [ ] Test with `--append-text " "` CLI flag
- [ ] Test with `VOXTYPE_APPEND_TEXT=" "` env var