### PR TITLE
Add evdev hotkey profile modifiers for per-recording post-processing

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -41,6 +41,16 @@ modifiers = []
 # - toggle: Press hotkey once to start recording, press again to stop
 # mode = "push_to_talk"
 
+# Modifier key for secondary model selection (evdev only)
+# Hold this key while pressing the hotkey to use secondary_model
+# model_modifier = "LEFTSHIFT"
+
+# Profile modifiers for context-aware post-processing (evdev only)
+# Maps modifier keys to named profiles defined in [profiles.*] sections
+# [hotkey.profile_modifiers]
+# LEFTSHIFT = "translate"   # Shift+hotkey activates [profiles.translate]
+# RIGHTALT = "formal"       # RightAlt+hotkey activates [profiles.formal]
+
 [audio]
 # Audio input device ("default" uses system default)
 # List devices with: pactl list sources short

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -241,6 +241,39 @@ cancel_key = "ESC"  # Press Escape to cancel
 
 **Note:** This only applies when using evdev hotkey detection (`enabled = true`). When using compositor keybindings, use `voxtype record cancel` instead. See [User Manual - Canceling Transcription](USER_MANUAL.md#canceling-transcription).
 
+### [hotkey.profile_modifiers]
+
+**Type:** Table (key = modifier name, value = profile name)
+**Default:** Empty (disabled)
+**Required:** No
+
+Maps modifier keys to named profiles. When a profile modifier is held while pressing the hotkey, that profile's post-processing command is used instead of the default. Profiles are defined in `[profiles.<name>]` sections.
+
+**Example:**
+```toml
+[hotkey]
+key = "SCROLLLOCK"
+
+[hotkey.profile_modifiers]
+RIGHTSHIFT = "translate"   # Shift + hotkey activates [profiles.translate]
+RIGHTALT = "formal"        # RightAlt + hotkey activates [profiles.formal]
+
+[profiles.translate]
+post_process_command = "my-script.sh --translate-en"
+timeout_ms = 10000
+
+[profiles.formal]
+post_process_command = "my-script.sh --formal"
+```
+
+**Valid key names:** Same modifier keys as `modifiers` option:
+- `LEFTSHIFT`, `RIGHTSHIFT`
+- `LEFTCTRL`, `RIGHTCTRL`
+- `LEFTALT`, `RIGHTALT`
+- `LEFTMETA`, `RIGHTMETA`
+
+**Note:** This only applies when using evdev hotkey detection (`enabled = true`). When using compositor keybindings, use `voxtype record start --profile <name>` instead. Avoid using the same key in both `modifiers` and `profile_modifiers` -- every hotkey press would always activate that profile.
+
 ---
 
 ## [audio]

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -436,6 +436,26 @@ Available modifiers:
 - `LEFTSHIFT`, `RIGHTSHIFT`
 - `LEFTMETA`, `RIGHTMETA` (Super/Windows key)
 
+### Profile Modifiers
+
+Map modifier keys to named profiles for different post-processing per recording. Hold a profile modifier while pressing the hotkey to activate that profile:
+
+```toml
+[hotkey]
+key = "SCROLLLOCK"
+
+[hotkey.profile_modifiers]
+RIGHTSHIFT = "translate"
+
+[profiles.translate]
+post_process_command = "my-cleanup.sh --translate-en"
+timeout_ms = 10000
+```
+
+With this config, bare ScrollLock uses default post-processing, while Right Shift + ScrollLock translates to English. See [Configuration - profile_modifiers](CONFIGURATION.md#hotkeyprofile_modifiers) for details.
+
+When using compositor keybindings instead of evdev, use `voxtype record start --profile <name>` to achieve the same effect.
+
 ---
 
 ## Compositor Keybindings

--- a/src/config.rs
+++ b/src/config.rs
@@ -397,6 +397,12 @@ pub struct HotkeyConfig {
     /// Examples: "LEFTSHIFT", "RIGHTALT", "LEFTCTRL"
     #[serde(default)]
     pub model_modifier: Option<String>,
+
+    /// Optional modifier keys that activate named profiles (evdev KEY_* names, without KEY_ prefix)
+    /// When held while pressing the hotkey, activates the named profile for post-processing
+    /// Example: { "LEFTSHIFT" = "translate" } activates [profiles.translate] when Shift is held
+    #[serde(default)]
+    pub profile_modifiers: HashMap<String, String>,
 }
 
 /// Audio capture configuration
@@ -1745,6 +1751,7 @@ impl Default for Config {
                 enabled: true,
                 cancel_key: None,
                 model_modifier: None,
+                profile_modifiers: std::collections::HashMap::new(),
             },
             audio: AudioConfig {
                 device: "default".to_string(),
@@ -3622,5 +3629,80 @@ mod tests {
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(!config.output.restore_clipboard);
         assert_eq!(config.output.restore_clipboard_delay_ms, 200);
+    }
+
+    #[test]
+    fn test_parse_profile_modifiers() {
+        let toml_str = r#"
+            [hotkey]
+            key = "SCROLLLOCK"
+
+            [hotkey.profile_modifiers]
+            LEFTSHIFT = "translate"
+            RIGHTALT = "formal"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = "en"
+
+            [output]
+            mode = "type"
+
+            [profiles.translate]
+            post_process_command = "translate.sh"
+
+            [profiles.formal]
+            post_process_command = "formal.sh"
+            post_process_timeout_ms = 15000
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.hotkey.profile_modifiers.len(), 2);
+        assert_eq!(
+            config.hotkey.profile_modifiers.get("LEFTSHIFT").unwrap(),
+            "translate"
+        );
+        assert_eq!(
+            config.hotkey.profile_modifiers.get("RIGHTALT").unwrap(),
+            "formal"
+        );
+        assert!(config.get_profile("translate").is_some());
+        assert!(config.get_profile("formal").is_some());
+        assert_eq!(
+            config
+                .get_profile("translate")
+                .unwrap()
+                .post_process_command
+                .as_deref(),
+            Some("translate.sh")
+        );
+    }
+
+    #[test]
+    fn test_profile_modifiers_default_empty() {
+        let toml_str = r#"
+            [hotkey]
+            key = "SCROLLLOCK"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = "en"
+
+            [output]
+            mode = "type"
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.hotkey.profile_modifiers.is_empty());
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -231,6 +231,17 @@ fn cleanup_profile_override() {
     let _ = std::fs::remove_file(&profile_file);
 }
 
+/// Write a profile override file so the daemon uses the named profile for post-processing.
+/// Same mechanism as `voxtype record start --profile <name>`.
+fn write_profile_override(profile_name: &str) {
+    let profile_file = Config::runtime_dir().join("profile_override");
+    if let Err(e) = std::fs::write(&profile_file, profile_name) {
+        tracing::warn!("Failed to write profile override: {}", e);
+    } else {
+        tracing::info!("Profile modifier activated: {}", profile_name);
+    }
+}
+
 /// Read and consume a boolean override file from the runtime directory.
 /// Returns Some(true) or Some(false) if the file exists and is valid, None otherwise.
 fn read_bool_override(name: &str) -> Option<bool> {
@@ -1465,8 +1476,9 @@ impl Daemon {
     pub async fn run(&mut self) -> Result<()> {
         tracing::info!("Starting voxtype daemon");
 
-        // Clean up any stale cancel file from previous runs
+        // Clean up any stale override/cancel files from previous runs
         cleanup_cancel_file();
+        cleanup_profile_override();
 
         // Clean up any stale meeting command files
         cleanup_meeting_files();
@@ -1636,10 +1648,15 @@ impl Daemon {
                 } => {
                     match (hotkey_event, activation_mode) {
                         // === PUSH-TO-TALK MODE ===
-                        (HotkeyEvent::Pressed { model_override }, ActivationMode::PushToTalk) => {
-                            tracing::debug!("Received HotkeyEvent::Pressed (push-to-talk), state.is_idle() = {}, model_override = {:?}",
-                                state.is_idle(), model_override);
+                        (HotkeyEvent::Pressed { model_override, profile_override }, ActivationMode::PushToTalk) => {
+                            tracing::debug!("Received HotkeyEvent::Pressed (push-to-talk), state.is_idle() = {}, model_override = {:?}, profile_override = {:?}",
+                                state.is_idle(), model_override, profile_override);
                             if state.is_idle() {
+                                // Write profile override file if a profile modifier was held
+                                if let Some(ref profile_name) = profile_override {
+                                    write_profile_override(profile_name);
+                                }
+
                                 tracing::info!("Recording started");
 
                                 // Send notification if enabled
@@ -1740,6 +1757,7 @@ impl Daemon {
                                     }
                                     Err(e) => {
                                         tracing::error!("Failed to create audio capture: {}", e);
+                                        cleanup_profile_override();
                                         self.play_feedback(SoundEvent::Error);
                                     }
                                 }
@@ -1818,11 +1836,16 @@ impl Daemon {
                         }
 
                         // === TOGGLE MODE ===
-                        (HotkeyEvent::Pressed { model_override }, ActivationMode::Toggle) => {
-                            tracing::debug!("Received HotkeyEvent::Pressed (toggle), state.is_idle() = {}, state.is_recording() = {}, model_override = {:?}",
-                                state.is_idle(), state.is_recording(), model_override);
+                        (HotkeyEvent::Pressed { model_override, profile_override }, ActivationMode::Toggle) => {
+                            tracing::debug!("Received HotkeyEvent::Pressed (toggle), state.is_idle() = {}, state.is_recording() = {}, model_override = {:?}, profile_override = {:?}",
+                                state.is_idle(), state.is_recording(), model_override, profile_override);
 
                             if state.is_idle() {
+                                // Write profile override file if a profile modifier was held
+                                if let Some(ref profile_name) = profile_override {
+                                    write_profile_override(profile_name);
+                                }
+
                                 // Start recording
                                 tracing::info!("Recording started (toggle mode)");
 
@@ -1920,6 +1943,7 @@ impl Daemon {
                                     }
                                     Err(e) => {
                                         tracing::error!("Failed to create audio capture: {}", e);
+                                        cleanup_profile_override();
                                         self.play_feedback(SoundEvent::Error);
                                     }
                                 }
@@ -2720,6 +2744,9 @@ impl Daemon {
             tracing::info!("Stopping active meeting on shutdown");
             let _ = self.stop_meeting().await;
         }
+
+        // Remove override files on shutdown
+        cleanup_profile_override();
 
         // Remove state file on shutdown
         if let Some(ref path) = self.state_file_path {

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -31,6 +31,8 @@ pub struct EvdevListener {
     model_modifier: Option<Key>,
     /// Secondary model to use when model_modifier is held
     secondary_model: Option<String>,
+    /// Modifier keys that activate named profiles for post-processing
+    profile_modifiers: HashMap<Key, String>,
     /// Signal to stop the listener task
     stop_signal: Option<oneshot::Sender<()>>,
 }
@@ -60,6 +62,25 @@ impl EvdevListener {
             .map(|k| parse_key_name(k))
             .transpose()?;
 
+        // Parse profile modifier keys
+        let profile_modifiers = config
+            .profile_modifiers
+            .iter()
+            .map(|(k, v)| Ok((parse_key_name(k)?, v.clone())))
+            .collect::<Result<HashMap<Key, String>, HotkeyError>>()?;
+
+        // Warn if profile modifier keys overlap with required modifiers
+        for (key, profile_name) in &profile_modifiers {
+            if modifier_keys.contains(key) {
+                tracing::warn!(
+                    "Profile modifier {:?} for profile '{}' is also a required modifier — \
+                     every hotkey press will activate this profile",
+                    key,
+                    profile_name
+                );
+            }
+        }
+
         // Verify we can access /dev/input (permission check)
         std::fs::read_dir("/dev/input")
             .map_err(|e| HotkeyError::DeviceAccess(format!("/dev/input: {}", e)))?;
@@ -70,6 +91,7 @@ impl EvdevListener {
             cancel_key,
             model_modifier,
             secondary_model: None, // Set later via set_secondary_model
+            profile_modifiers,
             stop_signal: None,
         })
     }
@@ -92,6 +114,7 @@ impl HotkeyListener for EvdevListener {
         let cancel_key = self.cancel_key;
         let model_modifier = self.model_modifier;
         let secondary_model = self.secondary_model.clone();
+        let profile_modifiers = self.profile_modifiers.clone();
 
         // Spawn the listener task
         tokio::task::spawn_blocking(move || {
@@ -101,6 +124,7 @@ impl HotkeyListener for EvdevListener {
                 cancel_key,
                 model_modifier,
                 secondary_model,
+                profile_modifiers,
                 tx,
                 stop_rx,
             ) {
@@ -366,6 +390,7 @@ fn evdev_listener_loop(
     cancel_key: Option<Key>,
     model_modifier: Option<Key>,
     secondary_model: Option<String>,
+    profile_modifiers: HashMap<Key, String>,
     tx: mpsc::Sender<HotkeyEvent>,
     mut stop_rx: oneshot::Receiver<()>,
 ) -> Result<(), HotkeyError> {
@@ -376,6 +401,9 @@ fn evdev_listener_loop(
 
     // Track if model modifier is currently held
     let mut model_modifier_held = false;
+
+    // Track which profile modifier is currently held
+    let mut active_profile_modifier: Option<String> = None;
 
     // Track if we're currently "pressed" (to handle repeat events)
     let mut is_pressed = false;
@@ -474,6 +502,19 @@ fn evdev_listener_loop(
                 }
             }
 
+            // Track profile modifier state
+            if let Some(profile_name) = profile_modifiers.get(&key) {
+                match value {
+                    1 => active_profile_modifier = Some(profile_name.clone()),
+                    0 => {
+                        if active_profile_modifier.as_deref() == Some(profile_name.as_str()) {
+                            active_profile_modifier = None;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
             // Check cancel key first (if configured)
             if let Some(cancel) = cancel_key {
                 if key == cancel && value == 1 {
@@ -504,17 +545,24 @@ fn evdev_listener_loop(
                                 None
                             };
 
-                            if model_override.is_some() {
+                            // Determine profile override based on profile_modifier state
+                            let profile_override = active_profile_modifier.clone();
+
+                            if model_override.is_some() || profile_override.is_some() {
                                 tracing::debug!(
-                                    "Hotkey pressed with model override: {:?}",
-                                    model_override
+                                    "Hotkey pressed with model_override: {:?}, profile_override: {:?}",
+                                    model_override,
+                                    profile_override
                                 );
                             } else {
                                 tracing::debug!("Hotkey pressed");
                             }
 
                             if tx
-                                .blocking_send(HotkeyEvent::Pressed { model_override })
+                                .blocking_send(HotkeyEvent::Pressed {
+                                    model_override,
+                                    profile_override,
+                                })
                                 .is_err()
                             {
                                 return Ok(()); // Channel closed

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -15,10 +15,12 @@ use tokio::sync::mpsc;
 /// Events emitted by the hotkey listener
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HotkeyEvent {
-    /// The hotkey was pressed, optionally with a model override
+    /// The hotkey was pressed, optionally with a model override and/or profile override
     Pressed {
         /// Model to use for this transcription (None = use default)
         model_override: Option<String>,
+        /// Profile to activate for post-processing (None = use default)
+        profile_override: Option<String>,
     },
     /// The hotkey was released
     Released,


### PR DESCRIPTION
## Summary

- Add `[hotkey.profile_modifiers]` config for evdev hotkey detection: map modifier keys to named profiles so holding a modifier while pressing the hotkey activates a different post-processing pipeline
- Reuses the existing profile override file mechanism (same as CLI `--profile` flag), so all profile features (custom post-process command, timeout, output mode) work automatically
- Adds cleanup on error/shutdown paths and warns at startup if a profile modifier key overlaps with required modifiers

**Example config:**
```toml
[hotkey]
key = "SCROLLLOCK"
enabled = true

[hotkey.profile_modifiers]
RIGHTSHIFT = "translate"

[profiles.translate]
post_process_command = "my-cleanup.sh --translate-en"
timeout_ms = 10000
```

Bare ScrollLock uses default post-processing; Right Shift + ScrollLock translates to English.

Only applies to evdev hotkey detection (`enabled = true`). When using compositor keybindings, use `voxtype record start --profile <name>` instead.

## Files changed

- `src/config.rs` — New `profile_modifiers` field on `HotkeyConfig` + 2 tests
- `src/hotkey/mod.rs` — `profile_override` field on `HotkeyEvent::Pressed`
- `src/hotkey/evdev_listener.rs` — Parse, track, and emit profile modifier state
- `src/daemon.rs` — Write profile override file from hotkey event; cleanup on error/shutdown/startup
- `docs/CONFIGURATION.md` — New `[hotkey.profile_modifiers]` section
- `docs/USER_MANUAL.md` — Profile modifiers subsection under hotkeys
- `config/default.toml` — Commented example

## Test plan

- [x] `cargo test` — 549 tests pass (including 2 new profile_modifiers config tests)
- [x] `cargo clippy` — no new warnings
- [x] Manual test: Shift+ScrLock activates translate profile, bare ScrLock uses default

🤖 Generated with [Claude Code](https://claude.com/claude-code)