### PR TITLE
Add pipewire-alsa as required RPM dependency

### DIFF
--- a/packaging/rpm/voxtype.spec
+++ b/packaging/rpm/voxtype.spec
@@ -15,11 +15,11 @@ BuildRequires:  systemd-rpm-macros
 BuildRequires:  cmake
 
 Requires:       curl
+Requires:       pipewire-alsa
 Recommends:     wtype
 Recommends:     wl-clipboard
 Suggests:       ydotool
 Suggests:       libnotify
-Suggests:       pipewire
 
 %description
 Voxtype is a push-to-talk voice-to-text daemon for Linux.

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -589,6 +589,7 @@ if [[ "$BUILD_DEB" == "true" ]]; then
         --depends "libasound2 | libasound2t64" \
         --depends libc6 \
         --depends curl \
+        --deb-recommends pipewire-alsa \
         --deb-recommends wtype \
         --deb-recommends wl-clipboard \
         --deb-suggests ydotool \
@@ -622,6 +623,7 @@ if [[ "$BUILD_RPM" == "true" ]]; then
         --depends "alsa-lib" \
         --depends "glibc" \
         --depends "curl" \
+        --depends "pipewire-alsa" \
         --rpm-summary "$DESCRIPTION" \
         --package "$RPM_FILE" \
         usr etc


### PR DESCRIPTION
## Summary

- Adds `pipewire-alsa` as `Requires` in RPM spec (was `Suggests: pipewire`)
- Adds `pipewire-alsa` as `--depends` in the fpm RPM build command
- Adds `pipewire-alsa` as `--deb-recommends` for deb packages

Voxtype uses cpal which accesses audio through the ALSA API. On PipeWire systems, `pipewire-alsa` provides the ALSA compatibility layer. Without it, audio capture fails with cryptic ALSA errors.

Closes #186

## Test plan

- [ ] Build RPM with `scripts/package.sh` and verify pipewire-alsa is listed as a dependency
- [ ] Install RPM on Fedora, verify audio works without manually installing pipewire-alsa