### PR TITLE
voxtype.service: run in quiet mode

### DIFF
--- a/packaging/debian/voxtype.service
+++ b/packaging/debian/voxtype.service
@@ -7,7 +7,7 @@ Wants=ydotool.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/voxtype daemon
+ExecStart=/usr/bin/voxtype -q daemon
 Restart=on-failure
 RestartSec=5
 

--- a/packaging/systemd/voxtype.service
+++ b/packaging/systemd/voxtype.service
@@ -7,7 +7,7 @@ Wants=ydotool.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/voxtype daemon
+ExecStart=/usr/bin/voxtype -q daemon
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
Keep journalctl's log free of all dictated text by running in quiet mode

## Description

Add `-q` switch to service units to keep journalctl free of dictated text. Potential privacy concerns, etc.

## Related Issue

Fixes #(issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [ ] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy` with no warnings
- [ ] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [x] No documentation changes are needed

## Additional Notes

Any additional information reviewers should know.
