### PR TITLE
[EXPERIMENT] Add OpenVINO GenAI engine backend for NPU/GPU acceleration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,8 @@ dolphin-tensorrt = ["dolphin", "ort/tensorrt"]
 omnilingual = ["onnx-common"]
 omnilingual-cuda = ["omnilingual", "ort/cuda"]
 omnilingual-tensorrt = ["omnilingual", "ort/tensorrt"]
+# OpenVINO GenAI backend (Intel CPU/GPU/NPU via WhisperPipeline)
+openvino-genai = []
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -325,6 +325,10 @@ pub struct Config {
     #[serde(default)]
     pub omnilingual: Option<OmnilingualConfig>,
 
+    /// OpenVINO GenAI configuration (optional, only used when engine = "openvino-genai")
+    #[serde(default)]
+    pub openvino_genai: Option<OpenvinoGenaiConfig>,
+
     /// Text processing configuration (replacements, spoken punctuation)
     #[serde(default)]
     pub text: TextConfig,
@@ -1108,6 +1112,43 @@ impl Default for OmnilingualConfig {
     }
 }
 
+/// OpenVINO GenAI speech-to-text configuration
+/// Uses WhisperPipeline for hardware-accelerated transcription on CPU/GPU/NPU
+/// Requires: cargo build --features openvino-genai
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OpenvinoGenaiConfig {
+    /// Model name or path to OpenVINO IR model directory
+    pub model: String,
+
+    /// Device to run inference on: "CPU", "GPU", or "NPU"
+    #[serde(default)]
+    pub device: Option<String>,
+
+    /// Language code (e.g., "en", "fr", "zh") or None for auto-detect
+    #[serde(default)]
+    pub language: Option<String>,
+
+    /// Translate to English instead of transcribing
+    #[serde(default)]
+    pub translate: Option<bool>,
+
+    /// Load model on-demand when recording starts (true) or keep loaded (false)
+    #[serde(default = "default_on_demand_loading")]
+    pub on_demand_loading: bool,
+}
+
+impl Default for OpenvinoGenaiConfig {
+    fn default() -> Self {
+        Self {
+            model: "whisper-base-ov".to_string(),
+            device: Some("CPU".to_string()),
+            language: Some("en".to_string()),
+            translate: None,
+            on_demand_loading: false,
+        }
+    }
+}
+
 /// Transcription engine selection (which ASR technology to use)
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
@@ -1133,6 +1174,10 @@ pub enum TranscriptionEngine {
     /// Use Omnilingual (FunASR 50+ language CTC encoder via ONNX Runtime)
     /// Requires: cargo build --features omnilingual
     Omnilingual,
+    /// Use OpenVINO GenAI WhisperPipeline (Intel CPU/GPU/NPU acceleration)
+    /// Requires: cargo build --features openvino-genai
+    #[serde(rename = "openvino-genai")]
+    OpenvinoGenai,
 }
 
 /// VAD backend selection
@@ -1789,6 +1834,7 @@ impl Default for Config {
             paraformer: None,
             dolphin: None,
             omnilingual: None,
+            openvino_genai: None,
             text: TextConfig::default(),
             vad: VadConfig::default(),
             status: StatusConfig::default(),
@@ -1897,6 +1943,11 @@ impl Config {
                 .as_ref()
                 .map(|o| o.on_demand_loading)
                 .unwrap_or(false),
+            TranscriptionEngine::OpenvinoGenai => self
+                .openvino_genai
+                .as_ref()
+                .map(|o| o.on_demand_loading)
+                .unwrap_or(false),
         }
     }
 
@@ -1934,6 +1985,11 @@ impl Config {
                 .as_ref()
                 .map(|o| o.model.as_str())
                 .unwrap_or("omnilingual (not configured)"),
+            TranscriptionEngine::OpenvinoGenai => self
+                .openvino_genai
+                .as_ref()
+                .map(|o| o.model.as_str())
+                .unwrap_or("openvino-genai (not configured)"),
         }
     }
 
@@ -2002,6 +2058,7 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
             "paraformer" => config.engine = TranscriptionEngine::Paraformer,
             "dolphin" => config.engine = TranscriptionEngine::Dolphin,
             "omnilingual" => config.engine = TranscriptionEngine::Omnilingual,
+            "openvino-genai" | "openvino" => config.engine = TranscriptionEngine::OpenvinoGenai,
             _ => tracing::warn!("Unknown VOXTYPE_ENGINE value: {}", engine),
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -661,7 +661,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::SenseVoice
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
-                | crate::config::TranscriptionEngine::Omnilingual => {
+                | crate::config::TranscriptionEngine::Omnilingual | crate::config::TranscriptionEngine::OpenvinoGenai => {
                     if let Some(ref t) = transcriber_preloaded {
                         Ok(t.clone())
                     } else {
@@ -1567,7 +1567,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::SenseVoice
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
-                | crate::config::TranscriptionEngine::Omnilingual => {
+                | crate::config::TranscriptionEngine::Omnilingual | crate::config::TranscriptionEngine::OpenvinoGenai => {
                     // Parakeet/Moonshine uses its own model loading
                     transcriber_preloaded = Some(Arc::from(crate::transcribe::create_transcriber(
                         &self.config,
@@ -1665,7 +1665,7 @@ impl Daemon {
                                         | crate::config::TranscriptionEngine::SenseVoice
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
-                | crate::config::TranscriptionEngine::Omnilingual => {
+                | crate::config::TranscriptionEngine::Omnilingual | crate::config::TranscriptionEngine::OpenvinoGenai => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -1688,7 +1688,7 @@ impl Daemon {
                                         | crate::config::TranscriptionEngine::SenseVoice
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
-                | crate::config::TranscriptionEngine::Omnilingual => {
+                | crate::config::TranscriptionEngine::Omnilingual | crate::config::TranscriptionEngine::OpenvinoGenai => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -1848,7 +1848,7 @@ impl Daemon {
                                         | crate::config::TranscriptionEngine::SenseVoice
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
-                | crate::config::TranscriptionEngine::Omnilingual => {
+                | crate::config::TranscriptionEngine::Omnilingual | crate::config::TranscriptionEngine::OpenvinoGenai => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -1871,7 +1871,7 @@ impl Daemon {
                                         | crate::config::TranscriptionEngine::SenseVoice
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
-                | crate::config::TranscriptionEngine::Omnilingual => {
+                | crate::config::TranscriptionEngine::Omnilingual | crate::config::TranscriptionEngine::OpenvinoGenai => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -2280,7 +2280,7 @@ impl Daemon {
                                 | crate::config::TranscriptionEngine::SenseVoice
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
-                | crate::config::TranscriptionEngine::Omnilingual => {
+                | crate::config::TranscriptionEngine::Omnilingual | crate::config::TranscriptionEngine::OpenvinoGenai => {
                                     let config = self.config.clone();
                                     self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                         crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -2302,7 +2302,7 @@ impl Daemon {
                                 | crate::config::TranscriptionEngine::SenseVoice
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
-                | crate::config::TranscriptionEngine::Omnilingual => {
+                | crate::config::TranscriptionEngine::Omnilingual | crate::config::TranscriptionEngine::OpenvinoGenai => {
                                     if let Some(ref t) = transcriber_preloaded {
                                         let transcriber = t.clone();
                                         tokio::task::spawn_blocking(move || {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -100,6 +100,7 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
         crate::config::TranscriptionEngine::Paraformer => "\u{1F4AC}",   // 💬
         crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",      // 🐬
         crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}",  // 🌍
+        crate::config::TranscriptionEngine::OpenvinoGenai => "{1F9E0}",  // brain
     }
 }
 

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -54,7 +54,10 @@ pub mod dolphin;
 #[cfg(feature = "omnilingual")]
 pub mod omnilingual;
 
-use crate::config::{Config, TranscriptionEngine, WhisperConfig, WhisperMode};
+#[cfg(feature = "openvino-genai")]
+pub mod openvino_genai;
+
+use crate::config::{Config, OpenvinoGenaiConfig, TranscriptionEngine, WhisperConfig, WhisperMode};
 use crate::error::TranscribeError;
 use crate::setup::gpu;
 
@@ -173,6 +176,17 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
         #[cfg(not(feature = "omnilingual"))]
         TranscriptionEngine::Omnilingual => Err(TranscribeError::InitFailed(
             "Omnilingual engine requested but voxtype was not compiled with --features omnilingual"
+                .to_string(),
+        )),
+        #[cfg(feature = "openvino-genai")]
+        TranscriptionEngine::OpenvinoGenai => {
+            let default_cfg = crate::config::OpenvinoGenaiConfig::default();
+            let cfg = config.openvino_genai.as_ref().unwrap_or(&default_cfg);
+            Ok(Box::new(openvino_genai::OpenvinoGenaiTranscriber::new(cfg)?))
+        }
+        #[cfg(not(feature = "openvino-genai"))]
+        TranscriptionEngine::OpenvinoGenai => Err(TranscribeError::InitFailed(
+            "OpenVINO GenAI engine requested but voxtype was not compiled with --features openvino-genai"
                 .to_string(),
         )),
     }

--- a/src/transcribe/openvino_genai.rs
+++ b/src/transcribe/openvino_genai.rs
@@ -1,0 +1,307 @@
+//! OpenVINO GenAI speech-to-text transcription
+//!
+//! Uses Intel OpenVINO GenAI's WhisperPipeline for hardware-accelerated
+//! transcription on CPU, GPU, or NPU (Intel AI Boost).
+//!
+//! Links directly to libopenvino_genai_c.so via FFI. The WhisperPipeline
+//! runs the entire Whisper model (encoder + decoder + tokenizer) through
+//! OpenVINO, enabling full NPU/GPU offload.
+
+use super::Transcriber;
+use crate::config::OpenvinoGenaiConfig;
+use crate::error::TranscribeError;
+use std::ffi::{CStr, CString};
+use std::path::PathBuf;
+use std::ptr;
+
+// ============================================================================
+// FFI bindings to OpenVINO GenAI C API (libopenvino_genai_c.so)
+// ============================================================================
+
+#[allow(non_camel_case_types)]
+type ov_status_e = i32;
+const OV_STATUS_OK: ov_status_e = 0;
+
+#[repr(C)]
+struct ov_genai_whisper_pipeline_opaque {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+struct ov_genai_whisper_decoded_results_opaque {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+struct ov_genai_whisper_generation_config_opaque {
+    _private: [u8; 0],
+}
+
+type WhisperPipelinePtr = *mut ov_genai_whisper_pipeline_opaque;
+type DecodedResultsPtr = *mut ov_genai_whisper_decoded_results_opaque;
+type GenerationConfigPtr = *mut ov_genai_whisper_generation_config_opaque;
+
+#[link(name = "openvino_genai_c")]
+extern "C" {
+    fn ov_genai_whisper_pipeline_create(
+        models_path: *const i8,
+        device: *const i8,
+        property_args_size: usize,
+        pipeline: *mut WhisperPipelinePtr,
+        ...
+    ) -> ov_status_e;
+
+    fn ov_genai_whisper_pipeline_free(pipeline: WhisperPipelinePtr);
+
+    fn ov_genai_whisper_pipeline_generate(
+        pipeline: WhisperPipelinePtr,
+        raw_speech: *const f32,
+        raw_speech_size: usize,
+        config: GenerationConfigPtr,
+        results: *mut DecodedResultsPtr,
+    ) -> ov_status_e;
+
+    fn ov_genai_whisper_pipeline_get_generation_config(
+        pipeline: WhisperPipelinePtr,
+        config: *mut GenerationConfigPtr,
+    ) -> ov_status_e;
+
+    fn ov_genai_whisper_generation_config_free(config: GenerationConfigPtr);
+
+    fn ov_genai_whisper_generation_config_set_language(
+        config: GenerationConfigPtr,
+        language: *const i8,
+    ) -> ov_status_e;
+
+    fn ov_genai_whisper_generation_config_set_task(
+        config: GenerationConfigPtr,
+        task: *const i8,
+    ) -> ov_status_e;
+
+    fn ov_genai_whisper_decoded_results_get_texts_count(
+        results: DecodedResultsPtr,
+        count: *mut usize,
+    ) -> ov_status_e;
+
+    fn ov_genai_whisper_decoded_results_get_text_at(
+        results: DecodedResultsPtr,
+        index: usize,
+        text: *mut i8,
+        text_size: *mut usize,
+    ) -> ov_status_e;
+
+    fn ov_genai_whisper_decoded_results_free(results: DecodedResultsPtr);
+}
+
+// ============================================================================
+// Safe Rust wrapper
+// ============================================================================
+
+struct Pipeline {
+    ptr: WhisperPipelinePtr,
+}
+
+impl Pipeline {
+    fn new(model_path: &str, device: &str) -> Result<Self, TranscribeError> {
+        let model_c = CString::new(model_path)
+            .map_err(|e| TranscribeError::InitFailed(format!("Invalid model path: {}", e)))?;
+        let device_c = CString::new(device)
+            .map_err(|e| TranscribeError::InitFailed(format!("Invalid device: {}", e)))?;
+
+        let mut ptr: WhisperPipelinePtr = ptr::null_mut();
+        let status = unsafe {
+            ov_genai_whisper_pipeline_create(
+                model_c.as_ptr(),
+                device_c.as_ptr(),
+                0,
+                &mut ptr,
+            )
+        };
+
+        if status != OV_STATUS_OK || ptr.is_null() {
+            return Err(TranscribeError::InitFailed(format!(
+                "Failed to create WhisperPipeline on {} (status={})",
+                device, status
+            )));
+        }
+
+        Ok(Self { ptr })
+    }
+
+    fn generate(
+        &self,
+        samples: &[f32],
+        language: Option<&str>,
+        task: &str,
+    ) -> Result<String, TranscribeError> {
+        // Get generation config
+        let mut config_ptr: GenerationConfigPtr = ptr::null_mut();
+        let status = unsafe {
+            ov_genai_whisper_pipeline_get_generation_config(self.ptr, &mut config_ptr)
+        };
+        if status != OV_STATUS_OK || config_ptr.is_null() {
+            return Err(TranscribeError::InferenceFailed(
+                "Failed to get generation config".to_string(),
+            ));
+        }
+
+        // Set language
+        if let Some(lang) = language {
+            let lang_token = if lang.starts_with("<|") {
+                lang.to_string()
+            } else {
+                format!("<|{}|>", lang)
+            };
+            let lang_c = CString::new(lang_token).unwrap();
+            unsafe {
+                ov_genai_whisper_generation_config_set_language(config_ptr, lang_c.as_ptr());
+            }
+        }
+
+        // Set task
+        let task_c = CString::new(task).unwrap();
+        unsafe {
+            ov_genai_whisper_generation_config_set_task(config_ptr, task_c.as_ptr());
+        }
+
+        // Run inference
+        let mut results_ptr: DecodedResultsPtr = ptr::null_mut();
+        let status = unsafe {
+            ov_genai_whisper_pipeline_generate(
+                self.ptr,
+                samples.as_ptr(),
+                samples.len(),
+                config_ptr,
+                &mut results_ptr,
+            )
+        };
+
+        unsafe {
+            ov_genai_whisper_generation_config_free(config_ptr);
+        }
+
+        if status != OV_STATUS_OK || results_ptr.is_null() {
+            return Err(TranscribeError::InferenceFailed(format!(
+                "WhisperPipeline generate failed (status={})",
+                status
+            )));
+        }
+
+        // Get text count
+        let mut count: usize = 0;
+        unsafe {
+            ov_genai_whisper_decoded_results_get_texts_count(results_ptr, &mut count);
+        }
+
+        let mut text = String::new();
+        for i in 0..count {
+            // Two-call pattern: get size, then get text
+            let mut size: usize = 0;
+            unsafe {
+                ov_genai_whisper_decoded_results_get_text_at(
+                    results_ptr, i, ptr::null_mut(), &mut size,
+                );
+            }
+            let mut buf = vec![0u8; size + 1];
+            unsafe {
+                ov_genai_whisper_decoded_results_get_text_at(
+                    results_ptr, i, buf.as_mut_ptr() as *mut i8, &mut size,
+                );
+            }
+            if let Ok(s) = unsafe { CStr::from_ptr(buf.as_ptr() as *const i8) }.to_str() {
+                text.push_str(s);
+            }
+        }
+
+        unsafe {
+            ov_genai_whisper_decoded_results_free(results_ptr);
+        }
+
+        Ok(text.trim().to_string())
+    }
+}
+
+impl Drop for Pipeline {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                ov_genai_whisper_pipeline_free(self.ptr);
+            }
+        }
+    }
+}
+
+unsafe impl Send for Pipeline {}
+unsafe impl Sync for Pipeline {}
+
+// ============================================================================
+// Transcriber implementation
+// ============================================================================
+
+pub struct OpenvinoGenaiTranscriber {
+    pipeline: Pipeline,
+    language: Option<String>,
+    translate: bool,
+}
+
+impl OpenvinoGenaiTranscriber {
+    pub fn new(config: &OpenvinoGenaiConfig) -> Result<Self, TranscribeError> {
+        let model_path = resolve_model_path(&config.model)?;
+        let device = std::env::var("OPENVINO_DEVICE")
+            .ok()
+            .or_else(|| config.device.clone())
+            .unwrap_or_else(|| "CPU".to_string());
+        let device = device.as_str();
+
+        tracing::info!(
+            "Loading OpenVINO GenAI WhisperPipeline from {:?} on {}",
+            model_path, device
+        );
+        let start = std::time::Instant::now();
+
+        let pipeline = Pipeline::new(
+            model_path.to_str()
+                .ok_or_else(|| TranscribeError::ModelNotFound("Invalid path".to_string()))?,
+            device,
+        )?;
+
+        tracing::info!(
+            "WhisperPipeline loaded in {:.2}s on {}",
+            start.elapsed().as_secs_f32(), device
+        );
+
+        Ok(Self {
+            pipeline,
+            language: config.language.clone(),
+            translate: config.translate.unwrap_or(false),
+        })
+    }
+}
+
+impl Transcriber for OpenvinoGenaiTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        let task = if self.translate { "translate" } else { "transcribe" };
+        self.pipeline.generate(samples, self.language.as_deref(), task)
+    }
+}
+
+fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
+    let path = PathBuf::from(model);
+    if path.is_absolute() && path.exists() {
+        return Ok(path);
+    }
+    if let Some(home) = std::env::var("HOME").ok().map(PathBuf::from) {
+        let candidate = home.join(".local/share/voxtype/models").join(model);
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    if path.exists() {
+        return Ok(path);
+    }
+    Err(TranscribeError::ModelNotFound(format!(
+        "OpenVINO model not found: {}. Export with: \
+         optimum-cli export openvino --model openai/whisper-base ~/.local/share/voxtype/models/{}",
+        model, model
+    )))
+}

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -62,7 +62,7 @@ pub fn create_vad(config: &Config) -> Result<Option<Box<dyn VoiceActivityDetecto
                 | TranscriptionEngine::SenseVoice
                 | TranscriptionEngine::Paraformer
                 | TranscriptionEngine::Dolphin
-                | TranscriptionEngine::Omnilingual => VadBackend::Energy,
+                | TranscriptionEngine::Omnilingual | TranscriptionEngine::OpenvinoGenai => VadBackend::Energy,
             }
         }
         explicit => explicit,


### PR DESCRIPTION
## Summary

This adds a new `openvino-genai` transcription engine that uses Intel OpenVINO GenAI's WhisperPipeline for hardware-accelerated speech-to-text on Intel NPU (AI Boost) and GPU. The implementation uses direct Rust FFI to `libopenvino_genai_c.so` with no Python or subprocess dependencies.

**Status: Experimental** — tested on Dell XPS 16 (Panther Lake) with OpenVINO 2026.0. Marked as draft for review and feedback.

## How It Works

```
Copilot key -> voxtype daemon -> PipeWire capture (16kHz f32)
  -> Rust FFI -> libopenvino_genai_c.so -> WhisperPipeline
  -> NPU inference -> transcribed text -> wtype (at cursor)
```

The `Transcriber` trait implementation is straightforward — `transcribe(&self, &[f32]) -> String` calls through FFI to the OpenVINO GenAI C API's `ov_genai_whisper_pipeline_generate()`.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `openvino-genai` feature flag |
| `src/transcribe/openvino_genai.rs` | **New**: FFI bindings + `OpenvinoGenaiTranscriber` |
| `src/config.rs` | Add `OpenvinoGenaiConfig`, `OpenvinoGenai` enum variant, `OPENVINO_DEVICE` env var |
| `src/transcribe/mod.rs` | Wire up engine factory with default config fallback |
| `src/daemon.rs` | Add `OpenvinoGenai` match arms |
| `src/vad/mod.rs` | Add `OpenvinoGenai` -> Energy VAD |
| `src/output/mod.rs` | Add emoji indicator |

## Usage

```bash
# Build
cargo build --release --features openvino-genai

# Run (CPU)
VOXTYPE_ENGINE=openvino voxtype daemon

# Run (NPU)
VOXTYPE_ENGINE=openvino OPENVINO_DEVICE=NPU voxtype daemon

# Config file
[openvino_genai]
model = "whisper-base-ov"
device = "NPU"
language = "en"
```

## Prerequisites

- OpenVINO 2026.0+ with GenAI (`pip install openvino openvino-genai`)
- `libopenvino_genai_c.so` (built from [openvino.genai](https://github.com/openvinotoolkit/openvino.genai) source)
- NPU: `intel-npu-driver` + `intel_vpu` kernel module + `render` group
- Whisper model in OpenVINO IR format (`optimum-cli export openvino --model openai/whisper-base`)

## Benchmark: CPU vs NPU (3-Minute Realistic Dictation Workload)

Tested on Dell XPS 16 (Panther Lake), Core Ultra X7 358H, Intel AI Boost NPU, whisper-base model.

Simulated realistic usage: random 2-8s voice inputs with 1-3s pauses, total 3 minutes per device.

| Metric | CPU | NPU | Improvement |
|--------|-----|-----|-------------|
| Avg inference time | 797ms | 683ms | **14% faster** |
| Avg CPU per inference | 13.6% | 8.5% | **37% less CPU** |
| Peak CPU per inference | 14.9% | 9.6% | 36% lower peak |
| SoC temp peak | 33C | 31C | **2C cooler** |
| SoC temp average | 31.4C | 30.3C | 1.1C cooler |
| Throughput (3min) | 62 inputs | 69 inputs | **11% more** |
| Memory peak | 2823MB | 2738MB | 85MB less |
| NPU active total | 0ms | 41,151ms | Full NPU offload |

<details>
<summary>Raw benchmark data (CPU, first 20 of 62 inferences)</summary>

```
Time    Infer   CPU%   Temp   NPU     Text
0.0s    788ms   14.4%  28.0C  0ms    "So let's check out what he does..."
3.2s    772ms   13.6%  28.0C  0ms    "And it looks like we're in a basement..."
5.3s    834ms   13.9%  29.0C  0ms    "Let's check out what he does..."
7.3s    812ms   13.7%  30.0C  0ms    "does and it looks like we're in a basement..."
10.7s   799ms   13.5%  29.0C  0ms    "out what he does and it looks like..."
14.3s   801ms   13.8%  29.0C  0ms    "what he does and it looks like..."
17.3s   768ms   13.3%  29.0C  0ms    "But one thing I see right away is like..."
19.1s   789ms   13.4%  30.0C  0ms    "which is kind of cool..."
22.5s   768ms   13.5%  30.0C  0ms    "But one thing I see right away is like..."
25.9s   765ms   13.2%  30.0C  0ms    "So one thing I see right away is like..."
```
</details>

<details>
<summary>Raw benchmark data (NPU, first 20 of 69 inferences)</summary>

```
Time    Infer   CPU%   Temp   NPU     Text
0.0s    744ms   8.3%   30.0C  535ms  "So let's check out what he does..."
2.0s    685ms   9.2%   31.0C  468ms  "check out what he does and it looks like..."
5.6s    708ms   8.1%   31.0C  504ms  "advice here. So let's check out what he..."
7.8s    695ms   7.8%   31.0C  490ms  "out what he does and it looks like..."
10.4s   649ms   9.0%   31.0C  439ms  "check out what he does and it looks like..."
13.9s   635ms   8.2%   31.0C  437ms  "check out what he does and it looks like..."
16.9s   716ms   8.4%   31.0C  512ms  "Let's check out what he does..."
20.6s   707ms   8.1%   31.0C  504ms  "what he does and it looks like..."
23.2s   738ms   8.3%   31.0C  525ms  "So let's check out what he does..."
25.9s   669ms   9.2%   31.0C  458ms  "which is kind of cool..."
```
</details>

## Future Work

- Upstream `openvino-rs` PR [#185](https://github.com/intel/openvino-rs/pull/185) would provide official Rust crate, replacing the direct FFI
- Test with larger Whisper models (whisper-medium, whisper-large-v3) for better accuracy
- Package `libopenvino_genai_c.so` for Arch Linux / Omarchy
- Model auto-download in `voxtype setup model`