### PR TITLE
Fix ydotool socket detection for non-standard paths (Fedora)

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -25,8 +25,65 @@ use crate::config::{OutputConfig, OutputDriver};
 use crate::error::OutputError;
 use std::borrow::Cow;
 use std::fs;
+use std::os::unix::fs::FileTypeExt;
+use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::Command;
+
+/// Find the ydotool daemon socket by checking known locations.
+///
+/// Fedora places the socket at `/tmp/.ydotool_socket`, while the ydotool CLI
+/// defaults to `$XDG_RUNTIME_DIR/.ydotool_socket`. Without setting `YDOTOOL_SOCKET`
+/// explicitly, ydotool commands fail on distros that use a non-default path.
+///
+/// Search order:
+/// 1. `$YDOTOOL_SOCKET` env var (user override)
+/// 2. `$XDG_RUNTIME_DIR/.ydotool_socket` (ydotool CLI default)
+/// 3. `/tmp/.ydotool_socket` (Fedora / systemd-wide service)
+/// 4. `/run/user/$UID/.ydotool_socket` (fallback if XDG_RUNTIME_DIR unset)
+pub fn find_ydotool_socket() -> Option<PathBuf> {
+    let candidates: Vec<PathBuf> = {
+        let mut paths = Vec::new();
+
+        // 1. Explicit env override
+        if let Ok(val) = std::env::var("YDOTOOL_SOCKET") {
+            paths.push(PathBuf::from(val));
+        }
+
+        // 2. XDG_RUNTIME_DIR (ydotool CLI default)
+        if let Ok(xdg) = std::env::var("XDG_RUNTIME_DIR") {
+            paths.push(PathBuf::from(xdg).join(".ydotool_socket"));
+        }
+
+        // 3. /tmp (Fedora systemd-wide ydotoold)
+        paths.push(PathBuf::from("/tmp/.ydotool_socket"));
+
+        // 4. /run/user/$UID fallback
+        let uid = unsafe { libc::getuid() };
+        paths.push(PathBuf::from(format!("/run/user/{}/.ydotool_socket", uid)));
+
+        paths
+    };
+
+    for path in &candidates {
+        if let Ok(meta) = fs::metadata(path) {
+            if meta.file_type().is_socket() {
+                tracing::debug!("Found ydotool socket at {}", path.display());
+                return Some(path.clone());
+            }
+        }
+    }
+
+    tracing::debug!(
+        "No ydotool socket found in: {}",
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    None
+}
 
 /// Normalize Unicode curly quotes to ASCII equivalents.
 ///
@@ -93,13 +150,13 @@ pub fn is_parakeet_binary_active() -> bool {
 /// Get the engine icon for notifications based on configured engine
 pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
     match engine {
-        crate::config::TranscriptionEngine::Parakeet => "\u{1F99C}",     // 🦜
+        crate::config::TranscriptionEngine::Parakeet => "\u{1F99C}", // 🦜
         crate::config::TranscriptionEngine::Whisper => "\u{1F5E3}\u{FE0F}", // 🗣️
-        crate::config::TranscriptionEngine::Moonshine => "\u{1F319}",    // 🌙
-        crate::config::TranscriptionEngine::SenseVoice => "\u{1F442}",   // 👂
-        crate::config::TranscriptionEngine::Paraformer => "\u{1F4AC}",   // 💬
-        crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",      // 🐬
-        crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}",  // 🌍
+        crate::config::TranscriptionEngine::Moonshine => "\u{1F319}", // 🌙
+        crate::config::TranscriptionEngine::SenseVoice => "\u{1F442}", // 👂
+        crate::config::TranscriptionEngine::Paraformer => "\u{1F4AC}", // 💬
+        crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",  // 🐬
+        crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
     }
 }
 
@@ -438,5 +495,33 @@ mod tests {
         let text = "Café \u{2019} emoji 😀";
         let result = normalize_quotes(text);
         assert_eq!(result, "Café ' emoji 😀");
+    }
+
+    #[test]
+    fn test_find_ydotool_socket_returns_none_when_no_socket() {
+        // In a test environment there should be no ydotoold running, so this
+        // should return None (no socket file exists at any candidate path).
+        // This primarily verifies the function does not panic.
+        let _result = find_ydotool_socket();
+    }
+
+    #[test]
+    fn test_find_ydotool_socket_respects_env_override() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join(".ydotool_socket");
+
+        // Create a real Unix socket so metadata().file_type().is_socket() is true
+        let _listener = UnixListener::bind(&sock_path).unwrap();
+
+        // Temporarily set YDOTOOL_SOCKET to point at our test socket.
+        // This is inherently racy in multi-threaded test runs, but it's the
+        // simplest way to exercise the env-var priority path.
+        std::env::set_var("YDOTOOL_SOCKET", &sock_path);
+        let result = find_ydotool_socket();
+        std::env::remove_var("YDOTOOL_SOCKET");
+
+        assert_eq!(result, Some(sock_path));
     }
 }

--- a/src/output/paste.rs
+++ b/src/output/paste.rs
@@ -11,6 +11,7 @@
 
 use super::TextOutput;
 use crate::error::OutputError;
+use crate::output::find_ydotool_socket;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -538,8 +539,11 @@ impl PasteOutput {
         }
 
         // Check if ydotoold is running by trying a no-op
-        Command::new("ydotool")
-            .args(["type", ""])
+        let mut cmd = Command::new("ydotool");
+        if let Some(socket) = find_ydotool_socket() {
+            cmd.env("YDOTOOL_SOCKET", socket);
+        }
+        cmd.args(["type", ""])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
@@ -591,6 +595,9 @@ impl PasteOutput {
         );
 
         let mut cmd = Command::new("ydotool");
+        if let Some(socket) = find_ydotool_socket() {
+            cmd.env("YDOTOOL_SOCKET", socket);
+        }
         cmd.arg("key");
 
         // Only add delay parameter if configured
@@ -681,7 +688,11 @@ impl PasteOutput {
 
         // Fall back to ydotool
         if self.is_ydotool_available().await {
-            let output = Command::new("ydotool")
+            let mut cmd = Command::new("ydotool");
+            if let Some(socket) = find_ydotool_socket() {
+                cmd.env("YDOTOOL_SOCKET", socket);
+            }
+            let output = cmd
                 .args(["key", "28:1", "28:0"])
                 .stdout(Stdio::null())
                 .stderr(Stdio::piped())

--- a/src/output/ydotool.rs
+++ b/src/output/ydotool.rs
@@ -10,6 +10,8 @@
 
 use super::TextOutput;
 use crate::error::OutputError;
+use crate::output::find_ydotool_socket;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
 use tokio::process::Command;
@@ -28,6 +30,8 @@ pub struct YdotoolOutput {
     auto_submit: bool,
     /// Text to append after transcription (before auto_submit)
     append_text: Option<String>,
+    /// Path to ydotoold socket, if found at a non-default location
+    socket_path: Option<PathBuf>,
 }
 
 impl YdotoolOutput {
@@ -47,6 +51,7 @@ impl YdotoolOutput {
         } else {
             tracing::debug!("ydotool does not support --key-hold flag, using --key-delay only");
         }
+        let socket_path = find_ydotool_socket();
         Self {
             type_delay_ms,
             pre_type_delay_ms,
@@ -54,6 +59,14 @@ impl YdotoolOutput {
             supports_key_hold,
             auto_submit,
             append_text,
+            socket_path,
+        }
+    }
+
+    /// Apply the discovered socket path to a ydotool Command, if any.
+    fn apply_socket_env(&self, cmd: &mut Command) {
+        if let Some(ref path) = self.socket_path {
+            cmd.env("YDOTOOL_SOCKET", path);
         }
     }
 
@@ -114,6 +127,7 @@ impl TextOutput for YdotoolOutput {
         }
 
         let mut cmd = Command::new("ydotool");
+        self.apply_socket_env(&mut cmd);
         cmd.arg("type");
 
         // Always set delay explicitly (ydotool defaults to 12ms if not specified)
@@ -166,6 +180,7 @@ impl TextOutput for YdotoolOutput {
         // Append text if configured (e.g., a space to separate sentences)
         if let Some(ref append) = self.append_text {
             let mut append_cmd = Command::new("ydotool");
+            self.apply_socket_env(&mut append_cmd);
             append_cmd.arg("type");
             append_cmd
                 .arg("--key-delay")
@@ -196,7 +211,9 @@ impl TextOutput for YdotoolOutput {
         // ydotool key uses evdev key codes: 28 is KEY_ENTER
         // Format: keycode:press (1) then keycode:release (0)
         if self.auto_submit {
-            let enter_output = Command::new("ydotool")
+            let mut enter_cmd = Command::new("ydotool");
+            self.apply_socket_env(&mut enter_cmd);
+            let enter_output = enter_cmd
                 .args(["key", "28:1", "28:0"])
                 .stdout(Stdio::null())
                 .stderr(Stdio::piped())
@@ -235,8 +252,9 @@ impl TextOutput for YdotoolOutput {
 
         // Check if ydotoold is running by trying a no-op
         // ydotool type "" should succeed quickly if daemon is running
-        Command::new("ydotool")
-            .args(["type", ""])
+        let mut cmd = Command::new("ydotool");
+        self.apply_socket_env(&mut cmd);
+        cmd.args(["type", ""])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()


### PR DESCRIPTION
## Summary

- Add `find_ydotool_socket()` helper that checks: `$YDOTOOL_SOCKET`, `$XDG_RUNTIME_DIR/.ydotool_socket`, `/tmp/.ydotool_socket`, `/run/user/$UID/.ydotool_socket`
- Set `YDOTOOL_SOCKET` env on all ydotool Command invocations in ydotool.rs and paste.rs
- Fixes Fedora 43 where the packaged ydotool.service writes the socket to `/tmp/.ydotool_socket`
- Adds two unit tests

Closes #306