### PR TITLE
Add option to pause media players during recording

### DIFF
--- a/src/audio/media.rs
+++ b/src/audio/media.rs
@@ -1,0 +1,95 @@
+//! MPRIS media player control via playerctl
+//!
+//! Pauses playing media players when recording starts and resumes
+//! only the players that were actually playing when recording stops.
+
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+/// Pause all currently playing MPRIS media players.
+/// Returns the names of players that were paused, so they can be resumed later.
+pub async fn pause_playing_players() -> Vec<String> {
+    // List players that are currently in "Playing" status
+    let output = match Command::new("playerctl")
+        .args(["--all-players", "-f", "{{playerName}}", "status"])
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(e) => {
+            warn!("playerctl not found or failed to run: {}", e);
+            return Vec::new();
+        }
+    };
+
+    if !output.status.success() {
+        // playerctl exits non-zero when no players are running
+        debug!("No MPRIS players found");
+        return Vec::new();
+    }
+
+    // playerctl with --all-players returns one status per line, but we need
+    // the player names paired with their statuses. Use a separate call to get
+    // player names and statuses together.
+    let players_output = match Command::new("playerctl")
+        .args([
+            "--all-players",
+            "-f",
+            "{{playerName}}\t{{status}}",
+            "status",
+        ])
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(_) => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&players_output.stdout);
+    let mut paused_players = Vec::new();
+
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((name, status)) = line.split_once('\t') {
+            if status == "Playing" {
+                debug!(player = %name, "Pausing media player");
+                let result = Command::new("playerctl")
+                    .args(["--player", name, "pause"])
+                    .output()
+                    .await;
+                if let Err(e) = result {
+                    warn!(player = %name, "Failed to pause player: {}", e);
+                } else {
+                    paused_players.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    if !paused_players.is_empty() {
+        debug!("Paused {} media player(s)", paused_players.len());
+    }
+
+    paused_players
+}
+
+/// Resume the specified MPRIS media players.
+pub async fn resume_players(players: Vec<String>) {
+    for name in &players {
+        debug!(player = %name, "Resuming media player");
+        let result = Command::new("playerctl")
+            .args(["--player", name, "play"])
+            .output()
+            .await;
+        if let Err(e) = result {
+            warn!(player = %name, "Failed to resume player: {}", e);
+        }
+    }
+
+    if !players.is_empty() {
+        debug!("Resumed {} media player(s)", players.len());
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -8,6 +8,7 @@ pub mod dual_capture;
 #[cfg(feature = "onnx-common")]
 pub mod enhance;
 pub mod feedback;
+pub mod media;
 
 pub use dual_capture::{AudioSourceType, DualCapture, DualSamples, SourcedSample};
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,7 +93,6 @@ pub struct Cli {
     pub model_modifier: Option<String>,
 
     // -- Whisper --
-
     /// Disable context window optimization for short recordings
     #[arg(long, help_heading = "Whisper")]
     pub no_whisper_context_optimization: bool,
@@ -156,7 +155,6 @@ pub struct Cli {
     pub remote_api_key: Option<String>,
 
     // -- Audio --
-
     /// Audio input device name (or "default" for system default)
     #[arg(long, value_name = "DEVICE", help_heading = "Audio")]
     pub audio_device: Option<String>,
@@ -173,8 +171,11 @@ pub struct Cli {
     #[arg(long, help_heading = "Audio")]
     pub no_audio_feedback: bool,
 
-    // -- Output --
+    /// Pause MPRIS media players during recording (requires playerctl)
+    #[arg(long, help_heading = "Audio")]
+    pub pause_media: bool,
 
+    // -- Output --
     /// Delay before typing starts (ms), helps prevent first character drop
     #[arg(long, value_name = "MS", help_heading = "Output")]
     pub pre_type_delay: Option<u32>,
@@ -227,7 +228,11 @@ pub struct Cli {
     pub fallback_to_clipboard: bool,
 
     /// Disable clipboard fallback
-    #[arg(long, conflicts_with = "fallback_to_clipboard", help_heading = "Output")]
+    #[arg(
+        long,
+        conflicts_with = "fallback_to_clipboard",
+        help_heading = "Output"
+    )]
     pub no_fallback_to_clipboard: bool,
 
     /// Enable spoken punctuation conversion (e.g., say "period" to get ".")
@@ -267,7 +272,6 @@ pub struct Cli {
     pub pre_recording_command: Option<String>,
 
     // -- VAD --
-
     /// Enable Voice Activity Detection (filter silence before transcription)
     #[arg(long, help_heading = "VAD")]
     pub vad: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,10 @@ sample_rate = 16000
 # Maximum recording duration in seconds (safety limit)
 max_duration_secs = 60
 
+# Pause MPRIS media players (Spotify, Firefox, etc.) when recording starts,
+# resume them when recording stops. Requires playerctl.
+# pause_media = false
+
 # [audio.feedback]
 # Enable audio feedback sounds (beeps when recording starts/stops)
 # enabled = true
@@ -420,6 +424,10 @@ pub struct AudioConfig {
 
     /// Maximum recording duration in seconds (safety limit)
     pub max_duration_secs: u32,
+
+    /// Pause MPRIS media players during recording and resume on stop
+    #[serde(default)]
+    pub pause_media: bool,
 
     /// Audio feedback settings
     #[serde(default)]
@@ -1768,6 +1776,7 @@ impl Default for Config {
                 device: "default".to_string(),
                 sample_rate: 16000,
                 max_duration_secs: 60,
+                pause_media: false,
                 feedback: AudioFeedbackConfig::default(),
             },
             whisper: WhisperConfig {
@@ -2079,6 +2088,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     }
     if let Ok(val) = std::env::var("VOXTYPE_AUDIO_FEEDBACK") {
         config.audio.feedback.enabled = parse_bool_env(&val);
+    }
+    if let Ok(val) = std::env::var("VOXTYPE_PAUSE_MEDIA") {
+        config.audio.pause_media = parse_bool_env(&val);
     }
 
     // Output

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -517,6 +517,8 @@ pub struct Daemon {
     // GTCRN speech enhancer for mic echo cancellation
     #[cfg(feature = "onnx-common")]
     speech_enhancer: Option<std::sync::Arc<audio::enhance::GtcrnEnhancer>>,
+    // Media players that were paused when recording started (for resume on stop)
+    paused_media_players: Vec<String>,
 }
 
 impl Daemon {
@@ -612,6 +614,7 @@ impl Daemon {
             meeting_event_rx: None,
             #[cfg(feature = "onnx-common")]
             speech_enhancer: None,
+            paused_media_players: Vec::new(),
         }
     }
 
@@ -619,6 +622,21 @@ impl Daemon {
     fn play_feedback(&self, event: SoundEvent) {
         if let Some(ref feedback) = self.audio_feedback {
             feedback.play(event);
+        }
+    }
+
+    /// Pause MPRIS media players if configured, storing which ones were paused
+    async fn pause_media_players(&mut self) {
+        if self.config.audio.pause_media {
+            self.paused_media_players = audio::media::pause_playing_players().await;
+        }
+    }
+
+    /// Resume any MPRIS media players that were paused at recording start
+    fn resume_media_players(&mut self) {
+        if !self.paused_media_players.is_empty() {
+            let players = std::mem::take(&mut self.paused_media_players);
+            tokio::spawn(audio::media::resume_players(players));
         }
     }
 
@@ -927,13 +945,14 @@ impl Daemon {
 
     /// Reset state to idle and run post_output_command to reset compositor submap
     /// Call this when exiting from recording/transcribing without normal output flow
-    async fn reset_to_idle(&self, state: &mut State) {
+    async fn reset_to_idle(&mut self, state: &mut State) {
         cleanup_output_mode_override();
         cleanup_model_override();
         cleanup_profile_override();
         cleanup_bool_override("auto_submit");
         cleanup_bool_override("shift_enter");
         cleanup_bool_override("smart_auto_submit");
+        self.resume_media_players();
         *state = State::Idle;
         self.update_state("idle");
 
@@ -1242,7 +1261,7 @@ impl Daemon {
 
     /// Handle transcription completion (called when transcription_task completes)
     async fn handle_transcription_result(
-        &self,
+        &mut self,
         state: &mut State,
         result: std::result::Result<TranscriptionResult, tokio::task::JoinError>,
     ) {
@@ -1384,6 +1403,7 @@ impl Daemon {
                             }
                         }
 
+                        self.resume_media_players();
                         *state = State::Idle;
                         self.update_state("idle");
                         return;
@@ -1452,6 +1472,7 @@ impl Daemon {
                         .await;
                     }
 
+                    self.resume_media_players();
                     *state = State::Idle;
                     self.update_state("idle");
                 }
@@ -1761,6 +1782,7 @@ impl Daemon {
                                         }
                                         self.update_state("recording");
                                         self.play_feedback(SoundEvent::RecordingStart);
+                                        self.pause_media_players().await;
 
                                         // Run pre-recording hook (e.g., enter compositor submap for cancel)
                                         if let Some(cmd) = &self.config.output.pre_recording_command {
@@ -1947,6 +1969,7 @@ impl Daemon {
                                         }
                                         self.update_state("recording");
                                         self.play_feedback(SoundEvent::RecordingStart);
+                                        self.pause_media_players().await;
 
                                         // Run pre-recording hook (e.g., enter compositor submap for cancel)
                                         if let Some(cmd) = &self.config.output.pre_recording_command {
@@ -2377,6 +2400,7 @@ impl Daemon {
                                     }
                                     self.update_state("recording");
                                     self.play_feedback(SoundEvent::RecordingStart);
+                                    self.pause_media_players().await;
 
                                     // Run pre-recording hook (e.g., enter compositor submap for cancel)
                                     if let Some(cmd) = &self.config.output.pre_recording_command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,6 +240,9 @@ async fn main() -> anyhow::Result<()> {
     if cli.no_audio_feedback {
         config.audio.feedback.enabled = false;
     }
+    if cli.pause_media {
+        config.audio.pause_media = true;
+    }
 
     // Output overrides
     if let Some(append_text) = cli.append_text {
@@ -1231,8 +1234,8 @@ async fn show_config(config: &config::Config) -> anyhow::Result<()> {
             if path.is_dir() {
                 let name = entry.file_name().to_string_lossy().to_string();
                 if name.contains("sensevoice") {
-                    let has_model = path.join("model.int8.onnx").exists()
-                        || path.join("model.onnx").exists();
+                    let has_model =
+                        path.join("model.int8.onnx").exists() || path.join("model.onnx").exists();
                     let has_tokens = path.join("tokens.txt").exists();
                     if has_model && has_tokens {
                         sensevoice_models.push(name);


### PR DESCRIPTION
## Summary

- Add `pause_media = false` config option under `[audio]`
- Add `--pause-media` CLI flag
- Add `src/audio/media.rs` module using `playerctl` for MPRIS control
- Pause playing media players on recording start, resume only those we paused on recording stop
- Handles missing `playerctl` gracefully (warns and skips)
- Uses `tokio::spawn` to avoid blocking recording start

Closes #249