### PR TITLE
Update documentation and website for v0.6.0

### DIFF
--- a/docs/MEETING_MODE.md
+++ b/docs/MEETING_MODE.md
@@ -1,0 +1,348 @@
+# Meeting Mode
+
+Meeting mode provides continuous transcription for meetings, lectures, interviews, or any long-form audio capture. Unlike push-to-talk dictation (which transcribes short bursts when you hold a hotkey), meeting mode records continuously and processes audio in chunks, building a timestamped transcript you can export and search later.
+
+## Table of Contents
+
+- [When to Use Meeting Mode](#when-to-use-meeting-mode)
+- [Quick Start](#quick-start)
+- [Commands](#commands)
+  - [Starting a Meeting](#starting-a-meeting)
+  - [Stopping a Meeting](#stopping-a-meeting)
+  - [Pausing and Resuming](#pausing-and-resuming)
+  - [Checking Status](#checking-status)
+  - [Listing Past Meetings](#listing-past-meetings)
+  - [Viewing Meeting Details](#viewing-meeting-details)
+  - [Exporting Transcripts](#exporting-transcripts)
+  - [Labeling Speakers](#labeling-speakers)
+  - [AI Summarization](#ai-summarization)
+  - [Deleting Meetings](#deleting-meetings)
+- [Configuration](#configuration)
+  - [Basic Settings](#basic-settings)
+  - [Audio Settings](#audio-settings)
+  - [Diarization Settings](#diarization-settings)
+  - [Summarization Settings](#summarization-settings)
+- [Storage](#storage)
+- [Tips for Best Results](#tips-for-best-results)
+
+---
+
+## When to Use Meeting Mode
+
+Use meeting mode when you need a transcript of a longer recording session. Good use cases:
+
+- Video calls and meetings (Zoom, Teams, Google Meet)
+- Lectures and presentations
+- Interviews
+- Brainstorming sessions
+
+For short dictation (a sentence or two at a time), stick with the normal push-to-talk workflow.
+
+---
+
+## Quick Start
+
+1. Enable meeting mode in your config:
+
+```toml
+[meeting]
+enabled = true
+```
+
+2. Start the voxtype daemon if it is not already running:
+
+```bash
+voxtype
+```
+
+3. Start a meeting:
+
+```bash
+voxtype meeting start --title "Weekly Standup"
+```
+
+4. When the meeting ends:
+
+```bash
+voxtype meeting stop
+```
+
+5. Export the transcript:
+
+```bash
+voxtype meeting export latest --format markdown --output standup.md
+```
+
+---
+
+## Commands
+
+### Starting a Meeting
+
+```bash
+voxtype meeting start
+voxtype meeting start --title "Project Kickoff"
+voxtype meeting start -t "1:1 with Alice"
+```
+
+The `--title` flag is optional. If omitted, the meeting is named by its date and time (e.g., "Meeting 2026-02-16 14:30"). The daemon must be running, and meeting mode must be enabled in config.
+
+Only one meeting can run at a time. Starting a second meeting while one is active will fail.
+
+### Stopping a Meeting
+
+```bash
+voxtype meeting stop
+```
+
+Stops recording, processes any remaining audio, saves the transcript, and returns to idle. You can stop a meeting whether it is active or paused.
+
+### Pausing and Resuming
+
+```bash
+voxtype meeting pause
+voxtype meeting resume
+```
+
+Pause temporarily stops recording without ending the meeting. Audio during the paused period is not captured. Resume picks up where you left off.
+
+This is useful for breaks, side conversations you do not want transcribed, or when switching contexts temporarily.
+
+### Checking Status
+
+```bash
+voxtype meeting status
+```
+
+Shows whether a meeting is active, paused, or idle, along with the meeting ID if one is in progress.
+
+### Listing Past Meetings
+
+```bash
+voxtype meeting list
+voxtype meeting list --limit 5
+```
+
+Lists recent meetings with their ID, title, date, duration, status, and chunk count. Defaults to showing the 10 most recent. Meetings are sorted by start time, newest first.
+
+### Viewing Meeting Details
+
+```bash
+voxtype meeting show latest
+voxtype meeting show <meeting-id>
+```
+
+Shows detailed information about a meeting: title, start/end times, duration, word count, number of chunks, speakers detected, and the transcription engine used.
+
+You can use `latest` as a shorthand for the most recent meeting's ID. This works with all commands that take a meeting ID.
+
+### Exporting Transcripts
+
+```bash
+# Markdown to stdout
+voxtype meeting export latest
+
+# Plain text to a file
+voxtype meeting export latest --format text --output meeting.txt
+
+# JSON with timestamps and speaker labels
+voxtype meeting export latest --format json --timestamps --speakers
+
+# Subtitle formats
+voxtype meeting export latest --format srt --output meeting.srt
+voxtype meeting export latest --format vtt --output meeting.vtt
+```
+
+**Supported formats:**
+
+| Format | Flag | Description |
+|--------|------|-------------|
+| Markdown | `markdown` or `md` | Default. Readable with headers and speaker labels. |
+| Plain text | `text` or `txt` | Just the words, no formatting. |
+| JSON | `json` | Structured data with all segment metadata. |
+| SRT | `srt` | SubRip subtitle format. |
+| VTT | `vtt` | WebVTT subtitle format. |
+
+**Export options:**
+
+| Flag | Description |
+|------|-------------|
+| `--format`, `-f` | Output format (default: markdown) |
+| `--output`, `-o` | Write to file instead of stdout |
+| `--timestamps` | Include timestamps in output |
+| `--speakers` | Include speaker labels |
+| `--metadata` | Include a metadata header (title, date, duration) |
+
+### Labeling Speakers
+
+When diarization detects multiple speakers, they are assigned auto-generated IDs like `SPEAKER_00`, `SPEAKER_01`, etc. You can replace these with real names:
+
+```bash
+voxtype meeting label latest SPEAKER_00 "Alice"
+voxtype meeting label latest 1 "Bob"
+```
+
+The speaker ID can be the full form (`SPEAKER_00`) or just the number (`0`). Labels are saved to the database and applied to the transcript, so subsequent exports will use the names you assigned.
+
+### AI Summarization
+
+Generate a summary with key points, action items, and decisions:
+
+```bash
+# Markdown summary to stdout
+voxtype meeting summarize latest
+
+# JSON format
+voxtype meeting summarize latest --format json
+
+# Save to file
+voxtype meeting summarize latest --output summary.md
+```
+
+Summarization requires a configured backend. See [Summarization Settings](#summarization-settings) below.
+
+The summary includes:
+- A brief overview of the meeting
+- Key discussion points
+- Action items (with assignees when mentioned)
+- Decisions made
+
+### Deleting Meetings
+
+```bash
+voxtype meeting delete <meeting-id> --force
+```
+
+Permanently deletes the meeting record, transcript, and any associated audio files. The `--force` flag is required to confirm deletion.
+
+---
+
+## Configuration
+
+All meeting settings live under the `[meeting]` section in `~/.config/voxtype/config.toml`.
+
+### Basic Settings
+
+```toml
+[meeting]
+# Enable meeting mode (required)
+enabled = true
+
+# Duration of each audio chunk in seconds (default: 30)
+# Shorter chunks mean faster partial results but more processing overhead
+chunk_duration_secs = 30
+
+# Where to store meeting data (default: auto)
+# "auto" uses ~/.local/share/voxtype/meetings/
+storage_path = "auto"
+
+# Keep raw audio files after transcription (default: false)
+# Enable if you want to re-transcribe with a different model later
+retain_audio = false
+
+# Maximum meeting duration in minutes (default: 180, 0 = unlimited)
+max_duration_mins = 180
+```
+
+### Audio Settings
+
+```toml
+[meeting.audio]
+# Microphone device (default: "default", uses your main audio device)
+mic_device = "default"
+
+# Loopback device for capturing remote participants' audio
+# "auto" = auto-detect, "disabled" = mic only, or a specific device name
+loopback_device = "auto"
+```
+
+Setting `loopback_device = "auto"` lets voxtype capture system audio (the other side of a call). When loopback is active, speaker attribution can distinguish between "You" (from the mic) and "Remote" (from system audio).
+
+Set `loopback_device = "disabled"` if you only want to capture your own microphone, or if loopback detection is causing problems.
+
+### Diarization Settings
+
+Speaker diarization identifies who said what in the transcript.
+
+```toml
+[meeting.diarization]
+# Enable speaker diarization (default: true)
+enabled = true
+
+# Backend: "simple", "ml", or "subprocess" (default: "simple")
+backend = "simple"
+
+# Maximum speakers to detect (default: 10)
+max_speakers = 10
+```
+
+**Backends:**
+
+- **simple**: Uses audio source (mic vs loopback) to attribute speech as "You" or "Remote". No ML model needed.
+- **ml**: Uses ONNX-based speaker embeddings to identify individual speakers. Requires the `ml-diarization` feature and a downloaded model.
+- **subprocess**: Same as `ml` but runs in a separate process for memory isolation.
+
+For most users, `simple` is sufficient. Use `ml` if you need to distinguish between multiple remote participants.
+
+### Summarization Settings
+
+```toml
+[meeting.summary]
+# Backend: "local", "remote", or "disabled" (default: "disabled")
+backend = "local"
+
+# Ollama settings (for local backend)
+ollama_url = "http://localhost:11434"
+ollama_model = "llama3.2"
+
+# Remote API settings (for remote backend)
+# remote_endpoint = "https://api.example.com/summarize"
+# remote_api_key = "your-api-key"
+
+# Request timeout in seconds (default: 120)
+timeout_secs = 120
+```
+
+**Using Ollama for local summarization:**
+
+1. Install Ollama: https://ollama.ai
+2. Pull a model: `ollama pull llama3.2`
+3. Set `backend = "local"` in config
+4. Run `voxtype meeting summarize latest`
+
+Ollama runs entirely on your machine. No transcript data leaves your computer. Any Ollama-compatible model works, but `llama3.2` is a good default for meeting summarization.
+
+---
+
+## Storage
+
+Meeting data is stored at `~/.local/share/voxtype/meetings/` by default (or the path you set in `storage_path`).
+
+Each meeting gets its own directory named by date and title:
+
+```
+~/.local/share/voxtype/meetings/
+  index.db                          # SQLite database with meeting metadata
+  2026-02-16-weekly-standup/
+    metadata.json                   # Meeting metadata
+    transcript.json                 # Full transcript with segments
+  2026-02-14-project-kickoff/
+    metadata.json
+    transcript.json
+```
+
+The `index.db` SQLite database stores meeting metadata for fast listing and lookup. Transcripts are stored as JSON files alongside the metadata for easy access and portability.
+
+---
+
+## Tips for Best Results
+
+**Choose the right model.** Meeting transcription processes many audio chunks, so model choice affects both speed and accuracy. A fast model like `base.en` keeps up with real-time audio on most hardware. Larger models like `large-v3-turbo` are more accurate but need a capable GPU to keep pace with 30-second chunks.
+
+**Use a good microphone.** Transcription accuracy depends heavily on audio quality. A dedicated microphone or headset works much better than a laptop's built-in mic, especially in rooms with echo or background noise.
+
+**Set chunk duration appropriately.** The default 30 seconds works well for most cases. Shorter chunks (15-20s) give faster partial results but increase processing overhead. Longer chunks (45-60s) can improve accuracy for slower hardware since the transcription engine has more context.
+
+**Label speakers after the meeting.** Run `voxtype meeting list` to find the meeting ID, then use `voxtype meeting label` to assign names to auto-detected speaker IDs. This makes the exported transcript much more readable.
+
+**Export in multiple formats.** You can export the same meeting in different formats for different purposes: markdown for reading, JSON for processing in other tools, SRT/VTT for adding subtitles to a recording.

--- a/website/index.html
+++ b/website/index.html
@@ -82,7 +82,7 @@
                 </div>
                 <div class="terminal-body">
                     <pre><code><span class="prompt">$</span> voxtype
-<span class="info">[INFO]</span> Voxtype v0.5.6 starting...
+<span class="info">[INFO]</span> Voxtype v0.6.0 starting...
 <span class="info">[INFO]</span> Using model: base.en
 <span class="info">[INFO]</span> Hotkey: SCROLLLOCK
 <span class="info">[INFO]</span> Ready! Hold SCROLLLOCK to record.
@@ -670,12 +670,12 @@
                 </table>
             </div>
 
-            <h3 class="model-category">Parakeet Models (English, experimental)</h3>
+            <h3 class="model-category">ONNX Engines (require ONNX binary variant)</h3>
             <div class="model-table-wrapper">
                 <table class="model-table">
                     <thead>
                         <tr>
-                            <th>Model</th>
+                            <th>Engine / Model</th>
                             <th>Size</th>
                             <th>Speed</th>
                             <th>Accuracy</th>
@@ -683,23 +683,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr>
-                            <td><code>parakeet-tdt-0.6b-v3</code></td>
-                            <td>2.6 GB</td>
-                            <td>
-                                <div class="speed-bar">
-                                    <div class="speed-fill" style="width: 90%"></div>
-                                </div>
-                            </td>
-                            <td>
-                                <div class="accuracy-bar">
-                                    <div class="accuracy-fill" style="width: 95%"></div>
-                                </div>
-                            </td>
-                            <td>Fast, accurate, includes punctuation</td>
-                        </tr>
                         <tr class="recommended">
-                            <td><code>parakeet-tdt-0.6b-v3-int8</code> <span class="rec-badge">Recommended</span></td>
+                            <td><code>parakeet-tdt-0.6b-v3-int8</code> <span class="rec-badge">English</span></td>
                             <td>670 MB</td>
                             <td>
                                 <div class="speed-bar">
@@ -708,16 +693,91 @@
                             </td>
                             <td>
                                 <div class="accuracy-bar">
-                                    <div class="accuracy-fill" style="width: 90%"></div>
+                                    <div class="accuracy-fill" style="width: 95%"></div>
                                 </div>
                             </td>
-                            <td>Smaller, faster, quantized</td>
+                            <td>Best English accuracy, built-in punctuation</td>
+                        </tr>
+                        <tr>
+                            <td><code>moonshine-base</code></td>
+                            <td>237 MB</td>
+                            <td>
+                                <div class="speed-bar">
+                                    <div class="speed-fill" style="width: 98%"></div>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="accuracy-bar">
+                                    <div class="accuracy-fill" style="width: 78%"></div>
+                                </div>
+                            </td>
+                            <td>Fastest CPU inference, English</td>
+                        </tr>
+                        <tr class="recommended">
+                            <td><code>sensevoice-small</code> <span class="rec-badge">CJK</span></td>
+                            <td>239 MB</td>
+                            <td>
+                                <div class="speed-bar">
+                                    <div class="speed-fill" style="width: 92%"></div>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="accuracy-bar">
+                                    <div class="accuracy-fill" style="width: 88%"></div>
+                                </div>
+                            </td>
+                            <td>Chinese, Japanese, Korean, Cantonese, English</td>
+                        </tr>
+                        <tr>
+                            <td><code>paraformer-zh</code></td>
+                            <td>487 MB</td>
+                            <td>
+                                <div class="speed-bar">
+                                    <div class="speed-fill" style="width: 88%"></div>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="accuracy-bar">
+                                    <div class="accuracy-fill" style="width: 85%"></div>
+                                </div>
+                            </td>
+                            <td>Chinese + English bilingual</td>
+                        </tr>
+                        <tr>
+                            <td><code>dolphin-base</code></td>
+                            <td>198 MB</td>
+                            <td>
+                                <div class="speed-bar">
+                                    <div class="speed-fill" style="width: 90%"></div>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="accuracy-bar">
+                                    <div class="accuracy-fill" style="width: 82%"></div>
+                                </div>
+                            </td>
+                            <td>40 languages + 22 Chinese dialects</td>
+                        </tr>
+                        <tr>
+                            <td><code>omnilingual-large</code></td>
+                            <td>3.9 GB</td>
+                            <td>
+                                <div class="speed-bar">
+                                    <div class="speed-fill" style="width: 40%"></div>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="accuracy-bar">
+                                    <div class="accuracy-fill" style="width: 75%"></div>
+                                </div>
+                            </td>
+                            <td>1600+ languages, rare and low-resource</td>
                         </tr>
                     </tbody>
                 </table>
             </div>
             <p class="model-note">
-                <strong>.en models</strong> are English-only but faster and more accurate for English. <strong>Parakeet</strong> and <strong>Moonshine</strong> require the ONNX binary variant.
+                <strong>.en models</strong> are English-only but faster and more accurate for English. All ONNX engines require the ONNX binary variant. Switch with <code>voxtype setup onnx --enable</code>.
             </p>
         </div>
     </section>
@@ -768,8 +828,8 @@ sudo pacman -S wtype wl-clipboard</code></pre>
                             <button class="copy-btn">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install (Ubuntu 24.04+, Debian Trixie+)</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.5.6/voxtype_0.5.6-1_amd64.deb
-sudo dpkg -i voxtype_0.5.6-1_amd64.deb
+wget https://github.com/peteonrails/voxtype/releases/download/v0.6.0/voxtype_0.6.0-1_amd64.deb
+sudo dpkg -i voxtype_0.6.0-1_amd64.deb
 sudo apt-get install -f
 
 <span class="comment"># Install optional dependencies</span>
@@ -785,8 +845,8 @@ sudo apt install wtype wl-clipboard</code></pre>
                             <button class="copy-btn">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install (Fedora 39+)</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.5.6/voxtype-0.5.6-1.x86_64.rpm
-sudo dnf install ./voxtype-0.5.6-1.x86_64.rpm
+wget https://github.com/peteonrails/voxtype/releases/download/v0.6.0/voxtype-0.6.0-1.x86_64.rpm
+sudo dnf install ./voxtype-0.6.0-1.x86_64.rpm
 
 <span class="comment"># Install optional dependencies</span>
 sudo dnf install wtype wl-clipboard</code></pre>

--- a/website/news/index.html
+++ b/website/news/index.html
@@ -9,16 +9,16 @@
     <!-- Open Graph / Social Media -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://voxtype.io/news/">
-    <meta property="og:title" content="Voxtype 0.5.6: Moonshine Backend, Voice Activity Detection, Eager Transcription">
-    <meta property="og:description" content="Moonshine transcription backend for fast CPU inference. Voice activity detection filters silence and prevents hallucinations. Eager input processing reduces perceived latency.">
+    <meta property="og:title" content="Voxtype 0.6.0: Five New Transcription Engines, Meeting Mode">
+    <meta property="og:description" content="Five new ONNX-based transcription engines for Chinese, Japanese, Korean, and 1600+ languages. Meeting mode for continuous transcription with speaker attribution and AI summaries.">
     <meta property="og:image" content="https://voxtype.io/images/gpu-isolation.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Voxtype 0.5.6: Moonshine Backend, Voice Activity Detection, Eager Transcription">
-    <meta name="twitter:description" content="Moonshine transcription backend for fast CPU inference. Voice activity detection filters silence and prevents hallucinations. Eager input processing reduces perceived latency.">
+    <meta name="twitter:title" content="Voxtype 0.6.0: Five New Transcription Engines, Meeting Mode">
+    <meta name="twitter:description" content="Five new ONNX-based transcription engines for Chinese, Japanese, Korean, and 1600+ languages. Meeting mode for continuous transcription with speaker attribution and AI summaries.">
     <meta name="twitter:image" content="https://voxtype.io/images/gpu-isolation.png">
 
     <title>News & Updates | Voxtype</title>
@@ -74,6 +74,170 @@
     <!-- News Articles -->
     <main class="news-content">
         <div class="container">
+
+            <!-- v0.6.x Era Posts -->
+
+            <article class="news-article" id="v060">
+                <div class="article-meta">
+                    <time datetime="2026-02-16">February 16, 2026</time>
+                    <span class="article-tag">Release</span>
+                </div>
+                <h2>v0.6.0: Five New Transcription Engines, Meeting Mode</h2>
+                <div class="article-body">
+                    <p>Voxtype 0.6.0 is a major release. Five new ONNX-based transcription engines bring support for Chinese, Japanese, Korean, Cantonese, and 1600+ additional languages. Meeting mode adds continuous transcription for meetings with speaker attribution, export to multiple formats, and AI-generated summaries. The ONNX binary variants now ship with every ONNX engine included.</p>
+
+                    <h3>Five New Transcription Engines</h3>
+                    <p>Voxtype previously offered two transcription engines: Whisper and Parakeet. This release adds five more, all running locally via ONNX Runtime. Each engine has different strengths and language coverage.</p>
+
+                    <table class="performance-table">
+                        <thead>
+                            <tr>
+                                <th>Engine</th>
+                                <th>Languages</th>
+                                <th>Best For</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>SenseVoice</td>
+                                <td>Chinese, English, Japanese, Korean, Cantonese</td>
+                                <td>CJK transcription with auto-detection</td>
+                            </tr>
+                            <tr>
+                                <td>Paraformer</td>
+                                <td>Chinese + English (bilingual), Chinese + Cantonese + English (trilingual)</td>
+                                <td>Mixed Chinese/English speech</td>
+                            </tr>
+                            <tr>
+                                <td>Dolphin</td>
+                                <td>40 languages + 22 Chinese dialects</td>
+                                <td>Chinese dialects and Eastern languages</td>
+                            </tr>
+                            <tr>
+                                <td>Omnilingual</td>
+                                <td>1600+ languages</td>
+                                <td>Low-resource and rare languages</td>
+                            </tr>
+                            <tr>
+                                <td>Moonshine</td>
+                                <td>English (+ Japanese, Mandarin, Korean, Arabic)</td>
+                                <td>Fast CPU inference</td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <p><strong>Why use them:</strong> If you speak a CJK language and want a model trained specifically for it, SenseVoice and Paraformer will outperform Whisper on that task. If you need a rare language that Whisper doesn't cover well, Omnilingual supports over 1600 languages via Meta's MMS model. Dolphin covers 40 languages plus 22 Chinese dialects, which is useful if your dialect isn't well-served by general-purpose models.</p>
+
+                    <p>All five engines are CTC-based, meaning they run in a single forward pass with no autoregressive decoder loop. In practice, this makes them fast on CPU.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>config.toml</span></div>
+                        <pre><code># SenseVoice for CJK + English
+engine = "sensevoice"
+
+[sensevoice]
+model = "SenseVoiceSmall"
+language = "auto"    # auto, zh, en, ja, ko, yue
+
+# Paraformer for bilingual Chinese/English
+engine = "paraformer"
+
+[paraformer]
+model = "paraformer-zh"
+
+# Omnilingual for 1600+ languages
+engine = "omnilingual"
+
+[omnilingual]
+model = "mms-1b-all"</code></pre>
+                    </div>
+
+                    <p>Download models with <code>voxtype setup model</code> and select from the interactive menu. The new engines share infrastructure with Parakeet and Moonshine: shared Fbank feature extraction, shared CTC decoding, and shared ONNX Runtime session management.</p>
+
+                    <h3>All ONNX Engines in Every ONNX Binary</h3>
+                    <p>Previously, the ONNX release binaries only included Parakeet. Starting with v0.6.0, all four ONNX binary variants (onnx-avx2, onnx-avx512, onnx-cuda, onnx-rocm) include every ONNX engine: Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, and Omnilingual. The three Whisper-only binaries (avx2, avx512, vulkan) remain Whisper-only. Switch engines by changing a single config line.</p>
+
+                    <p>The release binary naming also changed from <code>voxtype-*-parakeet-*</code> to <code>voxtype-*-onnx-*</code> to reflect this broader scope.</p>
+
+                    <h3>Meeting Mode</h3>
+                    <p>Meeting mode is a new way to use Voxtype: continuous transcription for meetings, calls, and lectures. Instead of push-to-talk, it records continuously in chunks and transcribes each chunk as it completes.</p>
+
+                    <div class="code-block">
+                        <pre><code># Start a meeting
+voxtype meeting start --title "Weekly standup"
+
+# Pause and resume
+voxtype meeting pause
+voxtype meeting resume
+
+# Stop when done
+voxtype meeting stop
+
+# Export the transcript
+voxtype meeting export latest --format markdown
+voxtype meeting export latest --format srt</code></pre>
+                    </div>
+
+                    <p><strong>Why use it:</strong> Push-to-talk is great for dictation, but meetings need continuous recording. Meeting mode handles that with automatic chunking (default 30-second chunks), so memory usage stays bounded even for long sessions up to 3 hours.</p>
+
+                    <h3>Speaker Attribution</h3>
+                    <p>Meeting mode can identify who is speaking. Two approaches are available:</p>
+
+                    <ul>
+                        <li><strong>Simple attribution:</strong> Uses dual audio capture (microphone + system loopback) to label segments as "You" or "Remote". Good for 1-on-1 calls where you just need to distinguish yourself from the other person.</li>
+                        <li><strong>ML diarization:</strong> Uses ONNX-based speaker embeddings to cluster speech by speaker and assign labels like SPEAKER_00, SPEAKER_01. Works for multi-person meetings. You can rename speakers after the fact with <code>voxtype meeting label</code>.</li>
+                    </ul>
+
+                    <div class="code-block">
+                        <pre><code># Label auto-generated speaker IDs with real names
+voxtype meeting label latest SPEAKER_00 "Alice"
+voxtype meeting label latest SPEAKER_01 "Bob"</code></pre>
+                    </div>
+
+                    <h3>Meeting Export Formats</h3>
+                    <p>Meeting transcripts can be exported in five formats: plain text, Markdown, JSON, SRT subtitles, and VTT subtitles. The subtitle formats include timestamps, so you can use them with video recordings of the same meeting.</p>
+
+                    <div class="code-block">
+                        <pre><code>voxtype meeting export latest --format text
+voxtype meeting export latest --format markdown
+voxtype meeting export latest --format json
+voxtype meeting export latest --format srt
+voxtype meeting export latest --format vtt</code></pre>
+                    </div>
+
+                    <h3>AI Meeting Summaries</h3>
+                    <p>After a meeting, you can generate a summary with key points, action items, and decisions using a local LLM via Ollama or a remote API endpoint.</p>
+
+                    <div class="code-block">
+                        <pre><code># Generate a summary using Ollama
+voxtype meeting summarize latest
+
+# Output as JSON for programmatic use
+voxtype meeting summarize latest --format json</code></pre>
+                    </div>
+
+                    <p>This requires Ollama running locally or a configured remote summarization endpoint. The summary extracts action items, key decisions, and a concise overview from the full transcript.</p>
+
+                    <h3>Setup ONNX Replaces Setup Parakeet</h3>
+                    <p>The <code>voxtype setup parakeet</code> command has been renamed to <code>voxtype setup onnx</code> to reflect that it now manages all ONNX-based engines, not just Parakeet. The old <code>setup parakeet</code> command still works as a hidden alias, so existing scripts and muscle memory won't break.</p>
+
+                    <div class="code-block">
+                        <pre><code># New name
+voxtype setup onnx
+
+# Old name still works
+voxtype setup parakeet</code></pre>
+                    </div>
+
+                    <h3>Other Changes</h3>
+                    <ul>
+                        <li>Shared Fbank feature extraction and CTC decoder modules reduce code duplication across ONNX engines</li>
+                        <li>Multi-engine transcription smoke tests for automated regression testing</li>
+                        <li>Fix Dolphin and Paraformer transcription backends after initial implementation</li>
+                        <li>Fix clippy warnings across the codebase</li>
+                    </ul>
+                </div>
+            </article>
 
             <!-- v0.5.x Era Posts -->
 


### PR DESCRIPTION
## Summary

- Rewrite model selection guide for all 7 engines with decision tree
- Update user manual with all engine sections and meeting mode
- Add meeting mode guide (new file)
- Update README with engine table, meeting mode, architecture diagram
- Add v0.6.0 news article to website
- Update website model grid with all ONNX engines, bump download URLs to 0.6.0

Cherry-picked from release/0.6.0 (post-#210 merge).

## Test plan

- Documentation review for accuracy
- Website renders correctly with new article and model grid