### PR TITLE
Clean up eager processing and credit contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ We want to hear from you! Voxtype is a young project and your feedback helps mak
 - [ayoahha](https://github.com/ayoahha) - CLI backend for whisper-cli subprocess transcription
 - [Loki Coyote](https://github.com/lokkju) - eitype output driver for KDE/GNOME support, media keys and numeric keycode hotkey support
 - [Umesh](https://github.com/radiorambo) - Documentation website
+- [Sami Jawhar](https://github.com/sjawhar) - Eager input processing wiring
 
 ## License
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1814,6 +1814,7 @@ impl Daemon {
                                     tracing::debug!("Eager recording produced empty result");
                                     self.reset_to_idle(&mut state).await;
                                 }
+                                eager_transcriber = None;
                             }
                         }
 
@@ -1988,6 +1989,7 @@ impl Daemon {
                                     tracing::debug!("Eager recording produced empty result");
                                     self.reset_to_idle(&mut state).await;
                                 }
+                                eager_transcriber = None;
                             }
                         }
 
@@ -2235,6 +2237,7 @@ impl Daemon {
                                         self.reset_to_idle(&mut state).await;
                                     }
                                 }
+                                eager_transcriber = None;
                             } else {
                                 for (_, task) in self.eager_chunk_tasks.drain(..) {
                                     task.abort();
@@ -2423,6 +2426,7 @@ impl Daemon {
                             tracing::debug!("Eager recording produced empty result");
                             self.reset_to_idle(&mut state).await;
                         }
+                        eager_transcriber = None;
                     }
                 }
 

--- a/website/news/index.html
+++ b/website/news/index.html
@@ -122,7 +122,7 @@ smart_auto_submit = true</code></pre>
                     </ul>
 
                     <h3>Contributors</h3>
-                    <p>Thanks to <a href="https://github.com/siebertm">Michael Siebert</a> for smart auto-submit, <a href="https://github.com/materemias">materemias</a> for meeting export improvements, <a href="https://github.com/repomaa">Joakim Repomaa</a> for the NixOS HM fix, <a href="https://github.com/benj9000">benj9000</a> for Parakeet documentation updates, and <a href="https://github.com/fazzledev">Syed Fazil Basheer</a> for diagnosing the ONNX status bug.</p>
+                    <p>Thanks to <a href="https://github.com/siebertm">Michael Siebert</a> for smart auto-submit, <a href="https://github.com/sjawhar">Sami Jawhar</a> for wiring eager input processing into the daemon, <a href="https://github.com/materemias">materemias</a> for meeting export improvements, <a href="https://github.com/repomaa">Joakim Repomaa</a> for the NixOS HM fix, <a href="https://github.com/benj9000">benj9000</a> for Parakeet documentation updates, and <a href="https://github.com/fazzledev">Syed Fazil Basheer</a> for diagnosing the ONNX status bug.</p>
                 </div>
             </article>
 


### PR DESCRIPTION
## Summary

Follow-up to #275. Addresses review items and adds contributor credit.

- Clear `eager_transcriber` cache after every eager recording stop (push-to-talk release, toggle stop, timeout, external trigger). Previously only cleared on cancel, which left a stale `Arc<dyn Transcriber>` between recordings.
- Add Sami Jawhar to README contributors and website news for #275.

## Why this matters

With `on_demand_loading = true` or model switching, holding a reference to the transcriber between recordings prevents the model from being unloaded. Clearing the cache after each eager recording ensures model resources can be released when the daemon returns to idle.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test` -- 547 tests pass
- [x] Verified all 4 `finish_eager_recording` call sites now clear the cache

Co-authored-by: Sami Jawhar <sami@trajectorylabs.net>