### PR TITLE
Add gpu_device config for multi-GPU device selection

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -568,6 +568,26 @@ gpu_isolation = true  # Release GPU memory between transcriptions
 
 **Note:** This setting only applies when using the local whisper backend (`backend = "local"`). It has no effect with remote transcription since no local GPU is used.
 
+### gpu_device
+
+**Type:** Integer
+**Default:** Not set (uses device index 0)
+**Required:** No
+
+GPU device index for Vulkan/CUDA/Metal backend selection. On multi-GPU systems, whisper.cpp may select the wrong GPU by default (e.g., an integrated GPU instead of a discrete GPU), causing slower transcription.
+
+This sets the device index passed directly to whisper.cpp. For systems where the integrated and discrete GPUs are from **different vendors** (e.g., Intel iGPU + NVIDIA dGPU), the `VOXTYPE_VULKAN_DEVICE` environment variable is usually simpler -- it filters by vendor at the Vulkan driver level. See the [Environment Variables](#environment-variables) section.
+
+Use `gpu_device` when you need precise index-level control, such as when both GPUs are from the same vendor.
+
+**Example:**
+```toml
+[whisper]
+gpu_device = 1  # Use discrete GPU (skip integrated GPU at index 0)
+```
+
+**How to find your GPU index:** Run `voxtype setup gpu` to see detected GPUs, or `vulkaninfo --summary` for Vulkan device indices.
+
 ### context_window_optimization
 
 **Type:** Boolean
@@ -2395,6 +2415,7 @@ Any config file setting can be overridden via environment variable. These are ap
 | `VOXTYPE_TRANSLATE` | bool | `whisper.translate` |
 | `VOXTYPE_THREADS` | integer | `whisper.threads` |
 | `VOXTYPE_GPU_ISOLATION` | bool | `whisper.gpu_isolation` |
+| `VOXTYPE_GPU_DEVICE` | integer | `whisper.gpu_device` |
 | `VOXTYPE_ON_DEMAND_LOADING` | bool | `whisper.on_demand_loading` |
 | `VOXTYPE_REMOTE_ENDPOINT` | string | `whisper.remote_endpoint` |
 | `VOXTYPE_WHISPER_API_KEY` | string | `whisper.remote_api_key` |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -864,6 +864,39 @@ threads = 8  # Match your CPU cores
 3. **Use English-only model:**
 `.en` models are faster than multilingual models.
 
+### Slow transcription on multi-GPU systems (Vulkan)
+
+**Cause:** whisper.cpp 1.7+ enumerates integrated GPUs via Vulkan. On systems with both an integrated GPU (e.g., Intel UHD) and a discrete GPU (e.g., NVIDIA RTX), the integrated GPU gets index 0 and becomes the default. This can cause ~3x slower transcription.
+
+**Solutions:**
+
+1. **Use VOXTYPE_VULKAN_DEVICE** (recommended for different-vendor GPUs):
+
+If your integrated and discrete GPUs are from different vendors (e.g., Intel iGPU + NVIDIA dGPU), this is the simplest fix. It filters out the unwanted vendor's Vulkan driver entirely.
+
+```bash
+# In your environment or systemd override:
+VOXTYPE_VULKAN_DEVICE=nvidia
+```
+
+Valid values: `nvidia`, `amd`, `intel`. See `voxtype setup gpu` for detected GPUs.
+
+2. **Set gpu_device in config** (for same-vendor GPUs or precise index control):
+
+This passes a device index directly to whisper.cpp, useful when both GPUs are from the same vendor.
+
+```toml
+[whisper]
+gpu_device = 1  # Use discrete GPU instead of integrated at index 0
+```
+
+3. **Or use the GGML_VK_VISIBLE_DEVICES env var:**
+```bash
+GGML_VK_VISIBLE_DEVICES=1 voxtype
+```
+
+**How to find the right GPU:** Run `voxtype setup gpu` to see detected GPUs, or `vulkaninfo --summary` to see the Vulkan device list and their indices.
+
 ### High CPU usage
 
 **Cause:** Whisper inference is CPU-intensive.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -119,6 +119,10 @@ pub struct Cli {
     #[arg(long, help_heading = "Whisper")]
     pub gpu_isolation: bool,
 
+    /// GPU device index for multi-GPU systems (e.g., 1 for discrete GPU)
+    #[arg(long, value_name = "INDEX", help_heading = "Whisper")]
+    pub gpu_device: Option<i32>,
+
     /// Load model on-demand when recording starts instead of keeping it loaded
     #[arg(long, help_heading = "Whisper")]
     pub on_demand_loading: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,13 @@ translate = false
 # Number of CPU threads for inference (omit for auto-detection)
 # threads = 4
 
+# GPU device index for Vulkan/CUDA backend selection.
+# On multi-GPU systems, whisper.cpp may default to the integrated GPU (index 0),
+# causing slower transcription. For different-vendor setups (e.g., Intel iGPU +
+# NVIDIA dGPU), use VOXTYPE_VULKAN_DEVICE=nvidia instead (simpler).
+# Use gpu_device for same-vendor GPUs or precise index control.
+# gpu_device = 1
+
 # Initial prompt to provide context for transcription
 # Use this to hint at terminology, proper nouns, or formatting conventions.
 # Example: "Technical discussion about Rust, TypeScript, and Kubernetes."
@@ -778,6 +785,15 @@ pub struct WhisperConfig {
     #[serde(default)]
     pub gpu_isolation: bool,
 
+    /// GPU device index for Vulkan/CUDA/Metal backend selection.
+    /// On multi-GPU systems, whisper.cpp may select the integrated GPU (index 0)
+    /// instead of the discrete GPU, causing slower transcription.
+    /// Set this to the index of your preferred GPU (e.g., 1 for the second device).
+    /// Leave unset to use the default device (index 0).
+    /// You can also use the GGML_VK_VISIBLE_DEVICES env var for Vulkan filtering.
+    #[serde(default)]
+    pub gpu_device: Option<i32>,
+
     /// Optimize context window for short recordings (default: true)
     /// When enabled, uses a smaller context window proportional to audio length
     /// for clips under 22.5 seconds. This significantly speeds up transcription
@@ -895,6 +911,7 @@ impl Default for WhisperConfig {
             threads: None,
             on_demand_loading: default_on_demand_loading(),
             gpu_isolation: false,
+            gpu_device: None,
             context_window_optimization: default_context_window_optimization(),
             eager_processing: false,
             eager_chunk_secs: default_eager_chunk_secs(),
@@ -1744,6 +1761,7 @@ impl Default for Config {
                 threads: None,
                 on_demand_loading: default_on_demand_loading(),
                 gpu_isolation: false,
+                gpu_device: None,
                 context_window_optimization: default_context_window_optimization(),
                 eager_processing: false,
                 eager_chunk_secs: default_eager_chunk_secs(),
@@ -2018,6 +2036,11 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     }
     if let Ok(val) = std::env::var("VOXTYPE_GPU_ISOLATION") {
         config.whisper.gpu_isolation = parse_bool_env(&val);
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_GPU_DEVICE") {
+        if let Ok(n) = val.parse::<i32>() {
+            config.whisper.gpu_device = Some(n);
+        }
     }
     if let Ok(val) = std::env::var("VOXTYPE_ON_DEMAND_LOADING") {
         config.whisper.on_demand_loading = parse_bool_env(&val);

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,9 @@ async fn main() -> anyhow::Result<()> {
     if cli.gpu_isolation {
         config.whisper.gpu_isolation = true;
     }
+    if let Some(gpu_device) = cli.gpu_device {
+        config.whisper.gpu_device = Some(gpu_device);
+    }
     if cli.on_demand_loading {
         config.whisper.on_demand_loading = true;
     }
@@ -1113,6 +1116,9 @@ async fn show_config(config: &config::Config) -> anyhow::Result<()> {
     println!("  translate = {}", config.whisper.translate);
     if let Some(threads) = config.whisper.threads {
         println!("  threads = {}", threads);
+    }
+    if let Some(gpu_device) = config.whisper.gpu_device {
+        println!("  gpu_device = {}", gpu_device);
     }
 
     // Show Parakeet status (experimental)

--- a/src/transcribe/whisper.rs
+++ b/src/transcribe/whisper.rs
@@ -37,11 +37,17 @@ impl WhisperTranscriber {
         tracing::info!("Loading whisper model from {:?}", model_path);
         let start = std::time::Instant::now();
 
+        let mut ctx_params = WhisperContextParameters::default();
+        if let Some(device) = config.gpu_device {
+            tracing::info!("Using GPU device index {}", device);
+            ctx_params.gpu_device(device);
+        }
+
         let ctx = WhisperContext::new_with_params(
             model_path
                 .to_str()
                 .ok_or_else(|| TranscribeError::ModelNotFound("Invalid path".to_string()))?,
-            WhisperContextParameters::default(),
+            ctx_params,
         )
         .map_err(|e| TranscribeError::InitFailed(e.to_string()))?;
 


### PR DESCRIPTION
## Summary

- Adds `[whisper] gpu_device` config option to select which GPU whisper.cpp uses by device index
- Fixes regression from whisper-rs 0.16.0 where integrated GPUs get index 0 and become the default on multi-GPU systems, causing ~3x slower transcription
- Complements the existing `VOXTYPE_VULKAN_DEVICE` vendor-level filtering for same-vendor multi-GPU setups and precise index control
- Configurable via config file (`gpu_device = 1`), CLI (`--gpu-device 1`), or env var (`VOXTYPE_GPU_DEVICE=1`)

Closes #273

## What changed

- `src/config.rs`: New `gpu_device: Option<i32>` field on `WhisperConfig`, `VOXTYPE_GPU_DEVICE` env var, default config template comment
- `src/cli.rs`: `--gpu-device <INDEX>` flag
- `src/main.rs`: CLI override wiring, `voxtype config` display when set
- `src/transcribe/whisper.rs`: Passes device index to `WhisperContextParameters::gpu_device()`
- `docs/CONFIGURATION.md`: `gpu_device` reference, `VOXTYPE_GPU_DEVICE` in env var table
- `docs/TROUBLESHOOTING.md`: New "Slow transcription on multi-GPU systems" section, leading with existing `VOXTYPE_VULKAN_DEVICE` as primary fix

## Test plan

- [x] `cargo test` -- 544 tests pass
- [x] `--gpu-device 1` accepted, shows in `voxtype config` output
- [x] `VOXTYPE_GPU_DEVICE=2` accepted, shows in `voxtype config` output
- [x] TOML `gpu_device = 1` parses without error
- [x] Default (not set) -- no behavior change, hidden in config display
- [ ] Multi-GPU system: verify `gpu_device = 1` routes to discrete GPU (needs hardware)

Co-authored-by: jan Lemata (DuskyElf) <janlemata@gmail.com>