### PR TITLE
Bump whisper-rs to 0.16.0 for clang 22 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,26 +155,6 @@ checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -183,6 +163,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -429,7 +411,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -3123,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
  "libc",
  "whisper-rs-sys",
@@ -3133,14 +3115,15 @@ dependencies = [
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cfg-if",
  "cmake",
  "fs_extra",
+ "semver",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ tempfile = "3"
 rodio = { version = "0.19", default-features = false, features = ["wav"] }
 
 # Whisper speech-to-text
-whisper-rs = "0.15.1"
+whisper-rs = "0.16.0"
 
 # Parakeet speech-to-text (optional, ONNX-based)
 parakeet-rs = { version = "0.3", optional = true }


### PR DESCRIPTION
## Summary

- Bumps `whisper-rs` from 0.15.1 to 0.16.0, which pulls in `whisper-rs-sys` 0.15.0 and `bindgen` 0.72.1
- Fixes compilation on systems with clang/LLVM 22+ (CachyOS now, Arch mainline soon)
- No API changes required; all 25 tests pass

## Root Cause

LLVM 22 changed how Clang's AST represents struct declarations ([llvm#147835](https://github.com/llvm/llvm-project/commit/91cdd35008e9ab32dffb7e401cdd7313b3461892)). `bindgen` 0.71.x interprets forward declarations as opaque types, generating 1-byte structs instead of full definitions. This causes size assertion failures in `whisper-rs-sys` bindings for `_IO_FILE` and `whisper_full_params`.

The fix landed in [bindgen 0.72.1](https://github.com/rust-lang/rust-bindgen/pull/3278), and `whisper-rs-sys` 0.15.0 adopted it.

## Test plan

- [x] `cargo check` passes
- [x] `cargo check --features gpu-vulkan` passes
- [x] `cargo test` passes (25/25)
- [ ] Verify AUR source build works on CachyOS/clang 22

Closes #262