### PR TITLE
Replace RPM post-install symlink with CPU-detecting wrapper script

### DIFF
--- a/scripts/voxtype-wrapper.sh
+++ b/scripts/voxtype-wrapper.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Voxtype CPU-adaptive wrapper script
+# Detects CPU capabilities and executes the appropriate binary variant
+
+VOXTYPE_LIB="/usr/lib/voxtype"
+
+# Detect AVX-512 support (Linux-specific)
+if [ -f /proc/cpuinfo ] && grep -q avx512f /proc/cpuinfo 2>/dev/null; then
+    # Prefer AVX-512 binary if available
+    if [ -x "$VOXTYPE_LIB/voxtype-avx512" ]; then
+        exec "$VOXTYPE_LIB/voxtype-avx512" "$@"
+    fi
+fi
+
+# Fall back to AVX2 (baseline for x86_64)
+if [ -x "$VOXTYPE_LIB/voxtype-avx2" ]; then
+    exec "$VOXTYPE_LIB/voxtype-avx2" "$@"
+fi
+
+# Final fallback for aarch64 or single-binary installs
+if [ -x "$VOXTYPE_LIB/voxtype" ]; then
+    exec "$VOXTYPE_LIB/voxtype" "$@"
+fi
+
+# If we get here, no binary was found
+echo "Error: No voxtype binary found in $VOXTYPE_LIB" >&2
+echo "Please reinstall the package." >&2
+exit 1


### PR DESCRIPTION
## Summary

- Replaces the post-install symlink approach with a wrapper script at `/usr/bin/voxtype`
- Wrapper detects CPU features at runtime and execs the appropriate binary (avx512, avx2, or generic)
- Eliminates the failure mode where post-install scripts don't run or fail silently on some distros
- Handles both x86_64 (multi-variant) and aarch64 (single binary) installs

Closes #169

## Test plan

- [ ] Build RPM with `scripts/package.sh` and verify `/usr/bin/voxtype` is the wrapper script
- [ ] Install on openSUSE Tumbleweed (reporter's platform) and verify `voxtype --version` works
- [ ] Install on Fedora and verify CPU detection picks the right binary
- [ ] Verify wrapper passes all arguments through correctly