### PR TITLE
v0.6.2: Echo cancellation, dual audio, and meeting bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@
 # Vendored dependencies (patched forks)
 /vendor/
 
-# Whisper models (large binary files)
-/models/*.bin
+# Model files (downloaded at runtime, not committed)
+/models/
 
 # Editor/IDE
 *.swp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,7 @@ Based on open issues and project direction:
 
 **Near Term:**
 - **Deterministic integration tests** - Automated smoke tests using pre-recorded audio files that can run in CI without LLM/human interaction
+- **Meeting echo cancellation edge trimming** - Remove residual bleed-through words at segment boundaries when loopback audio is active. GTCRN handles the bulk of echo removal, but 1-2 stray words can appear at the start/end of mic segments where the STFT window crosses a chunk boundary.
 
 **Medium Term:**
 - **Audio caching** ([#28](https://github.com/peteonrails/voxtype/issues/28)) - Save recordings for replay/re-transcription

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,7 +2906,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxtype"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "voxtype"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Peter Jackson", "Jean-Paul van Tillo", "Máté Rémiás", "Rob Zolkos", "Dan Heuckeroth", "Igor Warzocha", "Julian Kaiser", "Kevin Miller", "konnsim", "reisset", "Zubair", "Loki Coyote", "Umesh", "Barrett Ruth", "André Silva", "Chmouel Boudjnah", "Christopher Albert", "Phuoc Thinh Vu", "Alexander Bosu-Kellett", "ayoahha", "Toizi", "kakapt"]
 description = "Push-to-talk voice-to-text for Wayland"

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,0 +1,14 @@
+# Third-Party Licenses
+
+This file lists third-party models and assets distributed with or downloaded by voxtype.
+
+## GTCRN Speech Enhancement Model
+
+- **File:** `gtcrn_simple.onnx` (auto-downloaded on first meeting start)
+- **Source:** https://github.com/Xiaobin-Rong/gtcrn
+- **License:** MIT
+- **Copyright:** Copyright (c) 2024 Rong Xiaobin
+
+Used for removing speaker bleed-through from microphone audio during meeting
+transcription. The model is downloaded from the
+[sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) project's release assets.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1844,6 +1844,7 @@ max_duration_mins = 180          # Maximum meeting length (0 = unlimited)
 [meeting.audio]
 mic_device = "default"           # Microphone (uses audio.device if not set)
 loopback_device = "auto"         # Capture remote participants: "auto", "disabled", or device name
+echo_cancel = "auto"             # GTCRN neural enhancement + transcript dedup
 
 [meeting.diarization]
 enabled = true
@@ -1876,6 +1877,19 @@ Meeting summarization uses Ollama (local) or a remote API to generate a summary 
 # Requires [meeting.summary] backend set to "local" or "remote"
 voxtype meeting summarize latest
 voxtype meeting summarize latest --format markdown --output summary.md
+```
+
+### Echo Cancellation
+
+When `loopback_device` is enabled, meeting mode captures both your microphone and system audio (remote participants) on separate channels. Without echo cancellation, the remote participants' audio bleeds into your microphone recording and gets transcribed as your speech.
+
+Voxtype uses GTCRN, a lightweight neural speech enhancement model, to clean the mic signal before transcription. The model removes background noise and speaker bleed-through while preserving your voice. A second pass at the transcript level strips any residual echoed phrases.
+
+The GTCRN model (~523 KB) is downloaded automatically the first time you run `voxtype meeting start`. To disable echo cancellation (e.g., if you have PipeWire's `echo-cancel` module configured):
+
+```toml
+[meeting.audio]
+echo_cancel = "disabled"
 ```
 
 ---

--- a/src/audio/enhance.rs
+++ b/src/audio/enhance.rs
@@ -1,0 +1,312 @@
+//! GTCRN speech enhancement for echo/noise removal
+//!
+//! Uses a lightweight ONNX model (48K params, ~523KB) to clean up mic audio
+//! before transcription. Removes background noise and speaker bleed-through
+//! by processing STFT frames through the neural network.
+//!
+//! Model: GTCRN (Group Temporal Convolutional Recurrent Network)
+//! Input: 16kHz mono audio → STFT frames (512-point, 256-hop, sqrt-Hann)
+//! Output: Enhanced audio with noise/echo suppressed
+
+use ort::session::Session;
+use ort::value::Tensor;
+use rustfft::num_complex::Complex;
+use rustfft::FftPlanner;
+use std::sync::Mutex;
+
+/// STFT parameters matching the GTCRN model
+const N_FFT: usize = 512;
+const HOP_LENGTH: usize = 256;
+const FREQ_BINS: usize = N_FFT / 2 + 1; // 257
+
+/// GTCRN speech enhancer
+pub struct GtcrnEnhancer {
+    session: Mutex<Session>,
+}
+
+impl GtcrnEnhancer {
+    /// Load the GTCRN model from the given ONNX file path
+    pub fn load(model_path: &std::path::Path) -> Result<Self, String> {
+        let session = Session::builder()
+            .map_err(|e| format!("ONNX session builder failed: {}", e))?
+            .with_intra_threads(1)
+            .map_err(|e| format!("Failed to set threads: {}", e))?
+            .commit_from_file(model_path)
+            .map_err(|e| format!("Failed to load GTCRN model from {:?}: {}", model_path, e))?;
+
+        tracing::info!("GTCRN speech enhancer loaded from {:?}", model_path);
+
+        Ok(Self {
+            session: Mutex::new(session),
+        })
+    }
+
+    /// Enhance audio by removing noise and echo
+    ///
+    /// Takes 16kHz mono f32 samples, returns enhanced samples of the same length.
+    pub fn enhance(&self, samples: &[f32]) -> Result<Vec<f32>, String> {
+        if samples.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let start = std::time::Instant::now();
+
+        // 1. Compute STFT
+        let stft_frames = stft(samples);
+        let num_frames = stft_frames.len();
+
+        if num_frames == 0 {
+            return Ok(samples.to_vec());
+        }
+
+        // 2. Initialize state tensors (zeros)
+        let mut conv_cache = vec![0.0f32; 2 * 16 * 16 * 33];
+        let mut tra_cache = vec![0.0f32; 2 * 3 * 16];
+        let mut inter_cache = vec![0.0f32; 2 * 33 * 16];
+
+        // 3. Process each STFT frame through the model
+        let mut session = self
+            .session
+            .lock()
+            .map_err(|e| format!("Failed to lock GTCRN session: {}", e))?;
+
+        let mut enhanced_frames: Vec<[f32; FREQ_BINS * 2]> = Vec::with_capacity(num_frames);
+
+        for frame in &stft_frames {
+            // Input: [1, 257, 1, 2] — real and imaginary parts interleaved
+            let mut mix_data = vec![0.0f32; FREQ_BINS * 2];
+            for (i, bin) in frame.iter().enumerate() {
+                mix_data[i * 2] = bin.re;
+                mix_data[i * 2 + 1] = bin.im;
+            }
+
+            let mix_tensor =
+                Tensor::<f32>::from_array(([1usize, FREQ_BINS, 1, 2], mix_data)).map_err(|e| {
+                    format!("Failed to create mix tensor: {}", e)
+                })?;
+
+            let conv_tensor = Tensor::<f32>::from_array((
+                [2usize, 1, 16, 16, 33],
+                conv_cache.clone(),
+            ))
+            .map_err(|e| format!("Failed to create conv_cache tensor: {}", e))?;
+
+            let tra_tensor =
+                Tensor::<f32>::from_array(([2usize, 3, 1, 1, 16], tra_cache.clone()))
+                    .map_err(|e| format!("Failed to create tra_cache tensor: {}", e))?;
+
+            let inter_tensor =
+                Tensor::<f32>::from_array(([2usize, 1, 33, 16], inter_cache.clone()))
+                    .map_err(|e| format!("Failed to create inter_cache tensor: {}", e))?;
+
+            let inputs: Vec<(std::borrow::Cow<str>, ort::session::SessionInputValue)> = vec![
+                (std::borrow::Cow::Borrowed("mix"), mix_tensor.into()),
+                (
+                    std::borrow::Cow::Borrowed("conv_cache"),
+                    conv_tensor.into(),
+                ),
+                (std::borrow::Cow::Borrowed("tra_cache"), tra_tensor.into()),
+                (
+                    std::borrow::Cow::Borrowed("inter_cache"),
+                    inter_tensor.into(),
+                ),
+            ];
+
+            let outputs = session
+                .run(inputs)
+                .map_err(|e| format!("GTCRN inference failed: {}", e))?;
+
+            // Extract enhanced frame [1, 257, 1, 2]
+            let (_, enh_data) = outputs["enh"]
+                .try_extract_tensor::<f32>()
+                .map_err(|e| format!("Failed to extract enhanced frame: {}", e))?;
+
+            let mut enh_frame = [0.0f32; FREQ_BINS * 2];
+            for (i, &v) in enh_data.iter().enumerate().take(FREQ_BINS * 2) {
+                enh_frame[i] = v;
+            }
+            enhanced_frames.push(enh_frame);
+
+            // Update caches
+            let (_, conv_data) = outputs["conv_cache_out"]
+                .try_extract_tensor::<f32>()
+                .map_err(|e| format!("Failed to extract conv_cache: {}", e))?;
+            conv_cache = conv_data.to_vec();
+
+            let (_, tra_data) = outputs["tra_cache_out"]
+                .try_extract_tensor::<f32>()
+                .map_err(|e| format!("Failed to extract tra_cache: {}", e))?;
+            tra_cache = tra_data.to_vec();
+
+            let (_, inter_data) = outputs["inter_cache_out"]
+                .try_extract_tensor::<f32>()
+                .map_err(|e| format!("Failed to extract inter_cache: {}", e))?;
+            inter_cache = inter_data.to_vec();
+        }
+
+        // 4. Convert enhanced STFT frames back to complex
+        let enhanced_complex: Vec<Vec<Complex<f32>>> = enhanced_frames
+            .iter()
+            .map(|frame| {
+                (0..FREQ_BINS)
+                    .map(|i| Complex::new(frame[i * 2], frame[i * 2 + 1]))
+                    .collect()
+            })
+            .collect();
+
+        // 5. Inverse STFT
+        let result = istft(&enhanced_complex, samples.len());
+
+        tracing::debug!(
+            "GTCRN enhanced {} samples ({} frames) in {:.2}s",
+            samples.len(),
+            num_frames,
+            start.elapsed().as_secs_f32()
+        );
+
+        Ok(result)
+    }
+}
+
+/// Compute STFT with sqrt-Hann window
+/// Returns a Vec of frames, each containing FREQ_BINS complex values
+fn stft(samples: &[f32]) -> Vec<Vec<Complex<f32>>> {
+    let mut planner = FftPlanner::new();
+    let fft = planner.plan_fft_forward(N_FFT);
+
+    // sqrt-Hann window
+    let window: Vec<f32> = (0..N_FFT)
+        .map(|i| {
+            let hann = 0.5 * (1.0 - (2.0 * std::f32::consts::PI * i as f32 / N_FFT as f32).cos());
+            hann.sqrt()
+        })
+        .collect();
+
+    let mut frames = Vec::new();
+    let mut pos = 0;
+
+    while pos + N_FFT <= samples.len() {
+        // Apply window and create complex buffer
+        let mut buffer: Vec<Complex<f32>> = (0..N_FFT)
+            .map(|i| Complex::new(samples[pos + i] * window[i], 0.0))
+            .collect();
+
+        fft.process(&mut buffer);
+
+        // Keep only positive frequencies (0..N_FFT/2+1)
+        frames.push(buffer[..FREQ_BINS].to_vec());
+        pos += HOP_LENGTH;
+    }
+
+    // Handle last partial frame with zero-padding
+    if pos < samples.len() {
+        let remaining = samples.len() - pos;
+        let mut buffer: Vec<Complex<f32>> = (0..N_FFT)
+            .map(|i| {
+                if i < remaining {
+                    Complex::new(samples[pos + i] * window[i], 0.0)
+                } else {
+                    Complex::new(0.0, 0.0)
+                }
+            })
+            .collect();
+
+        fft.process(&mut buffer);
+        frames.push(buffer[..FREQ_BINS].to_vec());
+    }
+
+    frames
+}
+
+/// Inverse STFT with sqrt-Hann window and overlap-add
+fn istft(frames: &[Vec<Complex<f32>>], target_len: usize) -> Vec<f32> {
+    if frames.is_empty() {
+        return Vec::new();
+    }
+
+    let mut planner = FftPlanner::new();
+    let ifft = planner.plan_fft_inverse(N_FFT);
+
+    // sqrt-Hann window (same as forward)
+    let window: Vec<f32> = (0..N_FFT)
+        .map(|i| {
+            let hann = 0.5 * (1.0 - (2.0 * std::f32::consts::PI * i as f32 / N_FFT as f32).cos());
+            hann.sqrt()
+        })
+        .collect();
+
+    // Output buffer with overlap-add
+    let output_len = (frames.len() - 1) * HOP_LENGTH + N_FFT;
+    let mut output = vec![0.0f32; output_len];
+    let mut window_sum = vec![0.0f32; output_len];
+
+    for (frame_idx, frame) in frames.iter().enumerate() {
+        // Reconstruct full spectrum (mirror conjugate for negative frequencies)
+        let mut buffer = vec![Complex::new(0.0f32, 0.0); N_FFT];
+        buffer[..FREQ_BINS].copy_from_slice(frame);
+        for (j, buf) in buffer[FREQ_BINS..].iter_mut().enumerate() {
+            *buf = frame[FREQ_BINS - 2 - j].conj();
+        }
+
+        ifft.process(&mut buffer);
+
+        // Apply window and overlap-add
+        // rustfft doesn't normalize, so divide by N_FFT
+        let pos = frame_idx * HOP_LENGTH;
+        for i in 0..N_FFT {
+            if pos + i < output.len() {
+                let sample = buffer[i].re / N_FFT as f32;
+                output[pos + i] += sample * window[i];
+                window_sum[pos + i] += window[i] * window[i];
+            }
+        }
+    }
+
+    // Normalize by window sum (avoid division by zero)
+    for (o, &w) in output.iter_mut().zip(window_sum.iter()) {
+        if w > 1e-8 {
+            *o /= w;
+        }
+    }
+
+    // Trim to target length
+    output.truncate(target_len);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stft_istft_roundtrip() {
+        // Generate a simple test signal
+        let samples: Vec<f32> = (0..16000)
+            .map(|i| (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16000.0).sin())
+            .collect();
+
+        let frames = stft(&samples);
+        assert!(!frames.is_empty());
+        assert_eq!(frames[0].len(), FREQ_BINS);
+
+        let reconstructed = istft(&frames, samples.len());
+        assert_eq!(reconstructed.len(), samples.len());
+
+        // Check roundtrip accuracy (allow some tolerance from windowing)
+        // Skip first and last windows which have edge effects
+        let start = N_FFT;
+        let end = samples.len().saturating_sub(N_FFT);
+        if end > start {
+            let max_error: f32 = samples[start..end]
+                .iter()
+                .zip(reconstructed[start..end].iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0f32, f32::max);
+            assert!(
+                max_error < 0.05,
+                "STFT/ISTFT roundtrip error too high: {}",
+                max_error
+            );
+        }
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod cpal_capture;
 pub mod dual_capture;
+#[cfg(feature = "onnx-common")]
+pub mod enhance;
 pub mod feedback;
 
 pub use dual_capture::{AudioSourceType, DualCapture, DualSamples, SourcedSample};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1255,6 +1255,14 @@ pub struct MeetingAudioConfig {
     /// Options: "auto" (detect), "disabled", or specific device name
     #[serde(default = "default_loopback")]
     pub loopback_device: String,
+
+    /// Echo cancellation mode for removing speaker bleed-through from mic
+    /// Options: "auto" (GTCRN neural enhancement + transcript dedup), "disabled"
+    /// The GTCRN model (~523KB) is auto-downloaded on first meeting start.
+    /// For system-level echo cancellation, configure PipeWire's echo-cancel module
+    /// and set this to "disabled".
+    #[serde(default = "default_echo_cancel")]
+    pub echo_cancel: String,
 }
 
 fn default_mic_device() -> String {
@@ -1265,11 +1273,16 @@ fn default_loopback() -> String {
     "auto".to_string()
 }
 
+fn default_echo_cancel() -> String {
+    "auto".to_string()
+}
+
 impl Default for MeetingAudioConfig {
     fn default() -> Self {
         Self {
             mic_device: default_mic_device(),
             loopback_device: default_loopback(),
+            echo_cancel: default_echo_cancel(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1194,6 +1194,9 @@ async fn run_meeting_command(config: &config::Config, action: MeetingAction) -> 
                 }
             }
 
+            // Ensure GTCRN speech enhancement model is available
+            setup::model::ensure_gtcrn_model();
+
             // Write start trigger file (with optional title)
             let start_file = config::Config::runtime_dir().join("meeting_start");
             let content = title.unwrap_or_default();

--- a/website/index.html
+++ b/website/index.html
@@ -828,8 +828,8 @@ sudo pacman -S wtype wl-clipboard</code></pre>
                             <button class="copy-btn">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install (Ubuntu 24.04+, Debian Trixie+)</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.6.0/voxtype_0.6.0-1_amd64.deb
-sudo dpkg -i voxtype_0.6.0-1_amd64.deb
+wget https://github.com/peteonrails/voxtype/releases/download/v0.6.2/voxtype_0.6.2-1_amd64.deb
+sudo dpkg -i voxtype_0.6.2-1_amd64.deb
 sudo apt-get install -f
 
 <span class="comment"># Install optional dependencies</span>
@@ -845,8 +845,8 @@ sudo apt install wtype wl-clipboard</code></pre>
                             <button class="copy-btn">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install (Fedora 39+)</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.6.0/voxtype-0.6.0-1.x86_64.rpm
-sudo dnf install ./voxtype-0.6.0-1.x86_64.rpm
+wget https://github.com/peteonrails/voxtype/releases/download/v0.6.2/voxtype-0.6.2-1.x86_64.rpm
+sudo dnf install ./voxtype-0.6.2-1.x86_64.rpm
 
 <span class="comment"># Install optional dependencies</span>
 sudo dnf install wtype wl-clipboard</code></pre>

--- a/website/news/index.html
+++ b/website/news/index.html
@@ -77,6 +77,44 @@
 
             <!-- v0.6.x Era Posts -->
 
+            <article class="news-article" id="v062">
+                <div class="article-meta">
+                    <time datetime="2026-02-17">February 17, 2026</time>
+                    <span class="article-tag">Release</span>
+                </div>
+                <h2>v0.6.2: Echo Cancellation and Meeting Bug Fixes</h2>
+                <div class="article-body">
+                    <p>Voxtype 0.6.2 adds neural echo cancellation for meeting mode, rewrites loopback audio capture, and fixes three meeting bugs. If you use meeting mode with loopback enabled, remote participants' audio no longer bleeds into your mic transcript.</p>
+
+                    <h3>GTCRN Echo Cancellation</h3>
+                    <p>When meeting mode captures both your microphone and system audio (for remote participant transcription), the remote audio bleeds through your speakers into your mic. Previous approaches using signal subtraction and energy gating didn't work because the mic and loopback streams aren't sample-aligned.</p>
+
+                    <p>This release uses GTCRN (Group Temporal Convolutional Recurrent Network), a 48K-parameter speech enhancement model that processes mic audio frame-by-frame through STFT. It removes background noise and speaker bleed-through while preserving your voice. The model is 523 KB and runs at about 0.02x real-time on CPU, so processing 30 seconds of audio takes under 0.6 seconds.</p>
+
+                    <p><strong>Why use it:</strong> If you're in a video call and the other person's voice is showing up in your "You" segments, this fixes it. It's enabled by default when loopback capture is active.</p>
+
+                    <p>The GTCRN model downloads automatically the first time you start a meeting. To disable it (if you already have system-level echo cancellation via PipeWire):</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>config.toml</span></div>
+                        <pre><code>[meeting.audio]
+echo_cancel = "disabled"</code></pre>
+                    </div>
+
+                    <h3>Dual Audio Capture via parec</h3>
+                    <p>Loopback capture has been rewritten to use <code>parec</code> (PulseAudio recording client) instead of cpal. PipeWire's monitor sources aren't visible through ALSA, which is what cpal uses. The <code>parec</code> approach works with both PipeWire and PulseAudio and can access any monitor source listed by <code>pactl list short sources</code>.</p>
+
+                    <p>Mic and loopback audio now go into separate buffers, so they're transcribed independently. Mic chunks pass through GTCRN before transcription. A phrase-level dedup pass strips any residual echoed words that survive enhancement.</p>
+
+                    <h3>Bug Fixes</h3>
+                    <ul>
+                        <li><strong>Meeting stop/pause/resume not working:</strong> The daemon's event loop starved the meeting control channel when audio processing was active. Meeting commands now take priority.</li>
+                        <li><strong>Orphaned meetings on daemon restart:</strong> If the daemon crashed during a meeting, the meeting state file was never cleaned up, preventing new meetings from starting. The daemon now cleans up stale meeting state on startup.</li>
+                        <li><strong>ml-diarization compilation errors:</strong> Fixed type mismatches after the ort 2.0.0-rc.11 API change.</li>
+                    </ul>
+                </div>
+            </article>
+
             <article class="news-article" id="v060">
                 <div class="article-meta">
                     <time datetime="2026-02-16">February 16, 2026</time>


### PR DESCRIPTION
## Summary

- **GTCRN neural echo cancellation** for meeting mode — removes speaker bleed-through from mic audio using a 48K-parameter speech enhancement model (523 KB, MIT licensed). Processes 30s of audio in ~0.6s on CPU.
- **Dual audio capture rewrite** — loopback capture now uses `parec` instead of cpal, which can access PipeWire monitor sources not visible through ALSA. Mic and loopback go into separate buffers for independent transcription.
- **Phrase-level transcript dedup** — strips residual echoed words from mic segments by matching n-grams against the loopback transcript.
- **Auto-download GTCRN model** on first `voxtype meeting start` via curl (no daemon restart needed).
- **Three meeting bug fixes**: event loop starvation blocking stop/pause/resume, orphaned meeting state on daemon crash, ml-diarization compilation errors after ort 2.0 API change.
- **Documentation**: new `[meeting.audio]` section in CONFIGURATION.md, echo cancellation section in USER_MANUAL.md, edge trimming added to CLAUDE.md roadmap.
- **Website**: news article and updated download URLs for v0.6.2.

## Test plan

- [x] `cargo test` — 25 tests pass
- [x] `cargo clippy` — no new warnings (enhance.rs clean)
- [ ] Start meeting with loopback enabled → GTCRN loads → mic segments clean of bleed-through
- [ ] Start meeting without GTCRN model → auto-downloads → proceeds
- [ ] Start meeting with `echo_cancel = "disabled"` → no GTCRN, raw mic
- [ ] Meeting stop/pause/resume responsive during active recording
- [ ] Config file with no `[meeting.audio]` section → sensible defaults
- [ ] Old config files still work (backward compatible)