### PR TITLE
Close config override gap: CLI flags, env vars, per-recording overrides

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -20,33 +20,33 @@ services:
       context: .
       dockerfile: Dockerfile.build
       args:
-        VERSION: ${VERSION:-0.6.1}
+        VERSION: ${VERSION:-0.6.2}
     volumes:
-      - ./releases/${VERSION:-0.6.1}:/output
+      - ./releases/${VERSION:-0.6.2}:/output
     environment:
-      - VERSION=${VERSION:-0.6.1}
+      - VERSION=${VERSION:-0.6.2}
 
   vulkan:
     build:
       context: .
       dockerfile: Dockerfile.vulkan
       args:
-        VERSION: ${VERSION:-0.6.1}
+        VERSION: ${VERSION:-0.6.2}
     volumes:
-      - ./releases/${VERSION:-0.6.1}:/output
+      - ./releases/${VERSION:-0.6.2}:/output
     environment:
-      - VERSION=${VERSION:-0.6.1}
+      - VERSION=${VERSION:-0.6.2}
 
   avx512:
     build:
       context: .
       dockerfile: Dockerfile.avx512
       args:
-        VERSION: ${VERSION:-0.6.1}
+        VERSION: ${VERSION:-0.6.2}
     volumes:
-      - ./releases/${VERSION:-0.6.1}:/output
+      - ./releases/${VERSION:-0.6.2}:/output
     environment:
-      - VERSION=${VERSION:-0.6.1}
+      - VERSION=${VERSION:-0.6.2}
     profiles:
       - avx512  # Only build if explicitly requested (requires AVX-512 capable host)
 
@@ -56,11 +56,11 @@ services:
       context: .
       dockerfile: Dockerfile.onnx
       args:
-        VERSION: ${VERSION:-0.6.1}
+        VERSION: ${VERSION:-0.6.2}
     volumes:
-      - ./releases/${VERSION:-0.6.1}:/output
+      - ./releases/${VERSION:-0.6.2}:/output
     environment:
-      - VERSION=${VERSION:-0.6.1}
+      - VERSION=${VERSION:-0.6.2}
 
   # ONNX AVX-512 build (requires AVX-512 capable host)
   onnx-avx512:
@@ -68,11 +68,11 @@ services:
       context: .
       dockerfile: Dockerfile.onnx-avx512
       args:
-        VERSION: ${VERSION:-0.6.1}
+        VERSION: ${VERSION:-0.6.2}
     volumes:
-      - ./releases/${VERSION:-0.6.1}:/output
+      - ./releases/${VERSION:-0.6.2}:/output
     environment:
-      - VERSION=${VERSION:-0.6.1}
+      - VERSION=${VERSION:-0.6.2}
     profiles:
       - avx512  # Only build if explicitly requested (requires AVX-512 capable host)
 
@@ -82,11 +82,11 @@ services:
       context: .
       dockerfile: Dockerfile.onnx-cuda
       args:
-        VERSION: ${VERSION:-0.6.1}
+        VERSION: ${VERSION:-0.6.2}
     volumes:
-      - ./releases/${VERSION:-0.6.1}:/output
+      - ./releases/${VERSION:-0.6.2}:/output
     environment:
-      - VERSION=${VERSION:-0.6.1}
+      - VERSION=${VERSION:-0.6.2}
 
   # ONNX ROCm build (AMD GPU acceleration, requires AMD GPU host)
   onnx-rocm:
@@ -94,11 +94,11 @@ services:
       context: .
       dockerfile: Dockerfile.onnx-rocm
       args:
-        VERSION: ${VERSION:-0.6.1}
+        VERSION: ${VERSION:-0.6.2}
     volumes:
-      - ./releases/${VERSION:-0.6.1}:/output
+      - ./releases/${VERSION:-0.6.2}:/output
     environment:
-      - VERSION=${VERSION:-0.6.1}
+      - VERSION=${VERSION:-0.6.2}
 
   # ONNX model export (Japanese + Vietnamese Parakeet models)
   # Usage: docker compose -f docker-compose.build.yml up onnx-export

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2296,15 +2296,64 @@ XDG_DATA_HOME=/custom/data voxtype
 # Models stored in: /custom/data/voxtype/models/
 ```
 
-### VOXTYPE_WHISPER_API_KEY
+### VOXTYPE_* Configuration Overrides
 
-API key for remote Whisper server authentication. Used when `backend = "remote"`.
+Any config file setting can be overridden via environment variable. These are applied after the config file is loaded but before CLI flags, following the priority order: defaults < config file < env vars < CLI flags.
+
+**Hotkey:**
+
+| Variable | Type | Config equivalent |
+|----------|------|-------------------|
+| `VOXTYPE_HOTKEY` | string | `hotkey.key` |
+| `VOXTYPE_HOTKEY_ENABLED` | bool | `hotkey.enabled` |
+| `VOXTYPE_CANCEL_KEY` | string | `hotkey.cancel_key` |
+
+**Whisper / Engine:**
+
+| Variable | Type | Config equivalent |
+|----------|------|-------------------|
+| `VOXTYPE_MODEL` | string | `whisper.model` |
+| `VOXTYPE_ENGINE` | string | `engine` |
+| `VOXTYPE_LANGUAGE` | string | `whisper.language` |
+| `VOXTYPE_TRANSLATE` | bool | `whisper.translate` |
+| `VOXTYPE_THREADS` | integer | `whisper.threads` |
+| `VOXTYPE_GPU_ISOLATION` | bool | `whisper.gpu_isolation` |
+| `VOXTYPE_ON_DEMAND_LOADING` | bool | `whisper.on_demand_loading` |
+| `VOXTYPE_REMOTE_ENDPOINT` | string | `whisper.remote_endpoint` |
+| `VOXTYPE_WHISPER_API_KEY` | string | `whisper.remote_api_key` |
+
+**Audio:**
+
+| Variable | Type | Config equivalent |
+|----------|------|-------------------|
+| `VOXTYPE_AUDIO_DEVICE` | string | `audio.device` |
+| `VOXTYPE_MAX_DURATION_SECS` | integer | `audio.max_duration_secs` |
+| `VOXTYPE_AUDIO_FEEDBACK` | bool | `audio.feedback.enabled` |
+
+**Output:**
+
+| Variable | Type | Config equivalent |
+|----------|------|-------------------|
+| `VOXTYPE_OUTPUT_MODE` | string | `output.mode` |
+| `VOXTYPE_APPEND_TEXT` | string | `output.append_text` |
+| `VOXTYPE_AUTO_SUBMIT` | bool | `output.auto_submit` |
+| `VOXTYPE_SHIFT_ENTER_NEWLINES` | bool | `output.shift_enter_newlines` |
+| `VOXTYPE_PRE_TYPE_DELAY` | integer | `output.pre_type_delay_ms` |
+| `VOXTYPE_TYPE_DELAY` | integer | `output.type_delay_ms` |
+| `VOXTYPE_FALLBACK_TO_CLIPBOARD` | bool | `output.fallback_to_clipboard` |
+| `VOXTYPE_PASTE_KEYS` | string | `output.paste_keys` |
+| `VOXTYPE_DOTOOL_XKB_LAYOUT` | string | `output.dotool_xkb_layout` |
+| `VOXTYPE_SPOKEN_PUNCTUATION` | bool | `text.spoken_punctuation` |
+
+Boolean values: `true`, `1` to enable; `false`, `0` to disable.
 
 ```bash
-export VOXTYPE_WHISPER_API_KEY="sk-..."
-```
+# Example: enable auto-submit and Shift+Enter via environment
+VOXTYPE_AUTO_SUBMIT=true VOXTYPE_SHIFT_ENTER_NEWLINES=true voxtype
 
-This is the recommended way to provide API keys instead of putting them in the config file.
+# Example: override model and language
+VOXTYPE_MODEL=large-v3-turbo VOXTYPE_LANGUAGE=auto voxtype
+```
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -340,6 +340,35 @@ voxtype config > ~/.config/voxtype/config.toml
 voxtype -c /path/to/my/config.toml
 ```
 
+### Configuration Priority
+
+Settings are applied in layers, with later layers overriding earlier ones:
+
+1. **Built-in defaults** (lowest priority)
+2. **Config file** (`~/.config/voxtype/config.toml`)
+3. **Environment variables** (`VOXTYPE_*`)
+4. **CLI flags** (highest priority)
+
+Every config file option has a corresponding `VOXTYPE_*` environment variable and CLI flag. See `voxtype --help` for the full list of CLI flags, and [CONFIGURATION.md](CONFIGURATION.md#voxtype_-configuration-overrides) for the full list of environment variables.
+
+```bash
+# Override model and auto-submit via environment
+VOXTYPE_MODEL=large-v3-turbo VOXTYPE_AUTO_SUBMIT=true voxtype
+
+# Override via CLI flags (takes priority over env vars and config file)
+voxtype --model large-v3-turbo --auto-submit
+```
+
+Per-recording overrides are available on `record start` and `record toggle`:
+
+```bash
+# Auto-submit just this recording (even if config has auto_submit = false)
+voxtype record start --auto-submit
+
+# Disable auto-submit just this recording (even if config has auto_submit = true)
+voxtype record toggle --no-auto-submit
+```
+
 ---
 
 ## Hotkeys

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1626,4 +1626,93 @@ mod tests {
             _ => panic!("Expected Transcribe command"),
         }
     }
+
+    #[test]
+    fn test_record_start_auto_submit() {
+        let cli = Cli::parse_from(["voxtype", "record", "start", "--auto-submit"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.auto_submit_override(), Some(true));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_start_no_auto_submit() {
+        let cli = Cli::parse_from(["voxtype", "record", "start", "--no-auto-submit"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.auto_submit_override(), Some(false));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_start_auto_submit_default() {
+        let cli = Cli::parse_from(["voxtype", "record", "start"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.auto_submit_override(), None);
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_toggle_auto_submit() {
+        let cli = Cli::parse_from(["voxtype", "record", "toggle", "--auto-submit"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.auto_submit_override(), Some(true));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_start_shift_enter_newlines() {
+        let cli = Cli::parse_from(["voxtype", "record", "start", "--shift-enter-newlines"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.shift_enter_newlines_override(), Some(true));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_start_no_shift_enter_newlines() {
+        let cli = Cli::parse_from(["voxtype", "record", "start", "--no-shift-enter-newlines"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.shift_enter_newlines_override(), Some(false));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_start_shift_enter_default() {
+        let cli = Cli::parse_from(["voxtype", "record", "start"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.shift_enter_newlines_override(), None);
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_stop_has_no_auto_submit() {
+        let cli = Cli::parse_from(["voxtype", "record", "stop"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.auto_submit_override(), None);
+                assert_eq!(action.shift_enter_newlines_override(), None);
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,29 +59,107 @@ pub struct Cli {
     #[arg(long, value_name = "MODEL")]
     pub model: Option<String>,
 
-    /// Disable context window optimization for short recordings
-    #[arg(long)]
-    pub no_whisper_context_optimization: bool,
-
-    /// Initial prompt to provide context for transcription.
-    /// Hints at terminology, proper nouns, or formatting conventions.
-    #[arg(long, value_name = "PROMPT")]
-    pub initial_prompt: Option<String>,
-
     /// Override transcription engine: whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual
     #[arg(long, value_name = "ENGINE")]
     pub engine: Option<String>,
 
     /// Override hotkey (e.g., SCROLLLOCK, PAUSE, F13, MEDIA, WEV_234, EVTEST_226)
-    #[arg(long, value_name = "KEY")]
+    #[arg(long, value_name = "KEY", help_heading = "Hotkey")]
     pub hotkey: Option<String>,
 
     /// Use toggle mode (press to start/stop) instead of push-to-talk (hold to record)
-    #[arg(long)]
+    #[arg(long, help_heading = "Hotkey")]
     pub toggle: bool,
 
+    /// Disable built-in hotkey detection (use compositor keybindings instead)
+    #[arg(long, help_heading = "Hotkey")]
+    pub no_hotkey: bool,
+
+    /// Cancel key for aborting recording or transcription (e.g., ESC, BACKSPACE, F12)
+    #[arg(long, value_name = "KEY", help_heading = "Hotkey")]
+    pub cancel_key: Option<String>,
+
+    /// Modifier key for secondary model selection (e.g., LEFTSHIFT)
+    #[arg(long, value_name = "KEY", help_heading = "Hotkey")]
+    pub model_modifier: Option<String>,
+
+    // -- Whisper --
+
+    /// Disable context window optimization for short recordings
+    #[arg(long, help_heading = "Whisper")]
+    pub no_whisper_context_optimization: bool,
+
+    /// Initial prompt to provide context for transcription.
+    /// Hints at terminology, proper nouns, or formatting conventions.
+    #[arg(long, value_name = "PROMPT", help_heading = "Whisper")]
+    pub initial_prompt: Option<String>,
+
+    /// Language for transcription (e.g., en, fr, auto, or comma-separated: en,fr,de)
+    #[arg(long, value_name = "LANG", help_heading = "Whisper")]
+    pub language: Option<String>,
+
+    /// Translate non-English speech to English
+    #[arg(long, help_heading = "Whisper")]
+    pub translate: bool,
+
+    /// Number of CPU threads for inference
+    #[arg(long, value_name = "N", help_heading = "Whisper")]
+    pub threads: Option<usize>,
+
+    /// Run transcription in a subprocess to release GPU memory after each recording
+    #[arg(long, help_heading = "Whisper")]
+    pub gpu_isolation: bool,
+
+    /// Load model on-demand when recording starts instead of keeping it loaded
+    #[arg(long, help_heading = "Whisper")]
+    pub on_demand_loading: bool,
+
+    /// Whisper execution mode: local, remote, or cli
+    #[arg(long, value_name = "MODE", help_heading = "Whisper")]
+    pub whisper_mode: Option<String>,
+
+    /// Secondary model for difficult audio (used with --model-modifier)
+    #[arg(long, value_name = "MODEL", help_heading = "Whisper")]
+    pub secondary_model: Option<String>,
+
+    /// Enable eager input processing (transcribe chunks while recording continues)
+    #[arg(long, help_heading = "Whisper")]
+    pub eager_processing: bool,
+
+    /// Remote server endpoint URL (for remote whisper mode)
+    #[arg(long, value_name = "URL", help_heading = "Whisper")]
+    pub remote_endpoint: Option<String>,
+
+    /// Model name to send to remote server
+    #[arg(long, value_name = "MODEL", help_heading = "Whisper")]
+    pub remote_model: Option<String>,
+
+    /// API key for remote server (or use VOXTYPE_WHISPER_API_KEY env var)
+    #[arg(long, value_name = "KEY", help_heading = "Whisper")]
+    pub remote_api_key: Option<String>,
+
+    // -- Audio --
+
+    /// Audio input device name (or "default" for system default)
+    #[arg(long, value_name = "DEVICE", help_heading = "Audio")]
+    pub audio_device: Option<String>,
+
+    /// Maximum recording duration in seconds (safety limit)
+    #[arg(long, value_name = "SECS", help_heading = "Audio")]
+    pub max_duration: Option<u32>,
+
+    /// Enable audio feedback sounds (beeps when recording starts/stops)
+    #[arg(long, help_heading = "Audio")]
+    pub audio_feedback: bool,
+
+    /// Disable audio feedback sounds
+    #[arg(long, help_heading = "Audio")]
+    pub no_audio_feedback: bool,
+
+    // -- Output --
+
     /// Delay before typing starts (ms), helps prevent first character drop
-    #[arg(long, value_name = "MS")]
+    #[arg(long, value_name = "MS", help_heading = "Output")]
     pub pre_type_delay: Option<u32>,
 
     /// DEPRECATED: Use --pre-type-delay instead
@@ -90,30 +168,97 @@ pub struct Cli {
 
     /// Text to append after each transcription (e.g., " " for a trailing space).
     /// Appended before auto_submit. Useful for separating sentences when dictating incrementally.
-    #[arg(long, value_name = "TEXT")]
+    #[arg(long, value_name = "TEXT", help_heading = "Output")]
     pub append_text: Option<String>,
 
-    /// Output driver order for type mode (comma-separated)
-    /// Overrides config driver_order. Available: wtype, dotool, ydotool, clipboard
+    /// Output driver order for type mode (comma-separated).
+    /// Available: wtype, dotool, ydotool, clipboard.
     /// Example: --driver=ydotool,wtype,clipboard
-    #[arg(long, value_name = "DRIVERS")]
+    #[arg(long, value_name = "DRIVERS", help_heading = "Output")]
     pub driver: Option<String>,
 
+    /// Auto-submit (press Enter) after outputting transcribed text
+    #[arg(long, help_heading = "Output")]
+    pub auto_submit: bool,
+
+    /// Disable auto-submit (overrides config auto_submit = true)
+    #[arg(long, conflicts_with = "auto_submit", help_heading = "Output")]
+    pub no_auto_submit: bool,
+
+    /// Convert newlines to Shift+Enter instead of regular Enter
+    #[arg(long, help_heading = "Output")]
+    pub shift_enter_newlines: bool,
+
+    /// Disable Shift+Enter newlines (overrides config)
+    #[arg(long, conflicts_with = "shift_enter_newlines", help_heading = "Output")]
+    pub no_shift_enter_newlines: bool,
+
+    /// Delay between typed characters in milliseconds (0 = fastest)
+    #[arg(long, value_name = "MS", help_heading = "Output")]
+    pub type_delay: Option<u32>,
+
+    /// Fall back to clipboard if typing fails
+    #[arg(long, help_heading = "Output")]
+    pub fallback_to_clipboard: bool,
+
+    /// Disable clipboard fallback
+    #[arg(long, conflicts_with = "fallback_to_clipboard", help_heading = "Output")]
+    pub no_fallback_to_clipboard: bool,
+
+    /// Enable spoken punctuation conversion (e.g., say "period" to get ".")
+    #[arg(long, help_heading = "Output")]
+    pub spoken_punctuation: bool,
+
+    /// Keystroke for paste mode (e.g., ctrl+v, shift+insert, ctrl+shift+v)
+    #[arg(long, value_name = "KEYS", help_heading = "Output")]
+    pub paste_keys: Option<String>,
+
+    /// Keyboard layout for dotool (e.g., de, fr)
+    #[arg(long, value_name = "LAYOUT", help_heading = "Output")]
+    pub dotool_xkb_layout: Option<String>,
+
+    /// Keyboard layout variant for dotool (e.g., nodeadkeys)
+    #[arg(long, value_name = "VARIANT", help_heading = "Output")]
+    pub dotool_xkb_variant: Option<String>,
+
+    /// File path for file output mode
+    #[arg(long, value_name = "PATH", help_heading = "Output")]
+    pub file_path: Option<std::path::PathBuf>,
+
+    /// File write mode: overwrite or append
+    #[arg(long, value_name = "MODE", help_heading = "Output")]
+    pub file_mode: Option<String>,
+
+    /// Command to run before typing output (e.g., compositor submap switch)
+    #[arg(long, value_name = "CMD", help_heading = "Output")]
+    pub pre_output_command: Option<String>,
+
+    /// Command to run after typing output (e.g., reset compositor submap)
+    #[arg(long, value_name = "CMD", help_heading = "Output")]
+    pub post_output_command: Option<String>,
+
+    /// Command to run when recording starts (e.g., switch to compositor submap)
+    #[arg(long, value_name = "CMD", help_heading = "Output")]
+    pub pre_recording_command: Option<String>,
+
+    // -- VAD --
+
     /// Enable Voice Activity Detection (filter silence before transcription)
-    #[arg(long)]
+    #[arg(long, help_heading = "VAD")]
     pub vad: bool,
 
-    /// VAD speech detection threshold (0.0-1.0, default: 0.5)
+    /// VAD speech detection threshold (0.0-1.0, default: 0.5).
     /// Lower = more sensitive, Higher = less sensitive
-    #[arg(long, value_name = "THRESHOLD")]
+    #[arg(long, value_name = "THRESHOLD", help_heading = "VAD")]
     pub vad_threshold: Option<f32>,
 
-    /// VAD backend: auto, energy, whisper (default: auto)
-    /// - auto: Whisper VAD for Whisper engine, Energy for Parakeet
-    /// - energy: Fast RMS-based detection, no model download needed
-    /// - whisper: Silero VAD via whisper-rs, more accurate, needs model
-    #[arg(long, value_name = "BACKEND")]
+    /// VAD backend: auto, energy, whisper
+    #[arg(long, value_name = "BACKEND", help_heading = "VAD")]
     pub vad_backend: Option<String>,
+
+    /// Minimum speech duration in milliseconds for VAD
+    #[arg(long, value_name = "MS", help_heading = "VAD")]
+    pub vad_min_speech_ms: Option<u32>,
 
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -255,6 +400,22 @@ pub enum RecordAction {
         /// Profiles are defined in config.toml under [profiles.name]
         #[arg(long, value_name = "NAME")]
         profile: Option<String>,
+
+        /// Auto-submit (press Enter) after this transcription
+        #[arg(long)]
+        auto_submit: bool,
+
+        /// Disable auto-submit for this transcription (overrides config)
+        #[arg(long, conflicts_with = "auto_submit")]
+        no_auto_submit: bool,
+
+        /// Use Shift+Enter for newlines in this transcription
+        #[arg(long)]
+        shift_enter_newlines: bool,
+
+        /// Disable Shift+Enter newlines for this transcription (overrides config)
+        #[arg(long, conflicts_with = "shift_enter_newlines")]
+        no_shift_enter_newlines: bool,
     },
     /// Stop recording and transcribe (send SIGUSR2 to daemon)
     Stop {
@@ -297,6 +458,22 @@ pub enum RecordAction {
         /// Profiles are defined in config.toml under [profiles.name]
         #[arg(long, value_name = "NAME")]
         profile: Option<String>,
+
+        /// Auto-submit (press Enter) after this transcription
+        #[arg(long)]
+        auto_submit: bool,
+
+        /// Disable auto-submit for this transcription (overrides config)
+        #[arg(long, conflicts_with = "auto_submit")]
+        no_auto_submit: bool,
+
+        /// Use Shift+Enter for newlines in this transcription
+        #[arg(long)]
+        shift_enter_newlines: bool,
+
+        /// Disable Shift+Enter newlines for this transcription (overrides config)
+        #[arg(long, conflicts_with = "shift_enter_newlines")]
+        no_shift_enter_newlines: bool,
     },
     /// Cancel current recording or transcription (discard without output)
     Cancel,
@@ -464,6 +641,58 @@ impl RecordAction {
             RecordAction::Start { profile, .. } => profile.as_deref(),
             RecordAction::Toggle { profile, .. } => profile.as_deref(),
             RecordAction::Stop { .. } | RecordAction::Cancel => None,
+        }
+    }
+
+    /// Get the auto_submit override from --auto-submit / --no-auto-submit flags
+    /// Returns Some(true) for --auto-submit, Some(false) for --no-auto-submit, None if unset
+    pub fn auto_submit_override(&self) -> Option<bool> {
+        let (auto_submit, no_auto_submit) = match self {
+            RecordAction::Start {
+                auto_submit,
+                no_auto_submit,
+                ..
+            } => (*auto_submit, *no_auto_submit),
+            RecordAction::Toggle {
+                auto_submit,
+                no_auto_submit,
+                ..
+            } => (*auto_submit, *no_auto_submit),
+            RecordAction::Stop { .. } | RecordAction::Cancel => return None,
+        };
+
+        if auto_submit {
+            Some(true)
+        } else if no_auto_submit {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    /// Get the shift_enter_newlines override from --shift-enter-newlines / --no-shift-enter-newlines flags
+    /// Returns Some(true) to enable, Some(false) to disable, None if unset
+    pub fn shift_enter_newlines_override(&self) -> Option<bool> {
+        let (shift_enter, no_shift_enter) = match self {
+            RecordAction::Start {
+                shift_enter_newlines,
+                no_shift_enter_newlines,
+                ..
+            } => (*shift_enter_newlines, *no_shift_enter_newlines),
+            RecordAction::Toggle {
+                shift_enter_newlines,
+                no_shift_enter_newlines,
+                ..
+            } => (*shift_enter_newlines, *no_shift_enter_newlines),
+            RecordAction::Stop { .. } | RecordAction::Cancel => return None,
+        };
+
+        if shift_enter {
+            Some(true)
+        } else if no_shift_enter {
+            Some(false)
+        } else {
+            None
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1940,6 +1940,12 @@ impl Config {
     }
 }
 
+/// Parse a boolean from an environment variable value.
+/// Only "1" and "true" (case-insensitive) are truthy; everything else is falsy.
+fn parse_bool_env(val: &str) -> bool {
+    val == "1" || val.eq_ignore_ascii_case("true")
+}
+
 /// Load configuration from file, with defaults for missing values
 pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     // Start with defaults
@@ -1968,7 +1974,7 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         config.hotkey.key = key;
     }
     if let Ok(val) = std::env::var("VOXTYPE_HOTKEY_ENABLED") {
-        config.hotkey.enabled = val != "0" && val.to_lowercase() != "false";
+        config.hotkey.enabled = parse_bool_env(&val);
     }
     if let Ok(key) = std::env::var("VOXTYPE_CANCEL_KEY") {
         config.hotkey.cancel_key = Some(key);
@@ -1994,7 +2000,7 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         config.whisper.language = LanguageConfig::from_comma_separated(&lang);
     }
     if let Ok(val) = std::env::var("VOXTYPE_TRANSLATE") {
-        config.whisper.translate = val != "0" && val.to_lowercase() != "false";
+        config.whisper.translate = parse_bool_env(&val);
     }
     if let Ok(val) = std::env::var("VOXTYPE_THREADS") {
         if let Ok(n) = val.parse::<usize>() {
@@ -2002,10 +2008,10 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         }
     }
     if let Ok(val) = std::env::var("VOXTYPE_GPU_ISOLATION") {
-        config.whisper.gpu_isolation = val != "0" && val.to_lowercase() != "false";
+        config.whisper.gpu_isolation = parse_bool_env(&val);
     }
     if let Ok(val) = std::env::var("VOXTYPE_ON_DEMAND_LOADING") {
-        config.whisper.on_demand_loading = val != "0" && val.to_lowercase() != "false";
+        config.whisper.on_demand_loading = parse_bool_env(&val);
     }
 
     // Audio
@@ -2018,7 +2024,7 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         }
     }
     if let Ok(val) = std::env::var("VOXTYPE_AUDIO_FEEDBACK") {
-        config.audio.feedback.enabled = val != "0" && val.to_lowercase() != "false";
+        config.audio.feedback.enabled = parse_bool_env(&val);
     }
 
     // Output
@@ -2034,10 +2040,10 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         config.output.append_text = Some(append_text);
     }
     if let Ok(val) = std::env::var("VOXTYPE_AUTO_SUBMIT") {
-        config.output.auto_submit = val != "0" && val.to_lowercase() != "false";
+        config.output.auto_submit = parse_bool_env(&val);
     }
     if let Ok(val) = std::env::var("VOXTYPE_SHIFT_ENTER_NEWLINES") {
-        config.output.shift_enter_newlines = val != "0" && val.to_lowercase() != "false";
+        config.output.shift_enter_newlines = parse_bool_env(&val);
     }
     if let Ok(val) = std::env::var("VOXTYPE_PRE_TYPE_DELAY") {
         if let Ok(n) = val.parse::<u32>() {
@@ -2050,10 +2056,10 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         }
     }
     if let Ok(val) = std::env::var("VOXTYPE_FALLBACK_TO_CLIPBOARD") {
-        config.output.fallback_to_clipboard = val != "0" && val.to_lowercase() != "false";
+        config.output.fallback_to_clipboard = parse_bool_env(&val);
     }
     if let Ok(val) = std::env::var("VOXTYPE_SPOKEN_PUNCTUATION") {
-        config.text.spoken_punctuation = val != "0" && val.to_lowercase() != "false";
+        config.text.spoken_punctuation = parse_bool_env(&val);
     }
     if let Ok(keys) = std::env::var("VOXTYPE_PASTE_KEYS") {
         config.output.paste_keys = Some(keys);
@@ -2070,7 +2076,7 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         config.whisper.remote_api_key = Some(key);
     }
     if let Ok(val) = std::env::var("VOXTYPE_RESTORE_CLIPBOARD") {
-        config.output.restore_clipboard = val == "1" || val.eq_ignore_ascii_case("true");
+        config.output.restore_clipboard = parse_bool_env(&val);
     }
     if let Ok(val) = std::env::var("VOXTYPE_RESTORE_CLIPBOARD_DELAY_MS") {
         if let Ok(ms) = val.parse::<u32>() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1937,21 +1937,111 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     }
 
     // Override from environment variables
+    // Hotkey
     if let Ok(key) = std::env::var("VOXTYPE_HOTKEY") {
         config.hotkey.key = key;
     }
+    if let Ok(val) = std::env::var("VOXTYPE_HOTKEY_ENABLED") {
+        config.hotkey.enabled = val != "0" && val.to_lowercase() != "false";
+    }
+    if let Ok(key) = std::env::var("VOXTYPE_CANCEL_KEY") {
+        config.hotkey.cancel_key = Some(key);
+    }
+
+    // Whisper / engine
     if let Ok(model) = std::env::var("VOXTYPE_MODEL") {
         config.whisper.model = model;
     }
+    if let Ok(engine) = std::env::var("VOXTYPE_ENGINE") {
+        match engine.to_lowercase().as_str() {
+            "whisper" => config.engine = TranscriptionEngine::Whisper,
+            "parakeet" => config.engine = TranscriptionEngine::Parakeet,
+            "moonshine" => config.engine = TranscriptionEngine::Moonshine,
+            "sensevoice" => config.engine = TranscriptionEngine::SenseVoice,
+            "paraformer" => config.engine = TranscriptionEngine::Paraformer,
+            "dolphin" => config.engine = TranscriptionEngine::Dolphin,
+            "omnilingual" => config.engine = TranscriptionEngine::Omnilingual,
+            _ => tracing::warn!("Unknown VOXTYPE_ENGINE value: {}", engine),
+        }
+    }
+    if let Ok(lang) = std::env::var("VOXTYPE_LANGUAGE") {
+        config.whisper.language = LanguageConfig::from_comma_separated(&lang);
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_TRANSLATE") {
+        config.whisper.translate = val != "0" && val.to_lowercase() != "false";
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_THREADS") {
+        if let Ok(n) = val.parse::<usize>() {
+            config.whisper.threads = Some(n);
+        }
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_GPU_ISOLATION") {
+        config.whisper.gpu_isolation = val != "0" && val.to_lowercase() != "false";
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_ON_DEMAND_LOADING") {
+        config.whisper.on_demand_loading = val != "0" && val.to_lowercase() != "false";
+    }
+
+    // Audio
+    if let Ok(device) = std::env::var("VOXTYPE_AUDIO_DEVICE") {
+        config.audio.device = device;
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_MAX_DURATION_SECS") {
+        if let Ok(n) = val.parse::<u32>() {
+            config.audio.max_duration_secs = n;
+        }
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_AUDIO_FEEDBACK") {
+        config.audio.feedback.enabled = val != "0" && val.to_lowercase() != "false";
+    }
+
+    // Output
     if let Ok(mode) = std::env::var("VOXTYPE_OUTPUT_MODE") {
         config.output.mode = match mode.to_lowercase().as_str() {
             "clipboard" => OutputMode::Clipboard,
             "paste" => OutputMode::Paste,
+            "file" => OutputMode::File,
             _ => OutputMode::Type,
         };
     }
     if let Ok(append_text) = std::env::var("VOXTYPE_APPEND_TEXT") {
         config.output.append_text = Some(append_text);
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_AUTO_SUBMIT") {
+        config.output.auto_submit = val != "0" && val.to_lowercase() != "false";
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_SHIFT_ENTER_NEWLINES") {
+        config.output.shift_enter_newlines = val != "0" && val.to_lowercase() != "false";
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_PRE_TYPE_DELAY") {
+        if let Ok(n) = val.parse::<u32>() {
+            config.output.pre_type_delay_ms = n;
+        }
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_TYPE_DELAY") {
+        if let Ok(n) = val.parse::<u32>() {
+            config.output.type_delay_ms = n;
+        }
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_FALLBACK_TO_CLIPBOARD") {
+        config.output.fallback_to_clipboard = val != "0" && val.to_lowercase() != "false";
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_SPOKEN_PUNCTUATION") {
+        config.text.spoken_punctuation = val != "0" && val.to_lowercase() != "false";
+    }
+    if let Ok(keys) = std::env::var("VOXTYPE_PASTE_KEYS") {
+        config.output.paste_keys = Some(keys);
+    }
+    if let Ok(layout) = std::env::var("VOXTYPE_DOTOOL_XKB_LAYOUT") {
+        config.output.dotool_xkb_layout = Some(layout);
+    }
+
+    // Remote whisper
+    if let Ok(endpoint) = std::env::var("VOXTYPE_REMOTE_ENDPOINT") {
+        config.whisper.remote_endpoint = Some(endpoint);
+    }
+    if let Ok(key) = std::env::var("VOXTYPE_WHISPER_API_KEY") {
+        config.whisper.remote_api_key = Some(key);
     }
 
     Ok(config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,6 @@ async fn main() -> anyhow::Result<()> {
                 model,
                 default_model
             );
-            // Send desktop notification
             let _ = Command::new("notify-send")
                 .args([
                     "--app-name=Voxtype",
@@ -139,12 +138,25 @@ async fn main() -> anyhow::Result<()> {
             }
         }
     }
+
+    // Hotkey overrides
     if let Some(hotkey) = cli.hotkey {
         config.hotkey.key = hotkey;
     }
     if cli.toggle {
         config.hotkey.mode = config::ActivationMode::Toggle;
     }
+    if cli.no_hotkey {
+        config.hotkey.enabled = false;
+    }
+    if let Some(cancel_key) = cli.cancel_key {
+        config.hotkey.cancel_key = Some(cancel_key);
+    }
+    if let Some(model_modifier) = cli.model_modifier {
+        config.hotkey.model_modifier = Some(model_modifier);
+    }
+
+    // Whisper overrides
     if let Some(delay) = cli.pre_type_delay {
         config.output.pre_type_delay_ms = delay;
     }
@@ -158,6 +170,66 @@ async fn main() -> anyhow::Result<()> {
     if let Some(prompt) = cli.initial_prompt {
         config.whisper.initial_prompt = Some(prompt);
     }
+    if let Some(lang) = cli.language {
+        config.whisper.language = config::LanguageConfig::from_comma_separated(&lang);
+    }
+    if cli.translate {
+        config.whisper.translate = true;
+    }
+    if let Some(threads) = cli.threads {
+        config.whisper.threads = Some(threads);
+    }
+    if cli.gpu_isolation {
+        config.whisper.gpu_isolation = true;
+    }
+    if cli.on_demand_loading {
+        config.whisper.on_demand_loading = true;
+    }
+    if let Some(ref mode) = cli.whisper_mode {
+        match mode.to_lowercase().as_str() {
+            "local" => config.whisper.mode = Some(config::WhisperMode::Local),
+            "remote" => config.whisper.mode = Some(config::WhisperMode::Remote),
+            "cli" => config.whisper.mode = Some(config::WhisperMode::Cli),
+            _ => {
+                eprintln!(
+                    "Error: Invalid whisper mode '{}'. Valid options: local, remote, cli",
+                    mode
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+    if let Some(model) = cli.secondary_model {
+        config.whisper.secondary_model = Some(model);
+    }
+    if cli.eager_processing {
+        config.whisper.eager_processing = true;
+    }
+    if let Some(endpoint) = cli.remote_endpoint {
+        config.whisper.remote_endpoint = Some(endpoint);
+    }
+    if let Some(model) = cli.remote_model {
+        config.whisper.remote_model = Some(model);
+    }
+    if let Some(key) = cli.remote_api_key {
+        config.whisper.remote_api_key = Some(key);
+    }
+
+    // Audio overrides
+    if let Some(device) = cli.audio_device {
+        config.audio.device = device;
+    }
+    if let Some(max_dur) = cli.max_duration {
+        config.audio.max_duration_secs = max_dur;
+    }
+    if cli.audio_feedback {
+        config.audio.feedback.enabled = true;
+    }
+    if cli.no_audio_feedback {
+        config.audio.feedback.enabled = false;
+    }
+
+    // Output overrides
     if let Some(append_text) = cli.append_text {
         config.output.append_text = Some(append_text);
     }
@@ -172,6 +244,66 @@ async fn main() -> anyhow::Result<()> {
             }
         }
     }
+    if cli.auto_submit {
+        config.output.auto_submit = true;
+    }
+    if cli.no_auto_submit {
+        config.output.auto_submit = false;
+    }
+    if cli.shift_enter_newlines {
+        config.output.shift_enter_newlines = true;
+    }
+    if cli.no_shift_enter_newlines {
+        config.output.shift_enter_newlines = false;
+    }
+    if let Some(delay) = cli.type_delay {
+        config.output.type_delay_ms = delay;
+    }
+    if cli.fallback_to_clipboard {
+        config.output.fallback_to_clipboard = true;
+    }
+    if cli.no_fallback_to_clipboard {
+        config.output.fallback_to_clipboard = false;
+    }
+    if cli.spoken_punctuation {
+        config.text.spoken_punctuation = true;
+    }
+    if let Some(keys) = cli.paste_keys {
+        config.output.paste_keys = Some(keys);
+    }
+    if let Some(layout) = cli.dotool_xkb_layout {
+        config.output.dotool_xkb_layout = Some(layout);
+    }
+    if let Some(variant) = cli.dotool_xkb_variant {
+        config.output.dotool_xkb_variant = Some(variant);
+    }
+    if let Some(path) = cli.file_path {
+        config.output.file_path = Some(path);
+    }
+    if let Some(ref mode) = cli.file_mode {
+        match mode.to_lowercase().as_str() {
+            "overwrite" => config.output.file_mode = config::FileMode::Overwrite,
+            "append" => config.output.file_mode = config::FileMode::Append,
+            _ => {
+                eprintln!(
+                    "Error: Invalid file mode '{}'. Valid options: overwrite, append",
+                    mode
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+    if let Some(cmd) = cli.pre_output_command {
+        config.output.pre_output_command = Some(cmd);
+    }
+    if let Some(cmd) = cli.post_output_command {
+        config.output.post_output_command = Some(cmd);
+    }
+    if let Some(cmd) = cli.pre_recording_command {
+        config.output.pre_recording_command = Some(cmd);
+    }
+
+    // VAD overrides
     if cli.vad {
         config.vad.enabled = true;
     }
@@ -191,6 +323,9 @@ async fn main() -> anyhow::Result<()> {
                 std::process::exit(1);
             }
         };
+    }
+    if let Some(min_speech) = cli.vad_min_speech_ms {
+        config.vad.min_speech_duration_ms = min_speech;
     }
 
     // Run the appropriate command
@@ -531,6 +666,20 @@ fn send_record_command(
         let profile_file = config::Config::runtime_dir().join("profile_override");
         std::fs::write(&profile_file, profile_name)
             .map_err(|e| anyhow::anyhow!("Failed to write profile override: {}", e))?;
+    }
+
+    // Write auto_submit override file if specified
+    if let Some(value) = action.auto_submit_override() {
+        let override_file = config::Config::runtime_dir().join("auto_submit_override");
+        std::fs::write(&override_file, if value { "true" } else { "false" })
+            .map_err(|e| anyhow::anyhow!("Failed to write auto_submit override: {}", e))?;
+    }
+
+    // Write shift_enter_newlines override file if specified
+    if let Some(value) = action.shift_enter_newlines_override() {
+        let override_file = config::Config::runtime_dir().join("shift_enter_override");
+        std::fs::write(&override_file, if value { "true" } else { "false" })
+            .map_err(|e| anyhow::anyhow!("Failed to write shift_enter override: {}", e))?;
     }
 
     // For toggle, we need to read current state to decide which signal to send


### PR DESCRIPTION
## Summary

- Adds `--auto-submit` / `--no-auto-submit` and `--shift-enter-newlines` / `--no-shift-enter-newlines` per-recording overrides to `record start` and `record toggle` (closes #221)
- Adds 30+ daemon-level CLI flags organized under help headings (Hotkey, Whisper, Audio, Output, VAD)
- Expands environment variables from 4 to 30+ (`VOXTYPE_*` for all major config options)
- Documents env var reference table in CONFIGURATION.md and configuration priority in USER_MANUAL.md

Addresses project principle #5: "Every option configurable everywhere."

## Test plan

- [ ] `cargo test` passes (508 tests)
- [ ] `cargo clippy` clean
- [ ] `voxtype --help` shows flags grouped under section headings
- [ ] `voxtype record start --auto-submit` writes override file, daemon applies it
- [ ] `voxtype record start --no-auto-submit` overrides config `auto_submit = true`
- [ ] `VOXTYPE_AUTO_SUBMIT=true voxtype` enables auto-submit via env var
- [ ] CLI flag overrides env var (priority order preserved)
- [ ] Old config files still work without changes