### PR TITLE
Update flake.nix - derive package from Cargo.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
         mkVoxtypeUnwrapped = { pname ? "voxtype", features ? [], extraNativeBuildInputs ? [], extraBuildInputs ? [] }:
           pkgs.rustPlatform.buildRustPackage {
             inherit pname;
-            version = "0.5.0";
+            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
 
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;


### PR DESCRIPTION
## Description

The hard-coded version of 0.5.0 in flake.nix doesn't get updated with releases, causing voxtype --version and nix flake to report incorrect version info.

This change reads direct from Cargo.toml so version stays in sync.


## Related Issue

Fixes #(issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy` with no warnings
- [x] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [x] No documentation changes are needed

## Additional Notes


