### PR TITLE
Bump parakeet-rs to 0.3 to fix ort version mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "parakeet-rs"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7667842fd2f3b97b029a30fb9a00138867c6915229f5acd6bd809d08250d2ee"
+checksum = "6cbd5310b3d9a1d8ab59369a2e6dd20511f46a81de08f5aaca0ba811059c2c93"
 dependencies = [
  "eyre",
  "hound",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rodio = { version = "0.19", default-features = false, features = ["wav"] }
 whisper-rs = "0.15.1"
 
 # Parakeet speech-to-text (optional, ONNX-based)
-parakeet-rs = { version = "0.2.9", optional = true }
+parakeet-rs = { version = "0.3", optional = true }
 
 
 # CPU count for thread detection


### PR DESCRIPTION
## Summary

- Updates parakeet-rs from 0.2.9 to 0.3 in Cargo.toml and Cargo.lock
- Resolves ONNX Runtime version mismatch on NixOS 25.11 where ort 2.0.0-rc.11 required ONNX Runtime >= 1.23.x but the system provided 1.22.2

Closes #181

## Test plan

- [x] `cargo check --features parakeet` compiles
- [ ] Test parakeet transcription on NixOS with ONNX Runtime 1.23+
- [ ] Verify no API breakage between parakeet-rs 0.2.9 and 0.3