### PR TITLE
NixOS: rename parakeet packages to onnx, add all engine features

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,38 @@
           pciutils      # GPU detection (lspci)
         ];
 
+        # ONNX engine feature sets
+        # All ONNX engines: Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual
+        onnxCpuFeatures = [
+          "parakeet-load-dynamic"
+          "moonshine"
+          "sensevoice"
+          "paraformer"
+          "dolphin"
+          "omnilingual"
+        ];
+
+        onnxCudaFeatures = [
+          "parakeet-load-dynamic"
+          "parakeet-cuda"
+          "moonshine-cuda"
+          "sensevoice-cuda"
+          "paraformer-cuda"
+          "dolphin-cuda"
+          "omnilingual-cuda"
+        ];
+
+        # Only Parakeet has ROCm support; other engines run on CPU
+        onnxRocmFeatures = [
+          "parakeet-load-dynamic"
+          "parakeet-rocm"
+          "moonshine"
+          "sensevoice"
+          "paraformer"
+          "dolphin"
+          "omnilingual"
+        ];
+
         # Wrap a package with runtime dependencies
         wrapVoxtype = pkg: pkgs.symlinkJoin {
           name = "${pkg.pname or "voxtype"}-wrapped-${pkg.version}";
@@ -58,17 +90,18 @@
           inherit (pkg) meta;
         };
 
-        # Wrap a parakeet package with runtime dependencies and ORT_DYLIB_PATH
-        # Parakeet uses ONNX Runtime, which needs to know where to find the library
+        # Wrap an ONNX package with runtime dependencies and ORT_DYLIB_PATH
+        # ONNX engines need ONNX Runtime at runtime for inference
         libExt = if pkgs.stdenv.isDarwin then "dylib" else "so";
-        wrapParakeet = { onnxruntime ? pkgs.onnxruntime, pkg }: pkgs.symlinkJoin {
+        wrapOnnx = { onnxruntime ? pkgs.onnxruntime, pkg }: pkgs.symlinkJoin {
           name = "${pkg.pname or "voxtype"}-wrapped-${pkg.version}";
           paths = [ pkg ];
           buildInputs = [ pkgs.makeWrapper ];
           postBuild = ''
             wrapProgram $out/bin/voxtype \
               --prefix PATH : ${pkgs.lib.makeBinPath runtimeDeps} \
-              --set ORT_DYLIB_PATH "${onnxruntime}/lib/libonnxruntime.${libExt}"
+              --set ORT_DYLIB_PATH "${onnxruntime}/lib/libonnxruntime.${libExt}" \
+              --prefix LD_LIBRARY_PATH : "${onnxruntime}/lib"
           '';
           inherit (pkg) meta;
         };
@@ -129,7 +162,8 @@
               longDescription = ''
                 Voxtype is a push-to-talk voice-to-text daemon for Linux.
                 Hold a hotkey while speaking, release to transcribe and output
-                text at your cursor position. Fully offline using whisper.cpp.
+                text at your cursor position. Supports Whisper, Parakeet,
+                SenseVoice, Moonshine, Paraformer, Dolphin, and Omnilingual engines.
               '';
               homepage = "https://voxtype.io";
               license = licenses.mit;
@@ -164,7 +198,7 @@
           '';
         });
 
-        # Build the ROCm/HIP variant for AMD GPUs (unwrapped)
+        # Build the ROCm/HIP variant for AMD GPUs (unwrapped, Whisper only)
         rocmUnwrapped = let
           pkg = mkVoxtypeUnwrapped {
             pname = "voxtype-rocm";
@@ -189,40 +223,54 @@
           '';
         });
 
-        # Build the Parakeet variant (CPU, uses ONNX Runtime)
-        # Uses load-dynamic feature to load system ONNX Runtime at runtime
-        parakeetUnwrapped = mkVoxtypeUnwrapped {
-          pname = "voxtype-parakeet";
-          features = [ "parakeet-load-dynamic" ];
-          extraBuildInputs = with pkgs; [ onnxruntime ];
-        };
+        # Build the ONNX variant (CPU, all engines)
+        # Uses load-dynamic for Parakeet, ort for other engines
+        onnxUnwrapped = let
+          pkg = mkVoxtypeUnwrapped {
+            pname = "voxtype-onnx";
+            features = onnxCpuFeatures;
+            extraBuildInputs = with pkgs; [ onnxruntime ];
+          };
+        in pkg.overrideAttrs (old: {
+          # Tell ort-sys where to find ONNX Runtime (avoids sandbox download)
+          ORT_LIB_LOCATION = "${pkgs.onnxruntime}/lib";
+        });
 
-        # Build the Parakeet + CUDA variant for NVIDIA GPUs
+        # Build the ONNX + CUDA variant for NVIDIA GPUs
         # Uses pkgsUnfree because CUDA has a non-free license (CUDA EULA)
-        parakeetCudaUnwrapped = mkVoxtypeUnwrapped {
-          pname = "voxtype-parakeet-cuda";
-          features = [ "parakeet-load-dynamic" "parakeet-cuda" ];
-          extraNativeBuildInputs = [ pkgsUnfree.cudaPackages.cuda_nvcc ];
-          extraBuildInputs = [
-            onnxruntimeCuda
-            pkgsUnfree.cudaPackages.cudatoolkit
-            pkgsUnfree.cudaPackages.cudnn
-          ];
-        };
+        onnxCudaUnwrapped = let
+          pkg = mkVoxtypeUnwrapped {
+            pname = "voxtype-onnx-cuda";
+            features = onnxCudaFeatures;
+            extraNativeBuildInputs = [ pkgsUnfree.cudaPackages.cuda_nvcc ];
+            extraBuildInputs = [
+              onnxruntimeCuda
+              pkgsUnfree.cudaPackages.cudatoolkit
+              pkgsUnfree.cudaPackages.cudnn
+            ];
+          };
+        in pkg.overrideAttrs (old: {
+          ORT_LIB_LOCATION = "${onnxruntimeCuda}/lib";
+        });
 
-        # Build the Parakeet + ROCm variant for AMD GPUs
-        parakeetRocmUnwrapped = mkVoxtypeUnwrapped {
-          pname = "voxtype-parakeet-rocm";
-          features = [ "parakeet-load-dynamic" "parakeet-rocm" ];
-          extraNativeBuildInputs = with pkgs; [
-            rocmPackages.clr
-          ];
-          extraBuildInputs = [
-            onnxruntimeRocm
-            pkgs.rocmPackages.clr
-            pkgs.rocmPackages.rocblas
-          ];
-        };
+        # Build the ONNX + ROCm variant for AMD GPUs
+        # Only Parakeet gets ROCm acceleration; other engines run on CPU
+        onnxRocmUnwrapped = let
+          pkg = mkVoxtypeUnwrapped {
+            pname = "voxtype-onnx-rocm";
+            features = onnxRocmFeatures;
+            extraNativeBuildInputs = with pkgs; [
+              rocmPackages.clr
+            ];
+            extraBuildInputs = [
+              onnxruntimeRocm
+              pkgs.rocmPackages.clr
+              pkgs.rocmPackages.rocblas
+            ];
+          };
+        in pkg.overrideAttrs (old: {
+          ORT_LIB_LOCATION = "${onnxruntimeRocm}/lib";
+        });
 
       in {
         packages = {
@@ -232,19 +280,29 @@
           vulkan = wrapVoxtype vulkanUnwrapped;
           rocm = wrapVoxtype rocmUnwrapped;
 
-          # Parakeet variants (ONNX-based speech recognition)
-          # Uses NVIDIA's Parakeet models instead of Whisper
-          parakeet = wrapParakeet { pkg = parakeetUnwrapped; };
-          parakeet-cuda = wrapParakeet { onnxruntime = onnxruntimeCuda; pkg = parakeetCudaUnwrapped; };
-          parakeet-rocm = wrapParakeet { onnxruntime = onnxruntimeRocm; pkg = parakeetRocmUnwrapped; };
+          # ONNX variants (all ONNX engines: Parakeet, Moonshine, SenseVoice,
+          # Paraformer, Dolphin, Omnilingual)
+          onnx = wrapOnnx { pkg = onnxUnwrapped; };
+          onnx-cuda = wrapOnnx { onnxruntime = onnxruntimeCuda; pkg = onnxCudaUnwrapped; };
+          onnx-rocm = wrapOnnx { onnxruntime = onnxruntimeRocm; pkg = onnxRocmUnwrapped; };
+
+          # Backwards-compatible aliases (parakeet → onnx)
+          parakeet = wrapOnnx { pkg = onnxUnwrapped; };
+          parakeet-cuda = wrapOnnx { onnxruntime = onnxruntimeCuda; pkg = onnxCudaUnwrapped; };
+          parakeet-rocm = wrapOnnx { onnxruntime = onnxruntimeRocm; pkg = onnxRocmUnwrapped; };
 
           # Unwrapped packages (for custom wrapping scenarios)
           voxtype-unwrapped = mkVoxtypeUnwrapped {};
           voxtype-vulkan-unwrapped = vulkanUnwrapped;
           voxtype-rocm-unwrapped = rocmUnwrapped;
-          voxtype-parakeet-unwrapped = parakeetUnwrapped;
-          voxtype-parakeet-cuda-unwrapped = parakeetCudaUnwrapped;
-          voxtype-parakeet-rocm-unwrapped = parakeetRocmUnwrapped;
+          voxtype-onnx-unwrapped = onnxUnwrapped;
+          voxtype-onnx-cuda-unwrapped = onnxCudaUnwrapped;
+          voxtype-onnx-rocm-unwrapped = onnxRocmUnwrapped;
+
+          # Backwards-compatible aliases
+          voxtype-parakeet-unwrapped = onnxUnwrapped;
+          voxtype-parakeet-cuda-unwrapped = onnxCudaUnwrapped;
+          voxtype-parakeet-rocm-unwrapped = onnxRocmUnwrapped;
         };
 
         # Development shell with all dependencies

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -16,11 +16,23 @@
 #     };
 #   };
 #
-#   # Parakeet example:
+#   # ONNX engine example (SenseVoice for Chinese/Japanese/Korean):
+#   programs.voxtype = {
+#     enable = true;
+#     engine = "sensevoice";
+#     package = voxtype.packages.${system}.onnx-cuda;
+#     model.path = "/path/to/sensevoice-small";
+#     service.enable = true;
+#     settings = {
+#       hotkey.enabled = false;
+#     };
+#   };
+#
+#   # Parakeet example (English, high accuracy):
 #   programs.voxtype = {
 #     enable = true;
 #     engine = "parakeet";
-#     package = voxtype.packages.${system}.parakeet-cuda;
+#     package = voxtype.packages.${system}.onnx;
 #     model.path = "/path/to/parakeet-tdt-1.1b";
 #     service.enable = true;
 #     settings = {
@@ -34,6 +46,10 @@ let
   cfg = config.programs.voxtype;
   tomlFormat = pkgs.formats.toml { };
   modelDefs = import ./models.nix;
+
+  # Engines that use ONNX Runtime (need model.path, not model.name)
+  onnxEngines = [ "parakeet" "moonshine" "sensevoice" "paraformer" "dolphin" "omnilingual" ];
+  isOnnxEngine = builtins.elem cfg.engine onnxEngines;
 
   # Fetch model from HuggingFace if using declarative model management
   fetchedModel = lib.optionalAttrs (cfg.model.name != null) (
@@ -67,15 +83,23 @@ in {
     enable = lib.mkEnableOption "VoxType push-to-talk voice-to-text";
 
     engine = lib.mkOption {
-      type = lib.types.enum [ "whisper" "parakeet" ];
+      type = lib.types.enum [ "whisper" "parakeet" "moonshine" "sensevoice" "paraformer" "dolphin" "omnilingual" ];
       default = "whisper";
       description = ''
         Speech recognition engine to use.
-        - whisper: Local transcription via whisper.cpp (default)
-        - parakeet: NVIDIA Parakeet models via ONNX Runtime
 
-        When using parakeet, set model.name to null and use model.path
-        to point to your Parakeet model directory.
+        Whisper engine (default package):
+        - whisper: Local transcription via whisper.cpp
+
+        ONNX engines (require onnx/onnx-cuda/onnx-rocm package):
+        - parakeet: NVIDIA Parakeet models (English, high accuracy)
+        - moonshine: Moonshine models (English, fast)
+        - sensevoice: Alibaba SenseVoice (Chinese, Japanese, Korean, English)
+        - paraformer: Alibaba Paraformer (Chinese, English)
+        - dolphin: Dolphin (Chinese-focused)
+        - omnilingual: Omnilingual (multilingual)
+
+        When using ONNX engines, use model.path to point to the model directory.
       '';
     };
 
@@ -89,10 +113,10 @@ in {
         - packages.vulkan: Vulkan GPU acceleration (AMD/NVIDIA/Intel)
         - packages.rocm: ROCm/HIP acceleration (AMD only)
 
-        Parakeet packages (set engine = "parakeet"):
-        - packages.parakeet: CPU-only Parakeet
-        - packages.parakeet-cuda: CUDA acceleration (NVIDIA)
-        - packages.parakeet-rocm: ROCm acceleration (AMD)
+        ONNX packages (for parakeet, moonshine, sensevoice, etc.):
+        - packages.onnx: CPU-only ONNX engines
+        - packages.onnx-cuda: CUDA acceleration (NVIDIA)
+        - packages.onnx-rocm: ROCm acceleration (AMD, Parakeet only)
 
         All packages include runtime dependencies (wtype, dotool, ydotool, etc.).
       '';
@@ -105,7 +129,7 @@ in {
         default = null;
         description = ''
           Whisper model to download from HuggingFace. Only used when engine = "whisper".
-          Set to null when using Parakeet or managing models manually.
+          Set to null when using ONNX engines or managing models manually.
 
           Available: tiny, tiny.en, base, base.en, small, small.en,
           medium, medium.en, large-v3, large-v3-turbo
@@ -118,11 +142,11 @@ in {
         description = ''
           Path to a model file or directory.
           - For Whisper: path to a .bin model file
-          - For Parakeet: path to the model directory containing ONNX files
+          - For ONNX engines: path to the model directory containing ONNX files
 
           Overrides model.name when set.
         '';
-        example = "/home/user/.local/share/voxtype/models/parakeet-tdt-1.1b";
+        example = "/home/user/.local/share/voxtype/models/sensevoice-small";
       };
     };
 
@@ -145,9 +169,9 @@ in {
             language = "en";
             translate = false;
           };
-          # For Parakeet engine:
-          # parakeet = {
-          #   model_type = "tdt";
+          # For SenseVoice engine:
+          # sensevoice = {
+          #   language = "auto";  # auto, zh, en, ja, ko, yue
           # };
           output = {
             mode = "type";
@@ -175,8 +199,8 @@ in {
         message = "programs.voxtype: cannot set both model.name and model.path";
       }
       {
-        assertion = !(cfg.engine == "parakeet" && cfg.model.name != null);
-        message = "programs.voxtype: model.name is only for Whisper models. Use model.path for Parakeet.";
+        assertion = !(isOnnxEngine && cfg.model.name != null);
+        message = "programs.voxtype: model.name is only for Whisper models. Use model.path for ONNX engines (${cfg.engine}).";
       }
     ];
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -40,9 +40,16 @@ in {
       type = lib.types.package;
       description = ''
         The VoxType package to install. Use the flake's wrapped packages:
-        - packages.default: CPU-only
+
+        Whisper packages:
+        - packages.default: CPU-only Whisper
         - packages.vulkan: Vulkan GPU acceleration
         - packages.rocm: ROCm/HIP acceleration (AMD)
+
+        ONNX packages (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual):
+        - packages.onnx: CPU-only ONNX engines
+        - packages.onnx-cuda: CUDA acceleration (NVIDIA)
+        - packages.onnx-rocm: ROCm acceleration (AMD, Parakeet only)
 
         These packages include all runtime dependencies (wtype, dotool, ydotool, etc.)
         in their PATH.


### PR DESCRIPTION
## Summary

Re-opens #211 against main (was accidentally merged to `release/0.6.0` and reverted in #223).

- Rename flake packages from `parakeet`/`parakeet-cuda`/`parakeet-rocm` to `onnx`/`onnx-cuda`/`onnx-rocm` (old names kept as aliases)
- Add all six ONNX engine features to builds: Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual
- Set `ORT_LIB_LOCATION` on ONNX builds so `ort-sys` doesn't try to download in the Nix sandbox
- Add `LD_LIBRARY_PATH` to wrapper for `ort` runtime library loading
- Expand Home Manager engine enum to include all ONNX engines
- Generalize `model.name` assertion to block for any ONNX engine, not just parakeet
- Update NixOS module package descriptions

## Test plan

- [ ] `nix build .#onnx` compiles with all engine features
- [ ] `nix build .#default` still builds Whisper-only
- [ ] `nix build .#parakeet` still works (backwards-compatible alias)
- [ ] Home Manager module accepts `engine = "sensevoice"` and other new engines
- [ ] Home Manager module rejects `model.name` for ONNX engines
- [ ] Verify `ORT_DYLIB_PATH` and `LD_LIBRARY_PATH` are set in the wrapped binary