### PR TITLE
Document --features parakeet for building from source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ What actually happened.
 
 ## Logs
 
-Run `voxtype -vv` and paste relevant output:
+Run `voxtype -vv` (single dash, two v's) and paste relevant output:
 
 ```
 (paste logs here)

--- a/README.md
+++ b/README.md
@@ -462,11 +462,21 @@ sudo dnf install alsa-lib-devel
 # Ubuntu:
 sudo apt install libasound2-dev
 
-# Build
+# Build (Whisper engine only)
 cargo build --release
+
+# Build with ONNX engines (Parakeet, Moonshine, SenseVoice, etc.)
+cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin
+
+# Or just the engine you need
+cargo build --release --features parakeet
 
 # Binary is at: target/release/voxtype
 ```
+
+ONNX engines require the corresponding Cargo feature at build time. Without it, setting
+`engine = "parakeet"` in your config will fail with an error. The prebuilt release binaries
+(`-onnx-avx2`, `-onnx-cuda`, etc.) include all ONNX engines.
 
 ## Waybar Integration
 


### PR DESCRIPTION
## Summary

- Add ONNX engine feature flags (`--features parakeet`, etc.) to the Building from Source section in README
- Note that prebuilt `-onnx-*` binaries already include all ONNX engines
- Clarify `-vv` flag syntax in bug report template (single dash, two v's)

Closes #304

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `cargo build --release --features parakeet` builds successfully