### PR TITLE
Add native StatusNotifierItem system tray support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +139,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,26 +175,6 @@ checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -183,6 +183,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -308,6 +310,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
@@ -325,7 +342,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -352,7 +369,7 @@ version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ea63a92086df93893164221ad4f24142086d535b3a0957b9b9bea2dc86301"
 dependencies = [
- "clap",
+ "clap 4.5.53",
  "roff",
 ]
 
@@ -429,7 +446,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -518,7 +535,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn",
 ]
 
@@ -547,6 +564,37 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-codegen"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49da9fdfbe872d4841d56605dc42efa5e6ca3291299b87f44e1cde91a28617c"
+dependencies = [
+ "clap 2.34.0",
+ "dbus",
+ "xml-rs",
+]
+
+[[package]]
+name = "dbus-tree"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f456e698ae8e54575e19ddb1f9b7bce2298568524f215496b248eb9498b4f508"
+dependencies = [
+ "dbus",
+]
 
 [[package]]
 name = "der"
@@ -876,6 +924,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1211,6 +1268,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4934310bdd016e55725482b8d35ac0c16fd058c1b955d8959aa2d953b918c85b"
+dependencies = [
+ "dbus",
+ "dbus-codegen",
+ "dbus-tree",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1296,15 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -1606,7 +1684,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -2413,6 +2491,12 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -2462,6 +2546,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2779,6 +2872,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,6 +2998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,7 +3016,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap",
+ "clap 4.5.53",
  "clap_mangen",
  "cpal",
  "directories",
@@ -2919,6 +3024,7 @@ dependencies = [
  "evdev",
  "hound",
  "inotify 0.10.2",
+ "ksni",
  "libc",
  "ndarray 0.16.1",
  "nix 0.29.0",
@@ -3123,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
  "libc",
  "whisper-rs-sys",
@@ -3133,14 +3239,15 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cfg-if",
  "cmake",
  "fs_extra",
+ "semver",
 ]
 
 [[package]]
@@ -3285,6 +3392,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3673,6 +3789,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xtask"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ tempfile = "3"
 rodio = { version = "0.19", default-features = false, features = ["wav"] }
 
 # Whisper speech-to-text
-whisper-rs = "0.15.1"
+whisper-rs = "0.16.0"
 
 # Parakeet speech-to-text (optional, ONNX-based)
 parakeet-rs = { version = "0.3", optional = true }
@@ -84,6 +84,9 @@ notify = "6"
 # Single instance check
 pidlock = "0.1"
 
+# System tray (StatusNotifierItem via DBus)
+ksni = { version = "0.2", optional = true }
+
 # Meeting mode (Pro feature)
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -91,6 +94,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 
 [features]
 default = []
+tray = ["dep:ksni"]
 gpu-vulkan = ["whisper-rs/vulkan"]
 gpu-cuda = ["whisper-rs/cuda"]
 gpu-metal = ["whisper-rs/metal"]

--- a/Dockerfile.avx512
+++ b/Dockerfile.avx512
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libasound2-dev \
+    libdbus-1-dev \
     git \
     binutils \
     && rm -rf /var/lib/apt/lists/*
@@ -35,7 +36,7 @@ COPY . .
 # Build with native optimizations (will use AVX-512 if available on host)
 ENV RUSTFLAGS="-C target-cpu=native"
 
-RUN cargo build --release \
+RUN cargo build --release --features tray \
     && cp target/release/voxtype /tmp/voxtype-avx512
 
 # Verify AVX-512 instructions ARE present

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libasound2-dev \
+    libdbus-1-dev \
     git \
     binutils \
     && rm -rf /var/lib/apt/lists/*
@@ -54,7 +55,7 @@ ENV CMAKE_C_FLAGS="-mno-avx512f -mno-avx512vl -mno-avx512bw -mno-avx512dq -mno-a
 ENV CMAKE_CXX_FLAGS="-mno-avx512f -mno-avx512vl -mno-avx512bw -mno-avx512dq -mno-avx512cd -mno-gfni -mno-avxvnni"
 
 # Build AVX2 binary
-RUN cargo build --release \
+RUN cargo build --release --features tray \
     && cp target/release/voxtype /tmp/voxtype-avx2
 
 # Verify no AVX-512 or GFNI instructions

--- a/Dockerfile.onnx
+++ b/Dockerfile.onnx
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libasound2-dev \
+    libdbus-1-dev \
     libssl-dev \
     protobuf-compiler \
     libprotobuf-dev \
@@ -62,7 +63,7 @@ ENV ORT_STRATEGY=download
 
 # Disable LTO for faster builds (can hang on TrueNAS)
 # Build with all ONNX engines
-RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual \
+RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,tray \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-avx2

--- a/Dockerfile.onnx-avx512
+++ b/Dockerfile.onnx-avx512
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libasound2-dev \
+    libdbus-1-dev \
     libssl-dev \
     protobuf-compiler \
     libprotobuf-dev \
@@ -48,7 +49,7 @@ ENV ORT_STRATEGY=download
 
 # Disable LTO for faster builds
 # Build with all ONNX engines
-RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual \
+RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,tray \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-avx512

--- a/Dockerfile.onnx-cuda
+++ b/Dockerfile.onnx-cuda
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libasound2-dev \
+    libdbus-1-dev \
     libssl-dev \
     protobuf-compiler \
     libprotobuf-dev \
@@ -49,7 +50,7 @@ ENV ORT_STRATEGY=download
 
 # Disable LTO for faster builds
 # Build with all ONNX engines + CUDA support for NVIDIA GPUs
-RUN cargo build --release --features parakeet-cuda,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda \
+RUN cargo build --release --features parakeet-cuda,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,tray \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-cuda

--- a/Dockerfile.onnx-rocm
+++ b/Dockerfile.onnx-rocm
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libasound2-dev \
+    libdbus-1-dev \
     libssl-dev \
     protobuf-compiler \
     libprotobuf-dev \
@@ -48,7 +49,7 @@ ENV ORT_STRATEGY=download
 
 # Disable LTO for faster builds
 # Build with all ONNX engines + ROCm for Parakeet (only engine with ROCm support)
-RUN cargo build --release --features parakeet-rocm,moonshine,sensevoice,paraformer,dolphin,omnilingual \
+RUN cargo build --release --features parakeet-rocm,moonshine,sensevoice,paraformer,dolphin,omnilingual,tray \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-rocm

--- a/Dockerfile.vulkan
+++ b/Dockerfile.vulkan
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libasound2-dev \
+    libdbus-1-dev \
     git \
     binutils \
     libvulkan-dev \
@@ -57,7 +58,7 @@ ENV GGML_NATIVE=ON
 
 # Build Vulkan binary (verbose to show progress)
 # Override Cargo.toml's LTO settings to prevent linking hangs
-RUN cargo build --release --features gpu-vulkan \
+RUN cargo build --release --features gpu-vulkan,tray \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     -vv 2>&1 | tee /tmp/build.log \

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2344,6 +2344,27 @@ voxtype status --format json --icon-theme nerd-font
 
 ---
 
+## [tray]
+
+System tray icon via StatusNotifierItem (DBus). Disabled by default.
+
+Requires building with `--features tray` (included in release binaries) and a StatusNotifierHost (KDE Plasma, GNOME with AppIndicator extension, Waybar with tray module).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Show system tray icon |
+
+**Environment variable:** `VOXTYPE_TRAY_ENABLED=true`
+
+**CLI flag:** `--tray`
+
+```toml
+[tray]
+enabled = true
+```
+
+---
+
 ## Environment Variables
 
 ### RUST_LOG

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -23,6 +23,7 @@ Voxtype is a push-to-talk voice-to-text tool for Linux. Optimized for Wayland, w
 - [Profiles](#profiles)
 - [Voice Activity Detection](#voice-activity-detection)
 - [Meeting Mode](#meeting-mode)
+- [System Tray](#system-tray)
 - [Tips & Best Practices](#tips--best-practices)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
 - [Integration Examples](#integration-examples)
@@ -1957,6 +1958,57 @@ The GTCRN model (~523 KB) is downloaded automatically the first time you run `vo
 [meeting.audio]
 echo_cancel = "disabled"
 ```
+
+---
+
+## System Tray
+
+Voxtype can show a system tray icon that reflects the current state and lets you control recording.
+
+### Setup
+
+Enable the tray in your config:
+
+```toml
+[tray]
+enabled = true
+```
+
+Or use the CLI flag: `voxtype --tray`
+
+Or set the environment variable: `VOXTYPE_TRAY_ENABLED=true`
+
+### Requirements
+
+The tray uses the StatusNotifierItem (SNI) DBus protocol. You need a StatusNotifierHost:
+
+- **KDE Plasma**: Built-in support
+- **GNOME**: Install the AppIndicator extension
+- **Waybar**: Enable the `tray` module in your Waybar config
+- **Other**: Any compositor/panel that supports SNI
+
+### Usage
+
+- **Left-click**: Toggle recording on/off
+- **Right-click**: Context menu with Toggle Recording, Cancel (during transcription), and Quit
+
+### Icons
+
+The tray uses XDG named icons:
+
+| State | Icon |
+|-------|------|
+| Idle | `microphone-sensitivity-high` |
+| Recording | `media-record` |
+| Transcribing | `content-loading-symbolic` |
+
+### Troubleshooting
+
+If the tray icon doesn't appear:
+
+1. Verify `DBUS_SESSION_BUS_ADDRESS` is set (required for SNI)
+2. Check that your panel/compositor has a StatusNotifierHost
+3. Run with `-vv` to see tray-related log messages
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -258,6 +258,12 @@ pub struct Cli {
     #[arg(long, value_name = "CMD", help_heading = "Output")]
     pub pre_recording_command: Option<String>,
 
+    // -- Tray --
+
+    /// Enable system tray icon (StatusNotifierItem)
+    #[arg(long, help_heading = "Tray")]
+    pub tray: bool,
+
     // -- VAD --
 
     /// Enable Voice Activity Detection (filter silence before transcription)

--- a/src/config.rs
+++ b/src/config.rs
@@ -264,6 +264,12 @@ on_transcription = true
 # transcribing = "⏳"
 # stopped = ""
 
+# [tray]
+# System tray icon via StatusNotifierItem (DBus)
+# Requires building with --features tray (included in release binaries)
+# Requires a StatusNotifierHost (KDE Plasma, GNOME with AppIndicator, Waybar tray module)
+# enabled = false
+
 # [profiles]
 # Named profiles for context-specific post-processing
 # Use with: voxtype record start --profile slack
@@ -349,11 +355,29 @@ pub struct Config {
     #[serde(default = "default_state_file")]
     pub state_file: Option<String>,
 
+    /// System tray configuration
+    #[serde(default)]
+    pub tray: TrayConfig,
+
     /// Named profiles for context-specific settings
     /// Example: [profiles.slack], [profiles.code]
     /// Use with: `voxtype record start --profile slack`
     #[serde(default)]
     pub profiles: HashMap<String, Profile>,
+}
+
+/// System tray (StatusNotifierItem) configuration
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TrayConfig {
+    /// Enable the system tray icon (default: false)
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for TrayConfig {
+    fn default() -> Self {
+        Self { enabled: false }
+    }
 }
 
 /// Hotkey detection configuration
@@ -1793,6 +1817,7 @@ impl Default for Config {
             vad: VadConfig::default(),
             status: StatusConfig::default(),
             meeting: MeetingConfig::default(),
+            tray: TrayConfig::default(),
             state_file: Some("auto".to_string()),
             profiles: HashMap::new(),
         }
@@ -2094,6 +2119,11 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     }
     if let Ok(val) = std::env::var("VOXTYPE_SMART_AUTO_SUBMIT") {
         config.text.smart_auto_submit = parse_bool_env(&val);
+    }
+
+    // Tray
+    if let Ok(val) = std::env::var("VOXTYPE_TRAY_ENABLED") {
+        config.tray.enabled = parse_bool_env(&val);
     }
 
     Ok(config)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2873,14 +2873,22 @@ impl Daemon {
                 }
 
                 // Handle system tray events (pending forever when tray feature is not enabled)
-                Some(tray_event) = async {
+                tray_event = async {
                     match &mut tray_event_rx {
                         Some(rx) => rx.recv().await,
                         None => std::future::pending::<Option<DaemonTrayEvent>>().await,
                     }
                 } => {
-                    if self.handle_tray_event(tray_event, &mut state, &mut audio_capture, &transcriber_preloaded).await {
-                        break;
+                    match tray_event {
+                        Some(event) => {
+                            if self.handle_tray_event(event, &mut state, &mut audio_capture, &transcriber_preloaded).await {
+                                break;
+                            }
+                        }
+                        None => {
+                            tracing::warn!("Tray event channel closed");
+                            tray_event_rx = None;
+                        }
                     }
                 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -466,6 +466,14 @@ fn cleanup_model_override() {
 /// Result type for transcription task
 type TranscriptionResult = std::result::Result<String, crate::error::TranscribeError>;
 
+/// Tray event type used in the select loop.
+/// When the tray feature is enabled, this wraps the real TrayEvent.
+/// When disabled, this is a unit struct that can never be constructed.
+#[cfg(feature = "tray")]
+type DaemonTrayEvent = crate::tray::TrayEvent;
+#[cfg(not(feature = "tray"))]
+type DaemonTrayEvent = std::convert::Infallible;
+
 /// Main daemon that orchestrates all components
 pub struct Daemon {
     config: Config,
@@ -506,6 +514,9 @@ pub struct Daemon {
     // GTCRN speech enhancer for mic echo cancellation
     #[cfg(feature = "onnx-common")]
     speech_enhancer: Option<std::sync::Arc<audio::enhance::GtcrnEnhancer>>,
+    // System tray state sender
+    #[cfg(feature = "tray")]
+    tray_state_tx: Option<tokio::sync::watch::Sender<crate::tray::TrayState>>,
 }
 
 impl Daemon {
@@ -601,6 +612,8 @@ impl Daemon {
             meeting_event_rx: None,
             #[cfg(feature = "onnx-common")]
             speech_enhancer: None,
+            #[cfg(feature = "tray")]
+            tray_state_tx: None,
         }
     }
 
@@ -611,10 +624,20 @@ impl Daemon {
         }
     }
 
-    /// Update the state file if configured
+    /// Update the state file if configured, and notify tray
     fn update_state(&self, state_name: &str) {
         if let Some(ref path) = self.state_file_path {
             write_state_file(path, state_name);
+        }
+
+        #[cfg(feature = "tray")]
+        if let Some(ref tx) = self.tray_state_tx {
+            let tray_state = match state_name {
+                "recording" => crate::tray::TrayState::Recording,
+                "transcribing" => crate::tray::TrayState::Transcribing,
+                _ => crate::tray::TrayState::Idle,
+            };
+            let _ = tx.send(tray_state);
         }
     }
 
@@ -1461,6 +1484,242 @@ impl Daemon {
         }
     }
 
+    /// Handle a single tray event. Returns `true` if the daemon should quit.
+    #[cfg(feature = "tray")]
+    async fn handle_tray_event(
+        &mut self,
+        event: crate::tray::TrayEvent,
+        state: &mut State,
+        audio_capture: &mut Option<Box<dyn AudioCapture>>,
+        transcriber_preloaded: &Option<Arc<dyn Transcriber>>,
+    ) -> bool {
+        use crate::tray::TrayEvent;
+
+        match event {
+            TrayEvent::ToggleRecording => {
+                tracing::debug!("Tray: toggle recording");
+                if state.is_idle() {
+                    tracing::info!("Recording started (tray toggle)");
+
+                    if self.config.output.notification.on_recording_start {
+                        send_notification(
+                            "Recording Started",
+                            "Tray toggle",
+                            self.config.output.notification.show_engine_icon,
+                            self.config.engine,
+                        )
+                        .await;
+                    }
+
+                    if self.config.on_demand_loading() {
+                        match self.config.engine {
+                            crate::config::TranscriptionEngine::Whisper => {
+                                let config = self.config.whisper.clone();
+                                let config_path = self.config_path.clone();
+                                self.model_load_task =
+                                    Some(tokio::task::spawn_blocking(move || {
+                                        let mut temp_manager =
+                                            ModelManager::new(&config, config_path);
+                                        temp_manager.get_transcriber(None)
+                                    }));
+                            }
+                            crate::config::TranscriptionEngine::Parakeet
+                            | crate::config::TranscriptionEngine::Moonshine
+                            | crate::config::TranscriptionEngine::SenseVoice
+                            | crate::config::TranscriptionEngine::Paraformer
+                            | crate::config::TranscriptionEngine::Dolphin
+                            | crate::config::TranscriptionEngine::Omnilingual => {
+                                let config = self.config.clone();
+                                self.model_load_task =
+                                    Some(tokio::task::spawn_blocking(move || {
+                                        crate::transcribe::create_transcriber(&config)
+                                            .map(Arc::from)
+                                    }));
+                            }
+                        }
+                    } else {
+                        match self.config.engine {
+                            crate::config::TranscriptionEngine::Whisper => {
+                                if let Some(ref mut mm) = self.model_manager {
+                                    if let Err(e) = mm.prepare_model(None) {
+                                        tracing::warn!("Failed to prepare model: {}", e);
+                                    }
+                                }
+                            }
+                            crate::config::TranscriptionEngine::Parakeet
+                            | crate::config::TranscriptionEngine::Moonshine
+                            | crate::config::TranscriptionEngine::SenseVoice
+                            | crate::config::TranscriptionEngine::Paraformer
+                            | crate::config::TranscriptionEngine::Dolphin
+                            | crate::config::TranscriptionEngine::Omnilingual => {
+                                if let Some(ref t) = transcriber_preloaded {
+                                    let transcriber = t.clone();
+                                    tokio::task::spawn_blocking(move || {
+                                        transcriber.prepare();
+                                    });
+                                }
+                            }
+                        }
+                    }
+
+                    match audio::create_capture(&self.config.audio) {
+                        Ok(mut capture) => {
+                            if let Err(e) = capture.start().await {
+                                tracing::error!("Failed to start audio: {}", e);
+                            } else {
+                                *audio_capture = Some(capture);
+
+                                if self.config.whisper.eager_processing {
+                                    tracing::info!("Using eager input processing");
+                                    *state = State::EagerRecording {
+                                        started_at: std::time::Instant::now(),
+                                        model_override: None,
+                                        accumulated_audio: Vec::new(),
+                                        chunks_sent: 0,
+                                        chunk_results: Vec::new(),
+                                        tasks_in_flight: 0,
+                                    };
+                                } else {
+                                    *state = State::Recording {
+                                        started_at: std::time::Instant::now(),
+                                        model_override: None,
+                                    };
+                                }
+                                self.update_state("recording");
+                                self.play_feedback(SoundEvent::RecordingStart);
+
+                                // Run pre-recording hook
+                                if let Some(cmd) = &self.config.output.pre_recording_command {
+                                    if let Err(e) = output::run_hook(cmd, "pre_recording").await {
+                                        tracing::warn!("{}", e);
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to create audio capture: {}", e);
+                            self.play_feedback(SoundEvent::Error);
+                        }
+                    }
+                } else if let State::Recording {
+                    model_override, ..
+                } = state
+                {
+                    let transcriber = match self
+                        .get_transcriber_for_recording(
+                            model_override.as_deref(),
+                            transcriber_preloaded,
+                        )
+                        .await
+                    {
+                        Ok(t) => Some(t),
+                        Err(()) => {
+                            *state = State::Idle;
+                            self.update_state("idle");
+                            return false;
+                        }
+                    };
+
+                    self.start_transcription_task(state, audio_capture, transcriber)
+                        .await;
+                } else if state.is_eager_recording() {
+                    // Stop eager recording (same path as SIGUSR2 eager stop)
+                    let model_override = match state {
+                        State::EagerRecording { model_override, .. } => model_override.clone(),
+                        _ => None,
+                    };
+
+                    let duration = state.recording_duration().unwrap_or_default();
+                    tracing::info!(
+                        "Eager recording stopped via tray ({:.1}s)",
+                        duration.as_secs_f32()
+                    );
+
+                    self.play_feedback(SoundEvent::RecordingStop);
+
+                    if self.config.output.notification.on_recording_stop {
+                        send_notification(
+                            "Recording Stopped",
+                            "Transcribing...",
+                            self.config.output.notification.show_engine_icon,
+                            self.config.engine,
+                        )
+                        .await;
+                    }
+
+                    if let Some(mut capture) = audio_capture.take() {
+                        if let Ok(final_samples) = capture.stop().await {
+                            if let State::EagerRecording {
+                                accumulated_audio, ..
+                            } = state
+                            {
+                                accumulated_audio.extend(final_samples);
+                            }
+                        }
+                    }
+
+                    let transcriber = match self
+                        .get_transcriber_for_recording(
+                            model_override.as_deref(),
+                            transcriber_preloaded,
+                        )
+                        .await
+                    {
+                        Ok(t) => t,
+                        Err(()) => {
+                            *state = State::Idle;
+                            self.update_state("idle");
+                            return false;
+                        }
+                    };
+
+                    self.update_state("transcribing");
+
+                    if let Some(text) =
+                        self.finish_eager_recording(state, transcriber).await
+                    {
+                        *state = State::Transcribing { audio: Vec::new() };
+                        self.handle_transcription_result(state, Ok(Ok(text)))
+                            .await;
+                    } else {
+                        tracing::debug!("Eager recording produced empty result");
+                        self.reset_to_idle(state).await;
+                    }
+                }
+            }
+            TrayEvent::CancelTranscription => {
+                tracing::debug!("Tray: cancel transcription");
+                if matches!(state, State::Transcribing { .. }) {
+                    if let Some(task) = self.transcription_task.take() {
+                        task.abort();
+                    }
+                    tracing::info!("Transcription cancelled (tray)");
+                    self.play_feedback(SoundEvent::Cancelled);
+                    self.reset_to_idle(state).await;
+                }
+            }
+            TrayEvent::Quit => {
+                tracing::info!("Quit requested from tray, shutting down...");
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// No-op tray event handler when tray feature is not compiled in
+    #[cfg(not(feature = "tray"))]
+    async fn handle_tray_event(
+        &mut self,
+        _event: DaemonTrayEvent,
+        _state: &mut State,
+        _audio_capture: &mut Option<Box<dyn AudioCapture>>,
+        _transcriber_preloaded: &Option<Arc<dyn Transcriber>>,
+    ) -> bool {
+        // Infallible can never be constructed, so this is unreachable
+        false
+    }
+
     /// Run the daemon main loop
     pub async fn run(&mut self) -> Result<()> {
         tracing::info!("Starting voxtype daemon");
@@ -1616,6 +1875,26 @@ impl Daemon {
                 self.config.hotkey.key,
                 mode_desc
             );
+        }
+
+        // Initialize system tray if enabled
+        let mut tray_event_rx: Option<tokio::sync::mpsc::Receiver<DaemonTrayEvent>> = None;
+        #[cfg(feature = "tray")]
+        if self.config.tray.enabled {
+            match crate::tray::spawn_tray() {
+                Some((rx, tx)) => {
+                    tracing::info!("System tray enabled");
+                    tray_event_rx = Some(rx);
+                    self.tray_state_tx = Some(tx);
+                }
+                None => {
+                    tracing::warn!("Tray requested but DBus session bus unavailable");
+                }
+            }
+        }
+        #[cfg(not(feature = "tray"))]
+        if self.config.tray.enabled {
+            tracing::warn!("Tray enabled in config but binary built without tray feature");
         }
 
         // Write initial state
@@ -2590,6 +2869,18 @@ impl Daemon {
                             tracing::debug!("Meeting event channel closed");
                             self.meeting_event_rx = None;
                         }
+                    }
+                }
+
+                // Handle system tray events (pending forever when tray feature is not enabled)
+                Some(tray_event) = async {
+                    match &mut tray_event_rx {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending::<Option<DaemonTrayEvent>>().await,
+                    }
+                } => {
+                    if self.handle_tray_event(tray_event, &mut state, &mut audio_capture, &transcriber_preloaded).await {
+                        break;
                     }
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,8 @@ pub mod setup;
 pub mod state;
 pub mod text;
 pub mod transcribe;
+#[cfg(feature = "tray")]
+pub mod tray;
 pub mod vad;
 
 pub use cli::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,6 +315,18 @@ async fn main() -> anyhow::Result<()> {
         config.output.pre_recording_command = Some(cmd);
     }
 
+    // Tray override
+    if cli.tray {
+        #[cfg(feature = "tray")]
+        {
+            config.tray.enabled = true;
+        }
+        #[cfg(not(feature = "tray"))]
+        {
+            tracing::warn!("--tray flag ignored: binary built without tray feature");
+        }
+    }
+
     // VAD overrides
     if cli.vad {
         config.vad.enabled = true;

--- a/src/tray/mod.rs
+++ b/src/tray/mod.rs
@@ -1,0 +1,37 @@
+//! System tray integration via StatusNotifierItem (SNI) protocol
+//!
+//! Provides a tray icon that reflects daemon state and accepts user interaction.
+//! Requires a StatusNotifierHost (KDE Plasma, GNOME with AppIndicator extension,
+//! Waybar with tray module, etc.).
+
+mod sni;
+
+/// Tray icon state, mirroring daemon state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrayState {
+    Idle,
+    Recording,
+    Transcribing,
+}
+
+/// Events sent from the tray to the daemon
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrayEvent {
+    ToggleRecording,
+    CancelTranscription,
+    Quit,
+}
+
+/// Spawn the system tray icon.
+///
+/// Returns channels for bidirectional communication, or `None` if the tray
+/// could not be started (e.g., no DBus session bus available).
+///
+/// - `Receiver<TrayEvent>`: events from user interaction (click, menu)
+/// - `watch::Sender<TrayState>`: send state updates to the tray icon
+pub fn spawn_tray() -> Option<(
+    tokio::sync::mpsc::Receiver<TrayEvent>,
+    tokio::sync::watch::Sender<TrayState>,
+)> {
+    sni::spawn()
+}

--- a/src/tray/sni.rs
+++ b/src/tray/sni.rs
@@ -130,20 +130,20 @@ pub fn spawn() -> Option<(
 
     // Preflight: check DBus session bus is available before spawning ksni,
     // since ksni::TrayService::spawn() panics on DBus failure.
-    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_err() {
-        tracing::warn!("DBUS_SESSION_BUS_ADDRESS not set, skipping tray");
-        return None;
+    match std::env::var("DBUS_SESSION_BUS_ADDRESS") {
+        Err(_) => {
+            tracing::warn!("DBUS_SESSION_BUS_ADDRESS not set, skipping tray");
+            return None;
+        }
+        Ok(val) if val.trim().is_empty() => {
+            tracing::warn!("DBUS_SESSION_BUS_ADDRESS is empty, skipping tray");
+            return None;
+        }
+        Ok(_) => {}
     }
 
-    // Start the ksni service (runs its own event loop on a separate thread)
-    let service = ksni::TrayService::new(tray);
-
-    let handle = service.handle();
-    service.spawn();
-
-    // Dedicated thread to bridge std::sync::mpsc -> tokio::sync::mpsc.
-    // ksni callbacks run on ksni's thread, so they use std::sync::mpsc.
-    // This thread blocks on recv() and forwards to the tokio channel.
+    // Spawn the bridge thread first, before ksni service, so we don't
+    // leave an orphaned tray icon if thread creation fails.
     if std::thread::Builder::new()
         .name("tray-event-bridge".to_string())
         .spawn(move || {
@@ -158,6 +158,11 @@ pub fn spawn() -> Option<(
         tracing::warn!("Failed to spawn tray event bridge thread");
         return None;
     }
+
+    // Start the ksni service (runs its own event loop on a separate thread)
+    let service = ksni::TrayService::new(tray);
+    let handle = service.handle();
+    service.spawn();
 
     // Task: watch for state changes and update the tray
     tokio::spawn(async move {

--- a/src/tray/sni.rs
+++ b/src/tray/sni.rs
@@ -1,0 +1,178 @@
+//! StatusNotifierItem implementation using ksni
+
+use super::{TrayEvent, TrayState};
+use std::sync::{Arc, Mutex};
+
+/// Mutable state shared with ksni callbacks (runs on ksni's thread).
+/// Only `state` needs the mutex — it's updated from the tokio watcher task.
+struct SharedState {
+    state: TrayState,
+}
+
+struct VoxtypeTray {
+    shared: Arc<Mutex<SharedState>>,
+    /// Event sender lives outside the mutex — it's Clone+Send and never mutated.
+    event_tx: std::sync::mpsc::Sender<TrayEvent>,
+}
+
+impl VoxtypeTray {
+    fn send_event(&self, event: TrayEvent) {
+        let _ = self.event_tx.send(event);
+    }
+}
+
+impl ksni::Tray for VoxtypeTray {
+    fn id(&self) -> String {
+        "voxtype".to_string()
+    }
+
+    fn title(&self) -> String {
+        "Voxtype".to_string()
+    }
+
+    fn category(&self) -> ksni::Category {
+        ksni::Category::ApplicationStatus
+    }
+
+    fn icon_name(&self) -> String {
+        let state = self.shared.lock().unwrap().state;
+        match state {
+            TrayState::Idle => "microphone-sensitivity-high".to_string(),
+            TrayState::Recording => "media-record".to_string(),
+            TrayState::Transcribing => "content-loading-symbolic".to_string(),
+        }
+    }
+
+    fn tool_tip(&self) -> ksni::ToolTip {
+        let state = self.shared.lock().unwrap().state;
+        let description = match state {
+            TrayState::Idle => "Voxtype: Ready",
+            TrayState::Recording => "Voxtype: Recording...",
+            TrayState::Transcribing => "Voxtype: Transcribing...",
+        };
+        ksni::ToolTip {
+            title: description.to_string(),
+            description: String::new(),
+            icon_name: String::new(),
+            icon_pixmap: Vec::new(),
+        }
+    }
+
+    fn activate(&mut self, _x: i32, _y: i32) {
+        self.send_event(TrayEvent::ToggleRecording);
+    }
+
+    fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
+        let state = self.shared.lock().unwrap().state;
+
+        let status_label = match state {
+            TrayState::Idle => "Status: Idle",
+            TrayState::Recording => "Status: Recording",
+            TrayState::Transcribing => "Status: Transcribing",
+        };
+
+        vec![
+            ksni::MenuItem::Standard(ksni::menu::StandardItem {
+                label: "Toggle Recording".to_string(),
+                activate: Box::new(|tray: &mut Self| {
+                    tray.send_event(TrayEvent::ToggleRecording);
+                }),
+                ..Default::default()
+            }),
+            ksni::MenuItem::Standard(ksni::menu::StandardItem {
+                label: "Cancel".to_string(),
+                enabled: state == TrayState::Transcribing,
+                activate: Box::new(|tray: &mut Self| {
+                    tray.send_event(TrayEvent::CancelTranscription);
+                }),
+                ..Default::default()
+            }),
+            ksni::MenuItem::Separator,
+            ksni::MenuItem::Standard(ksni::menu::StandardItem {
+                label: status_label.to_string(),
+                enabled: false,
+                ..Default::default()
+            }),
+            ksni::MenuItem::Separator,
+            ksni::MenuItem::Standard(ksni::menu::StandardItem {
+                label: "Quit".to_string(),
+                activate: Box::new(|tray: &mut Self| {
+                    tray.send_event(TrayEvent::Quit);
+                }),
+                ..Default::default()
+            }),
+        ]
+    }
+}
+
+/// Spawn the tray service and return communication channels.
+///
+/// Returns `None` if the tray service fails to start (e.g., no DBus session bus).
+pub fn spawn() -> Option<(
+    tokio::sync::mpsc::Receiver<TrayEvent>,
+    tokio::sync::watch::Sender<TrayState>,
+)> {
+    // Channels: daemon <-> tray
+    let (state_tx, mut state_rx) = tokio::sync::watch::channel(TrayState::Idle);
+    let (event_tx, event_rx) = tokio::sync::mpsc::channel::<TrayEvent>(8);
+
+    // Bridge channel: ksni thread (std::sync) -> tokio task -> tokio mpsc
+    let (std_event_tx, std_event_rx) = std::sync::mpsc::channel::<TrayEvent>();
+
+    let shared = Arc::new(Mutex::new(SharedState {
+        state: TrayState::Idle,
+    }));
+
+    let tray = VoxtypeTray {
+        shared: shared.clone(),
+        event_tx: std_event_tx,
+    };
+
+    // Preflight: check DBus session bus is available before spawning ksni,
+    // since ksni::TrayService::spawn() panics on DBus failure.
+    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_err() {
+        tracing::warn!("DBUS_SESSION_BUS_ADDRESS not set, skipping tray");
+        return None;
+    }
+
+    // Start the ksni service (runs its own event loop on a separate thread)
+    let service = ksni::TrayService::new(tray);
+
+    let handle = service.handle();
+    service.spawn();
+
+    // Dedicated thread to bridge std::sync::mpsc -> tokio::sync::mpsc.
+    // ksni callbacks run on ksni's thread, so they use std::sync::mpsc.
+    // This thread blocks on recv() and forwards to the tokio channel.
+    if std::thread::Builder::new()
+        .name("tray-event-bridge".to_string())
+        .spawn(move || {
+            while let Ok(event) = std_event_rx.recv() {
+                if event_tx.blocking_send(event).is_err() {
+                    break; // receiver dropped, daemon shutting down
+                }
+            }
+        })
+        .is_err()
+    {
+        tracing::warn!("Failed to spawn tray event bridge thread");
+        return None;
+    }
+
+    // Task: watch for state changes and update the tray
+    tokio::spawn(async move {
+        while state_rx.changed().await.is_ok() {
+            let new_state = *state_rx.borrow();
+            {
+                let mut s = shared.lock().unwrap();
+                s.state = new_state;
+            }
+            handle.update(|_tray| {
+                // The tray reads from shared state, so just triggering
+                // an update is enough to refresh icon/tooltip/menu
+            });
+        }
+    });
+
+    Some((event_rx, state_tx))
+}


### PR DESCRIPTION
## Summary

- Add opt-in system tray icon via StatusNotifierItem (SNI) DBus protocol using `ksni` crate
- Tray shows daemon state (idle/recording/transcribing) with XDG named icons, left-click toggles recording, right-click context menu with toggle/cancel/quit
- New `tray` Cargo feature flag, `[tray] enabled` config option, `--tray` CLI flag, `VOXTYPE_TRAY_ENABLED` env var — disabled by default, gracefully degrades without DBus
- Upgrades whisper-rs 0.15.1 → 0.16.0 to fix bindgen failures with clang 22 / glibc 2.43
- All 7 release Dockerfiles updated with `libdbus-1-dev` and `--features tray`
- Documentation added to CONFIGURATION.md and USER_MANUAL.md

## Test plan

- [ ] `cargo build` (without tray feature) compiles clean
- [ ] `cargo build --features tray` compiles clean
- [ ] `cargo test --features tray` passes all tests
- [ ] Run with `--tray -vv` on KDE/GNOME/Waybar — verify tray icon appears
- [ ] Left-click toggles recording, icon changes between states
- [ ] Right-click menu: Toggle Recording, Cancel (grayed unless transcribing), Quit
- [ ] Quit from tray shuts down daemon cleanly
- [ ] `DBUS_SESSION_BUS_ADDRESS=""` — logs warning, runs without tray
- [ ] Without `[tray]` in config — no tray icon appears
- [ ] `--tray` without feature compiled — logs warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)