### PR TITLE
Fix 6 bugs and add 3 enhancements for v0.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ sudo apt install wtype
 
 ### Compositor Keybindings
 
-Voxtype works best with your compositor's native keybindings. Add these to your compositor config:
+Voxtype works best with your compositor's native keybindings. Add these to your compositor config.
+
+> **Not sure which compositor you have?** Run `echo $XDG_CURRENT_DESKTOP` in a terminal. Common values: `Hyprland`, `sway`, `river`, `KDE`, `GNOME`.
 
 **Hyprland** (`~/.config/hypr/hyprland.conf`):
 ```
@@ -66,6 +68,15 @@ bindsym --release $mod+v exec voxtype record stop
 riverctl map normal Super V spawn 'voxtype record start'
 riverctl map -release normal Super V spawn 'voxtype record stop'
 ```
+
+**KDE Plasma (KWin):**
+
+KDE does not support key-release events, so use toggle mode. Open **System Settings > Shortcuts > Custom Shortcuts**, create a new shortcut, and set the command to:
+```
+voxtype record toggle
+```
+
+Assign your preferred key combination (e.g., Meta+V). Since KDE handles the keybinding, the built-in hotkey should be disabled (see below).
 
 Then disable the built-in hotkey in your config:
 ```toml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -186,6 +186,10 @@ bindsym $mod+v exec voxtype record start
 bindsym --release $mod+v exec voxtype record stop
 ```
 
+**KDE Plasma (KWin):**
+
+KDE does not support key-release events, so use toggle mode. Open **System Settings > Shortcuts > Custom Shortcuts**, create a new global shortcut, and set the command to `voxtype record toggle`. Assign your preferred key combination (e.g., Meta+V).
+
 **Note:** For `toggle` mode to work correctly, you must also set `state_file = "auto"` so voxtype can track its current state.
 
 See [User Manual - Compositor Keybindings](USER_MANUAL.md#compositor-keybindings) for complete setup instructions.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -514,9 +514,32 @@ riverctl map -release normal Super V spawn 'voxtype record stop'
 riverctl map normal Super V spawn 'voxtype record toggle'
 ```
 
+### KDE Plasma (KWin)
+
+KDE Plasma uses KWin as its compositor. KWin does not support key-release events, so push-to-talk (hold to record) is not available. Use toggle mode instead (press once to start recording, press again to stop).
+
+1. Open **System Settings > Shortcuts > Custom Shortcuts**.
+2. Click **Edit > New > Global Shortcut > Command/URL**.
+3. Name it something like "Voxtype Toggle".
+4. On the **Trigger** tab, click the button and press your desired key combination (e.g., Meta+V).
+5. On the **Action** tab, set the command to:
+   ```
+   voxtype record toggle
+   ```
+6. Click **Apply**.
+
+Then disable the built-in hotkey in `~/.config/voxtype/config.toml`:
+
+```toml
+[hotkey]
+enabled = false
+```
+
+Restart the voxtype daemon after changing the config.
+
 ### Other Compositors/Desktops
 
-For compositors without key release support (GNOME, KDE), use toggle mode:
+For other compositors without key release support (GNOME, etc.), use toggle mode:
 
 ```bash
 # Generic: bind this to your preferred key

--- a/src/audio/feedback.rs
+++ b/src/audio/feedback.rs
@@ -15,6 +15,8 @@ pub enum SoundEvent {
     RecordingStart,
     /// Recording stopped
     RecordingStop,
+    /// Transcription completed and text output successfully
+    TranscriptionComplete,
     /// Recording/transcription cancelled
     Cancelled,
     /// Error occurred
@@ -33,6 +35,7 @@ pub struct AudioFeedback {
 struct SoundTheme {
     start: Vec<u8>,
     stop: Vec<u8>,
+    complete: Vec<u8>,
     cancel: Vec<u8>,
     error: Vec<u8>,
 }
@@ -62,6 +65,7 @@ impl AudioFeedback {
         let sound_data = match event {
             SoundEvent::RecordingStart => &self.theme.start,
             SoundEvent::RecordingStop => &self.theme.stop,
+            SoundEvent::TranscriptionComplete => &self.theme.complete,
             SoundEvent::Cancelled => &self.theme.cancel,
             SoundEvent::Error => &self.theme.error,
         };
@@ -117,6 +121,7 @@ fn load_custom_theme(path: &str) -> Result<SoundTheme, String> {
     Ok(SoundTheme {
         start: load_file("start.wav"),
         stop: load_file("stop.wav"),
+        complete: load_file("complete.wav"),
         cancel: load_file("cancel.wav"),
         error: load_file("error.wav"),
     })
@@ -234,6 +239,8 @@ fn generate_default_theme() -> SoundTheme {
         start: generate_two_tone_wav(440.0, 880.0, 150, 20),
         // Falling two-tone: 880Hz -> 440Hz (completion)
         stop: generate_two_tone_wav(880.0, 440.0, 150, 20),
+        // High ping: short 1200Hz tone (distinct from start/stop two-tones)
+        complete: generate_tone_wav(1200.0, 80, 15),
         // Quick descending triple-beep for cancel (distinct from stop)
         cancel: generate_tone_wav(600.0, 80, 10),
         // Low warning tone
@@ -248,6 +255,8 @@ fn generate_subtle_theme() -> SoundTheme {
         start: generate_tone_wav(1200.0, 50, 10),
         // Soft low click
         stop: generate_tone_wav(800.0, 50, 10),
+        // Gentle rising two-tone pip
+        complete: generate_two_tone_wav(900.0, 1100.0, 60, 10),
         // Quick mid-tone for cancel
         cancel: generate_tone_wav(600.0, 40, 8),
         // Double low click
@@ -262,6 +271,8 @@ fn generate_mechanical_theme() -> SoundTheme {
         start: generate_click_wav(30),
         // Softer click
         stop: generate_click_wav(20),
+        // Carriage return bell
+        complete: generate_tone_wav(2000.0, 40, 8),
         // Double click for cancel
         cancel: generate_click_wav(15),
         // Buzzer
@@ -287,15 +298,18 @@ mod tests {
         let default = generate_default_theme();
         assert!(!default.start.is_empty());
         assert!(!default.stop.is_empty());
+        assert!(!default.complete.is_empty());
         assert!(!default.cancel.is_empty());
         assert!(!default.error.is_empty());
 
         let subtle = generate_subtle_theme();
         assert!(!subtle.start.is_empty());
+        assert!(!subtle.complete.is_empty());
         assert!(!subtle.cancel.is_empty());
 
         let mechanical = generate_mechanical_theme();
         assert!(!mechanical.start.is_empty());
+        assert!(!mechanical.complete.is_empty());
         assert!(!mechanical.cancel.is_empty());
     }
 }

--- a/src/audio/media.rs
+++ b/src/audio/media.rs
@@ -1,0 +1,95 @@
+//! MPRIS media player control via playerctl
+//!
+//! Pauses playing media players when recording starts and resumes
+//! only the players that were actually playing when recording stops.
+
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+/// Pause all currently playing MPRIS media players.
+/// Returns the names of players that were paused, so they can be resumed later.
+pub async fn pause_playing_players() -> Vec<String> {
+    // List players that are currently in "Playing" status
+    let output = match Command::new("playerctl")
+        .args(["--all-players", "-f", "{{playerName}}", "status"])
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(e) => {
+            warn!("playerctl not found or failed to run: {}", e);
+            return Vec::new();
+        }
+    };
+
+    if !output.status.success() {
+        // playerctl exits non-zero when no players are running
+        debug!("No MPRIS players found");
+        return Vec::new();
+    }
+
+    // playerctl with --all-players returns one status per line, but we need
+    // the player names paired with their statuses. Use a separate call to get
+    // player names and statuses together.
+    let players_output = match Command::new("playerctl")
+        .args([
+            "--all-players",
+            "-f",
+            "{{playerName}}\t{{status}}",
+            "status",
+        ])
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(_) => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&players_output.stdout);
+    let mut paused_players = Vec::new();
+
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((name, status)) = line.split_once('\t') {
+            if status == "Playing" {
+                debug!(player = %name, "Pausing media player");
+                let result = Command::new("playerctl")
+                    .args(["--player", name, "pause"])
+                    .output()
+                    .await;
+                if let Err(e) = result {
+                    warn!(player = %name, "Failed to pause player: {}", e);
+                } else {
+                    paused_players.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    if !paused_players.is_empty() {
+        debug!("Paused {} media player(s)", paused_players.len());
+    }
+
+    paused_players
+}
+
+/// Resume the specified MPRIS media players.
+pub async fn resume_players(players: Vec<String>) {
+    for name in &players {
+        debug!(player = %name, "Resuming media player");
+        let result = Command::new("playerctl")
+            .args(["--player", name, "play"])
+            .output()
+            .await;
+        if let Err(e) = result {
+            warn!(player = %name, "Failed to resume player: {}", e);
+        }
+    }
+
+    if !players.is_empty() {
+        debug!("Resumed {} media player(s)", players.len());
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -8,6 +8,7 @@ pub mod dual_capture;
 #[cfg(feature = "onnx-common")]
 pub mod enhance;
 pub mod feedback;
+pub mod media;
 
 pub use dual_capture::{AudioSourceType, DualCapture, DualSamples, SourcedSample};
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,7 +93,6 @@ pub struct Cli {
     pub model_modifier: Option<String>,
 
     // -- Whisper --
-
     /// Disable context window optimization for short recordings
     #[arg(long, help_heading = "Whisper")]
     pub no_whisper_context_optimization: bool,
@@ -152,7 +151,6 @@ pub struct Cli {
     pub remote_api_key: Option<String>,
 
     // -- Audio --
-
     /// Audio input device name (or "default" for system default)
     #[arg(long, value_name = "DEVICE", help_heading = "Audio")]
     pub audio_device: Option<String>,
@@ -169,8 +167,11 @@ pub struct Cli {
     #[arg(long, help_heading = "Audio")]
     pub no_audio_feedback: bool,
 
-    // -- Output --
+    /// Pause MPRIS media players during recording (requires playerctl)
+    #[arg(long, help_heading = "Audio")]
+    pub pause_media: bool,
 
+    // -- Output --
     /// Delay before typing starts (ms), helps prevent first character drop
     #[arg(long, value_name = "MS", help_heading = "Output")]
     pub pre_type_delay: Option<u32>,
@@ -223,7 +224,11 @@ pub struct Cli {
     pub fallback_to_clipboard: bool,
 
     /// Disable clipboard fallback
-    #[arg(long, conflicts_with = "fallback_to_clipboard", help_heading = "Output")]
+    #[arg(
+        long,
+        conflicts_with = "fallback_to_clipboard",
+        help_heading = "Output"
+    )]
     pub no_fallback_to_clipboard: bool,
 
     /// Enable spoken punctuation conversion (e.g., say "period" to get ".")
@@ -263,7 +268,6 @@ pub struct Cli {
     pub pre_recording_command: Option<String>,
 
     // -- VAD --
-
     /// Enable Voice Activity Detection (filter silence before transcription)
     #[arg(long, help_heading = "VAD")]
     pub vad: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1668,7 +1668,7 @@ impl OutputConfig {
 pub enum OutputMode {
     /// Simulate keyboard input (requires ydotool)
     Type,
-    /// Copy to clipboard (requires wl-copy)
+    /// Copy to clipboard (wl-copy on Wayland, xclip on X11)
     Clipboard,
     /// Copy to clipboard then paste with Ctrl+V (requires wl-copy and ydotool)
     Paste,

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,10 @@ sample_rate = 16000
 # Maximum recording duration in seconds (safety limit)
 max_duration_secs = 60
 
+# Pause MPRIS media players (Spotify, Firefox, etc.) when recording starts,
+# resume them when recording stops. Requires playerctl.
+# pause_media = false
+
 # [audio.feedback]
 # Enable audio feedback sounds (beeps when recording starts/stops)
 # enabled = true
@@ -410,6 +414,10 @@ pub struct AudioConfig {
 
     /// Maximum recording duration in seconds (safety limit)
     pub max_duration_secs: u32,
+
+    /// Pause MPRIS media players during recording and resume on stop
+    #[serde(default)]
+    pub pause_media: bool,
 
     /// Audio feedback settings
     #[serde(default)]
@@ -1757,6 +1765,7 @@ impl Default for Config {
                 device: "default".to_string(),
                 sample_rate: 16000,
                 max_duration_secs: 60,
+                pause_media: false,
                 feedback: AudioFeedbackConfig::default(),
             },
             whisper: WhisperConfig {
@@ -2065,6 +2074,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     }
     if let Ok(val) = std::env::var("VOXTYPE_AUDIO_FEEDBACK") {
         config.audio.feedback.enabled = parse_bool_env(&val);
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_PAUSE_MEDIA") {
+        config.audio.pause_media = parse_bool_env(&val);
     }
 
     // Output

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -506,6 +506,8 @@ pub struct Daemon {
     // GTCRN speech enhancer for mic echo cancellation
     #[cfg(feature = "onnx-common")]
     speech_enhancer: Option<std::sync::Arc<audio::enhance::GtcrnEnhancer>>,
+    // Media players that were paused when recording started (for resume on stop)
+    paused_media_players: Vec<String>,
 }
 
 impl Daemon {
@@ -601,6 +603,7 @@ impl Daemon {
             meeting_event_rx: None,
             #[cfg(feature = "onnx-common")]
             speech_enhancer: None,
+            paused_media_players: Vec::new(),
         }
     }
 
@@ -608,6 +611,21 @@ impl Daemon {
     fn play_feedback(&self, event: SoundEvent) {
         if let Some(ref feedback) = self.audio_feedback {
             feedback.play(event);
+        }
+    }
+
+    /// Pause MPRIS media players if configured, storing which ones were paused
+    async fn pause_media_players(&mut self) {
+        if self.config.audio.pause_media {
+            self.paused_media_players = audio::media::pause_playing_players().await;
+        }
+    }
+
+    /// Resume any MPRIS media players that were paused at recording start
+    fn resume_media_players(&mut self) {
+        if !self.paused_media_players.is_empty() {
+            let players = std::mem::take(&mut self.paused_media_players);
+            tokio::spawn(audio::media::resume_players(players));
         }
     }
 
@@ -916,13 +934,14 @@ impl Daemon {
 
     /// Reset state to idle and run post_output_command to reset compositor submap
     /// Call this when exiting from recording/transcribing without normal output flow
-    async fn reset_to_idle(&self, state: &mut State) {
+    async fn reset_to_idle(&mut self, state: &mut State) {
         cleanup_output_mode_override();
         cleanup_model_override();
         cleanup_profile_override();
         cleanup_bool_override("auto_submit");
         cleanup_bool_override("shift_enter");
         cleanup_bool_override("smart_auto_submit");
+        self.resume_media_players();
         *state = State::Idle;
         self.update_state("idle");
 
@@ -1231,7 +1250,7 @@ impl Daemon {
 
     /// Handle transcription completion (called when transcription_task completes)
     async fn handle_transcription_result(
-        &self,
+        &mut self,
         state: &mut State,
         result: std::result::Result<TranscriptionResult, tokio::task::JoinError>,
     ) {
@@ -1374,6 +1393,7 @@ impl Daemon {
                             }
                         }
 
+                        self.resume_media_players();
                         *state = State::Idle;
                         self.update_state("idle");
                         return;
@@ -1446,6 +1466,7 @@ impl Daemon {
                         }
                     }
 
+                    self.resume_media_players();
                     *state = State::Idle;
                     self.update_state("idle");
                 }
@@ -1735,6 +1756,7 @@ impl Daemon {
                                         }
                                         self.update_state("recording");
                                         self.play_feedback(SoundEvent::RecordingStart);
+                                        self.pause_media_players().await;
 
                                         // Run pre-recording hook (e.g., enter compositor submap for cancel)
                                         if let Some(cmd) = &self.config.output.pre_recording_command {
@@ -1915,6 +1937,7 @@ impl Daemon {
                                         }
                                         self.update_state("recording");
                                         self.play_feedback(SoundEvent::RecordingStart);
+                                        self.pause_media_players().await;
 
                                         // Run pre-recording hook (e.g., enter compositor submap for cancel)
                                         if let Some(cmd) = &self.config.output.pre_recording_command {
@@ -2344,6 +2367,7 @@ impl Daemon {
                                     }
                                     self.update_state("recording");
                                     self.play_feedback(SoundEvent::RecordingStart);
+                                    self.pause_media_players().await;
 
                                     // Run pre-recording hook (e.g., enter compositor submap for cancel)
                                     if let Some(cmd) = &self.config.output.pre_recording_command {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1363,6 +1363,7 @@ impl Daemon {
                                     FileMode::Append => "appended",
                                 };
                                 tracing::info!("{} transcription to {:?}", mode_str, output_path);
+                                self.play_feedback(SoundEvent::TranscriptionComplete);
                             }
                             Err(e) => {
                                 tracing::error!(
@@ -1431,14 +1432,18 @@ impl Daemon {
                             .await
                     {
                         tracing::error!("Output failed: {}", e);
-                    } else if self.config.output.notification.on_transcription {
-                        // Send notification on successful output
-                        output::send_transcription_notification(
-                            &final_text,
-                            self.config.output.notification.show_engine_icon,
-                            self.config.engine,
-                        )
-                        .await;
+                    } else {
+                        self.play_feedback(SoundEvent::TranscriptionComplete);
+
+                        if self.config.output.notification.on_transcription {
+                            // Send notification on successful output
+                            output::send_transcription_notification(
+                                &final_text,
+                                self.config.output.notification.show_engine_icon,
+                                self.config.engine,
+                            )
+                            .await;
+                        }
                     }
 
                     *state = State::Idle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,9 @@ async fn main() -> anyhow::Result<()> {
     if cli.no_audio_feedback {
         config.audio.feedback.enabled = false;
     }
+    if cli.pause_media {
+        config.audio.pause_media = true;
+    }
 
     // Output overrides
     if let Some(append_text) = cli.append_text {
@@ -1228,8 +1231,8 @@ async fn show_config(config: &config::Config) -> anyhow::Result<()> {
             if path.is_dir() {
                 let name = entry.file_name().to_string_lossy().to_string();
                 if name.contains("sensevoice") {
-                    let has_model = path.join("model.int8.onnx").exists()
-                        || path.join("model.onnx").exists();
+                    let has_model =
+                        path.join("model.int8.onnx").exists() || path.join("model.onnx").exists();
                     let has_tokens = path.join("tokens.txt").exists();
                     if has_model && has_tokens {
                         sensevoice_models.push(name);

--- a/src/output/clipboard.rs
+++ b/src/output/clipboard.rs
@@ -13,42 +13,14 @@ use tokio::process::Command;
 
 /// Clipboard-based text output
 pub struct ClipboardOutput {
-    /// Whether to show a desktop notification
-    notify: bool,
     /// Text to append after transcription
     append_text: Option<String>,
 }
 
 impl ClipboardOutput {
     /// Create a new clipboard output
-    pub fn new(notify: bool, append_text: Option<String>) -> Self {
-        Self {
-            notify,
-            append_text,
-        }
-    }
-
-    /// Send a desktop notification
-    async fn send_notification(&self, text: &str) {
-        // Truncate preview for notification (use chars() to handle multi-byte UTF-8)
-        let preview = if text.chars().count() > 80 {
-            format!("{}...", text.chars().take(80).collect::<String>())
-        } else {
-            text.to_string()
-        };
-
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                "--urgency=low",
-                "--expire-time=3000",
-                "Copied to clipboard",
-                &preview,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
+    pub fn new(append_text: Option<String>) -> Self {
+        Self { append_text }
     }
 }
 
@@ -103,11 +75,6 @@ impl TextOutput for ClipboardOutput {
             ));
         }
 
-        // Send notification if enabled
-        if self.notify {
-            self.send_notification(&text).await;
-        }
-
         tracing::info!("Text copied to clipboard ({} chars)", text.len());
         Ok(())
     }
@@ -134,10 +101,10 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = ClipboardOutput::new(true, None);
-        assert!(output.notify);
+        let output = ClipboardOutput::new(None);
+        assert!(output.append_text.is_none());
 
-        let output = ClipboardOutput::new(false, None);
-        assert!(!output.notify);
+        let output = ClipboardOutput::new(Some(" ".to_string()));
+        assert_eq!(output.append_text, Some(" ".to_string()));
     }
 }

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -21,8 +21,6 @@ pub struct DotoolOutput {
     type_delay_ms: u32,
     /// Delay before typing starts in milliseconds
     pre_type_delay_ms: u32,
-    /// Whether to show a desktop notification
-    notify: bool,
     /// Whether to send Enter key after output
     auto_submit: bool,
     /// Text to append after transcription (before auto_submit)
@@ -38,7 +36,6 @@ impl DotoolOutput {
     pub fn new(
         type_delay_ms: u32,
         pre_type_delay_ms: u32,
-        notify: bool,
         auto_submit: bool,
         append_text: Option<String>,
         xkb_layout: Option<String>,
@@ -50,35 +47,11 @@ impl DotoolOutput {
         Self {
             type_delay_ms,
             pre_type_delay_ms,
-            notify,
             auto_submit,
             append_text,
             xkb_layout,
             xkb_variant,
         }
-    }
-
-    /// Send a desktop notification
-    async fn send_notification(&self, text: &str) {
-        // Truncate preview for notification
-        let preview: String = text.chars().take(100).collect();
-        let preview = if text.len() > 100 {
-            format!("{}...", preview)
-        } else {
-            preview
-        };
-
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                "--expire-time=3000",
-                "Transcribed",
-                &preview,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
     }
 
     /// Build the dotool command string to send via stdin
@@ -185,11 +158,6 @@ impl TextOutput for DotoolOutput {
 
         tracing::info!("Text typed via dotool ({} chars)", text.len());
 
-        // Send notification if enabled
-        if self.notify {
-            self.send_notification(text).await;
-        }
-
         Ok(())
     }
 
@@ -216,24 +184,23 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = DotoolOutput::new(10, 0, true, false, None, Some("de".to_string()), None);
+        let output = DotoolOutput::new(10, 0, false, None, Some("de".to_string()), None);
         assert_eq!(output.type_delay_ms, 10);
         assert_eq!(output.pre_type_delay_ms, 0);
-        assert!(output.notify);
         assert!(!output.auto_submit);
         assert_eq!(output.xkb_layout, Some("de".to_string()));
     }
 
     #[test]
     fn test_build_commands_simple() {
-        let output = DotoolOutput::new(0, 0, false, false, None, None, None);
+        let output = DotoolOutput::new(0, 0, false, None, None, None);
         let cmds = output.build_commands("Hello world");
         assert_eq!(cmds, "type Hello world\n");
     }
 
     #[test]
     fn test_build_commands_with_delay() {
-        let output = DotoolOutput::new(10, 0, false, false, None, None, None);
+        let output = DotoolOutput::new(10, 0, false, None, None, None);
         let cmds = output.build_commands("Test");
         assert!(cmds.contains("typedelay 10"));
         assert!(cmds.contains("typehold 10"));
@@ -242,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_build_commands_with_enter() {
-        let output = DotoolOutput::new(0, 0, false, true, None, None, None);
+        let output = DotoolOutput::new(0, 0, true, None, None, None);
         let cmds = output.build_commands("Test");
         assert!(cmds.contains("type Test"));
         assert!(cmds.contains("key enter"));

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -25,8 +25,65 @@ use crate::config::{OutputConfig, OutputDriver};
 use crate::error::OutputError;
 use std::borrow::Cow;
 use std::fs;
+use std::os::unix::fs::FileTypeExt;
+use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::Command;
+
+/// Find the ydotool daemon socket by checking known locations.
+///
+/// Fedora places the socket at `/tmp/.ydotool_socket`, while the ydotool CLI
+/// defaults to `$XDG_RUNTIME_DIR/.ydotool_socket`. Without setting `YDOTOOL_SOCKET`
+/// explicitly, ydotool commands fail on distros that use a non-default path.
+///
+/// Search order:
+/// 1. `$YDOTOOL_SOCKET` env var (user override)
+/// 2. `$XDG_RUNTIME_DIR/.ydotool_socket` (ydotool CLI default)
+/// 3. `/tmp/.ydotool_socket` (Fedora / systemd-wide service)
+/// 4. `/run/user/$UID/.ydotool_socket` (fallback if XDG_RUNTIME_DIR unset)
+pub fn find_ydotool_socket() -> Option<PathBuf> {
+    let candidates: Vec<PathBuf> = {
+        let mut paths = Vec::new();
+
+        // 1. Explicit env override
+        if let Ok(val) = std::env::var("YDOTOOL_SOCKET") {
+            paths.push(PathBuf::from(val));
+        }
+
+        // 2. XDG_RUNTIME_DIR (ydotool CLI default)
+        if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+            paths.push(PathBuf::from(xdg).join(".ydotool_socket"));
+        }
+
+        // 3. /tmp (Fedora systemd-wide ydotoold)
+        paths.push(PathBuf::from("/tmp/.ydotool_socket"));
+
+        // 4. /run/user/$UID fallback
+        let uid = unsafe { libc::getuid() };
+        paths.push(PathBuf::from(format!("/run/user/{}/.ydotool_socket", uid)));
+
+        paths
+    };
+
+    for path in &candidates {
+        if let Ok(meta) = fs::metadata(path) {
+            if meta.file_type().is_socket() {
+                tracing::debug!("Found ydotool socket at {}", path.display());
+                return Some(path.clone());
+            }
+        }
+    }
+
+    tracing::debug!(
+        "No ydotool socket found in: {}",
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    None
+}
 
 /// Normalize Unicode curly quotes to ASCII equivalents.
 ///
@@ -93,13 +150,13 @@ pub fn is_parakeet_binary_active() -> bool {
 /// Get the engine icon for notifications based on configured engine
 pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
     match engine {
-        crate::config::TranscriptionEngine::Parakeet => "\u{1F99C}",     // 🦜
+        crate::config::TranscriptionEngine::Parakeet => "\u{1F99C}", // 🦜
         crate::config::TranscriptionEngine::Whisper => "\u{1F5E3}\u{FE0F}", // 🗣️
-        crate::config::TranscriptionEngine::Moonshine => "\u{1F319}",    // 🌙
-        crate::config::TranscriptionEngine::SenseVoice => "\u{1F442}",   // 👂
-        crate::config::TranscriptionEngine::Paraformer => "\u{1F4AC}",   // 💬
-        crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",      // 🐬
-        crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}",  // 🌍
+        crate::config::TranscriptionEngine::Moonshine => "\u{1F319}", // 🌙
+        crate::config::TranscriptionEngine::SenseVoice => "\u{1F442}", // 👂
+        crate::config::TranscriptionEngine::Paraformer => "\u{1F4AC}", // 💬
+        crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",  // 🐬
+        crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
     }
 }
 
@@ -438,5 +495,33 @@ mod tests {
         let text = "Café \u{2019} emoji 😀";
         let result = normalize_quotes(text);
         assert_eq!(result, "Café ' emoji 😀");
+    }
+
+    #[test]
+    fn test_find_ydotool_socket_returns_none_when_no_socket() {
+        // In a test environment there should be no ydotoold running, so this
+        // should return None (no socket file exists at any candidate path).
+        // This primarily verifies the function does not panic.
+        let _result = find_ydotool_socket();
+    }
+
+    #[test]
+    fn test_find_ydotool_socket_respects_env_override() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join(".ydotool_socket");
+
+        // Create a real Unix socket so metadata().file_type().is_socket() is true
+        let _listener = UnixListener::bind(&sock_path).unwrap();
+
+        // Temporarily set YDOTOOL_SOCKET to point at our test socket.
+        // This is inherently racy in multi-threaded test runs, but it's the
+        // simplest way to exercise the env-var priority path.
+        std::env::set_var("YDOTOOL_SOCKET", &sock_path);
+        let result = find_ydotool_socket();
+        std::env::remove_var("YDOTOOL_SOCKET");
+
+        assert_eq!(result, Some(sock_path));
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -221,11 +221,7 @@ fn create_driver_output(
     driver: OutputDriver,
     config: &OutputConfig,
     pre_type_delay_ms: u32,
-    is_first: bool,
 ) -> Box<dyn TextOutput> {
-    // Only the first driver in the chain should show notifications
-    let show_notification = is_first && config.notification.on_transcription;
-
     match driver {
         OutputDriver::Wtype => Box::new(wtype::WtypeOutput::new(
             config.auto_submit,
@@ -244,7 +240,6 @@ fn create_driver_output(
         OutputDriver::Dotool => Box::new(dotool::DotoolOutput::new(
             config.type_delay_ms,
             pre_type_delay_ms,
-            show_notification,
             config.auto_submit,
             config.append_text.clone(),
             config.dotool_xkb_layout.clone(),
@@ -253,18 +248,13 @@ fn create_driver_output(
         OutputDriver::Ydotool => Box::new(ydotool::YdotoolOutput::new(
             config.type_delay_ms,
             pre_type_delay_ms,
-            show_notification,
             config.auto_submit,
             config.append_text.clone(),
         )),
-        OutputDriver::Clipboard => Box::new(clipboard::ClipboardOutput::new(
-            show_notification,
-            config.append_text.clone(),
-        )),
-        OutputDriver::Xclip => Box::new(xclip::XclipOutput::new(
-            show_notification,
-            config.append_text.clone(),
-        )),
+        OutputDriver::Clipboard => {
+            Box::new(clipboard::ClipboardOutput::new(config.append_text.clone()))
+        }
+        OutputDriver::Xclip => Box::new(xclip::XclipOutput::new(config.append_text.clone())),
     }
 }
 
@@ -310,12 +300,7 @@ pub fn create_output_chain_with_override(
                     continue;
                 }
 
-                chain.push(create_driver_output(
-                    *driver,
-                    config,
-                    pre_type_delay_ms,
-                    i == 0,
-                ));
+                chain.push(create_driver_output(*driver, config, pre_type_delay_ms));
             }
 
             // If fallback_to_clipboard is true but clipboard wasn't in the custom order, add it
@@ -324,7 +309,6 @@ pub fn create_output_chain_with_override(
                 && !driver_order.contains(&OutputDriver::Clipboard)
             {
                 chain.push(Box::new(clipboard::ClipboardOutput::new(
-                    false,
                     config.append_text.clone(),
                 )));
             }
@@ -332,7 +316,6 @@ pub fn create_output_chain_with_override(
         crate::config::OutputMode::Clipboard => {
             // Only clipboard
             chain.push(Box::new(clipboard::ClipboardOutput::new(
-                config.notification.on_transcription,
                 config.append_text.clone(),
             )));
         }
@@ -355,7 +338,6 @@ pub fn create_output_chain_with_override(
                 "Output mode is 'file' but no file_path configured. Falling back to clipboard."
             );
             chain.push(Box::new(clipboard::ClipboardOutput::new(
-                config.notification.on_transcription,
                 config.append_text.clone(),
             )));
         }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -319,7 +319,6 @@ pub fn create_output_chain_with_override(
                 config.append_text.clone(),
             )));
             chain.push(Box::new(xclip::XclipOutput::new(
-                config.notification.on_transcription,
                 config.append_text.clone(),
             )));
         }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -314,8 +314,12 @@ pub fn create_output_chain_with_override(
             }
         }
         crate::config::OutputMode::Clipboard => {
-            // Only clipboard
+            // Clipboard with X11 fallback: wl-copy first, then xclip
             chain.push(Box::new(clipboard::ClipboardOutput::new(
+                config.append_text.clone(),
+            )));
+            chain.push(Box::new(xclip::XclipOutput::new(
+                config.notification.on_transcription,
                 config.append_text.clone(),
             )));
         }

--- a/src/output/paste.rs
+++ b/src/output/paste.rs
@@ -5,8 +5,9 @@
 //!
 //! Requires:
 //! - wl-copy installed (for clipboard access)
-//! - wtype OR ydotool installed (for keystroke simulation)
+//! - wtype OR eitype OR ydotool installed (for keystroke simulation)
 //!   - wtype: Wayland-native, no daemon needed (preferred)
+//!   - eitype: EI protocol, works on GNOME/KDE/Sway with libei
 //!   - ydotool: Works on X11/Wayland/TTY, requires ydotoold daemon
 
 use super::TextOutput;
@@ -72,6 +73,24 @@ impl ParsedKeystroke {
             args.push("-m".to_string());
             args.push(modifier.clone());
         }
+
+        args
+    }
+
+    /// Convert to eitype arguments
+    /// e.g., "ctrl+v" -> ["-M", "ctrl", "-k", "v"]
+    fn to_eitype_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        // Press modifiers
+        for modifier in &self.modifiers {
+            args.push("-M".to_string());
+            args.push(modifier.clone());
+        }
+
+        // Tap the key
+        args.push("-k".to_string());
+        args.push(self.key.clone());
 
         args
     }
@@ -522,6 +541,18 @@ impl PasteOutput {
         std::env::var("WAYLAND_DISPLAY").is_ok()
     }
 
+    /// Check if eitype is available
+    async fn is_eitype_available(&self) -> bool {
+        Command::new("which")
+            .arg("eitype")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
     /// Check if ydotool is available (installed and daemon running)
     async fn is_ydotool_available(&self) -> bool {
         // Check if ydotool exists
@@ -582,6 +613,36 @@ impl PasteOutput {
         Ok(())
     }
 
+    /// Simulate paste keystroke using eitype
+    async fn simulate_paste_eitype(&self) -> Result<(), OutputError> {
+        let args = self.keystroke.to_eitype_args();
+        tracing::debug!("Running: eitype {}", args.join(" "));
+
+        let output = Command::new("eitype")
+            .args(&args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    OutputError::EitypeNotFound
+                } else {
+                    OutputError::CtrlVFailed(e.to_string())
+                }
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(OutputError::CtrlVFailed(format!(
+                "eitype failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Simulate paste keystroke using ydotool
     async fn simulate_paste_ydotool(&self) -> Result<(), OutputError> {
         let args = self.keystroke.to_ydotool_args().map_err(|e| {
@@ -634,7 +695,7 @@ impl PasteOutput {
         Ok(())
     }
 
-    /// Simulate paste keystroke, trying wtype first then ydotool
+    /// Simulate paste keystroke, trying wtype first, then eitype, then ydotool
     async fn simulate_paste_keystroke(&self) -> Result<(), OutputError> {
         // Try wtype first (preferred - no daemon needed)
         if self.is_wtype_available().await {
@@ -644,7 +705,20 @@ impl PasteOutput {
                     return Ok(());
                 }
                 Err(e) => {
-                    tracing::debug!("wtype paste failed: {}, trying ydotool", e);
+                    tracing::debug!("wtype paste failed: {}, trying eitype", e);
+                }
+            }
+        }
+
+        // Try eitype (EI protocol - works on GNOME/KDE/Sway with libei)
+        if self.is_eitype_available().await {
+            match self.simulate_paste_eitype().await {
+                Ok(()) => {
+                    tracing::debug!("Paste keystroke sent via eitype");
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::debug!("eitype paste failed: {}, trying ydotool", e);
                 }
             }
         }
@@ -664,7 +738,7 @@ impl PasteOutput {
         }
 
         Err(OutputError::CtrlVFailed(
-            "Neither wtype nor ydotool available for paste keystroke".to_string(),
+            "No keystroke tool available (tried wtype, eitype, ydotool)".to_string(),
         ))
     }
 
@@ -674,6 +748,22 @@ impl PasteOutput {
         if self.is_wtype_available().await {
             let output = Command::new("wtype")
                 .args(["-k", "Return"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .output()
+                .await;
+
+            if let Ok(out) = output {
+                if out.status.success() {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Try eitype
+        if self.is_eitype_available().await {
+            let output = Command::new("eitype")
+                .args(["-k", "return"])
                 .stdout(Stdio::null())
                 .stderr(Stdio::piped())
                 .output()
@@ -814,21 +904,23 @@ impl TextOutput for PasteOutput {
             return false;
         }
 
-        // Check if EITHER wtype OR ydotool is available for keystroke simulation
+        // Check if wtype, eitype, or ydotool is available for keystroke simulation
         let wtype_available = self.is_wtype_available().await;
+        let eitype_available = self.is_eitype_available().await;
         let ydotool_available = self.is_ydotool_available().await;
 
-        if !wtype_available && !ydotool_available {
+        if !wtype_available && !eitype_available && !ydotool_available {
             tracing::debug!(
-                "paste mode unavailable: neither wtype nor ydotool available \
-                (wtype needs WAYLAND_DISPLAY, ydotool needs daemon running)"
+                "paste mode unavailable: no keystroke tool available \
+                (wtype needs WAYLAND_DISPLAY, eitype needs libei, ydotool needs daemon running)"
             );
             return false;
         }
 
         tracing::debug!(
-            "paste mode available (wtype: {}, ydotool: {})",
+            "paste mode available (wtype: {}, eitype: {}, ydotool: {})",
             wtype_available,
+            eitype_available,
             ydotool_available
         );
         true

--- a/src/output/paste.rs
+++ b/src/output/paste.rs
@@ -11,6 +11,7 @@
 
 use super::TextOutput;
 use crate::error::OutputError;
+use crate::output::find_ydotool_socket;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -538,8 +539,11 @@ impl PasteOutput {
         }
 
         // Check if ydotoold is running by trying a no-op
-        Command::new("ydotool")
-            .args(["type", ""])
+        let mut cmd = Command::new("ydotool");
+        if let Some(socket) = find_ydotool_socket() {
+            cmd.env("YDOTOOL_SOCKET", socket);
+        }
+        cmd.args(["type", ""])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
@@ -591,6 +595,9 @@ impl PasteOutput {
         );
 
         let mut cmd = Command::new("ydotool");
+        if let Some(socket) = find_ydotool_socket() {
+            cmd.env("YDOTOOL_SOCKET", socket);
+        }
         cmd.arg("key");
 
         // Only add delay parameter if configured
@@ -681,7 +688,11 @@ impl PasteOutput {
 
         // Fall back to ydotool
         if self.is_ydotool_available().await {
-            let output = Command::new("ydotool")
+            let mut cmd = Command::new("ydotool");
+            if let Some(socket) = find_ydotool_socket() {
+                cmd.env("YDOTOOL_SOCKET", socket);
+            }
+            let output = cmd
                 .args(["key", "28:1", "28:0"])
                 .stdout(Stdio::null())
                 .stderr(Stdio::piped())

--- a/src/output/xclip.rs
+++ b/src/output/xclip.rs
@@ -13,42 +13,14 @@ use tokio::process::Command;
 
 /// xclip-based text output for X11
 pub struct XclipOutput {
-    /// Whether to show a desktop notification
-    notify: bool,
     /// Text to append after transcription
     append_text: Option<String>,
 }
 
 impl XclipOutput {
     /// Create a new xclip output
-    pub fn new(notify: bool, append_text: Option<String>) -> Self {
-        Self {
-            notify,
-            append_text,
-        }
-    }
-
-    /// Send a desktop notification
-    async fn send_notification(&self, text: &str) {
-        // Truncate preview for notification (use chars() to handle multi-byte UTF-8)
-        let preview = if text.chars().count() > 80 {
-            format!("{}...", text.chars().take(80).collect::<String>())
-        } else {
-            text.to_string()
-        };
-
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                "--urgency=low",
-                "--expire-time=3000",
-                "Copied to clipboard",
-                &preview,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
+    pub fn new(append_text: Option<String>) -> Self {
+        Self { append_text }
     }
 }
 
@@ -104,11 +76,6 @@ impl TextOutput for XclipOutput {
             ));
         }
 
-        // Send notification if enabled
-        if self.notify {
-            self.send_notification(&text).await;
-        }
-
         tracing::info!("Text copied to X11 clipboard ({} chars)", text.len());
         Ok(())
     }
@@ -141,10 +108,10 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = XclipOutput::new(true, None);
-        assert!(output.notify);
+        let output = XclipOutput::new(None);
+        assert!(output.append_text.is_none());
 
-        let output = XclipOutput::new(false, None);
-        assert!(!output.notify);
+        let output = XclipOutput::new(Some(" ".to_string()));
+        assert_eq!(output.append_text, Some(" ".to_string()));
     }
 }

--- a/src/output/ydotool.rs
+++ b/src/output/ydotool.rs
@@ -22,8 +22,6 @@ pub struct YdotoolOutput {
     type_delay_ms: u32,
     /// Delay before typing starts in milliseconds
     pre_type_delay_ms: u32,
-    /// Whether to show a desktop notification
-    notify: bool,
     /// Whether ydotool supports --key-hold flag (added in newer versions)
     supports_key_hold: bool,
     /// Whether to send Enter key after output
@@ -41,7 +39,6 @@ impl YdotoolOutput {
     pub fn new(
         type_delay_ms: u32,
         pre_type_delay_ms: u32,
-        notify: bool,
         auto_submit: bool,
         append_text: Option<String>,
     ) -> Self {
@@ -55,7 +52,6 @@ impl YdotoolOutput {
         Self {
             type_delay_ms,
             pre_type_delay_ms,
-            notify,
             supports_key_hold,
             auto_submit,
             append_text,
@@ -84,29 +80,6 @@ impl YdotoolOutput {
                 stdout.contains("--key-hold") || stderr.contains("--key-hold")
             })
             .unwrap_or(false)
-    }
-
-    /// Send a desktop notification
-    async fn send_notification(&self, text: &str) {
-        // Truncate preview for notification
-        let preview: String = text.chars().take(100).collect();
-        let preview = if text.len() > 100 {
-            format!("{}...", preview)
-        } else {
-            preview
-        };
-
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                "--expire-time=3000",
-                "Transcribed",
-                &preview,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
     }
 }
 
@@ -229,11 +202,6 @@ impl TextOutput for YdotoolOutput {
             }
         }
 
-        // Send notification if enabled
-        if self.notify {
-            self.send_notification(text).await;
-        }
-
         Ok(())
     }
 
@@ -274,10 +242,9 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = YdotoolOutput::new(10, 0, true, false, None);
+        let output = YdotoolOutput::new(10, 0, false, None);
         assert_eq!(output.type_delay_ms, 10);
         assert_eq!(output.pre_type_delay_ms, 0);
-        assert!(output.notify);
         assert!(!output.auto_submit);
         // supports_key_hold depends on system ydotool version, so we just check it's set
         let _ = output.supports_key_hold;
@@ -285,15 +252,14 @@ mod tests {
 
     #[test]
     fn test_new_with_enter() {
-        let output = YdotoolOutput::new(0, 0, false, true, None);
+        let output = YdotoolOutput::new(0, 0, true, None);
         assert_eq!(output.type_delay_ms, 0);
-        assert!(!output.notify);
         assert!(output.auto_submit);
     }
 
     #[test]
     fn test_new_with_pre_type_delay() {
-        let output = YdotoolOutput::new(0, 200, false, false, None);
+        let output = YdotoolOutput::new(0, 200, false, None);
         assert_eq!(output.type_delay_ms, 0);
         assert_eq!(output.pre_type_delay_ms, 200);
     }

--- a/src/output/ydotool.rs
+++ b/src/output/ydotool.rs
@@ -10,6 +10,8 @@
 
 use super::TextOutput;
 use crate::error::OutputError;
+use crate::output::find_ydotool_socket;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 use tokio::process::Command;
@@ -28,6 +30,8 @@ pub struct YdotoolOutput {
     auto_submit: bool,
     /// Text to append after transcription (before auto_submit)
     append_text: Option<String>,
+    /// Path to ydotoold socket, if found at a non-default location
+    socket_path: Option<PathBuf>,
 }
 
 impl YdotoolOutput {
@@ -47,6 +51,7 @@ impl YdotoolOutput {
         } else {
             tracing::debug!("ydotool does not support --key-hold flag, using --key-delay only");
         }
+        let socket_path = find_ydotool_socket();
         Self {
             type_delay_ms,
             pre_type_delay_ms,
@@ -54,6 +59,14 @@ impl YdotoolOutput {
             supports_key_hold,
             auto_submit,
             append_text,
+            socket_path,
+        }
+    }
+
+    /// Apply the discovered socket path to a ydotool Command, if any.
+    fn apply_socket_env(&self, cmd: &mut Command) {
+        if let Some(ref path) = self.socket_path {
+            cmd.env("YDOTOOL_SOCKET", path);
         }
     }
 
@@ -114,6 +127,7 @@ impl TextOutput for YdotoolOutput {
         }
 
         let mut cmd = Command::new("ydotool");
+        self.apply_socket_env(&mut cmd);
         cmd.arg("type");
 
         // Always set delay explicitly (ydotool defaults to 12ms if not specified)
@@ -166,6 +180,7 @@ impl TextOutput for YdotoolOutput {
         // Append text if configured (e.g., a space to separate sentences)
         if let Some(ref append) = self.append_text {
             let mut append_cmd = Command::new("ydotool");
+            self.apply_socket_env(&mut append_cmd);
             append_cmd.arg("type");
             append_cmd
                 .arg("--key-delay")
@@ -196,7 +211,9 @@ impl TextOutput for YdotoolOutput {
         // ydotool key uses evdev key codes: 28 is KEY_ENTER
         // Format: keycode:press (1) then keycode:release (0)
         if self.auto_submit {
-            let enter_output = Command::new("ydotool")
+            let mut enter_cmd = Command::new("ydotool");
+            self.apply_socket_env(&mut enter_cmd);
+            let enter_output = enter_cmd
                 .args(["key", "28:1", "28:0"])
                 .stdout(Stdio::null())
                 .stderr(Stdio::piped())
@@ -235,8 +252,9 @@ impl TextOutput for YdotoolOutput {
 
         // Check if ydotoold is running by trying a no-op
         // ydotool type "" should succeed quickly if daemon is running
-        Command::new("ydotool")
-            .args(["type", ""])
+        let mut cmd = Command::new("ydotool");
+        self.apply_socket_env(&mut cmd);
+        cmd.args(["type", ""])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -47,12 +47,19 @@ impl TextProcessor {
     pub fn process(&self, text: &str) -> String {
         let mut result = text.to_string();
 
-        // Apply spoken punctuation first (so user replacements can override if needed)
+        // Apply replacements first so phrases containing spoken punctuation words
+        // (e.g. "slash pr" → "/pr") match before those words are converted to
+        // punctuation characters.
+        if !self.replacements.is_empty() {
+            result = self.apply_replacements(&result);
+        }
+
         if self.spoken_punctuation {
             result = self.apply_spoken_punctuation(&result);
         }
 
-        // Apply custom replacements
+        // Apply replacements again to catch patterns that only became matchable
+        // after spoken punctuation conversion.
         if !self.replacements.is_empty() {
             result = self.apply_replacements(&result);
         }
@@ -505,5 +512,23 @@ mod tests {
         let (text, submit) = processor.detect_submit("hello world submit", Some(false));
         assert_eq!(text, "hello world submit");
         assert!(!submit);
+    }
+
+    #[test]
+    fn test_replacements_match_spoken_words_before_punctuation() {
+        // "slash pr" should match the replacement before "slash" is converted to "/"
+        let config = make_config(true, &[("slash pr", "/pr")]);
+        let processor = TextProcessor::new(&config);
+
+        assert_eq!(processor.process("slash pr"), "/pr");
+    }
+
+    #[test]
+    fn test_replacements_with_multiple_spoken_punctuation_words() {
+        // "dash dash" should match the replacement before each "dash" is converted to "-"
+        let config = make_config(true, &[("dash dash", "--")]);
+        let processor = TextProcessor::new(&config);
+
+        assert_eq!(processor.process("dash dash"), "--");
     }
 }

--- a/src/transcribe/remote.rs
+++ b/src/transcribe/remote.rs
@@ -26,6 +26,8 @@ pub struct RemoteTranscriber {
     translate: bool,
     /// Optional API key for authentication
     api_key: Option<String>,
+    /// Optional initial prompt for transcription context
+    initial_prompt: Option<String>,
     /// Request timeout
     timeout: Duration,
 }
@@ -91,12 +93,19 @@ impl RemoteTranscriber {
             timeout.as_secs()
         );
 
+        let initial_prompt = config
+            .initial_prompt
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned();
+
         Ok(Self {
             endpoint,
             model,
             language: config.language.clone(),
             translate: config.translate,
             api_key,
+            initial_prompt,
             timeout,
         })
     }
@@ -164,6 +173,14 @@ impl RemoteTranscriber {
             body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
             body.extend_from_slice(b"Content-Disposition: form-data; name=\"language\"\r\n\r\n");
             body.extend_from_slice(self.language.primary().as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+
+        // Add prompt field (if initial_prompt is configured)
+        if let Some(ref prompt) = self.initial_prompt {
+            body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+            body.extend_from_slice(b"Content-Disposition: form-data; name=\"prompt\"\r\n\r\n");
+            body.extend_from_slice(prompt.as_bytes());
             body.extend_from_slice(b"\r\n");
         }
 
@@ -343,6 +360,61 @@ mod tests {
         assert!(body_str.contains("name=\"language\""));
         assert!(body_str.contains("name=\"response_format\""));
         assert!(body_str.contains("json"));
+    }
+
+    #[test]
+    fn test_multipart_body_includes_prompt() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            initial_prompt: Some("Technical discussion about Rust and Kubernetes.".to_string()),
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        let wav_data = vec![0u8; 100];
+
+        let (_boundary, body) = transcriber.build_multipart_body(&wav_data);
+        let body_str = String::from_utf8_lossy(&body);
+
+        assert!(body_str.contains("name=\"prompt\""));
+        assert!(body_str.contains("Technical discussion about Rust and Kubernetes."));
+    }
+
+    #[test]
+    fn test_multipart_body_excludes_empty_prompt() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            initial_prompt: Some("".to_string()),
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        let wav_data = vec![0u8; 100];
+
+        let (_boundary, body) = transcriber.build_multipart_body(&wav_data);
+        let body_str = String::from_utf8_lossy(&body);
+
+        assert!(!body_str.contains("name=\"prompt\""));
+    }
+
+    #[test]
+    fn test_multipart_body_excludes_prompt_when_none() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            initial_prompt: None,
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        let wav_data = vec![0u8; 100];
+
+        let (_boundary, body) = transcriber.build_multipart_body(&wav_data);
+        let body_str = String::from_utf8_lossy(&body);
+
+        assert!(!body_str.contains("name=\"prompt\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Fix #306**: ydotool socket detection for non-standard paths (Fedora puts socket at `/tmp/.ydotool_socket`)
- **Fix #268**: Duplicate desktop notifications when using ydotool/dotool/clipboard drivers
- **Fix #278**: Forward `initial_prompt` config to remote transcription endpoints as `prompt` field
- **Fix #172**: Apply text replacements before spoken punctuation conversion so patterns like "slash pr" work
- **Fix #259**: Add eitype to paste mode Ctrl+V simulation chain (KDE Plasma Wayland support)
- **Fix #256**: Add xclip fallback in clipboard mode for X11 sessions
- **#258**: Audio feedback on transcription completion (new `TranscriptionComplete` sound event)
- **#296**: KDE Plasma (KWin) compositor keybindings in README, User Manual, and Configuration docs
- **#249**: Pause MPRIS media players during recording (`pause_media` config + `--pause-media` CLI flag)

Closes #306, #268, #278, #172, #259, #256, #258, #296, #249

## Test plan

- [x] All 25 unit tests pass (including new tests for #172, #278, #306)
- [x] `cargo clippy` clean (pre-existing warnings only)
- [x] Binary built and installed
- [x] Daemon starts and responds to status queries
- [x] Structural verification of all 9 changes (code paths, config fields, CLI flags)
- [ ] Live recording cycle with audio feedback (#258)
- [ ] Media pause with playerctl (#249)
- [ ] Notification count verification (#268)