### PR TITLE
v0.6.3: Clipboard Restoration, Full Config Override, NixOS Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,7 +2906,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxtype"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "voxtype"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["Peter Jackson", "Jean-Paul van Tillo", "Máté Rémiás", "Rob Zolkos", "Dan Heuckeroth", "Igor Warzocha", "Julian Kaiser", "Kevin Miller", "konnsim", "reisset", "Zubair", "Loki Coyote", "Umesh", "Barrett Ruth", "André Silva", "Chmouel Boudjnah", "Christopher Albert", "Phuoc Thinh Vu", "Alexander Bosu-Kellett", "ayoahha", "Toizi", "kakapt"]
 description = "Push-to-talk voice-to-text for Wayland"

--- a/website/index.html
+++ b/website/index.html
@@ -828,8 +828,8 @@ sudo pacman -S wtype wl-clipboard</code></pre>
                             <button class="copy-btn">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install (Ubuntu 24.04+, Debian Trixie+)</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.6.2/voxtype_0.6.2-1_amd64.deb
-sudo dpkg -i voxtype_0.6.2-1_amd64.deb
+wget https://github.com/peteonrails/voxtype/releases/download/v0.6.3/voxtype_0.6.3-1_amd64.deb
+sudo dpkg -i voxtype_0.6.3-1_amd64.deb
 sudo apt-get install -f
 
 <span class="comment"># Install optional dependencies</span>
@@ -845,8 +845,8 @@ sudo apt install wtype wl-clipboard</code></pre>
                             <button class="copy-btn">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install (Fedora 39+)</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.6.2/voxtype-0.6.2-1.x86_64.rpm
-sudo dnf install ./voxtype-0.6.2-1.x86_64.rpm
+wget https://github.com/peteonrails/voxtype/releases/download/v0.6.3/voxtype-0.6.3-1.x86_64.rpm
+sudo dnf install ./voxtype-0.6.3-1.x86_64.rpm
 
 <span class="comment"># Install optional dependencies</span>
 sudo dnf install wtype wl-clipboard</code></pre>

--- a/website/news/index.html
+++ b/website/news/index.html
@@ -9,16 +9,16 @@
     <!-- Open Graph / Social Media -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://voxtype.io/news/">
-    <meta property="og:title" content="Voxtype 0.6.0: Five New Transcription Engines, Meeting Mode">
-    <meta property="og:description" content="Five new ONNX-based transcription engines for Chinese, Japanese, Korean, and 1600+ languages. Meeting mode for continuous transcription with speaker attribution and AI summaries.">
+    <meta property="og:title" content="Voxtype 0.6.3: Clipboard Restoration, Full Config Override, NixOS Improvements">
+    <meta property="og:description" content="Restore clipboard after paste mode, every config option now configurable via CLI flags and env vars, NixOS packaging improvements and bug fixes.">
     <meta property="og:image" content="https://voxtype.io/images/gpu-isolation.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Voxtype 0.6.0: Five New Transcription Engines, Meeting Mode">
-    <meta name="twitter:description" content="Five new ONNX-based transcription engines for Chinese, Japanese, Korean, and 1600+ languages. Meeting mode for continuous transcription with speaker attribution and AI summaries.">
+    <meta name="twitter:title" content="Voxtype 0.6.3: Clipboard Restoration, Full Config Override, NixOS Improvements">
+    <meta name="twitter:description" content="Restore clipboard after paste mode, every config option now configurable via CLI flags and env vars, NixOS packaging improvements and bug fixes.">
     <meta name="twitter:image" content="https://voxtype.io/images/gpu-isolation.png">
 
     <title>News & Updates | Voxtype</title>
@@ -76,6 +76,74 @@
         <div class="container">
 
             <!-- v0.6.x Era Posts -->
+
+            <article class="news-article" id="v063">
+                <div class="article-meta">
+                    <time datetime="2026-02-25">February 25, 2026</time>
+                    <span class="article-tag">Release</span>
+                </div>
+                <h2>v0.6.3: Clipboard Restoration, Full Config Override, NixOS Improvements</h2>
+                <div class="article-body">
+                    <p>Voxtype 0.6.3 restores your clipboard after paste mode output, closes the config override gap so every option is configurable via CLI flags and environment variables, and includes several NixOS packaging improvements.</p>
+
+                    <h3>Clipboard Restoration</h3>
+                    <p>When using paste mode, voxtype copies transcribed text to the clipboard and simulates Ctrl+V. Previously, this replaced whatever you had on your clipboard. Now voxtype can save your clipboard contents before pasting and restore them afterward.</p>
+
+                    <p><strong>Why use it:</strong> You can dictate text without losing the link, code snippet, or image you copied earlier.</p>
+
+                    <p>Supports both Wayland (wl-paste/wl-copy) and X11 (xclip), preserving binary content and MIME types on Wayland. A 100 MB size cap prevents memory issues with large clipboard contents.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>config.toml</span></div>
+                        <pre><code>[output]
+mode = "paste"
+restore_clipboard = true
+restore_clipboard_delay_ms = 200</code></pre>
+                    </div>
+
+                    <p>The delay gives applications time to process the paste before the clipboard is restored. The default 200ms works well for most apps including Electron-based editors.</p>
+
+                    <h3>Every Option Configurable Everywhere</h3>
+                    <p>Project principle #5 says every option should be configurable via CLI flag, environment variable, or config file. This release closes that gap. The daemon now accepts 30+ CLI flags organized by section (Hotkey, Whisper, Audio, Output, VAD), and every config option has a corresponding <code>VOXTYPE_*</code> environment variable.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>CLI flags (examples)</span></div>
+                        <pre><code># Override model and language via CLI
+voxtype --model large-v3 --language en daemon
+
+# Override via environment variables
+VOXTYPE_MODEL=large-v3 VOXTYPE_LANGUAGE=en voxtype daemon</code></pre>
+                    </div>
+
+                    <p>The <code>record start</code> and <code>record toggle</code> commands also gained per-recording overrides for <code>--auto-submit</code> and <code>--shift-enter-newlines</code>, so compositor keybindings can toggle these per-dictation.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>Hyprland example</span></div>
+                        <pre><code># Normal dictation
+bind = , F8, exec, voxtype record toggle
+
+# Dictation that presses Enter after output
+bind = SHIFT, F8, exec, voxtype record toggle --auto-submit</code></pre>
+                    </div>
+
+                    <h3>NixOS Packaging</h3>
+                    <p>Several improvements for NixOS users:</p>
+                    <ul>
+                        <li>ONNX packages now include all six engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual) instead of just Parakeet. The <code>parakeet</code> package names still work as aliases.</li>
+                        <li>flake.nix derives version from Cargo.toml instead of a hard-coded string, so <code>voxtype --version</code> stays in sync.</li>
+                        <li>dotool added to Nix runtime dependencies.</li>
+                        <li>LIBCLANG_PATH set correctly for the devshell.</li>
+                    </ul>
+
+                    <h3>Bug Fixes</h3>
+                    <ul>
+                        <li><strong>Post-process EPIPE errors:</strong> Commands that don't read stdin (like <code>echo</code> or <code>head -1</code>) could exit before voxtype finished writing to the pipe, causing a spurious fallback to the original text. The command's exit code and stdout now determine success, not whether it consumed all of stdin. This also fixed a deterministic test failure on aarch64 that was blocking NixOS packaging.</li>
+                    </ul>
+
+                    <h3>Contributors</h3>
+                    <p>Thanks to <a href="https://github.com/grota">grota</a> for clipboard restoration, <a href="https://github.com/digunix">digunix</a> for the flake.nix version fix, <a href="https://github.com/ekisu">ekisu</a> for dotool in Nix deps, and <a href="https://github.com/DuskyElf">DuskyElf</a> for the devshell LIBCLANG_PATH fix and NixOS packaging co-ownership.</p>
+                </div>
+            </article>
 
             <article class="news-article" id="v062">
                 <div class="article-meta">


### PR DESCRIPTION
## Summary

- Bump version to 0.6.3 for Nixpkgs packaging (requested in #237)
- Add v0.6.3 news article to website
- Update deb/rpm download URLs on homepage

The GitHub release (with binaries and full release notes) will be created after this merges and the tag is pushed.

### Changes included in v0.6.3 (since v0.6.2)

- **Clipboard restoration** after paste mode output (#176, @grota)
- **30+ daemon CLI flags and VOXTYPE_* env vars** for every config option (#224)
- **Per-recording overrides** for --auto-submit and --shift-enter-newlines (#224)
- **NixOS packaging improvements**: ONNX packages renamed with all 6 engines (#225), flake.nix derives version from Cargo.toml (#222, @digunix), dotool in Nix deps (#216, @ekisu), LIBCLANG_PATH fix (#228, @DuskyElf), code owners (#226)
- **Post-process EPIPE fix** for commands that don't consume stdin (#237)