### PR TITLE
Add NixOS packaging code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 # All files require review from the repository owner
 * @peteonrails
+
+# NixOS packaging and configuration
+flake.nix @peteonrails @digunix @DuskyElf
+flake.lock @peteonrails @digunix @DuskyElf
+nix/ @peteonrails @digunix @DuskyElf


### PR DESCRIPTION
## Summary

- Add @digunix and @DuskyElf as code owners for NixOS packaging files (`flake.nix`, `flake.lock`, `nix/`)
- Both have contributed to the NixOS packaging and can review/merge their own Nix PRs once invited as collaborators

## Test plan

- [ ] Verify CODEOWNERS syntax is valid (GitHub will flag errors on the PR if not)