### PR TITLE
Fix status command reporting wrong model and backend for ONNX engines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -846,19 +846,24 @@ struct ExtendedStatusInfo {
 
 impl ExtendedStatusInfo {
     fn from_config(config: &config::Config) -> Self {
-        let backend = setup::gpu::detect_current_backend()
-            .map(|b| match b {
+        // Try Whisper backend detection first, then fall back to ONNX backend detection
+        let backend = if let Some(b) = setup::gpu::detect_current_backend() {
+            match b {
                 setup::gpu::Backend::Cpu => "CPU (legacy)",
                 setup::gpu::Backend::Native => "CPU (native)",
                 setup::gpu::Backend::Avx2 => "CPU (AVX2)",
                 setup::gpu::Backend::Avx512 => "CPU (AVX-512)",
                 setup::gpu::Backend::Vulkan => "GPU (Vulkan)",
-            })
-            .unwrap_or("unknown")
-            .to_string();
+            }
+            .to_string()
+        } else if let Some(pb) = setup::parakeet::detect_current_parakeet_backend() {
+            pb.display_name().to_string()
+        } else {
+            "unknown".to_string()
+        };
 
         Self {
-            model: config.whisper.model.clone(),
+            model: config.model_name().to_string(),
             device: config.audio.device.clone(),
             backend,
         }

--- a/src/setup/parakeet.rs
+++ b/src/setup/parakeet.rs
@@ -33,7 +33,7 @@ impl ParakeetBackend {
         }
     }
 
-    fn display_name(&self) -> &'static str {
+    pub fn display_name(&self) -> &'static str {
         match self {
             ParakeetBackend::Avx2 => "ONNX (AVX2)",
             ParakeetBackend::Avx512 => "ONNX (AVX-512)",
@@ -447,10 +447,7 @@ mod tests {
     #[test]
     fn test_parakeet_backend_binary_names() {
         assert_eq!(ParakeetBackend::Avx2.binary_name(), "voxtype-onnx-avx2");
-        assert_eq!(
-            ParakeetBackend::Avx512.binary_name(),
-            "voxtype-onnx-avx512"
-        );
+        assert_eq!(ParakeetBackend::Avx512.binary_name(), "voxtype-onnx-avx512");
         assert_eq!(ParakeetBackend::Cuda.binary_name(), "voxtype-onnx-cuda");
         assert_eq!(ParakeetBackend::Rocm.binary_name(), "voxtype-onnx-rocm");
         assert_eq!(ParakeetBackend::Custom.binary_name(), "voxtype-onnx");


### PR DESCRIPTION
## Summary

- Use `config.model_name()` instead of hardcoded `config.whisper.model` so the status JSON reports the correct model for whichever engine is active
- Fall back to `detect_current_parakeet_backend()` when the Whisper backend check returns `None`, so ONNX binaries report "ONNX (AVX2)", "ONNX (CUDA)", etc. instead of "unknown"

Closes #246