### PR TITLE
Fix meeting context tracking and env var test thread safety

### DIFF
--- a/src/meeting/mod.rs
+++ b/src/meeting/mod.rs
@@ -312,8 +312,9 @@ impl MeetingDaemon {
                         .await;
                 }
             }
-            // Update context for next chunk (per source)
-            if let Some(last_seg) = result.segments.last() {
+            // Update context for next chunk (per source), using the last non-empty
+            // segment to avoid losing useful context when a chunk ends with silence
+            if let Some(last_seg) = result.segments.iter().rfind(|s| !s.text.is_empty()) {
                 self.last_chunk_text
                     .insert(source, last_seg.text.clone());
             }

--- a/src/output/post_process.rs
+++ b/src/output/post_process.rs
@@ -288,9 +288,11 @@ mod tests {
         assert_eq!(result, "context:unset stdin:current text");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_context_env_not_inherited_from_parent() {
-        // Even if VOXTYPE_CONTEXT is set in parent env, it should be cleared when context is None
+        // Even if VOXTYPE_CONTEXT is set in parent env, it should be cleared when context is None.
+        // Uses current_thread runtime because std::env::set_var is not thread-safe
+        // and will become unsafe in Rust edition 2024.
         std::env::set_var("VOXTYPE_CONTEXT", "stale parent context");
         let config = make_config("echo \"${VOXTYPE_CONTEXT:-unset}\"", 5000);
         let processor = PostProcessor::new(&config);


### PR DESCRIPTION
## Summary

Follow-up fixes for #292 (meeting post-processing and dictation context):

- **Last non-empty segment for context**: Use `rfind(|s| !s.text.is_empty())` instead of `last()` when updating meeting chunk context. Prevents trailing silence segments from replacing useful context with an empty string.
- **Thread-safe env var test**: Use `#[tokio::test(flavor = "current_thread")]` for the test that calls `std::env::set_var`. This avoids a data race with concurrent tests, and prepares for Rust edition 2024 where `set_var` becomes `unsafe`.

## Test plan

- [x] `cargo test` -- 550 tests pass
- [x] `cargo clippy` -- no new warnings