### PR TITLE
fix: wire eager processing into daemon recording loop

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1622,6 +1622,9 @@ impl Daemon {
         self.update_state("idle");
 
         // Main event loop
+        // Cached transcriber for eager chunk processing during recording
+        let mut eager_transcriber: Option<Arc<dyn Transcriber>> = None;
+
         loop {
             tokio::select! {
                 // Handle hotkey events (only if hotkey listener is enabled)
@@ -2087,11 +2090,26 @@ impl Daemon {
                             task.abort();
                         }
 
+                        if let State::EagerRecording {
+                            accumulated_audio,
+                            chunk_results,
+                            chunks_sent,
+                            tasks_in_flight,
+                            ..
+                        } = &mut state
+                        {
+                            accumulated_audio.clear();
+                            chunk_results.clear();
+                            *chunks_sent = 0;
+                            *tasks_in_flight = 0;
+                        }
+
                         cleanup_output_mode_override();
                         cleanup_model_override();
                         cleanup_profile_override();
                         cleanup_bool_override("smart_auto_submit");
                         state = State::Idle;
+                        eager_transcriber = None;
                         self.update_state("idle");
                         self.play_feedback(SoundEvent::Cancelled);
 
@@ -2109,6 +2127,61 @@ impl Daemon {
                         continue;
                     }
 
+                    // Populate eager transcriber cache on first poll
+                    if eager_transcriber.is_none() && state.is_eager_recording() {
+                        let model_override = match &state {
+                            State::EagerRecording { model_override, .. } => model_override.as_deref(),
+                            _ => None,
+                        };
+                        eager_transcriber = transcriber_preloaded.clone();
+                        if eager_transcriber.is_none() {
+                            // Whisper engine: get from model manager
+                            if let Some(ref mut mm) = self.model_manager {
+                                match mm.get_prepared_transcriber(model_override) {
+                                    Ok(t) => {
+                                        tracing::debug!("Created eager transcriber for chunk dispatch");
+                                        eager_transcriber = Some(t);
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!("Failed to create eager transcriber: {}", e);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if let State::EagerRecording {
+                        accumulated_audio,
+                        chunks_sent,
+                        chunk_results,
+                        tasks_in_flight,
+                        ..
+                    } = &mut state
+                    {
+                        if let Some(ref mut capture) = audio_capture {
+                            let new_samples = capture.get_samples().await;
+                            if !new_samples.is_empty() {
+                                accumulated_audio.extend(new_samples);
+                            }
+                        }
+
+                        if let Some(ref transcriber) = eager_transcriber {
+                            let transcriber = transcriber.clone();
+                            self.process_eager_chunks(
+                                accumulated_audio,
+                                chunks_sent,
+                                tasks_in_flight,
+                                &transcriber,
+                            );
+                        }
+
+                        let completed = self.poll_chunk_tasks().await;
+                        if !completed.is_empty() {
+                            *tasks_in_flight = tasks_in_flight.saturating_sub(completed.len());
+                            chunk_results.extend(completed);
+                        }
+                    }
+
                     // Check for recording timeout
                     if let Some(duration) = state.recording_duration() {
                         if duration > max_duration {
@@ -2116,11 +2189,6 @@ impl Daemon {
                                 "Recording timeout ({:.0}s limit), transcribing captured audio",
                                 max_duration.as_secs_f32()
                             );
-
-                            // Cancel any pending eager chunk tasks
-                            for (_, task) in self.eager_chunk_tasks.drain(..) {
-                                task.abort();
-                            }
 
                             cleanup_output_mode_override();
                             cleanup_model_override();
@@ -2147,12 +2215,37 @@ impl Daemon {
                                 }
                             };
 
-                            // Transcribe the captured audio
-                            self.start_transcription_task(
-                                &mut state,
-                                &mut audio_capture,
-                                transcriber,
-                            ).await;
+                            if state.is_eager_recording() {
+                                if let Some(mut capture) = audio_capture.take() {
+                                    if let Ok(final_samples) = capture.stop().await {
+                                        if let State::EagerRecording { accumulated_audio, .. } = &mut state {
+                                            accumulated_audio.extend(final_samples);
+                                        }
+                                    }
+                                }
+
+                                if let Some(transcriber) = transcriber {
+                                    self.update_state("transcribing");
+
+                                    if let Some(text) = self.finish_eager_recording(&mut state, transcriber).await {
+                                        state = State::Transcribing { audio: Vec::new() };
+                                        self.handle_transcription_result(&mut state, Ok(Ok(text))).await;
+                                    } else {
+                                        tracing::debug!("Eager recording timeout produced empty result");
+                                        self.reset_to_idle(&mut state).await;
+                                    }
+                                }
+                            } else {
+                                for (_, task) in self.eager_chunk_tasks.drain(..) {
+                                    task.abort();
+                                }
+
+                                self.start_transcription_task(
+                                    &mut state,
+                                    &mut audio_capture,
+                                    transcriber,
+                                ).await;
+                            }
                         }
                     }
                 }

--- a/src/eager.rs
+++ b/src/eager.rs
@@ -239,6 +239,13 @@ mod tests {
     }
 
     #[test]
+    fn test_count_complete_chunks_twelve_seconds() {
+        let config = test_config();
+        let audio_len = 192000;
+        assert_eq!(count_complete_chunks(audio_len, &config), 2);
+    }
+
+    #[test]
     fn test_extract_chunk_insufficient_data() {
         let config = test_config();
         let audio = vec![0.0; 40000]; // Less than one chunk
@@ -262,6 +269,22 @@ mod tests {
         assert_eq!(chunk.len(), 80000);
         // Second chunk starts at stride (72000)
         assert_eq!(chunk[0], 72000.0);
+    }
+
+    #[test]
+    fn test_extract_chunk_ranges_for_twelve_seconds_audio() {
+        let config = test_config();
+        let audio: Vec<f32> = (0..192000).map(|i| i as f32).collect();
+
+        let chunk0 = extract_chunk(&audio, 0, &config).unwrap();
+        assert_eq!(chunk0.len(), 80000);
+        assert_eq!(chunk0[0], 0.0);
+        assert_eq!(chunk0[79999], 79999.0);
+
+        let chunk1 = extract_chunk(&audio, 1, &config).unwrap();
+        assert_eq!(chunk1.len(), 80000);
+        assert_eq!(chunk1[0], 72000.0);
+        assert_eq!(chunk1[79999], 151999.0);
     }
 
     #[test]
@@ -343,6 +366,25 @@ mod tests {
             },
         ];
         assert_eq!(combine_chunk_results(results), "hello world foo bar baz");
+    }
+
+    #[test]
+    fn test_combine_chunk_results_deduplicates_overlap_boundary() {
+        let results = vec![
+            ChunkResult {
+                text: "we should deploy this now".to_string(),
+                chunk_index: 0,
+            },
+            ChunkResult {
+                text: "deploy this now please".to_string(),
+                chunk_index: 1,
+            },
+        ];
+
+        assert_eq!(
+            combine_chunk_results(results),
+            "we should deploy this now please"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the eager input processing feature by wiring the existing infrastructure into the daemon main event loop. PR #149 merged the scaffolding (`process_eager_chunks()`, `poll_chunk_tasks()`, `finish_eager_recording()`, `EagerConfig`, state machine) but never connected it to the 100ms recording poll branch — these functions had zero call sites and were dead code.

Closes #70

## What changed

**`src/daemon.rs`** — 3 additions to the recording poll branch:

1. **Eager chunk polling (100ms loop)**: During `State::EagerRecording`, drains audio samples via `capture.get_samples()`, dispatches ready chunks via `process_eager_chunks()`, and collects completed results via `poll_chunk_tasks()`. Uses a cached `eager_transcriber` that falls back to `model_manager.get_prepared_transcriber()` for Whisper/remote backends where `transcriber_preloaded` is `None`.

2. **Cancel path cleanup**: When recording is cancelled during `EagerRecording`, clears `accumulated_audio`, `chunk_results`, resets counters, and drops the cached transcriber.

3. **Timeout path**: Distinguishes eager vs non-eager recording on timeout — eager timeout calls `finish_eager_recording()` (preserving already-transcribed chunks + tail), non-eager timeout uses the existing `start_transcription_task()` path.

**`src/eager.rs`** — 3 new tests covering chunk extraction ranges, chunk counting, and overlap boundary deduplication.

## Before / After

**Before** (30s recording, remote Groq backend):
```
Finishing eager recording: 30.4s of audio, 0 chunks already transcribed
Remote transcription completed in 1.25s  <- entire recording sent as single API call
```

**After** (30s recording, same backend):
```
Remote transcription completed in 0.84s: "Okay, I am running another test..."  <- chunk 1 during recording
Remote transcription completed in 0.67s: "It is while I am throwing..."        <- chunk 2 during recording
Remote transcription completed in 0.72s: "There is a bag."                     <- chunk 3 during recording
Remote transcription completed in 0.85s: "It is now in the garbage..."         <- chunk 4 during recording
Remote transcription completed in 0.79s: "many, many cans..."                  <- chunk 5 during recording
Remote transcription completed in 0.61s: "In the garden. Oh, wow..."           <- chunk 6 during recording
Finishing eager recording: 30.4s of audio, 6 chunks already transcribed
Remote transcription completed in 0.61s: "That is also in the garbage."        <- only tail after stop
```

Stop-to-paste latency drops from "full recording transcription time" to "tail chunk time + post-processing" (~1.4s for a 30s recording).

## Testing

- `cargo check` — zero errors (2 pre-existing warnings unrelated to this change)
- `cargo test` — 522 passed, 0 failed
- Smoke tested with live recordings on remote Groq backend