### PR TITLE
feat: add Voxtral presets for remote STT backends

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -872,6 +872,9 @@ remote_endpoint = "http://192.168.1.100:8080"
 
 # OpenAI API
 remote_endpoint = "https://api.openai.com"
+
+# Mistral API
+remote_endpoint = "https://api.mistral.ai"
 ```
 
 **Security note:** Voxtype logs a warning if you use HTTP (unencrypted) for non-localhost endpoints, as your audio would be transmitted in the clear.
@@ -879,20 +882,54 @@ remote_endpoint = "https://api.openai.com"
 ### remote_model
 
 **Type:** String
-**Default:** `"whisper-1"`
+**Default:** provider-dependent
 **Required:** No
 
 The model name to send to the remote server.
 
 - For **whisper.cpp server**: This is ignored (the server uses whatever model it was started with)
-- For **OpenAI API**: Must be `"whisper-1"`
-- For **other providers**: Check their documentation
+- For **OpenAI API**: default is `"whisper-1"`
+- For **Mistral API**: default is `"voxtral-mini-latest"`
+- For **local vLLM / generic self-hosted OpenAI-compatible endpoints**: default is `"mistralai/Voxtral-Mini-3B-2507"`
+- For **other providers**: set `remote_model` explicitly
+
+### remote_provider
+
+**Type:** String
+**Default:** `"auto"`
+**Required:** No
+
+Optional provider preset used to choose the default `remote_model`.
+
+Supported values:
+- `auto`: infer from endpoint; defaults to self-hosted Voxtral when not obviously OpenAI or Mistral
+- `vllm`: self-hosted OpenAI-compatible endpoint serving Voxtral
+- `mistral`: Mistral hosted STT API
+- `openai`: OpenAI hosted Whisper API
+- `generic`: generic OpenAI-compatible endpoint, using the self-hosted Voxtral default model
 
 **Example:**
 ```toml
 [whisper]
 backend = "remote"
+remote_endpoint = "http://127.0.0.1:8000"
+remote_provider = "vllm"
+remote_model = "mistralai/Voxtral-Mini-3B-2507"
+```
+
+```toml
+[whisper]
+backend = "remote"
+remote_endpoint = "https://api.mistral.ai"
+remote_provider = "mistral"
+remote_model = "voxtral-mini-latest"
+```
+
+```toml
+[whisper]
+backend = "remote"
 remote_endpoint = "https://api.openai.com"
+remote_provider = "openai"
 remote_model = "whisper-1"
 ```
 
@@ -2361,6 +2398,8 @@ Any config file setting can be overridden via environment variable. These are ap
 | `VOXTYPE_GPU_ISOLATION` | bool | `whisper.gpu_isolation` |
 | `VOXTYPE_ON_DEMAND_LOADING` | bool | `whisper.on_demand_loading` |
 | `VOXTYPE_REMOTE_ENDPOINT` | string | `whisper.remote_endpoint` |
+| `VOXTYPE_REMOTE_PROVIDER` | string | `whisper.remote_provider` |
+| `VOXTYPE_REMOTE_MODEL` | string | `whisper.remote_model` |
 | `VOXTYPE_WHISPER_API_KEY` | string | `whisper.remote_api_key` |
 
 **Audio:**

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1023,11 +1023,12 @@ backend = "remote"
 # Language setting still applies
 language = "en"
 
-# Your whisper.cpp server address
-remote_endpoint = "http://192.168.1.100:8080"
+# Your self-hosted OpenAI-compatible STT server
+remote_endpoint = "http://127.0.0.1:8000"
 
-# Model name sent to server (whisper.cpp ignores this, but OpenAI requires it)
-remote_model = "whisper-1"
+# Provider preset and default model for local Voxtral via vLLM
+remote_provider = "vllm"
+remote_model = "mistralai/Voxtral-Mini-3B-2507"
 
 # Request timeout in seconds (increase for large files or slow networks)
 remote_timeout_secs = 30
@@ -1038,13 +1039,24 @@ remote_timeout_secs = 30
 
 ### Using with Cloud Services (OpenAI, etc.)
 
-While this feature was built for self-hosted servers, it also works with OpenAI's hosted Whisper API and other compatible services:
+While this feature was built for self-hosted servers, it also works with Mistral's Voxtral API, OpenAI's hosted Whisper API, and other compatible services:
+
+```toml
+[whisper]
+backend = "remote"
+language = "en"
+remote_endpoint = "https://api.mistral.ai"
+remote_provider = "mistral"
+remote_model = "voxtral-mini-latest"
+remote_timeout_secs = 30
+```
 
 ```toml
 [whisper]
 backend = "remote"
 language = "en"
 remote_endpoint = "https://api.openai.com"
+remote_provider = "openai"
 remote_model = "whisper-1"
 remote_timeout_secs = 30
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,6 +151,10 @@ pub struct Cli {
     #[arg(long, value_name = "URL", help_heading = "Whisper")]
     pub remote_endpoint: Option<String>,
 
+    /// Remote provider preset: auto, vllm, mistral, openai, or generic
+    #[arg(long, value_name = "PROVIDER", help_heading = "Whisper")]
+    pub remote_provider: Option<String>,
+
     /// Model name to send to remote server
     #[arg(long, value_name = "MODEL", help_heading = "Whisper")]
     pub remote_model: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,11 +137,22 @@ translate = false
 # Remote server endpoint URL (required for remote backend)
 # Examples:
 #   - whisper.cpp server: "http://192.168.1.100:8080"
+#   - local vLLM Voxtral server: "http://127.0.0.1:8000"
 #   - OpenAI API: "https://api.openai.com"
+#   - Mistral API: "https://api.mistral.ai"
 # remote_endpoint = "http://192.168.1.100:8080"
 #
-# Model name to send to remote server (default: "whisper-1")
-# remote_model = "whisper-1"
+# Remote provider preset (default: "auto")
+# - auto: infer from endpoint; prefers local Voxtral-compatible servers
+# - vllm: self-hosted OpenAI-compatible server, defaults to mistralai/Voxtral-Mini-3B-2507
+# - mistral: Mistral hosted API, defaults to voxtral-mini-latest
+# - openai: OpenAI hosted API, defaults to whisper-1
+# - generic: generic OpenAI-compatible endpoint, defaults to mistralai/Voxtral-Mini-3B-2507
+# remote_provider = "auto"
+#
+# Model name to send to remote server.
+# If unset, the provider preset selects a sensible default.
+# remote_model = "mistralai/Voxtral-Mini-3B-2507"
 #
 # API key for remote server (optional, or use VOXTYPE_WHISPER_API_KEY env var)
 # remote_api_key = ""
@@ -713,6 +724,23 @@ pub enum WhisperMode {
     Cli,
 }
 
+/// Remote API provider preset for OpenAI-compatible transcription backends.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteProvider {
+    /// Infer provider from endpoint and prefer self-hosted Voxtral-compatible backends.
+    #[default]
+    Auto,
+    /// Self-hosted vLLM or similar OpenAI-compatible server serving Voxtral.
+    Vllm,
+    /// Mistral hosted speech-to-text API.
+    Mistral,
+    /// OpenAI hosted Whisper API.
+    OpenAi,
+    /// Generic OpenAI-compatible server.
+    Generic,
+}
+
 /// Language configuration supporting single language or array of allowed languages
 ///
 /// Supports three modes:
@@ -876,9 +904,14 @@ pub struct WhisperConfig {
     #[serde(default)]
     pub remote_endpoint: Option<String>,
 
-    /// Model name to send to remote server (default: "whisper-1")
+    /// Model name to send to remote server. When unset, the remote provider
+    /// preset selects a sensible default.
     #[serde(default)]
     pub remote_model: Option<String>,
+
+    /// Remote provider preset used for default model selection.
+    #[serde(default)]
+    pub remote_provider: Option<RemoteProvider>,
 
     /// API key for remote server (optional, can also use VOXTYPE_WHISPER_API_KEY env var)
     #[serde(default)]
@@ -946,6 +979,7 @@ impl Default for WhisperConfig {
             cold_model_timeout_secs: default_cold_model_timeout(),
             remote_endpoint: None,
             remote_model: None,
+            remote_provider: None,
             remote_api_key: None,
             remote_timeout_secs: None,
             whisper_cli_path: None,
@@ -1823,6 +1857,7 @@ impl Default for Config {
                 cold_model_timeout_secs: default_cold_model_timeout(),
                 remote_endpoint: None,
                 remote_model: None,
+                remote_provider: None,
                 remote_api_key: None,
                 remote_timeout_secs: None,
                 whisper_cli_path: None,
@@ -2149,6 +2184,31 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     // Remote whisper
     if let Ok(endpoint) = std::env::var("VOXTYPE_REMOTE_ENDPOINT") {
         config.whisper.remote_endpoint = Some(endpoint);
+    }
+    if let Ok(model) = std::env::var("VOXTYPE_REMOTE_MODEL") {
+        let trimmed = model.trim();
+        if !trimmed.is_empty() {
+            config.whisper.remote_model = Some(trimmed.to_string());
+        }
+    }
+    if let Ok(provider) = std::env::var("VOXTYPE_REMOTE_PROVIDER") {
+        let trimmed = provider.trim().to_lowercase();
+        if !trimmed.is_empty() {
+            config.whisper.remote_provider = Some(match trimmed.as_str() {
+                "auto" => RemoteProvider::Auto,
+                "vllm" => RemoteProvider::Vllm,
+                "mistral" => RemoteProvider::Mistral,
+                "openai" => RemoteProvider::OpenAi,
+                "generic" => RemoteProvider::Generic,
+                other => {
+                    tracing::warn!(
+                        "Ignoring invalid VOXTYPE_REMOTE_PROVIDER '{}'; expected auto, vllm, mistral, openai, or generic",
+                        other
+                    );
+                    config.whisper.remote_provider.unwrap_or_default()
+                }
+            });
+        }
     }
     if let Ok(key) = std::env::var("VOXTYPE_WHISPER_API_KEY") {
         config.whisper.remote_api_key = Some(key);
@@ -3005,6 +3065,34 @@ mod tests {
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.whisper.mode, Some(WhisperMode::Remote));
         assert_eq!(config.whisper.effective_mode(), WhisperMode::Remote);
+    }
+
+    #[test]
+    fn test_parse_remote_provider_mistral() {
+        let toml_str = r#"
+            [hotkey]
+            key = "SCROLLLOCK"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            mode = "remote"
+            language = "en"
+            remote_endpoint = "https://api.mistral.ai"
+            remote_provider = "mistral"
+
+            [output]
+            mode = "type"
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.whisper.remote_provider,
+            Some(RemoteProvider::Mistral)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,22 @@ async fn main() -> anyhow::Result<()> {
     if let Some(endpoint) = cli.remote_endpoint {
         config.whisper.remote_endpoint = Some(endpoint);
     }
+    if let Some(provider) = cli.remote_provider {
+        match provider.to_lowercase().as_str() {
+            "auto" => config.whisper.remote_provider = Some(config::RemoteProvider::Auto),
+            "vllm" => config.whisper.remote_provider = Some(config::RemoteProvider::Vllm),
+            "mistral" => config.whisper.remote_provider = Some(config::RemoteProvider::Mistral),
+            "openai" => config.whisper.remote_provider = Some(config::RemoteProvider::OpenAi),
+            "generic" => config.whisper.remote_provider = Some(config::RemoteProvider::Generic),
+            _ => {
+                eprintln!(
+                    "Error: Invalid remote provider '{}'. Valid options: auto, vllm, mistral, openai, generic",
+                    provider
+                );
+                std::process::exit(1);
+            }
+        }
+    }
     if let Some(model) = cli.remote_model {
         config.whisper.remote_model = Some(model);
     }

--- a/src/transcribe/remote.rs
+++ b/src/transcribe/remote.rs
@@ -7,7 +7,7 @@
 //! configured, the first/primary language is used.
 
 use super::Transcriber;
-use crate::config::{LanguageConfig, WhisperConfig};
+use crate::config::{LanguageConfig, RemoteProvider, WhisperConfig};
 use crate::error::TranscribeError;
 use std::io::Cursor;
 use std::time::Duration;
@@ -68,10 +68,11 @@ impl RemoteTranscriber {
             .clone()
             .or_else(|| std::env::var("VOXTYPE_WHISPER_API_KEY").ok());
 
+        let provider = infer_remote_provider(config.remote_provider, &endpoint);
         let model = config
             .remote_model
             .clone()
-            .unwrap_or_else(|| "whisper-1".to_string());
+            .unwrap_or_else(|| default_model_for_provider(provider).to_string());
 
         let timeout = Duration::from_secs(config.remote_timeout_secs.unwrap_or(30));
 
@@ -85,8 +86,9 @@ impl RemoteTranscriber {
         }
 
         tracing::info!(
-            "Configured remote transcriber: endpoint={}, model={}, timeout={}s",
+            "Configured remote transcriber: endpoint={}, provider={:?}, model={}, timeout={}s",
             endpoint,
+            provider,
             model,
             timeout.as_secs()
         );
@@ -176,6 +178,32 @@ impl RemoteTranscriber {
         body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
 
         (boundary, body)
+    }
+}
+
+fn infer_remote_provider(configured: Option<RemoteProvider>, endpoint: &str) -> RemoteProvider {
+    if let Some(provider) = configured {
+        return provider;
+    }
+
+    let normalized = endpoint.trim().to_lowercase();
+    if normalized.contains("api.openai.com") {
+        return RemoteProvider::OpenAi;
+    }
+    if normalized.contains("api.mistral.ai") {
+        return RemoteProvider::Mistral;
+    }
+
+    RemoteProvider::Vllm
+}
+
+fn default_model_for_provider(provider: RemoteProvider) -> &'static str {
+    match provider {
+        RemoteProvider::OpenAi => "whisper-1",
+        RemoteProvider::Mistral => "voxtral-mini-latest",
+        RemoteProvider::Vllm | RemoteProvider::Generic | RemoteProvider::Auto => {
+            "mistralai/Voxtral-Mini-3B-2507"
+        }
     }
 }
 
@@ -427,5 +455,68 @@ mod tests {
 
         let transcriber = RemoteTranscriber::new(&config).unwrap();
         assert_eq!(transcriber.timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_default_provider_and_model_for_local_endpoint_prefers_voxtral() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://127.0.0.1:8000".to_string()),
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        assert_eq!(
+            infer_remote_provider(None, "http://127.0.0.1:8000"),
+            RemoteProvider::Vllm
+        );
+        assert_eq!(transcriber.model, "mistralai/Voxtral-Mini-3B-2507");
+    }
+
+    #[test]
+    fn test_openai_endpoint_defaults_to_whisper_1() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("https://api.openai.com".to_string()),
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        assert_eq!(
+            infer_remote_provider(None, "https://api.openai.com"),
+            RemoteProvider::OpenAi
+        );
+        assert_eq!(transcriber.model, "whisper-1");
+    }
+
+    #[test]
+    fn test_explicit_mistral_provider_defaults_to_voxtral_latest() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("https://gateway.example.com".to_string()),
+            remote_provider: Some(RemoteProvider::Mistral),
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        assert_eq!(
+            infer_remote_provider(Some(RemoteProvider::Mistral), "https://gateway.example.com"),
+            RemoteProvider::Mistral
+        );
+        assert_eq!(transcriber.model, "voxtral-mini-latest");
+    }
+
+    #[test]
+    fn test_explicit_remote_model_overrides_provider_default() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("https://api.mistral.ai".to_string()),
+            remote_provider: Some(RemoteProvider::Mistral),
+            remote_model: Some("custom-voxtral".to_string()),
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        assert_eq!(transcriber.model, "custom-voxtral");
     }
 }


### PR DESCRIPTION
## Summary
- add remote provider presets for OpenAI-compatible STT backends
- default remote mode to Voxtral for self-hosted/local endpoints while preserving `whisper-1` for OpenAI
- document local vLLM, Mistral API, and OpenAI config examples

## Details
- adds `remote_provider` config/env/CLI support: `auto`, `vllm`, `mistral`, `openai`, `generic`
- chooses default `remote_model` from the provider when the user does not set one explicitly
- keeps explicit `remote_model` as the override path
- adds regression tests around provider inference and remote service interoperability

## Tested
- `cargo test transcribe::remote:: -- --nocapture`
- `cargo test config::tests::test_parse_remote_provider_mistral -- --nocapture`
- `cargo test remote_client_can_call_local_service -- --nocapture`
- `cargo test language_outside_allowed_set_is_rejected -- --nocapture`

## Notes
- The local/self-hosted default is `mistralai/Voxtral-Mini-3B-2507`
- The Mistral hosted API default is `voxtral-mini-latest`
- OpenAI still defaults to `whisper-1`