### PR TITLE
Add post-processing to meeting mode and dictation context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,26 +155,6 @@ checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -183,6 +163,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -429,7 +411,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -3123,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
  "libc",
  "whisper-rs-sys",
@@ -3133,14 +3115,15 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cfg-if",
  "cmake",
  "fs_extra",
+ "semver",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ tempfile = "3"
 rodio = { version = "0.19", default-features = false, features = ["wav"] }
 
 # Whisper speech-to-text
-whisper-rs = "0.15.1"
+whisper-rs = "0.16.0"
 
 # Parakeet speech-to-text (optional, ONNX-based)
 parakeet-rs = { version = "0.3", optional = true }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1645,6 +1645,16 @@ command = "ollama run llama3.2:1b 'Clean up:'"
 timeout_ms = 45000  # 45 second timeout for LLM
 ```
 
+### Context from Previous Dictation
+
+When post-processing is enabled, voxtype passes the previous dictation's text via the `VOXTYPE_CONTEXT` environment variable (if the previous dictation was within 60 seconds). This helps LLM-based cleanup scripts maintain continuity across rapid-fire dictations.
+
+- Stdin always contains only the current text (existing scripts work unchanged)
+- Scripts that want context can optionally read `$VOXTYPE_CONTEXT`
+- In meeting mode, context is tracked per audio source (mic/loopback) to prevent speaker bleed
+
+See the example scripts in `examples/` for how to use `VOXTYPE_CONTEXT`.
+
 ### Error Handling
 
 If the post-processing command fails for any reason (command not found, non-zero

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1676,6 +1676,26 @@ Make it executable: `chmod +x ~/.config/voxtype/lm-studio-cleanup.sh`
 | Local LLMs (Ollama, llama.cpp) | 30000-60000ms (30-60 seconds) |
 | Remote APIs | 30000ms or higher |
 
+### Context from Previous Dictation
+
+When post-processing is enabled, voxtype automatically passes the previous dictation's text to your script via the `VOXTYPE_CONTEXT` environment variable if the previous dictation was within 60 seconds. This helps LLMs maintain continuity when you dictate in quick succession.
+
+Your script receives:
+- **Stdin**: Current text only (existing scripts work unchanged)
+- **`$VOXTYPE_CONTEXT`**: Previous dictation text (optional, read it if you want context)
+
+Example usage in a cleanup script:
+```bash
+PROMPT="Clean up this dictation:"
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  printf -v PROMPT '%s\n\nPrevious dictation for context (do NOT include in output):\n%s\n\nCurrent text to clean up:' "$PROMPT" "$VOXTYPE_CONTEXT"
+fi
+```
+
+In meeting mode, context is tracked separately for microphone and loopback audio to prevent speaker bleed.
+
+See the example scripts in `examples/` for full implementations.
+
 ### Error Handling
 
 Post-processing is designed to be fault-tolerant:

--- a/examples/gemini-cleanup.sh
+++ b/examples/gemini-cleanup.sh
@@ -29,13 +29,20 @@ if [[ -z "$INPUT" ]]; then
     exit 0
 fi
 
+# Build prompt with optional context from previous dictation
+PROMPT="Clean up this dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations:"
+
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  printf -v PROMPT '%s\n\nPrevious dictation for context (do NOT include this in your output):\n%s\n\nCurrent text to clean up:' "$PROMPT" "$VOXTYPE_CONTEXT"
+fi
+
 # Build JSON payload with jq to handle special characters
-JSON=$(jq -n --arg text "$INPUT" '{
+JSON=$(jq -n --arg text "$INPUT" --arg prompt "$PROMPT" '{
   contents: [
     {
       parts: [
         {
-          text: ("Clean up this dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations:\n\n" + $text)
+          text: ($prompt + "\n\n" + $text)
         }
       ]
     }

--- a/examples/ollama-cleanup.sh
+++ b/examples/ollama-cleanup.sh
@@ -17,10 +17,17 @@
 
 INPUT=$(cat)
 
+# Build prompt with optional context from previous dictation
+PROMPT="Clean up this dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations:"
+
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  printf -v PROMPT '%s\n\nPrevious dictation for context (do NOT include this in your output):\n%s\n\nCurrent text to clean up:' "$PROMPT" "$VOXTYPE_CONTEXT"
+fi
+
 # Build JSON payload properly with jq to handle special characters
-JSON=$(jq -n --arg text "$INPUT" '{
+JSON=$(jq -n --arg text "$INPUT" --arg prompt "$PROMPT" '{
   model: "llama3.2:1b",
-  prompt: ("Clean up this dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations:\n\n" + $text),
+  prompt: ($prompt + "\n\n" + $text),
   stream: false
 }')
 

--- a/examples/openai-cleanup.sh
+++ b/examples/openai-cleanup.sh
@@ -29,21 +29,33 @@ if [[ -z "$INPUT" ]]; then
     exit 0
 fi
 
+# Build prompt with optional context from previous dictation
+SYSTEM_PROMPT="You clean up dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations."
+
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  SYSTEM_PROMPT="${SYSTEM_PROMPT} You will receive the previous dictation for context - do NOT include it in your output, only clean up the current text."
+fi
+
 # Build JSON payload with jq to handle special characters
-JSON=$(jq -n --arg text "$INPUT" '{
-  model: "gpt-4o-mini",
-  messages: [
-    {
-      role: "system",
-      content: "You clean up dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations."
-    },
-    {
-      role: "user",
-      content: $text
-    }
-  ],
-  max_tokens: 1000
-}')
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  JSON=$(jq -n --arg text "$INPUT" --arg system "$SYSTEM_PROMPT" --arg context "$VOXTYPE_CONTEXT" '{
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: $system },
+      { role: "user", content: ("Previous dictation for context:\n" + $context + "\n\nCurrent text to clean up:\n" + $text) }
+    ],
+    max_tokens: 1000
+  }')
+else
+  JSON=$(jq -n --arg text "$INPUT" --arg system "$SYSTEM_PROMPT" '{
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: $system },
+      { role: "user", content: $text }
+    ],
+    max_tokens: 1000
+  }')
+fi
 
 # Call OpenAI API
 RESPONSE=$(curl -s --max-time 8 \

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1305,7 +1305,7 @@ impl Daemon {
                             let result = profile_processor
                                 .process_with_context(&processed_text, recent_context)
                                 .await;
-                            tracing::info!("Post-processed: {:?}", result);
+                            tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
                             result
                         } else {
                             // Profile exists but has no post_process_command, use default
@@ -1314,7 +1314,7 @@ impl Daemon {
                                 let result = post_processor
                                     .process_with_context(&processed_text, recent_context)
                                     .await;
-                                tracing::info!("Post-processed: {:?}", result);
+                                tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
                                 result
                             } else {
                                 processed_text
@@ -1325,7 +1325,7 @@ impl Daemon {
                         let result = post_processor
                             .process_with_context(&processed_text, recent_context)
                             .await;
-                        tracing::info!("Post-processed: {:?}", result);
+                        tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
                         result
                     } else {
                         processed_text

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1280,15 +1280,14 @@ impl Daemon {
                         }
                     }
 
-                    // Get context from last dictation if within 2 minutes
+                    // Get context from last dictation if within 60 seconds
                     let recent_context = self.last_dictation.as_ref().and_then(|(text, when)| {
-                        if when.elapsed() < Duration::from_secs(120) {
+                        if when.elapsed() < Duration::from_secs(60) {
                             Some(text.as_str())
                         } else {
                             None
                         }
                     });
-
                     // Apply post-processing command (profile overrides default)
                     let final_text = if let Some(profile) = active_profile {
                         if let Some(ref cmd) = profile.post_process_command {
@@ -1299,8 +1298,9 @@ impl Daemon {
                             };
                             let profile_processor = PostProcessor::new(&profile_config);
                             tracing::info!(
-                                "Post-processing with profile: {:?}",
-                                profile_override.as_ref().unwrap()
+                                "Post-processing with profile: {:?}, context: {:?}",
+                                profile_override.as_ref().unwrap(),
+                                recent_context
                             );
                             let result = profile_processor
                                 .process_with_context(&processed_text, recent_context)
@@ -1310,7 +1310,7 @@ impl Daemon {
                         } else {
                             // Profile exists but has no post_process_command, use default
                             if let Some(ref post_processor) = self.post_processor {
-                                tracing::info!("Post-processing: {:?}", processed_text);
+                                tracing::info!("Post-processing: {:?}, context: {:?}", processed_text, recent_context);
                                 let result = post_processor
                                     .process_with_context(&processed_text, recent_context)
                                     .await;
@@ -1321,7 +1321,7 @@ impl Daemon {
                             }
                         }
                     } else if let Some(ref post_processor) = self.post_processor {
-                        tracing::info!("Post-processing: {:?}", processed_text);
+                        tracing::info!("Post-processing: {:?}, context: {:?}", processed_text, recent_context);
                         let result = post_processor
                             .process_with_context(&processed_text, recent_context)
                             .await;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -20,7 +20,7 @@ use pidlock::Pidlock;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::process::Command;
 use tokio::signal::unix::{signal, SignalKind};
 
@@ -475,6 +475,8 @@ pub struct Daemon {
     audio_feedback: Option<AudioFeedback>,
     text_processor: TextProcessor,
     post_processor: Option<PostProcessor>,
+    /// Last post-processed text and when it was produced, for context in subsequent dictations
+    last_dictation: Option<(String, Instant)>,
     // Model manager for multi-model support
     model_manager: Option<ModelManager>,
     // Background task for loading model on-demand
@@ -588,6 +590,7 @@ impl Daemon {
             audio_feedback,
             text_processor,
             post_processor,
+            last_dictation: None,
             model_manager: None,
             model_load_task: None,
             transcription_task: None,
@@ -1231,7 +1234,7 @@ impl Daemon {
 
     /// Handle transcription completion (called when transcription_task completes)
     async fn handle_transcription_result(
-        &self,
+        &mut self,
         state: &mut State,
         result: std::result::Result<TranscriptionResult, tokio::task::JoinError>,
     ) {
@@ -1277,6 +1280,15 @@ impl Daemon {
                         }
                     }
 
+                    // Get context from last dictation if within 2 minutes
+                    let recent_context = self.last_dictation.as_ref().and_then(|(text, when)| {
+                        if when.elapsed() < Duration::from_secs(120) {
+                            Some(text.as_str())
+                        } else {
+                            None
+                        }
+                    });
+
                     // Apply post-processing command (profile overrides default)
                     let final_text = if let Some(profile) = active_profile {
                         if let Some(ref cmd) = profile.post_process_command {
@@ -1290,14 +1302,18 @@ impl Daemon {
                                 "Post-processing with profile: {:?}",
                                 profile_override.as_ref().unwrap()
                             );
-                            let result = profile_processor.process(&processed_text).await;
+                            let result = profile_processor
+                                .process_with_context(&processed_text, recent_context)
+                                .await;
                             tracing::info!("Post-processed: {:?}", result);
                             result
                         } else {
                             // Profile exists but has no post_process_command, use default
                             if let Some(ref post_processor) = self.post_processor {
                                 tracing::info!("Post-processing: {:?}", processed_text);
-                                let result = post_processor.process(&processed_text).await;
+                                let result = post_processor
+                                    .process_with_context(&processed_text, recent_context)
+                                    .await;
                                 tracing::info!("Post-processed: {:?}", result);
                                 result
                             } else {
@@ -1306,12 +1322,18 @@ impl Daemon {
                         }
                     } else if let Some(ref post_processor) = self.post_processor {
                         tracing::info!("Post-processing: {:?}", processed_text);
-                        let result = post_processor.process(&processed_text).await;
+                        let result = post_processor
+                            .process_with_context(&processed_text, recent_context)
+                            .await;
                         tracing::info!("Post-processed: {:?}", result);
                         result
                     } else {
                         processed_text
                     };
+
+                    // Track last dictation for context in subsequent post-processing
+                    self.last_dictation =
+                        Some((final_text.clone(), Instant::now()));
 
                     if smart_submit {
                         tracing::debug!(

--- a/src/meeting/data.rs
+++ b/src/meeting/data.rs
@@ -44,7 +44,7 @@ impl std::str::FromStr for MeetingId {
 }
 
 /// Audio source for speaker attribution
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[derive(Default)]
 pub enum AudioSource {

--- a/src/meeting/mod.rs
+++ b/src/meeting/mod.rs
@@ -40,7 +40,9 @@ pub use state::{ChunkState, MeetingState};
 pub use storage::{MeetingStorage, StorageConfig, StorageError};
 
 use crate::error::{MeetingError, Result};
+use crate::output::post_process::PostProcessor;
 use crate::transcribe::{self, Transcriber};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -100,6 +102,10 @@ pub struct MeetingDaemon {
     transcriber: Option<Arc<dyn Transcriber>>,
     engine_name: String,
     event_tx: mpsc::Sender<MeetingEvent>,
+    post_processor: Option<PostProcessor>,
+    /// Previous chunk's post-processed text, tracked per audio source
+    /// so mic and loopback contexts don't bleed into each other
+    last_chunk_text: HashMap<AudioSource, String>,
 }
 
 impl MeetingDaemon {
@@ -116,6 +122,15 @@ impl MeetingDaemon {
             Arc::from(transcribe::create_transcriber(app_config)?);
         let engine_name = format!("{:?}", app_config.engine).to_lowercase();
 
+        let post_processor = app_config.output.post_process.as_ref().map(|cfg| {
+            tracing::info!(
+                "Meeting post-processing enabled: command={:?}, timeout={}ms",
+                cfg.command,
+                cfg.timeout_ms
+            );
+            PostProcessor::new(cfg)
+        });
+
         Ok(Self {
             config,
             state: MeetingState::Idle,
@@ -124,6 +139,8 @@ impl MeetingDaemon {
             transcriber: Some(transcriber),
             engine_name,
             event_tx,
+            post_processor,
+            last_chunk_text: HashMap::new(),
         })
     }
 
@@ -190,6 +207,7 @@ impl MeetingDaemon {
         }
 
         self.state = std::mem::take(&mut self.state).stop();
+        self.last_chunk_text.clear();
 
         // Finalize meeting
         if let Some(ref mut meeting) = self.current_meeting {
@@ -280,9 +298,26 @@ impl MeetingDaemon {
         let mut buffer = processor.new_buffer(chunk_id, source, start_offset_ms);
         buffer.add_samples(&samples);
 
-        let result = processor
+        let mut result = processor
             .process_chunk(buffer)
             .map_err(crate::error::VoxtypeError::Transcribe)?;
+
+        // Post-process segment text if configured
+        if let Some(ref post_processor) = self.post_processor {
+            let context = self.last_chunk_text.get(&source).map(|s| s.as_str());
+            for segment in &mut result.segments {
+                if !segment.text.is_empty() {
+                    segment.text = post_processor
+                        .process_with_context(&segment.text, context)
+                        .await;
+                }
+            }
+            // Update context for next chunk (per source)
+            if let Some(last_seg) = result.segments.last() {
+                self.last_chunk_text
+                    .insert(source, last_seg.text.clone());
+            }
+        }
 
         // Add segments to transcript
         if let Some(ref mut meeting) = self.current_meeting {

--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -36,12 +36,20 @@ impl PostProcessor {
         }
     }
 
-    /// Process text through the external command
+    /// Process text with optional context from a previous chunk
     ///
+    /// When context is provided (meeting mode), formats stdin with a separator so the
+    /// post-processing command can use previous chunk text for continuity.
     /// Returns the processed text on success, or the original text on any failure.
-    /// This ensures voice-to-text always produces output even when post-processing fails.
-    pub async fn process(&self, text: &str) -> String {
-        match self.execute_command(text).await {
+    pub async fn process_with_context(&self, text: &str, context: Option<&str>) -> String {
+        let input = match context {
+            Some(ctx) => format!(
+                "--- CONTEXT (previous chunk) ---\n{}\n--- CURRENT (clean up this text) ---\n{}",
+                ctx, text
+            ),
+            None => text.to_string(),
+        };
+        match self.execute_command(&input).await {
             Ok(processed) => {
                 if processed.is_empty() {
                     tracing::warn!(
@@ -62,6 +70,14 @@ impl PostProcessor {
                 text.to_string()
             }
         }
+    }
+
+    /// Process text through the external command
+    ///
+    /// Returns the processed text on success, or the original text on any failure.
+    /// This ensures voice-to-text always produces output even when post-processing fails.
+    pub async fn process(&self, text: &str) -> String {
+        self.process_with_context(text, None).await
     }
 
     async fn execute_command(&self, text: &str) -> Result<String, PostProcessError> {

--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -85,6 +85,8 @@ impl PostProcessor {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        // Always clear to prevent inheriting stale context from parent environment
+        cmd.env_remove("VOXTYPE_CONTEXT");
         if let Some(ctx) = context {
             cmd.env("VOXTYPE_CONTEXT", ctx);
         }

--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -38,18 +38,12 @@ impl PostProcessor {
 
     /// Process text with optional context from a previous chunk
     ///
-    /// When context is provided (meeting mode), formats stdin with a separator so the
-    /// post-processing command can use previous chunk text for continuity.
+    /// When context is provided, it is passed via the VOXTYPE_CONTEXT environment
+    /// variable so the post-processing command can use it for continuity.
+    /// Stdin always contains only the current text, keeping existing scripts compatible.
     /// Returns the processed text on success, or the original text on any failure.
     pub async fn process_with_context(&self, text: &str, context: Option<&str>) -> String {
-        let input = match context {
-            Some(ctx) => format!(
-                "--- CONTEXT (previous chunk) ---\n{}\n--- CURRENT (clean up this text) ---\n{}",
-                ctx, text
-            ),
-            None => text.to_string(),
-        };
-        match self.execute_command(&input).await {
+        match self.execute_command_with_env(text, context).await {
             Ok(processed) => {
                 if processed.is_empty() {
                     tracing::warn!(
@@ -80,13 +74,22 @@ impl PostProcessor {
         self.process_with_context(text, None).await
     }
 
-    async fn execute_command(&self, text: &str) -> Result<String, PostProcessError> {
-        // Spawn command via shell for proper parsing of complex commands
-        let mut child = Command::new("sh")
-            .args(["-c", &self.command])
+    async fn execute_command_with_env(
+        &self,
+        text: &str,
+        context: Option<&str>,
+    ) -> Result<String, PostProcessError> {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", &self.command])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        if let Some(ctx) = context {
+            cmd.env("VOXTYPE_CONTEXT", ctx);
+        }
+
+        let mut child = cmd
             .spawn()
             .map_err(|e| PostProcessError::SpawnFailed(e.to_string()))?;
 


### PR DESCRIPTION
## Summary

This PR adds post-processing support to two areas that previously lacked it:

### 1. Meeting mode post-processing (new)

Meeting mode previously skipped post-processing entirely. Now, if `[output.post_process]` is configured, each transcribed chunk is piped through the post-processing command before being stored in the transcript. Previous chunk text is passed as context so the LLM can maintain continuity across 30-second chunk boundaries.

Context is tracked per audio source (mic vs loopback) to prevent speaker bleed between channels. Context is cleared when a meeting stops so it doesn't leak into the next meeting.

### 2. Dictation mode context (new)

Regular push-to-talk dictation now passes the previous dictation's text as context to the post-processing command, if the previous dictation was within 60 seconds. This helps the LLM produce more coherent cleanup when dictating in quick succession.

The 60-second retention window is intentionally not configurable to avoid config fatigue. It covers rapid-fire dictation without leaking stale context.

### Context delivery mechanism

Context is passed via the `VOXTYPE_CONTEXT` environment variable, keeping stdin as plain current text. This means existing post-processing scripts work unchanged. Scripts that want context can optionally read `$VOXTYPE_CONTEXT`.

The env var is explicitly cleared before each command invocation to prevent inheriting stale context from the parent environment.

### Other changes

- `process()` now delegates to `process_with_context(text, None)`, removing ~20 lines of duplicated error-handling logic
- Post-processing tracing logs now include `changed: true/false` to indicate whether the command modified the text
- Example scripts (gemini, ollama, openai) updated to optionally use `$VOXTYPE_CONTEXT`
- Docs updated (CONFIGURATION.md, USER_MANUAL.md)

## Test plan

- [ ] Configure `[output.post_process]` and run a meeting, verify exported transcript shows post-processed text
- [ ] Verify post-processing failure falls back to original text
- [ ] Verify mic and loopback chunks get independent context (no speaker bleed)
- [ ] Verify context clears on meeting stop and doesn't leak to next meeting
- [ ] Verify regular dictation gets context from previous dictation within 60s
- [ ] Verify dictation context expires after 60s
- [ ] Verify existing scripts work without modification (stdin is plain text)
- [ ] Verify `VOXTYPE_CONTEXT` is not inherited from parent environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)