### PR TITLE
Tolerate stdin pipe errors in post-process commands

### DIFF
--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -76,11 +76,11 @@ impl PostProcessor {
 
         // Write text to stdin
         if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(text.as_bytes())
-                .await
-                .map_err(|e| PostProcessError::WriteFailed(e.to_string()))?;
-            // Close stdin to signal EOF
+            // Ignore write errors: the command may not read stdin or may exit
+            // before we finish writing (e.g., `echo` or `head -1`). The command's
+            // exit code and stdout output determine success, not whether it
+            // consumed all of stdin.
+            let _ = stdin.write_all(text.as_bytes()).await;
             drop(stdin);
         }
 


### PR DESCRIPTION
## Summary

- Fix race condition where post-process commands that don't consume stdin (e.g., `echo`, `head -1`) cause EPIPE, triggering an incorrect fallback to the original text
- The command's exit code and stdout determine success, not whether it consumed all of stdin

## Context

On aarch64, `echo` exits before voxtype finishes writing to the stdin pipe, making the `test_whitespace_trimming` failure deterministic. This blocks the NixOS packaging effort (nixpkgs PR #491124).

On x86_64 the timing happens to work, but the bug affects any post-process command that doesn't read all input.

Closes #235

## Test plan

- [x] All 12 post_process tests pass (including `test_whitespace_trimming`)
- [x] Full test suite passes (all 25 tests)
- [ ] NixOS aarch64 build succeeds with this fix