### PR TITLE
Add post-processing to meeting mode and dictation context

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1665,6 +1665,16 @@ command = "ollama run llama3.2:1b 'Clean up:'"
 timeout_ms = 45000  # 45 second timeout for LLM
 ```
 
+### Context from Previous Dictation
+
+When post-processing is enabled, voxtype passes the previous dictation's text via the `VOXTYPE_CONTEXT` environment variable (if the previous dictation was within 60 seconds). This helps LLM-based cleanup scripts maintain continuity across rapid-fire dictations.
+
+- Stdin always contains only the current text (existing scripts work unchanged)
+- Scripts that want context can optionally read `$VOXTYPE_CONTEXT`
+- In meeting mode, context is tracked per audio source (mic/loopback) to prevent speaker bleed
+
+See the example scripts in `examples/` for how to use `VOXTYPE_CONTEXT`.
+
 ### Error Handling
 
 If the post-processing command fails for any reason (command not found, non-zero

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1676,6 +1676,26 @@ Make it executable: `chmod +x ~/.config/voxtype/lm-studio-cleanup.sh`
 | Local LLMs (Ollama, llama.cpp) | 30000-60000ms (30-60 seconds) |
 | Remote APIs | 30000ms or higher |
 
+### Context from Previous Dictation
+
+When post-processing is enabled, voxtype automatically passes the previous dictation's text to your script via the `VOXTYPE_CONTEXT` environment variable if the previous dictation was within 60 seconds. This helps LLMs maintain continuity when you dictate in quick succession.
+
+Your script receives:
+- **Stdin**: Current text only (existing scripts work unchanged)
+- **`$VOXTYPE_CONTEXT`**: Previous dictation text (optional, read it if you want context)
+
+Example usage in a cleanup script:
+```bash
+PROMPT="Clean up this dictation:"
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  printf -v PROMPT '%s\n\nPrevious dictation for context (do NOT include in output):\n%s\n\nCurrent text to clean up:' "$PROMPT" "$VOXTYPE_CONTEXT"
+fi
+```
+
+In meeting mode, context is tracked separately for microphone and loopback audio to prevent speaker bleed.
+
+See the example scripts in `examples/` for full implementations.
+
 ### Error Handling
 
 Post-processing is designed to be fault-tolerant:

--- a/examples/gemini-cleanup.sh
+++ b/examples/gemini-cleanup.sh
@@ -29,13 +29,20 @@ if [[ -z "$INPUT" ]]; then
     exit 0
 fi
 
+# Build prompt with optional context from previous dictation
+PROMPT="Clean up this dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations:"
+
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  printf -v PROMPT '%s\n\nPrevious dictation for context (do NOT include this in your output):\n%s\n\nCurrent text to clean up:' "$PROMPT" "$VOXTYPE_CONTEXT"
+fi
+
 # Build JSON payload with jq to handle special characters
-JSON=$(jq -n --arg text "$INPUT" '{
+JSON=$(jq -n --arg text "$INPUT" --arg prompt "$PROMPT" '{
   contents: [
     {
       parts: [
         {
-          text: ("Clean up this dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations:\n\n" + $text)
+          text: ($prompt + "\n\n" + $text)
         }
       ]
     }

--- a/examples/ollama-cleanup.sh
+++ b/examples/ollama-cleanup.sh
@@ -17,10 +17,17 @@
 
 INPUT=$(cat)
 
+# Build prompt with optional context from previous dictation
+PROMPT="Clean up this dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations:"
+
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  printf -v PROMPT '%s\n\nPrevious dictation for context (do NOT include this in your output):\n%s\n\nCurrent text to clean up:' "$PROMPT" "$VOXTYPE_CONTEXT"
+fi
+
 # Build JSON payload properly with jq to handle special characters
-JSON=$(jq -n --arg text "$INPUT" '{
+JSON=$(jq -n --arg text "$INPUT" --arg prompt "$PROMPT" '{
   model: "llama3.2:1b",
-  prompt: ("Clean up this dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations:\n\n" + $text),
+  prompt: ($prompt + "\n\n" + $text),
   stream: false
 }')
 

--- a/examples/openai-cleanup.sh
+++ b/examples/openai-cleanup.sh
@@ -29,21 +29,33 @@ if [[ -z "$INPUT" ]]; then
     exit 0
 fi
 
+# Build prompt with optional context from previous dictation
+SYSTEM_PROMPT="You clean up dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations."
+
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  SYSTEM_PROMPT="${SYSTEM_PROMPT} You will receive the previous dictation for context - do NOT include it in your output, only clean up the current text."
+fi
+
 # Build JSON payload with jq to handle special characters
-JSON=$(jq -n --arg text "$INPUT" '{
-  model: "gpt-4o-mini",
-  messages: [
-    {
-      role: "system",
-      content: "You clean up dictated text. Remove filler words (um, uh, like), fix grammar and punctuation. Output ONLY the cleaned text - no quotes, no emojis, no explanations."
-    },
-    {
-      role: "user",
-      content: $text
-    }
-  ],
-  max_tokens: 1000
-}')
+if [[ -n "${VOXTYPE_CONTEXT:-}" ]]; then
+  JSON=$(jq -n --arg text "$INPUT" --arg system "$SYSTEM_PROMPT" --arg context "$VOXTYPE_CONTEXT" '{
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: $system },
+      { role: "user", content: ("Previous dictation for context:\n" + $context + "\n\nCurrent text to clean up:\n" + $text) }
+    ],
+    max_tokens: 1000
+  }')
+else
+  JSON=$(jq -n --arg text "$INPUT" --arg system "$SYSTEM_PROMPT" '{
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: $system },
+      { role: "user", content: $text }
+    ],
+    max_tokens: 1000
+  }')
+fi
 
 # Call OpenAI API
 RESPONSE=$(curl -s --max-time 8 \

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1305,7 +1305,7 @@ impl Daemon {
                             let result = profile_processor
                                 .process_with_context(&processed_text, recent_context)
                                 .await;
-                            tracing::info!("Post-processed: {:?}", result);
+                            tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
                             result
                         } else {
                             // Profile exists but has no post_process_command, use default
@@ -1314,7 +1314,7 @@ impl Daemon {
                                 let result = post_processor
                                     .process_with_context(&processed_text, recent_context)
                                     .await;
-                                tracing::info!("Post-processed: {:?}", result);
+                                tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
                                 result
                             } else {
                                 processed_text
@@ -1325,7 +1325,7 @@ impl Daemon {
                         let result = post_processor
                             .process_with_context(&processed_text, recent_context)
                             .await;
-                        tracing::info!("Post-processed: {:?}", result);
+                        tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
                         result
                     } else {
                         processed_text

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1283,7 +1283,7 @@ impl Daemon {
                     // Get context from last dictation if within 60 seconds
                     let recent_context = self.last_dictation.as_ref().and_then(|(text, when)| {
                         if when.elapsed() < Duration::from_secs(60) {
-                            Some(text.as_str())
+                            Some(text.clone())
                         } else {
                             None
                         }
@@ -1298,34 +1298,40 @@ impl Daemon {
                             };
                             let profile_processor = PostProcessor::new(&profile_config);
                             tracing::info!(
-                                "Post-processing with profile: {:?}, context: {:?}",
+                                "Post-processing with profile: {:?}, has_context: {}",
                                 profile_override.as_ref().unwrap(),
-                                recent_context
+                                recent_context.is_some()
                             );
+                            tracing::debug!("Post-processing context: {:?}", recent_context);
                             let result = profile_processor
-                                .process_with_context(&processed_text, recent_context)
+                                .process_with_context(&processed_text, recent_context.as_deref())
                                 .await;
-                            tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
+                            tracing::info!("Post-processed: changed: {}", result != processed_text);
+                            tracing::debug!("Post-processed result: {:?}", result);
                             result
                         } else {
                             // Profile exists but has no post_process_command, use default
                             if let Some(ref post_processor) = self.post_processor {
-                                tracing::info!("Post-processing: {:?}, context: {:?}", processed_text, recent_context);
+                                tracing::info!("Post-processing, has_context: {}", recent_context.is_some());
+                                tracing::debug!("Post-processing input: {:?}, context: {:?}", processed_text, recent_context);
                                 let result = post_processor
-                                    .process_with_context(&processed_text, recent_context)
+                                    .process_with_context(&processed_text, recent_context.as_deref())
                                     .await;
-                                tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
+                                tracing::info!("Post-processed: changed: {}", result != processed_text);
+                                tracing::debug!("Post-processed result: {:?}", result);
                                 result
                             } else {
                                 processed_text
                             }
                         }
                     } else if let Some(ref post_processor) = self.post_processor {
-                        tracing::info!("Post-processing: {:?}, context: {:?}", processed_text, recent_context);
+                        tracing::info!("Post-processing, has_context: {}", recent_context.is_some());
+                        tracing::debug!("Post-processing input: {:?}, context: {:?}", processed_text, recent_context);
                         let result = post_processor
-                            .process_with_context(&processed_text, recent_context)
+                            .process_with_context(&processed_text, recent_context.as_deref())
                             .await;
-                        tracing::info!("Post-processed: {:?}, changed: {}", result, result != processed_text);
+                        tracing::info!("Post-processed: changed: {}", result != processed_text);
+                        tracing::debug!("Post-processed result: {:?}", result);
                         result
                     } else {
                         processed_text

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1280,15 +1280,14 @@ impl Daemon {
                         }
                     }
 
-                    // Get context from last dictation if within 2 minutes
+                    // Get context from last dictation if within 60 seconds
                     let recent_context = self.last_dictation.as_ref().and_then(|(text, when)| {
-                        if when.elapsed() < Duration::from_secs(120) {
+                        if when.elapsed() < Duration::from_secs(60) {
                             Some(text.as_str())
                         } else {
                             None
                         }
                     });
-
                     // Apply post-processing command (profile overrides default)
                     let final_text = if let Some(profile) = active_profile {
                         if let Some(ref cmd) = profile.post_process_command {
@@ -1299,8 +1298,9 @@ impl Daemon {
                             };
                             let profile_processor = PostProcessor::new(&profile_config);
                             tracing::info!(
-                                "Post-processing with profile: {:?}",
-                                profile_override.as_ref().unwrap()
+                                "Post-processing with profile: {:?}, context: {:?}",
+                                profile_override.as_ref().unwrap(),
+                                recent_context
                             );
                             let result = profile_processor
                                 .process_with_context(&processed_text, recent_context)
@@ -1310,7 +1310,7 @@ impl Daemon {
                         } else {
                             // Profile exists but has no post_process_command, use default
                             if let Some(ref post_processor) = self.post_processor {
-                                tracing::info!("Post-processing: {:?}", processed_text);
+                                tracing::info!("Post-processing: {:?}, context: {:?}", processed_text, recent_context);
                                 let result = post_processor
                                     .process_with_context(&processed_text, recent_context)
                                     .await;
@@ -1321,7 +1321,7 @@ impl Daemon {
                             }
                         }
                     } else if let Some(ref post_processor) = self.post_processor {
-                        tracing::info!("Post-processing: {:?}", processed_text);
+                        tracing::info!("Post-processing: {:?}, context: {:?}", processed_text, recent_context);
                         let result = post_processor
                             .process_with_context(&processed_text, recent_context)
                             .await;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -20,7 +20,7 @@ use pidlock::Pidlock;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::process::Command;
 use tokio::signal::unix::{signal, SignalKind};
 
@@ -475,6 +475,8 @@ pub struct Daemon {
     audio_feedback: Option<AudioFeedback>,
     text_processor: TextProcessor,
     post_processor: Option<PostProcessor>,
+    /// Last post-processed text and when it was produced, for context in subsequent dictations
+    last_dictation: Option<(String, Instant)>,
     // Model manager for multi-model support
     model_manager: Option<ModelManager>,
     // Background task for loading model on-demand
@@ -588,6 +590,7 @@ impl Daemon {
             audio_feedback,
             text_processor,
             post_processor,
+            last_dictation: None,
             model_manager: None,
             model_load_task: None,
             transcription_task: None,
@@ -1231,7 +1234,7 @@ impl Daemon {
 
     /// Handle transcription completion (called when transcription_task completes)
     async fn handle_transcription_result(
-        &self,
+        &mut self,
         state: &mut State,
         result: std::result::Result<TranscriptionResult, tokio::task::JoinError>,
     ) {
@@ -1277,6 +1280,15 @@ impl Daemon {
                         }
                     }
 
+                    // Get context from last dictation if within 2 minutes
+                    let recent_context = self.last_dictation.as_ref().and_then(|(text, when)| {
+                        if when.elapsed() < Duration::from_secs(120) {
+                            Some(text.as_str())
+                        } else {
+                            None
+                        }
+                    });
+
                     // Apply post-processing command (profile overrides default)
                     let final_text = if let Some(profile) = active_profile {
                         if let Some(ref cmd) = profile.post_process_command {
@@ -1290,14 +1302,18 @@ impl Daemon {
                                 "Post-processing with profile: {:?}",
                                 profile_override.as_ref().unwrap()
                             );
-                            let result = profile_processor.process(&processed_text).await;
+                            let result = profile_processor
+                                .process_with_context(&processed_text, recent_context)
+                                .await;
                             tracing::info!("Post-processed: {:?}", result);
                             result
                         } else {
                             // Profile exists but has no post_process_command, use default
                             if let Some(ref post_processor) = self.post_processor {
                                 tracing::info!("Post-processing: {:?}", processed_text);
-                                let result = post_processor.process(&processed_text).await;
+                                let result = post_processor
+                                    .process_with_context(&processed_text, recent_context)
+                                    .await;
                                 tracing::info!("Post-processed: {:?}", result);
                                 result
                             } else {
@@ -1306,12 +1322,18 @@ impl Daemon {
                         }
                     } else if let Some(ref post_processor) = self.post_processor {
                         tracing::info!("Post-processing: {:?}", processed_text);
-                        let result = post_processor.process(&processed_text).await;
+                        let result = post_processor
+                            .process_with_context(&processed_text, recent_context)
+                            .await;
                         tracing::info!("Post-processed: {:?}", result);
                         result
                     } else {
                         processed_text
                     };
+
+                    // Track last dictation for context in subsequent post-processing
+                    self.last_dictation =
+                        Some((final_text.clone(), Instant::now()));
 
                     if smart_submit {
                         tracing::debug!(

--- a/src/meeting/data.rs
+++ b/src/meeting/data.rs
@@ -44,7 +44,7 @@ impl std::str::FromStr for MeetingId {
 }
 
 /// Audio source for speaker attribution
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[derive(Default)]
 pub enum AudioSource {

--- a/src/meeting/mod.rs
+++ b/src/meeting/mod.rs
@@ -40,7 +40,9 @@ pub use state::{ChunkState, MeetingState};
 pub use storage::{MeetingStorage, StorageConfig, StorageError};
 
 use crate::error::{MeetingError, Result};
+use crate::output::post_process::PostProcessor;
 use crate::transcribe::{self, Transcriber};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -100,6 +102,10 @@ pub struct MeetingDaemon {
     transcriber: Option<Arc<dyn Transcriber>>,
     engine_name: String,
     event_tx: mpsc::Sender<MeetingEvent>,
+    post_processor: Option<PostProcessor>,
+    /// Previous chunk's post-processed text, tracked per audio source
+    /// so mic and loopback contexts don't bleed into each other
+    last_chunk_text: HashMap<AudioSource, String>,
 }
 
 impl MeetingDaemon {
@@ -116,6 +122,15 @@ impl MeetingDaemon {
             Arc::from(transcribe::create_transcriber(app_config)?);
         let engine_name = format!("{:?}", app_config.engine).to_lowercase();
 
+        let post_processor = app_config.output.post_process.as_ref().map(|cfg| {
+            tracing::info!(
+                "Meeting post-processing enabled: command={:?}, timeout={}ms",
+                cfg.command,
+                cfg.timeout_ms
+            );
+            PostProcessor::new(cfg)
+        });
+
         Ok(Self {
             config,
             state: MeetingState::Idle,
@@ -124,6 +139,8 @@ impl MeetingDaemon {
             transcriber: Some(transcriber),
             engine_name,
             event_tx,
+            post_processor,
+            last_chunk_text: HashMap::new(),
         })
     }
 
@@ -190,6 +207,7 @@ impl MeetingDaemon {
         }
 
         self.state = std::mem::take(&mut self.state).stop();
+        self.last_chunk_text.clear();
 
         // Finalize meeting
         if let Some(ref mut meeting) = self.current_meeting {
@@ -280,9 +298,26 @@ impl MeetingDaemon {
         let mut buffer = processor.new_buffer(chunk_id, source, start_offset_ms);
         buffer.add_samples(&samples);
 
-        let result = processor
+        let mut result = processor
             .process_chunk(buffer)
             .map_err(crate::error::VoxtypeError::Transcribe)?;
+
+        // Post-process segment text if configured
+        if let Some(ref post_processor) = self.post_processor {
+            let context = self.last_chunk_text.get(&source).map(|s| s.as_str());
+            for segment in &mut result.segments {
+                if !segment.text.is_empty() {
+                    segment.text = post_processor
+                        .process_with_context(&segment.text, context)
+                        .await;
+                }
+            }
+            // Update context for next chunk (per source)
+            if let Some(last_seg) = result.segments.last() {
+                self.last_chunk_text
+                    .insert(source, last_seg.text.clone());
+            }
+        }
 
         // Add segments to transcript
         if let Some(ref mut meeting) = self.current_meeting {

--- a/src/meeting/mod.rs
+++ b/src/meeting/mod.rs
@@ -304,11 +304,11 @@ impl MeetingDaemon {
 
         // Post-process segment text if configured
         if let Some(ref post_processor) = self.post_processor {
-            let context = self.last_chunk_text.get(&source).map(|s| s.as_str());
+            let context = self.last_chunk_text.get(&source).cloned();
             for segment in &mut result.segments {
                 if !segment.text.is_empty() {
                     segment.text = post_processor
-                        .process_with_context(&segment.text, context)
+                        .process_with_context(&segment.text, context.as_deref())
                         .await;
                 }
             }

--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -267,4 +267,35 @@ mod tests {
         let result = processor.process("test input").await;
         assert_eq!(result, "prefix:\ntest input");
     }
+
+    #[tokio::test]
+    async fn test_context_passed_via_env_var() {
+        // Command prints VOXTYPE_CONTEXT env var, stdin is current text
+        let config = make_config("echo \"context:$VOXTYPE_CONTEXT stdin:$(cat)\"", 5000);
+        let processor = PostProcessor::new(&config);
+        let result = processor
+            .process_with_context("current text", Some("previous text"))
+            .await;
+        assert_eq!(result, "context:previous text stdin:current text");
+    }
+
+    #[tokio::test]
+    async fn test_no_context_env_var_when_none() {
+        // VOXTYPE_CONTEXT should not be set when context is None
+        let config = make_config("echo \"context:${VOXTYPE_CONTEXT:-unset} stdin:$(cat)\"", 5000);
+        let processor = PostProcessor::new(&config);
+        let result = processor.process_with_context("current text", None).await;
+        assert_eq!(result, "context:unset stdin:current text");
+    }
+
+    #[tokio::test]
+    async fn test_context_env_not_inherited_from_parent() {
+        // Even if VOXTYPE_CONTEXT is set in parent env, it should be cleared when context is None
+        std::env::set_var("VOXTYPE_CONTEXT", "stale parent context");
+        let config = make_config("echo \"${VOXTYPE_CONTEXT:-unset}\"", 5000);
+        let processor = PostProcessor::new(&config);
+        let result = processor.process_with_context("text", None).await;
+        std::env::remove_var("VOXTYPE_CONTEXT");
+        assert_eq!(result, "unset");
+    }
 }

--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -36,12 +36,20 @@ impl PostProcessor {
         }
     }
 
-    /// Process text through the external command
+    /// Process text with optional context from a previous chunk
     ///
+    /// When context is provided (meeting mode), formats stdin with a separator so the
+    /// post-processing command can use previous chunk text for continuity.
     /// Returns the processed text on success, or the original text on any failure.
-    /// This ensures voice-to-text always produces output even when post-processing fails.
-    pub async fn process(&self, text: &str) -> String {
-        match self.execute_command(text).await {
+    pub async fn process_with_context(&self, text: &str, context: Option<&str>) -> String {
+        let input = match context {
+            Some(ctx) => format!(
+                "--- CONTEXT (previous chunk) ---\n{}\n--- CURRENT (clean up this text) ---\n{}",
+                ctx, text
+            ),
+            None => text.to_string(),
+        };
+        match self.execute_command(&input).await {
             Ok(processed) => {
                 if processed.is_empty() {
                     tracing::warn!(
@@ -62,6 +70,14 @@ impl PostProcessor {
                 text.to_string()
             }
         }
+    }
+
+    /// Process text through the external command
+    ///
+    /// Returns the processed text on success, or the original text on any failure.
+    /// This ensures voice-to-text always produces output even when post-processing fails.
+    pub async fn process(&self, text: &str) -> String {
+        self.process_with_context(text, None).await
     }
 
     async fn execute_command(&self, text: &str) -> Result<String, PostProcessError> {

--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -85,6 +85,8 @@ impl PostProcessor {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        // Always clear to prevent inheriting stale context from parent environment
+        cmd.env_remove("VOXTYPE_CONTEXT");
         if let Some(ctx) = context {
             cmd.env("VOXTYPE_CONTEXT", ctx);
         }

--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -38,18 +38,12 @@ impl PostProcessor {
 
     /// Process text with optional context from a previous chunk
     ///
-    /// When context is provided (meeting mode), formats stdin with a separator so the
-    /// post-processing command can use previous chunk text for continuity.
+    /// When context is provided, it is passed via the VOXTYPE_CONTEXT environment
+    /// variable so the post-processing command can use it for continuity.
+    /// Stdin always contains only the current text, keeping existing scripts compatible.
     /// Returns the processed text on success, or the original text on any failure.
     pub async fn process_with_context(&self, text: &str, context: Option<&str>) -> String {
-        let input = match context {
-            Some(ctx) => format!(
-                "--- CONTEXT (previous chunk) ---\n{}\n--- CURRENT (clean up this text) ---\n{}",
-                ctx, text
-            ),
-            None => text.to_string(),
-        };
-        match self.execute_command(&input).await {
+        match self.execute_command_with_env(text, context).await {
             Ok(processed) => {
                 if processed.is_empty() {
                     tracing::warn!(
@@ -80,13 +74,22 @@ impl PostProcessor {
         self.process_with_context(text, None).await
     }
 
-    async fn execute_command(&self, text: &str) -> Result<String, PostProcessError> {
-        // Spawn command via shell for proper parsing of complex commands
-        let mut child = Command::new("sh")
-            .args(["-c", &self.command])
+    async fn execute_command_with_env(
+        &self,
+        text: &str,
+        context: Option<&str>,
+    ) -> Result<String, PostProcessError> {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", &self.command])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        if let Some(ctx) = context {
+            cmd.env("VOXTYPE_CONTEXT", ctx);
+        }
+
+        let mut child = cmd
             .spawn()
             .map_err(|e| PostProcessError::SpawnFailed(e.to_string()))?;
 


### PR DESCRIPTION
> **Note:** Reopened from #265, which was closed when the fork was deleted. This PR contains the same changes, rebased onto current main.

## Summary

This PR adds post-processing support to two areas that previously lacked it:

### 1. Meeting mode post-processing (new)

Meeting mode previously skipped post-processing entirely. Now, if `[output.post_process]` is configured, each transcribed chunk is piped through the post-processing command before being stored in the transcript. Previous chunk text is passed as context so the LLM can maintain continuity across 30-second chunk boundaries.

Context is tracked per audio source (mic vs loopback) to prevent speaker bleed between channels. Context is cleared when a meeting stops so it doesn't leak into the next meeting.

### 2. Dictation mode context (new)

Regular push-to-talk dictation now passes the previous dictation's text as context to the post-processing command, if the previous dictation was within 60 seconds. This helps the LLM produce more coherent cleanup when dictating in quick succession.

The 60-second retention window is intentionally not configurable to avoid config fatigue. It covers rapid-fire dictation without leaking stale context.

### Context delivery mechanism

Context is passed via the `VOXTYPE_CONTEXT` environment variable, keeping stdin as plain current text. This means existing post-processing scripts work unchanged. Scripts that want context can optionally read `$VOXTYPE_CONTEXT`.

The env var is explicitly cleared before each command invocation to prevent inheriting stale context from the parent environment.

### Other changes

- `process()` now delegates to `process_with_context(text, None)`, removing ~20 lines of duplicated error-handling logic
- Post-processing tracing logs now include `changed: true/false` to indicate whether the command modified the text
- Example scripts (gemini, ollama, openai) updated to optionally use `$VOXTYPE_CONTEXT`
- Docs updated (CONFIGURATION.md, USER_MANUAL.md)

## Test plan

- [ ] Configure `[output.post_process]` and run a meeting, verify exported transcript shows post-processed text
- [ ] Verify post-processing failure falls back to original text
- [ ] Verify mic and loopback chunks get independent context (no speaker bleed)
- [ ] Verify context clears on meeting stop and doesn't leak to next meeting
- [ ] Verify regular dictation gets context from previous dictation within 60s
- [ ] Verify dictation context expires after 60s
- [ ] Verify existing scripts work without modification (stdin is plain text)
- [ ] Verify `VOXTYPE_CONTEXT` is not inherited from parent environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)