### PR TITLE
fix: set LIBCLANG_PATH for local devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -309,6 +309,7 @@
         devShells.default = pkgs.mkShell {
           inputsFrom = [ self.packages.${system}.voxtype-unwrapped ];
 
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
           packages = with pkgs; [
             rust-analyzer
             rustfmt


### PR DESCRIPTION
## Description

set `LIBCLANG_PATH` for local devshell

Using flake.nix. `LIBCLANG_PATH` is needed to compile whisper-rs-sys
It had been used for the package, was missing from the devshell  

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested these changes locally

## Documentation

- [ ] I have updated documentation as needed
- [x] No documentation changes are needed