### PR TITLE
Add KDE Plasma (KWin) compositor keybindings to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ sudo apt install wtype
 
 ### Compositor Keybindings
 
-Voxtype works best with your compositor's native keybindings. Add these to your compositor config:
+Voxtype works best with your compositor's native keybindings. Add these to your compositor config.
+
+> **Not sure which compositor you have?** Run `echo $XDG_CURRENT_DESKTOP` in a terminal. Common values: `Hyprland`, `sway`, `river`, `KDE`, `GNOME`.
 
 **Hyprland** (`~/.config/hypr/hyprland.conf`):
 ```
@@ -66,6 +68,15 @@ bindsym --release $mod+v exec voxtype record stop
 riverctl map normal Super V spawn 'voxtype record start'
 riverctl map -release normal Super V spawn 'voxtype record stop'
 ```
+
+**KDE Plasma (KWin):**
+
+KDE does not support key-release events, so use toggle mode. Open **System Settings > Shortcuts > Custom Shortcuts**, create a new shortcut, and set the command to:
+```
+voxtype record toggle
+```
+
+Assign your preferred key combination (e.g., Meta+V). Since KDE handles the keybinding, the built-in hotkey should be disabled (see below).
 
 Then disable the built-in hotkey in your config:
 ```toml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -186,6 +186,10 @@ bindsym $mod+v exec voxtype record start
 bindsym --release $mod+v exec voxtype record stop
 ```
 
+**KDE Plasma (KWin):**
+
+KDE does not support key-release events, so use toggle mode. Open **System Settings > Shortcuts > Custom Shortcuts**, create a new global shortcut, and set the command to `voxtype record toggle`. Assign your preferred key combination (e.g., Meta+V).
+
 **Note:** For `toggle` mode to work correctly, you must also set `state_file = "auto"` so voxtype can track its current state.
 
 See [User Manual - Compositor Keybindings](USER_MANUAL.md#compositor-keybindings) for complete setup instructions.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -534,9 +534,32 @@ riverctl map -release normal Super V spawn 'voxtype record stop'
 riverctl map normal Super V spawn 'voxtype record toggle'
 ```
 
+### KDE Plasma (KWin)
+
+KDE Plasma uses KWin as its compositor. KWin does not support key-release events, so push-to-talk (hold to record) is not available. Use toggle mode instead (press once to start recording, press again to stop).
+
+1. Open **System Settings > Shortcuts > Custom Shortcuts**.
+2. Click **Edit > New > Global Shortcut > Command/URL**.
+3. Name it something like "Voxtype Toggle".
+4. On the **Trigger** tab, click the button and press your desired key combination (e.g., Meta+V).
+5. On the **Action** tab, set the command to:
+   ```
+   voxtype record toggle
+   ```
+6. Click **Apply**.
+
+Then disable the built-in hotkey in `~/.config/voxtype/config.toml`:
+
+```toml
+[hotkey]
+enabled = false
+```
+
+Restart the voxtype daemon after changing the config.
+
 ### Other Compositors/Desktops
 
-For compositors without key release support (GNOME, KDE), use toggle mode:
+For other compositors without key release support (GNOME, etc.), use toggle mode:
 
 ```bash
 # Generic: bind this to your preferred key


### PR DESCRIPTION
## Summary

- Add "How to identify your compositor" tip to README
- Add KDE Plasma (KWin) keybinding instructions using System Settings > Shortcuts > Custom Shortcuts
- Update USER_MANUAL.md with step-by-step KDE Plasma setup
- Add KDE Plasma example to CONFIGURATION.md

Closes #296