### PR TITLE
Fix xclip fallback in clipboard mode for X11 sessions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1678,7 +1678,7 @@ impl OutputConfig {
 pub enum OutputMode {
     /// Simulate keyboard input (requires ydotool)
     Type,
-    /// Copy to clipboard (requires wl-copy)
+    /// Copy to clipboard (wl-copy on Wayland, xclip on X11)
     Clipboard,
     /// Copy to clipboard then paste with Ctrl+V (requires wl-copy and ydotool)
     Paste,

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -273,8 +273,12 @@ pub fn create_output_chain_with_override(
             }
         }
         crate::config::OutputMode::Clipboard => {
-            // Only clipboard
+            // Clipboard with X11 fallback: wl-copy first, then xclip
             chain.push(Box::new(clipboard::ClipboardOutput::new(
+                config.notification.on_transcription,
+                config.append_text.clone(),
+            )));
+            chain.push(Box::new(xclip::XclipOutput::new(
                 config.notification.on_transcription,
                 config.append_text.clone(),
             )));


### PR DESCRIPTION
## Summary

- Add `XclipOutput` as second entry in the clipboard mode output chain, after `ClipboardOutput` (wl-copy)
- On Wayland, wl-copy succeeds and xclip is never tried
- On X11, wl-copy fails and xclip handles clipboard operations
- Update `OutputMode::Clipboard` doc comment

Closes #256