### PR TITLE
Add --flash-attention CLI flag, env var, and clean up logging

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,10 @@ pub struct Cli {
     #[arg(long, value_name = "INDEX", help_heading = "Whisper")]
     pub gpu_device: Option<i32>,
 
+    /// Enable flash attention for reduced GPU memory usage and faster inference
+    #[arg(long, help_heading = "Whisper")]
+    pub flash_attention: bool,
+
     /// Load model on-demand when recording starts instead of keeping it loaded
     #[arg(long, help_heading = "Whisper")]
     pub on_demand_loading: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,10 @@ translate = false
 # Use gpu_device for same-vendor GPUs or precise index control.
 # gpu_device = 1
 
+# Enable flash attention for GPU inference (default: false)
+# Reduces memory usage (~75%) and improves speed (~10%) on CUDA/Vulkan.
+# flash_attention = false
+
 # Initial prompt to provide context for transcription
 # Use this to hint at terminology, proper nouns, or formatting conventions.
 # Example: "Technical discussion about Rust, TypeScript, and Kubernetes."
@@ -2049,6 +2053,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         if let Ok(n) = val.parse::<i32>() {
             config.whisper.gpu_device = Some(n);
         }
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_FLASH_ATTENTION") {
+        config.whisper.flash_attention = parse_bool_env(&val);
     }
     if let Ok(val) = std::env::var("VOXTYPE_ON_DEMAND_LOADING") {
         config.whisper.on_demand_loading = parse_bool_env(&val);

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,6 +191,9 @@ async fn main() -> anyhow::Result<()> {
     if let Some(gpu_device) = cli.gpu_device {
         config.whisper.gpu_device = Some(gpu_device);
     }
+    if cli.flash_attention {
+        config.whisper.flash_attention = true;
+    }
     if cli.on_demand_loading {
         config.whisper.on_demand_loading = true;
     }

--- a/src/transcribe/whisper.rs
+++ b/src/transcribe/whisper.rs
@@ -43,7 +43,9 @@ impl WhisperTranscriber {
             ctx_params.gpu_device(device);
         }
         ctx_params.flash_attn(config.flash_attention);
-        tracing::info!("Flash attention: {}", config.flash_attention);
+        if config.flash_attention {
+            tracing::info!("Flash attention enabled");
+        }
 
         let ctx = WhisperContext::new_with_params(
             model_path


### PR DESCRIPTION
## Summary

Follow-up to #298. The flash_attention config field was wired through to WhisperContextParameters but was only configurable via config file.

- Add `--flash-attention` CLI flag for runtime override
- Add `VOXTYPE_FLASH_ATTENTION` env var override
- Add commented example in config template
- Only log at INFO when flash attention is enabled (was logging on every model load including the default `false` case)

## Test plan

- [x] `cargo test` -- 25 tests pass
- [x] `cargo run -- --help` shows `--flash-attention` under Whisper heading
- [x] `cargo clippy` clean

Co-authored-by: graysky <therealgraysky AT proton DOT me>