### PR TITLE
fix: wire flash_attention config field through to WhisperContextParam…

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -794,6 +794,12 @@ pub struct WhisperConfig {
     #[serde(default)]
     pub gpu_device: Option<i32>,
 
+    /// Enable flash attention for GPU inference (default: false)
+    /// Reduces memory bandwidth pressure in the attention layers.
+    /// Requires a compatible GPU backend (CUDA or Vulkan).
+    #[serde(default)]
+    pub flash_attention: bool,
+
     /// Optimize context window for short recordings (default: true)
     /// When enabled, uses a smaller context window proportional to audio length
     /// for clips under 22.5 seconds. This significantly speeds up transcription
@@ -912,6 +918,7 @@ impl Default for WhisperConfig {
             on_demand_loading: default_on_demand_loading(),
             gpu_isolation: false,
             gpu_device: None,
+            flash_attention: false,
             context_window_optimization: default_context_window_optimization(),
             eager_processing: false,
             eager_chunk_secs: default_eager_chunk_secs(),
@@ -1762,6 +1769,7 @@ impl Default for Config {
                 on_demand_loading: default_on_demand_loading(),
                 gpu_isolation: false,
                 gpu_device: None,
+                flash_attention: false,
                 context_window_optimization: default_context_window_optimization(),
                 eager_processing: false,
                 eager_chunk_secs: default_eager_chunk_secs(),

--- a/src/transcribe/whisper.rs
+++ b/src/transcribe/whisper.rs
@@ -42,6 +42,8 @@ impl WhisperTranscriber {
             tracing::info!("Using GPU device index {}", device);
             ctx_params.gpu_device(device);
         }
+        ctx_params.flash_attn(config.flash_attention);
+        tracing::info!("Flash attention: {}", config.flash_attention);
 
         let ctx = WhisperContext::new_with_params(
             model_path


### PR DESCRIPTION

## Description

The flash_attention field in [whisper] config was parsed from config.toml but never passed to WhisperContextParameters before model initialization, causing it to be silently ignored on all backends.

Fix: pass config.flash_attention to ctx_params.flash_attn() in WhisperTranscriber::new(), and add the missing field to WhisperConfig struct and its Default impl.

Tested on RTX 5060 Ti with large-v3-turbo, 6-minute audio file:
```
  Backend   flash_attn   encode buffer   wall time (avg 3 runs)
  -------   ----------   -------------   ---------
  CUDA      off          212 MB          7.00s
  Vulkan    off          220 MB          6.54s
  CUDA      on            55 MB          6.27s
  Vulkan    on            55 MB          6.26s
```
~10% reduction in wall time. Encode buffer reduced by ~75%, consistent with flash attention avoiding full attention matrix materialization.

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy` with no warnings
- [x] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [x] No documentation changes are needed

## Additional Notes

Any additional information reviewers should know.
