### PR TITLE
Add dotool to Nix runtime dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
         # Runtime dependencies wrapped into PATH
         runtimeDeps = with pkgs; [
           wtype         # Wayland typing
+          dotool        # Universal typing backend via uinput
           wl-clipboard  # Wayland clipboard (wl-copy, wl-paste)
           ydotool       # Alternative typing backend (X11 and Wayland)
           xdotool       # X11 typing fallback

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -94,7 +94,7 @@ in {
         - packages.parakeet-cuda: CUDA acceleration (NVIDIA)
         - packages.parakeet-rocm: ROCm acceleration (AMD)
 
-        All packages include runtime dependencies (wtype, ydotool, etc.).
+        All packages include runtime dependencies (wtype, dotool, ydotool, etc.).
       '';
       example = lib.literalExpression "voxtype.packages.\${system}.vulkan";
     };

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -44,7 +44,7 @@ in {
         - packages.vulkan: Vulkan GPU acceleration
         - packages.rocm: ROCm/HIP acceleration (AMD)
 
-        These packages include all runtime dependencies (wtype, ydotool, etc.)
+        These packages include all runtime dependencies (wtype, dotool, ydotool, etc.)
         in their PATH.
       '';
       example = lib.literalExpression "voxtype.packages.\${system}.vulkan";


### PR DESCRIPTION
## Description

The Nix package includes most runtime dependencies, including `ydotool`, but does not include `dotool`. As the docs do say `dotool` is preferred over `ydotool`, I've added it to the default runtime deps.

## Related Issue

--

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] I have tested these changes locally
- [ ] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy` with no warnings
- [ ] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [x] No documentation changes are needed

## Additional Notes

Any additional information reviewers should know.
