### PR TITLE
Add smart auto-submit feature

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1859,6 +1859,42 @@ If Whisper transcribes "vox type" (or "Vox Type"), it will be replaced with "vox
 "omar key" = "Omarchy"
 ```
 
+### smart_auto_submit
+
+**Type:** Boolean
+**Default:** `false`
+**Required:** No
+
+When `true`, Voxtype watches for the word "submit" at the end of each transcription. If detected, it strips the word from the output and presses Enter - as if `auto_submit` had fired, but triggered by voice rather than being permanently on. Trailing punctuation on "submit" (e.g., "submit." from spoken punctuation) is handled correctly.
+
+**Example:**
+
+```toml
+[text]
+smart_auto_submit = true
+```
+
+Saying "send a reply to Alice submit" types "send a reply to Alice" and presses Enter.
+
+**Per-recording override:**
+
+```bash
+# Enable for just this recording (even if config has it off)
+voxtype record start --smart-auto-submit
+voxtype record toggle --smart-auto-submit
+
+# Disable for just this recording (even if config has it on)
+voxtype record start --no-smart-auto-submit
+```
+
+**Environment variable:**
+
+```bash
+VOXTYPE_SMART_AUTO_SUBMIT=true voxtype
+```
+
+**Note:** `smart_auto_submit` is conditional - it only fires when you say "submit". The existing `auto_submit` option always presses Enter after every transcription. Use `smart_auto_submit` when you want the choice per dictation, and `auto_submit` when you always want Enter pressed.
+
 ---
 
 ## [vad]

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1452,6 +1452,33 @@ auto_submit = true  # Press Enter after transcription
 
 Useful for chat applications or command lines where you want to submit immediately after dictating.
 
+**Smart auto-submit (say "submit" to press Enter):**
+
+```toml
+[text]
+smart_auto_submit = true
+```
+
+With this enabled, ending your dictation with the word "submit" strips that word from the output and presses Enter. Unlike `auto_submit` (which always presses Enter), this only fires when you choose to say it.
+
+```
+# You say:   "reply to Alice and cc Bob submit"
+# Voxtype types: "reply to Alice and cc Bob"  [then presses Enter]
+```
+
+Per-recording override (useful with compositor keybindings):
+
+```bash
+voxtype record start --smart-auto-submit   # force on for this recording
+voxtype record start --no-smart-auto-submit  # force off for this recording
+```
+
+Or via environment variable for the whole session:
+
+```bash
+VOXTYPE_SMART_AUTO_SUBMIT=true voxtype
+```
+
 **Shift+Enter for newlines:**
 
 ```toml

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -202,6 +202,14 @@ pub struct Cli {
     #[arg(long, conflicts_with = "shift_enter_newlines", help_heading = "Output")]
     pub no_shift_enter_newlines: bool,
 
+    /// Enable smart auto-submit (say "submit" to press Enter)
+    #[arg(long, help_heading = "Output")]
+    pub smart_auto_submit: bool,
+
+    /// Disable smart auto-submit (overrides config)
+    #[arg(long, conflicts_with = "smart_auto_submit", help_heading = "Output")]
+    pub no_smart_auto_submit: bool,
+
     /// Delay between typed characters in milliseconds (0 = fastest)
     #[arg(long, value_name = "MS", help_heading = "Output")]
     pub type_delay: Option<u32>,
@@ -425,6 +433,14 @@ pub enum RecordAction {
         /// Disable Shift+Enter newlines for this transcription (overrides config)
         #[arg(long, conflicts_with = "shift_enter_newlines")]
         no_shift_enter_newlines: bool,
+
+        /// Enable smart auto-submit for this recording (say "submit" to press Enter)
+        #[arg(long, conflicts_with = "no_smart_auto_submit")]
+        smart_auto_submit: bool,
+
+        /// Disable smart auto-submit for this recording
+        #[arg(long, conflicts_with = "smart_auto_submit")]
+        no_smart_auto_submit: bool,
     },
     /// Stop recording and transcribe (send SIGUSR2 to daemon)
     Stop {
@@ -483,6 +499,14 @@ pub enum RecordAction {
         /// Disable Shift+Enter newlines for this transcription (overrides config)
         #[arg(long, conflicts_with = "shift_enter_newlines")]
         no_shift_enter_newlines: bool,
+
+        /// Enable smart auto-submit for this recording (say "submit" to press Enter)
+        #[arg(long, conflicts_with = "no_smart_auto_submit")]
+        smart_auto_submit: bool,
+
+        /// Disable smart auto-submit for this recording (overrides config)
+        #[arg(long, conflicts_with = "smart_auto_submit")]
+        no_smart_auto_submit: bool,
     },
     /// Cancel current recording or transcription (discard without output)
     Cancel,
@@ -699,6 +723,32 @@ impl RecordAction {
         if shift_enter {
             Some(true)
         } else if no_shift_enter {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    /// Get the smart auto-submit override from --smart-auto-submit / --no-smart-auto-submit flags
+    /// Returns Some(true) to enable, Some(false) to disable, None if not specified
+    pub fn smart_auto_submit_override(&self) -> Option<bool> {
+        let (enable, disable) = match self {
+            RecordAction::Start {
+                smart_auto_submit,
+                no_smart_auto_submit,
+                ..
+            } => (*smart_auto_submit, *no_smart_auto_submit),
+            RecordAction::Toggle {
+                smart_auto_submit,
+                no_smart_auto_submit,
+                ..
+            } => (*smart_auto_submit, *no_smart_auto_submit),
+            RecordAction::Stop { .. } | RecordAction::Cancel => return None,
+        };
+
+        if enable {
+            Some(true)
+        } else if disable {
             Some(false)
         } else {
             None
@@ -1711,6 +1761,91 @@ mod tests {
             Some(Commands::Record { action }) => {
                 assert_eq!(action.auto_submit_override(), None);
                 assert_eq!(action.shift_enter_newlines_override(), None);
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    // =========================================================================
+    // Smart auto-submit flag tests
+    // =========================================================================
+
+    #[test]
+    fn test_record_start_smart_auto_submit_enable() {
+        let cli = Cli::parse_from(["voxtype", "record", "start", "--smart-auto-submit"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.smart_auto_submit_override(), Some(true));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_start_no_smart_auto_submit() {
+        let cli = Cli::parse_from(["voxtype", "record", "start", "--no-smart-auto-submit"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.smart_auto_submit_override(), Some(false));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_start_smart_auto_submit_mutual_exclusion() {
+        let result = Cli::try_parse_from([
+            "voxtype",
+            "record",
+            "start",
+            "--smart-auto-submit",
+            "--no-smart-auto-submit",
+        ]);
+        assert!(
+            result.is_err(),
+            "Should not allow both flags simultaneously"
+        );
+    }
+
+    #[test]
+    fn test_record_start_smart_auto_submit_no_flags_returns_none() {
+        let cli = Cli::parse_from(["voxtype", "record", "start"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.smart_auto_submit_override(), None);
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_toggle_smart_auto_submit_enable() {
+        let cli = Cli::parse_from(["voxtype", "record", "toggle", "--smart-auto-submit"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.smart_auto_submit_override(), Some(true));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_toggle_no_smart_auto_submit() {
+        let cli = Cli::parse_from(["voxtype", "record", "toggle", "--no-smart-auto-submit"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.smart_auto_submit_override(), Some(false));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_record_stop_has_no_smart_auto_submit_override() {
+        let cli = Cli::parse_from(["voxtype", "record", "stop"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(action.smart_auto_submit_override(), None);
             }
             _ => panic!("Expected Record command"),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -226,6 +226,10 @@ on_transcription = true
 #
 # Custom word replacements (case-insensitive)
 # replacements = { "vox type" = "voxtype" }
+#
+# Smart auto-submit: say "submit" at the end of dictation to press Enter.
+# The word "submit" is stripped from the output text and Enter is pressed.
+# smart_auto_submit = false
 
 # [vad]
 # Voice Activity Detection - filters silence-only recordings
@@ -1215,6 +1219,11 @@ pub struct TextConfig {
     /// Example: { "vox type" = "voxtype" }
     #[serde(default)]
     pub replacements: HashMap<String, String>,
+
+    /// Smart auto-submit: say "submit" at the end of dictation to press Enter.
+    /// The word "submit" is stripped from the output and Enter is pressed.
+    #[serde(default)]
+    pub smart_auto_submit: bool,
 }
 
 /// Meeting transcription configuration
@@ -2082,6 +2091,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         if let Ok(ms) = val.parse::<u32>() {
             config.output.restore_clipboard_delay_ms = ms;
         }
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_SMART_AUTO_SUBMIT") {
+        config.text.smart_auto_submit = parse_bool_env(&val);
     }
 
     Ok(config)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -735,10 +735,11 @@ impl Daemon {
                         tracing::info!("Meeting started: {}", meeting_id);
 
                         // Start dual audio capture for meeting (mic + loopback)
-                        let loopback_device = match self.config.meeting.audio.loopback_device.as_str() {
-                            "disabled" | "" => None,
-                            other => Some(other),
-                        };
+                        let loopback_device =
+                            match self.config.meeting.audio.loopback_device.as_str() {
+                                "disabled" | "" => None,
+                                other => Some(other),
+                            };
                         match audio::DualCapture::new(&self.config.audio, loopback_device) {
                             Ok(mut capture) => {
                                 if let Err(e) = capture.start().await {
@@ -773,11 +774,17 @@ impl Daemon {
                                         tracing::info!("GTCRN speech enhancer loaded for meeting echo cancellation");
                                     }
                                     Err(e) => {
-                                        tracing::warn!("Failed to load GTCRN enhancer, continuing without: {}", e);
+                                        tracing::warn!(
+                                            "Failed to load GTCRN enhancer, continuing without: {}",
+                                            e
+                                        );
                                     }
                                 }
                             } else {
-                                tracing::debug!("GTCRN model not found at {:?}, skipping speech enhancement", model_path);
+                                tracing::debug!(
+                                    "GTCRN model not found at {:?}, skipping speech enhancement",
+                                    model_path
+                                );
                             }
                         }
 
@@ -915,6 +922,7 @@ impl Daemon {
         cleanup_profile_override();
         cleanup_bool_override("auto_submit");
         cleanup_bool_override("shift_enter");
+        cleanup_bool_override("smart_auto_submit");
         *state = State::Idle;
         self.update_state("idle");
 
@@ -1241,6 +1249,19 @@ impl Daemon {
                         tracing::debug!("After text processing: {:?}", processed_text);
                     }
 
+                    // Smart auto-submit: detect "submit" trigger word at end
+                    // CLI override (--smart-auto-submit / --no-smart-auto-submit) takes priority
+                    let smart_auto_submit_cli = read_bool_override("smart_auto_submit");
+                    let (processed_text, smart_submit) = self
+                        .text_processor
+                        .detect_submit(&processed_text, smart_auto_submit_cli);
+                    if smart_submit {
+                        tracing::debug!(
+                            "Smart auto-submit triggered, stripped text: {:?}",
+                            processed_text
+                        );
+                    }
+
                     // Check for profile override from CLI flags
                     let profile_override = read_profile_override();
                     let active_profile = profile_override
@@ -1291,6 +1312,13 @@ impl Daemon {
                     } else {
                         processed_text
                     };
+
+                    if smart_submit {
+                        tracing::debug!(
+                            "Smart auto-submit: final text after post-processing: {:?}",
+                            final_text
+                        );
+                    }
 
                     // Check for output mode override from CLI flags
                     let output_override = read_output_mode_override();
@@ -1379,6 +1407,11 @@ impl Daemon {
                     }
                     if let Some(shift_enter) = shift_enter_override {
                         output_config.shift_enter_newlines = shift_enter;
+                    }
+
+                    // If smart auto-submit triggered, enable auto_submit for this cycle
+                    if smart_submit {
+                        output_config.auto_submit = true;
                     }
 
                     let output_chain = output::create_output_chain(&output_config);
@@ -1985,6 +2018,7 @@ impl Daemon {
                                 cleanup_output_mode_override();
                                 cleanup_model_override();
                                 cleanup_profile_override();
+                                cleanup_bool_override("smart_auto_submit");
                                 state = State::Idle;
                                 self.update_state("idle");
                                 self.play_feedback(SoundEvent::Cancelled);
@@ -2010,6 +2044,7 @@ impl Daemon {
                                 cleanup_output_mode_override();
                                 cleanup_model_override();
                                 cleanup_profile_override();
+                                cleanup_bool_override("smart_auto_submit");
                                 state = State::Idle;
                                 self.update_state("idle");
                                 self.play_feedback(SoundEvent::Cancelled);
@@ -2055,6 +2090,7 @@ impl Daemon {
                         cleanup_output_mode_override();
                         cleanup_model_override();
                         cleanup_profile_override();
+                        cleanup_bool_override("smart_auto_submit");
                         state = State::Idle;
                         self.update_state("idle");
                         self.play_feedback(SoundEvent::Cancelled);
@@ -2089,6 +2125,7 @@ impl Daemon {
                             cleanup_output_mode_override();
                             cleanup_model_override();
                             cleanup_profile_override();
+                            cleanup_bool_override("smart_auto_submit");
 
                             // Get model override from state before transitioning
                             let model_override = match &state {
@@ -2320,6 +2357,7 @@ impl Daemon {
                         cleanup_output_mode_override();
                         cleanup_model_override();
                         cleanup_profile_override();
+                        cleanup_bool_override("smart_auto_submit");
                         state = State::Idle;
                         self.update_state("idle");
                         self.play_feedback(SoundEvent::Cancelled);

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,6 +262,12 @@ async fn main() -> anyhow::Result<()> {
     if cli.no_shift_enter_newlines {
         config.output.shift_enter_newlines = false;
     }
+    if cli.smart_auto_submit {
+        config.text.smart_auto_submit = true;
+    }
+    if cli.no_smart_auto_submit {
+        config.text.smart_auto_submit = false;
+    }
     if let Some(delay) = cli.type_delay {
         config.output.type_delay_ms = delay;
     }
@@ -640,6 +646,13 @@ fn send_record_command(
         let override_file = config::Config::runtime_dir().join("model_override");
         std::fs::write(&override_file, model)
             .map_err(|e| anyhow::anyhow!("Failed to write model override: {}", e))?;
+    }
+
+    // Write smart auto-submit override file if specified
+    if let Some(enabled) = action.smart_auto_submit_override() {
+        let override_file = config::Config::runtime_dir().join("smart_auto_submit_override");
+        std::fs::write(&override_file, if enabled { "true" } else { "false" })
+            .map_err(|e| anyhow::anyhow!("Failed to write smart auto-submit override: {}", e))?;
     }
 
     // Write profile override file if specified


### PR DESCRIPTION
  
## Description
Say "submit" at the end of dictation to strip the word and press Enter,  like `auto_submit` but triggered by voice rather than permanently on.

  - TextProcessor::detect_submit() detects "submit" (case-insensitive, handles trailing punctuation from spoken_punctuation) at end of text
  - config: `text.smart_auto_submit` (default false), `VOXTYPE_SMART_AUTO_SUBMIT` env var
  - CLI: `--smart-auto-submit` / `--no-smart-auto-submit` on record start/toggle
  - docs: CONFIGURATION.md, USER_MANUAL.md, SMOKE_TESTS.md


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy` with no warnings
- [x] I have run `cargo fmt` (it shows formatting errors on unrelated code)

## Documentation

- [x] I have updated documentation as needed
- [ ] No documentation changes are needed

## Additional Notes

I am no Rust developer. This was vibe-codeed using Claude Code. I have tested the functionality myself. Feel free to just close the PR or tell me what to change!
