### PR TITLE
Fix duplicate notification when using ydotool driver

### DIFF
--- a/src/output/clipboard.rs
+++ b/src/output/clipboard.rs
@@ -13,42 +13,14 @@ use tokio::process::Command;
 
 /// Clipboard-based text output
 pub struct ClipboardOutput {
-    /// Whether to show a desktop notification
-    notify: bool,
     /// Text to append after transcription
     append_text: Option<String>,
 }
 
 impl ClipboardOutput {
     /// Create a new clipboard output
-    pub fn new(notify: bool, append_text: Option<String>) -> Self {
-        Self {
-            notify,
-            append_text,
-        }
-    }
-
-    /// Send a desktop notification
-    async fn send_notification(&self, text: &str) {
-        // Truncate preview for notification (use chars() to handle multi-byte UTF-8)
-        let preview = if text.chars().count() > 80 {
-            format!("{}...", text.chars().take(80).collect::<String>())
-        } else {
-            text.to_string()
-        };
-
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                "--urgency=low",
-                "--expire-time=3000",
-                "Copied to clipboard",
-                &preview,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
+    pub fn new(append_text: Option<String>) -> Self {
+        Self { append_text }
     }
 }
 
@@ -103,11 +75,6 @@ impl TextOutput for ClipboardOutput {
             ));
         }
 
-        // Send notification if enabled
-        if self.notify {
-            self.send_notification(&text).await;
-        }
-
         tracing::info!("Text copied to clipboard ({} chars)", text.len());
         Ok(())
     }
@@ -134,10 +101,10 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = ClipboardOutput::new(true, None);
-        assert!(output.notify);
+        let output = ClipboardOutput::new(None);
+        assert!(output.append_text.is_none());
 
-        let output = ClipboardOutput::new(false, None);
-        assert!(!output.notify);
+        let output = ClipboardOutput::new(Some(" ".to_string()));
+        assert_eq!(output.append_text, Some(" ".to_string()));
     }
 }

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -21,8 +21,6 @@ pub struct DotoolOutput {
     type_delay_ms: u32,
     /// Delay before typing starts in milliseconds
     pre_type_delay_ms: u32,
-    /// Whether to show a desktop notification
-    notify: bool,
     /// Whether to send Enter key after output
     auto_submit: bool,
     /// Text to append after transcription (before auto_submit)
@@ -38,7 +36,6 @@ impl DotoolOutput {
     pub fn new(
         type_delay_ms: u32,
         pre_type_delay_ms: u32,
-        notify: bool,
         auto_submit: bool,
         append_text: Option<String>,
         xkb_layout: Option<String>,
@@ -50,35 +47,11 @@ impl DotoolOutput {
         Self {
             type_delay_ms,
             pre_type_delay_ms,
-            notify,
             auto_submit,
             append_text,
             xkb_layout,
             xkb_variant,
         }
-    }
-
-    /// Send a desktop notification
-    async fn send_notification(&self, text: &str) {
-        // Truncate preview for notification
-        let preview: String = text.chars().take(100).collect();
-        let preview = if text.len() > 100 {
-            format!("{}...", preview)
-        } else {
-            preview
-        };
-
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                "--expire-time=3000",
-                "Transcribed",
-                &preview,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
     }
 
     /// Build the dotool command string to send via stdin
@@ -185,11 +158,6 @@ impl TextOutput for DotoolOutput {
 
         tracing::info!("Text typed via dotool ({} chars)", text.len());
 
-        // Send notification if enabled
-        if self.notify {
-            self.send_notification(text).await;
-        }
-
         Ok(())
     }
 
@@ -216,24 +184,23 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = DotoolOutput::new(10, 0, true, false, None, Some("de".to_string()), None);
+        let output = DotoolOutput::new(10, 0, false, None, Some("de".to_string()), None);
         assert_eq!(output.type_delay_ms, 10);
         assert_eq!(output.pre_type_delay_ms, 0);
-        assert!(output.notify);
         assert!(!output.auto_submit);
         assert_eq!(output.xkb_layout, Some("de".to_string()));
     }
 
     #[test]
     fn test_build_commands_simple() {
-        let output = DotoolOutput::new(0, 0, false, false, None, None, None);
+        let output = DotoolOutput::new(0, 0, false, None, None, None);
         let cmds = output.build_commands("Hello world");
         assert_eq!(cmds, "type Hello world\n");
     }
 
     #[test]
     fn test_build_commands_with_delay() {
-        let output = DotoolOutput::new(10, 0, false, false, None, None, None);
+        let output = DotoolOutput::new(10, 0, false, None, None, None);
         let cmds = output.build_commands("Test");
         assert!(cmds.contains("typedelay 10"));
         assert!(cmds.contains("typehold 10"));
@@ -242,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_build_commands_with_enter() {
-        let output = DotoolOutput::new(0, 0, false, true, None, None, None);
+        let output = DotoolOutput::new(0, 0, true, None, None, None);
         let cmds = output.build_commands("Test");
         assert!(cmds.contains("type Test"));
         assert!(cmds.contains("key enter"));

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -93,13 +93,13 @@ pub fn is_parakeet_binary_active() -> bool {
 /// Get the engine icon for notifications based on configured engine
 pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
     match engine {
-        crate::config::TranscriptionEngine::Parakeet => "\u{1F99C}",     // 🦜
+        crate::config::TranscriptionEngine::Parakeet => "\u{1F99C}", // 🦜
         crate::config::TranscriptionEngine::Whisper => "\u{1F5E3}\u{FE0F}", // 🗣️
-        crate::config::TranscriptionEngine::Moonshine => "\u{1F319}",    // 🌙
-        crate::config::TranscriptionEngine::SenseVoice => "\u{1F442}",   // 👂
-        crate::config::TranscriptionEngine::Paraformer => "\u{1F4AC}",   // 💬
-        crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",      // 🐬
-        crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}",  // 🌍
+        crate::config::TranscriptionEngine::Moonshine => "\u{1F319}", // 🌙
+        crate::config::TranscriptionEngine::SenseVoice => "\u{1F442}", // 👂
+        crate::config::TranscriptionEngine::Paraformer => "\u{1F4AC}", // 💬
+        crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",  // 🐬
+        crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
     }
 }
 
@@ -164,11 +164,7 @@ fn create_driver_output(
     driver: OutputDriver,
     config: &OutputConfig,
     pre_type_delay_ms: u32,
-    is_first: bool,
 ) -> Box<dyn TextOutput> {
-    // Only the first driver in the chain should show notifications
-    let show_notification = is_first && config.notification.on_transcription;
-
     match driver {
         OutputDriver::Wtype => Box::new(wtype::WtypeOutput::new(
             config.auto_submit,
@@ -187,7 +183,6 @@ fn create_driver_output(
         OutputDriver::Dotool => Box::new(dotool::DotoolOutput::new(
             config.type_delay_ms,
             pre_type_delay_ms,
-            show_notification,
             config.auto_submit,
             config.append_text.clone(),
             config.dotool_xkb_layout.clone(),
@@ -196,18 +191,13 @@ fn create_driver_output(
         OutputDriver::Ydotool => Box::new(ydotool::YdotoolOutput::new(
             config.type_delay_ms,
             pre_type_delay_ms,
-            show_notification,
             config.auto_submit,
             config.append_text.clone(),
         )),
-        OutputDriver::Clipboard => Box::new(clipboard::ClipboardOutput::new(
-            show_notification,
-            config.append_text.clone(),
-        )),
-        OutputDriver::Xclip => Box::new(xclip::XclipOutput::new(
-            show_notification,
-            config.append_text.clone(),
-        )),
+        OutputDriver::Clipboard => {
+            Box::new(clipboard::ClipboardOutput::new(config.append_text.clone()))
+        }
+        OutputDriver::Xclip => Box::new(xclip::XclipOutput::new(config.append_text.clone())),
     }
 }
 
@@ -253,12 +243,7 @@ pub fn create_output_chain_with_override(
                     continue;
                 }
 
-                chain.push(create_driver_output(
-                    *driver,
-                    config,
-                    pre_type_delay_ms,
-                    i == 0,
-                ));
+                chain.push(create_driver_output(*driver, config, pre_type_delay_ms));
             }
 
             // If fallback_to_clipboard is true but clipboard wasn't in the custom order, add it
@@ -267,7 +252,6 @@ pub fn create_output_chain_with_override(
                 && !driver_order.contains(&OutputDriver::Clipboard)
             {
                 chain.push(Box::new(clipboard::ClipboardOutput::new(
-                    false,
                     config.append_text.clone(),
                 )));
             }
@@ -275,7 +259,6 @@ pub fn create_output_chain_with_override(
         crate::config::OutputMode::Clipboard => {
             // Only clipboard
             chain.push(Box::new(clipboard::ClipboardOutput::new(
-                config.notification.on_transcription,
                 config.append_text.clone(),
             )));
         }
@@ -298,7 +281,6 @@ pub fn create_output_chain_with_override(
                 "Output mode is 'file' but no file_path configured. Falling back to clipboard."
             );
             chain.push(Box::new(clipboard::ClipboardOutput::new(
-                config.notification.on_transcription,
                 config.append_text.clone(),
             )));
         }

--- a/src/output/xclip.rs
+++ b/src/output/xclip.rs
@@ -13,42 +13,14 @@ use tokio::process::Command;
 
 /// xclip-based text output for X11
 pub struct XclipOutput {
-    /// Whether to show a desktop notification
-    notify: bool,
     /// Text to append after transcription
     append_text: Option<String>,
 }
 
 impl XclipOutput {
     /// Create a new xclip output
-    pub fn new(notify: bool, append_text: Option<String>) -> Self {
-        Self {
-            notify,
-            append_text,
-        }
-    }
-
-    /// Send a desktop notification
-    async fn send_notification(&self, text: &str) {
-        // Truncate preview for notification (use chars() to handle multi-byte UTF-8)
-        let preview = if text.chars().count() > 80 {
-            format!("{}...", text.chars().take(80).collect::<String>())
-        } else {
-            text.to_string()
-        };
-
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                "--urgency=low",
-                "--expire-time=3000",
-                "Copied to clipboard",
-                &preview,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
+    pub fn new(append_text: Option<String>) -> Self {
+        Self { append_text }
     }
 }
 
@@ -104,11 +76,6 @@ impl TextOutput for XclipOutput {
             ));
         }
 
-        // Send notification if enabled
-        if self.notify {
-            self.send_notification(&text).await;
-        }
-
         tracing::info!("Text copied to X11 clipboard ({} chars)", text.len());
         Ok(())
     }
@@ -141,10 +108,10 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = XclipOutput::new(true, None);
-        assert!(output.notify);
+        let output = XclipOutput::new(None);
+        assert!(output.append_text.is_none());
 
-        let output = XclipOutput::new(false, None);
-        assert!(!output.notify);
+        let output = XclipOutput::new(Some(" ".to_string()));
+        assert_eq!(output.append_text, Some(" ".to_string()));
     }
 }

--- a/src/output/ydotool.rs
+++ b/src/output/ydotool.rs
@@ -20,8 +20,6 @@ pub struct YdotoolOutput {
     type_delay_ms: u32,
     /// Delay before typing starts in milliseconds
     pre_type_delay_ms: u32,
-    /// Whether to show a desktop notification
-    notify: bool,
     /// Whether ydotool supports --key-hold flag (added in newer versions)
     supports_key_hold: bool,
     /// Whether to send Enter key after output
@@ -37,7 +35,6 @@ impl YdotoolOutput {
     pub fn new(
         type_delay_ms: u32,
         pre_type_delay_ms: u32,
-        notify: bool,
         auto_submit: bool,
         append_text: Option<String>,
     ) -> Self {
@@ -50,7 +47,6 @@ impl YdotoolOutput {
         Self {
             type_delay_ms,
             pre_type_delay_ms,
-            notify,
             supports_key_hold,
             auto_submit,
             append_text,
@@ -71,29 +67,6 @@ impl YdotoolOutput {
                 stdout.contains("--key-hold") || stderr.contains("--key-hold")
             })
             .unwrap_or(false)
-    }
-
-    /// Send a desktop notification
-    async fn send_notification(&self, text: &str) {
-        // Truncate preview for notification
-        let preview: String = text.chars().take(100).collect();
-        let preview = if text.len() > 100 {
-            format!("{}...", preview)
-        } else {
-            preview
-        };
-
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                "--expire-time=3000",
-                "Transcribed",
-                &preview,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
     }
 }
 
@@ -212,11 +185,6 @@ impl TextOutput for YdotoolOutput {
             }
         }
 
-        // Send notification if enabled
-        if self.notify {
-            self.send_notification(text).await;
-        }
-
         Ok(())
     }
 
@@ -256,10 +224,9 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = YdotoolOutput::new(10, 0, true, false, None);
+        let output = YdotoolOutput::new(10, 0, false, None);
         assert_eq!(output.type_delay_ms, 10);
         assert_eq!(output.pre_type_delay_ms, 0);
-        assert!(output.notify);
         assert!(!output.auto_submit);
         // supports_key_hold depends on system ydotool version, so we just check it's set
         let _ = output.supports_key_hold;
@@ -267,15 +234,14 @@ mod tests {
 
     #[test]
     fn test_new_with_enter() {
-        let output = YdotoolOutput::new(0, 0, false, true, None);
+        let output = YdotoolOutput::new(0, 0, true, None);
         assert_eq!(output.type_delay_ms, 0);
-        assert!(!output.notify);
         assert!(output.auto_submit);
     }
 
     #[test]
     fn test_new_with_pre_type_delay() {
-        let output = YdotoolOutput::new(0, 200, false, false, None);
+        let output = YdotoolOutput::new(0, 200, false, None);
         assert_eq!(output.type_delay_ms, 0);
         assert_eq!(output.pre_type_delay_ms, 200);
     }


### PR DESCRIPTION
## Summary

- Remove driver-level `send_notification()` from ydotool, dotool, clipboard, and xclip output drivers
- Remove `notify` field and constructor parameter from all four drivers
- Remove `is_first`/`show_notification` logic from `create_driver_output()` in mod.rs
- The daemon already handles notifications consistently after output

Closes #268