### PR TITLE
Add AppImage packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,11 +494,13 @@ mv voxtype-*-x86_64.AppImage ~/.local/bin/voxtype
 ```
 
 Available AppImage variants:
-- `voxtype-{ver}-x86_64.AppImage` - CPU, Whisper engine (recommended)
-- `voxtype-{ver}-vulkan-x86_64.AppImage` - GPU via Vulkan (Whisper)
-- `voxtype-{ver}-onnx-x86_64.AppImage` - CPU, ONNX engines (Parakeet, Moonshine, etc.)
-- `voxtype-{ver}-onnx-cuda-x86_64.AppImage` - NVIDIA GPU, ONNX engines
-- `voxtype-{ver}-onnx-rocm-x86_64.AppImage` - AMD GPU, ONNX engines
+- `voxtype-{ver}-x86_64.AppImage` - Whisper engine with CPU and Vulkan GPU support (recommended)
+- `voxtype-{ver}-onnx-x86_64.AppImage` - ONNX engines (Parakeet, Moonshine, etc.) + Vulkan Whisper
+- `voxtype-{ver}-onnx-cuda-x86_64.AppImage` - ONNX engines with NVIDIA CUDA + Vulkan Whisper
+
+Each ONNX AppImage also includes the Vulkan Whisper binary, so you can switch between
+engines via `engine = "whisper"` or `engine = "parakeet"` in your config without changing
+AppImages. For GPU-accelerated Whisper in the Whisper-only AppImage, set `VOXTYPE_GPU=1`.
 
 ## Waybar Integration
 

--- a/README.md
+++ b/README.md
@@ -478,6 +478,28 @@ ONNX engines require the corresponding Cargo feature at build time. Without it, 
 `engine = "parakeet"` in your config will fail with an error. The prebuilt release binaries
 (`-onnx-avx2`, `-onnx-cuda`, etc.) include all ONNX engines.
 
+## AppImage (Universal)
+
+AppImage works on any Linux distribution without installation:
+
+```bash
+# Download the appropriate AppImage from the GitHub release
+chmod +x voxtype-*-x86_64.AppImage
+
+# Move to a permanent location
+mv voxtype-*-x86_64.AppImage ~/.local/bin/voxtype
+
+# Run setup (downloads model, configures service)
+~/.local/bin/voxtype setup
+```
+
+Available AppImage variants:
+- `voxtype-{ver}-x86_64.AppImage` - CPU, Whisper engine (recommended)
+- `voxtype-{ver}-vulkan-x86_64.AppImage` - GPU via Vulkan (Whisper)
+- `voxtype-{ver}-onnx-x86_64.AppImage` - CPU, ONNX engines (Parakeet, Moonshine, etc.)
+- `voxtype-{ver}-onnx-cuda-x86_64.AppImage` - NVIDIA GPU, ONNX engines
+- `voxtype-{ver}-onnx-rocm-x86_64.AppImage` - AMD GPU, ONNX engines
+
 ## Waybar Integration
 
 Add to your Waybar config:

--- a/packaging/appimage/AppRun
+++ b/packaging/appimage/AppRun
@@ -1,0 +1,9 @@
+#!/bin/sh
+# AppRun entry point for voxtype AppImage
+# Sets library path so the wrapper script finds binaries inside the AppImage
+
+APPDIR="$(dirname "$(readlink -f "$0")")"
+
+export VOXTYPE_LIB="$APPDIR/usr/lib/voxtype"
+
+exec "$APPDIR/usr/bin/voxtype" "$@"

--- a/packaging/appimage/voxtype-onnx-wrapper.sh
+++ b/packaging/appimage/voxtype-onnx-wrapper.sh
@@ -1,23 +1,76 @@
 #!/bin/sh
-# Voxtype ONNX CPU-adaptive wrapper script
-# Detects CPU capabilities and executes the appropriate ONNX binary variant
+# Voxtype multi-engine wrapper for AppImage
+# Dispatches to the correct binary based on configured engine and CPU features.
+# Bundled ONNX AppImages include both ONNX engine binaries and the Vulkan
+# Whisper binary, so users can switch engines without changing AppImages.
 
 VOXTYPE_LIB="${VOXTYPE_LIB:-/usr/lib/voxtype}"
 
-# Detect AVX-512 support (Linux-specific)
+# Detect which engine the user wants.
+# Priority: CLI --engine flag > VOXTYPE_ENGINE env var > config file > default
+detect_engine() {
+    # Check CLI args for --engine
+    for arg in "$@"; do
+        case "$prev" in
+            --engine) echo "$arg"; return ;;
+        esac
+        prev="$arg"
+    done
+
+    # Check environment variable
+    if [ -n "$VOXTYPE_ENGINE" ]; then
+        echo "$VOXTYPE_ENGINE"
+        return
+    fi
+
+    # Check config file
+    config="${XDG_CONFIG_HOME:-$HOME/.config}/voxtype/config.toml"
+    if [ -f "$config" ]; then
+        # Match uncommented engine = "..." line
+        engine=$(grep -E '^\s*engine\s*=' "$config" 2>/dev/null | head -1 | sed 's/.*=\s*"\([^"]*\)".*/\1/')
+        if [ -n "$engine" ]; then
+            echo "$engine"
+            return
+        fi
+    fi
+
+    echo "default"
+}
+
+ENGINE=$(detect_engine "$@")
+
+# Whisper engine: use the Vulkan binary if available, otherwise this
+# AppImage doesn't include a Whisper CPU binary so fall through to error
+case "$ENGINE" in
+    whisper)
+        if [ -x "$VOXTYPE_LIB/voxtype-vulkan" ]; then
+            exec "$VOXTYPE_LIB/voxtype-vulkan" "$@"
+        fi
+        echo "Error: Whisper engine requested but no Whisper binary found in this AppImage." >&2
+        echo "Use the Whisper AppImage for CPU-only Whisper, or set engine to an ONNX engine." >&2
+        exit 1
+        ;;
+esac
+
+# ONNX engines (parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual)
+# or default: use ONNX binaries with CPU dispatch
+
+# Detect AVX-512 support
 if [ -f /proc/cpuinfo ] && grep -q avx512f /proc/cpuinfo 2>/dev/null; then
-    # Prefer AVX-512 binary if available
     if [ -x "$VOXTYPE_LIB/voxtype-onnx-avx512" ]; then
         exec "$VOXTYPE_LIB/voxtype-onnx-avx512" "$@"
     fi
 fi
 
-# Fall back to AVX2 (baseline for x86_64)
+# Fall back to AVX2
 if [ -x "$VOXTYPE_LIB/voxtype-onnx-avx2" ]; then
     exec "$VOXTYPE_LIB/voxtype-onnx-avx2" "$@"
 fi
 
-# If we get here, no binary was found
-echo "Error: No voxtype ONNX binary found in $VOXTYPE_LIB" >&2
-echo "Please reinstall the package." >&2
+# Single ONNX binary (CUDA or ROCm AppImage)
+if [ -x "$VOXTYPE_LIB/voxtype-onnx-cuda" ]; then
+    exec "$VOXTYPE_LIB/voxtype-onnx-cuda" "$@"
+fi
+
+echo "Error: No voxtype binary found in $VOXTYPE_LIB" >&2
 exit 1

--- a/packaging/appimage/voxtype-onnx-wrapper.sh
+++ b/packaging/appimage/voxtype-onnx-wrapper.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Voxtype ONNX CPU-adaptive wrapper script
+# Detects CPU capabilities and executes the appropriate ONNX binary variant
+
+VOXTYPE_LIB="${VOXTYPE_LIB:-/usr/lib/voxtype}"
+
+# Detect AVX-512 support (Linux-specific)
+if [ -f /proc/cpuinfo ] && grep -q avx512f /proc/cpuinfo 2>/dev/null; then
+    # Prefer AVX-512 binary if available
+    if [ -x "$VOXTYPE_LIB/voxtype-onnx-avx512" ]; then
+        exec "$VOXTYPE_LIB/voxtype-onnx-avx512" "$@"
+    fi
+fi
+
+# Fall back to AVX2 (baseline for x86_64)
+if [ -x "$VOXTYPE_LIB/voxtype-onnx-avx2" ]; then
+    exec "$VOXTYPE_LIB/voxtype-onnx-avx2" "$@"
+fi
+
+# If we get here, no binary was found
+echo "Error: No voxtype ONNX binary found in $VOXTYPE_LIB" >&2
+echo "Please reinstall the package." >&2
+exit 1

--- a/packaging/appimage/voxtype.desktop
+++ b/packaging/appimage/voxtype.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Voxtype
+GenericName=Voice to Text
+Comment=Push-to-talk voice-to-text daemon for Linux
+Exec=voxtype daemon
+Icon=voxtype
+Categories=AudioVideo;Audio;Utility;Accessibility;
+Keywords=voice;speech;dictation;transcription;whisper;
+Terminal=false
+NoDisplay=true

--- a/packaging/appimage/voxtype.svg
+++ b/packaging/appimage/voxtype.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#58a6ff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
+  <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+  <line x1="12" y1="19" x2="12" y2="23"/>
+  <line x1="8" y1="23" x2="16" y2="23"/>
+</svg>

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -2,15 +2,19 @@
 # Build AppImage packages for voxtype
 # Uses pre-built release binaries from releases/{version}/
 #
+# Produces 3 AppImages:
+#   voxtype-{ver}-x86_64.AppImage          Whisper (avx2 + avx512 + vulkan)
+#   voxtype-{ver}-onnx-x86_64.AppImage     ONNX engines (onnx-avx2 + onnx-avx512 + vulkan)
+#   voxtype-{ver}-onnx-cuda-x86_64.AppImage  ONNX CUDA (onnx-cuda + vulkan)
+#
 # Usage:
 #   ./scripts/build-appimage.sh [options] VERSION
 #   ./scripts/build-appimage.sh 0.6.5
 #   ./scripts/build-appimage.sh --variant whisper 0.6.5
-#   ./scripts/build-appimage.sh --variant all --skip-build 0.6.5
 #
 # Options:
-#   --variant NAME   whisper, vulkan, onnx, onnx-cuda, onnx-rocm, all (default: all)
-#   --skip-build     Use existing binaries (default, binaries must exist)
+#   --variant NAME   whisper, onnx, onnx-cuda, all (default: all)
+#   --skip-build     Accepted for compatibility (binaries must already exist)
 
 set -euo pipefail
 
@@ -29,14 +33,12 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --skip-build)
-            # Accepted for compatibility with package.sh, but build-appimage
-            # always uses pre-built binaries
             shift
             ;;
         -h|--help)
             echo "Usage: $0 [--variant NAME] VERSION"
             echo ""
-            echo "Variants: whisper, vulkan, onnx, onnx-cuda, onnx-rocm, all"
+            echo "Variants: whisper, onnx, onnx-cuda, all"
             echo ""
             echo "Requires appimagetool (auto-downloaded if missing)"
             exit 0
@@ -120,6 +122,18 @@ populate_shared_files() {
     cp "$APPIMAGE_DIR/voxtype.svg" "$appdir/"
 }
 
+# Copy a binary into the AppDir if it exists
+copy_binary() {
+    local src="$1"
+    local dst="$2"
+    if [[ -f "$src" ]]; then
+        cp "$src" "$dst"
+        chmod 755 "$dst"
+        return 0
+    fi
+    return 1
+}
+
 # Build a single AppImage from a prepared AppDir
 build_appimage() {
     local appdir="$1"
@@ -132,14 +146,13 @@ build_appimage() {
     echo "  Created: $output_path ($(du -h "$output_path" | cut -f1))"
 }
 
-# Build Whisper CPU AppImage (avx2 + avx512 with wrapper)
+# Whisper AppImage: avx2 + avx512 + vulkan
+# Use VOXTYPE_GPU=1 to select the Vulkan binary at runtime
 build_whisper() {
     echo ""
-    echo "Building Whisper CPU AppImage..."
+    echo "Building Whisper AppImage (avx2 + avx512 + vulkan)..."
 
     local avx2="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-avx2"
-    local avx512="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-avx512"
-
     if [[ ! -f "$avx2" ]]; then
         echo "  Skipping: $avx2 not found" >&2
         return 1
@@ -151,19 +164,19 @@ build_whisper() {
 
     mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
 
-    # CPU-adaptive wrapper as the main binary
+    # CPU-adaptive wrapper (handles GPU dispatch via VOXTYPE_GPU=1)
     cp "$SCRIPT_DIR/voxtype-wrapper.sh" "$appdir/usr/bin/voxtype"
     chmod 755 "$appdir/usr/bin/voxtype"
 
-    # Tiered binaries
-    cp "$avx2" "$appdir/usr/lib/voxtype/voxtype-avx2"
-    chmod 755 "$appdir/usr/lib/voxtype/voxtype-avx2"
-    if [[ -f "$avx512" ]]; then
-        cp "$avx512" "$appdir/usr/lib/voxtype/voxtype-avx512"
-        chmod 755 "$appdir/usr/lib/voxtype/voxtype-avx512"
-    fi
+    # Whisper CPU binaries
+    copy_binary "$avx2" "$appdir/usr/lib/voxtype/voxtype-avx2"
+    copy_binary "$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-avx512" \
+        "$appdir/usr/lib/voxtype/voxtype-avx512" || true
 
-    # AppRun entry point
+    # Whisper Vulkan GPU binary
+    copy_binary "$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-vulkan" \
+        "$appdir/usr/lib/voxtype/voxtype-vulkan" || true
+
     cp "$APPIMAGE_DIR/AppRun" "$appdir/"
     chmod 755 "$appdir/AppRun"
 
@@ -171,43 +184,13 @@ build_whisper() {
     build_appimage "$appdir" "voxtype-${VERSION}-x86_64.AppImage"
 }
 
-# Build Vulkan GPU AppImage (single binary)
-build_vulkan() {
-    echo ""
-    echo "Building Vulkan GPU AppImage..."
-
-    local vulkan="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-vulkan"
-
-    if [[ ! -f "$vulkan" ]]; then
-        echo "  Skipping: $vulkan not found" >&2
-        return 1
-    fi
-
-    local appdir
-    appdir="$(mktemp -d "${TMPDIR:-/tmp}/voxtype-appimage.XXXXXX")"
-    trap 'rm -rf "$appdir"' RETURN
-
-    mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
-
-    cp "$vulkan" "$appdir/usr/lib/voxtype/voxtype-vulkan"
-    chmod 755 "$appdir/usr/lib/voxtype/voxtype-vulkan"
-    ln -s ../lib/voxtype/voxtype-vulkan "$appdir/usr/bin/voxtype"
-
-    cp "$APPIMAGE_DIR/AppRun" "$appdir/"
-    chmod 755 "$appdir/AppRun"
-
-    populate_shared_files "$appdir"
-    build_appimage "$appdir" "voxtype-${VERSION}-vulkan-x86_64.AppImage"
-}
-
-# Build ONNX CPU AppImage (onnx-avx2 + onnx-avx512 with wrapper)
+# ONNX AppImage: onnx-avx2 + onnx-avx512 + vulkan
+# Wrapper detects engine from config/CLI/env and dispatches accordingly
 build_onnx() {
     echo ""
-    echo "Building ONNX CPU AppImage..."
+    echo "Building ONNX AppImage (onnx-avx2 + onnx-avx512 + vulkan)..."
 
     local onnx_avx2="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-avx2"
-    local onnx_avx512="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-avx512"
-
     if [[ ! -f "$onnx_avx2" ]]; then
         echo "  Skipping: $onnx_avx2 not found" >&2
         return 1
@@ -219,16 +202,18 @@ build_onnx() {
 
     mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
 
-    # ONNX-specific CPU-adaptive wrapper
+    # Multi-engine wrapper (dispatches between ONNX and Vulkan)
     cp "$APPIMAGE_DIR/voxtype-onnx-wrapper.sh" "$appdir/usr/bin/voxtype"
     chmod 755 "$appdir/usr/bin/voxtype"
 
-    cp "$onnx_avx2" "$appdir/usr/lib/voxtype/voxtype-onnx-avx2"
-    chmod 755 "$appdir/usr/lib/voxtype/voxtype-onnx-avx2"
-    if [[ -f "$onnx_avx512" ]]; then
-        cp "$onnx_avx512" "$appdir/usr/lib/voxtype/voxtype-onnx-avx512"
-        chmod 755 "$appdir/usr/lib/voxtype/voxtype-onnx-avx512"
-    fi
+    # ONNX CPU binaries
+    copy_binary "$onnx_avx2" "$appdir/usr/lib/voxtype/voxtype-onnx-avx2"
+    copy_binary "$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-avx512" \
+        "$appdir/usr/lib/voxtype/voxtype-onnx-avx512" || true
+
+    # Vulkan binary for whisper engine fallback
+    copy_binary "$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-vulkan" \
+        "$appdir/usr/lib/voxtype/voxtype-vulkan" || true
 
     cp "$APPIMAGE_DIR/AppRun" "$appdir/"
     chmod 755 "$appdir/AppRun"
@@ -237,13 +222,12 @@ build_onnx() {
     build_appimage "$appdir" "voxtype-${VERSION}-onnx-x86_64.AppImage"
 }
 
-# Build ONNX CUDA AppImage (single binary)
+# ONNX CUDA AppImage: onnx-cuda + vulkan
 build_onnx_cuda() {
     echo ""
-    echo "Building ONNX CUDA AppImage..."
+    echo "Building ONNX CUDA AppImage (onnx-cuda + vulkan)..."
 
     local onnx_cuda="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-cuda"
-
     if [[ ! -f "$onnx_cuda" ]]; then
         echo "  Skipping: $onnx_cuda not found" >&2
         return 1
@@ -255,44 +239,22 @@ build_onnx_cuda() {
 
     mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
 
-    cp "$onnx_cuda" "$appdir/usr/lib/voxtype/voxtype-onnx-cuda"
-    chmod 755 "$appdir/usr/lib/voxtype/voxtype-onnx-cuda"
-    ln -s ../lib/voxtype/voxtype-onnx-cuda "$appdir/usr/bin/voxtype"
+    # Multi-engine wrapper
+    cp "$APPIMAGE_DIR/voxtype-onnx-wrapper.sh" "$appdir/usr/bin/voxtype"
+    chmod 755 "$appdir/usr/bin/voxtype"
+
+    # ONNX CUDA binary
+    copy_binary "$onnx_cuda" "$appdir/usr/lib/voxtype/voxtype-onnx-cuda"
+
+    # Vulkan binary for whisper engine fallback
+    copy_binary "$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-vulkan" \
+        "$appdir/usr/lib/voxtype/voxtype-vulkan" || true
 
     cp "$APPIMAGE_DIR/AppRun" "$appdir/"
     chmod 755 "$appdir/AppRun"
 
     populate_shared_files "$appdir"
     build_appimage "$appdir" "voxtype-${VERSION}-onnx-cuda-x86_64.AppImage"
-}
-
-# Build ONNX ROCm AppImage (single binary)
-build_onnx_rocm() {
-    echo ""
-    echo "Building ONNX ROCm AppImage..."
-
-    local onnx_rocm="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-rocm"
-
-    if [[ ! -f "$onnx_rocm" ]]; then
-        echo "  Skipping: $onnx_rocm not found" >&2
-        return 1
-    fi
-
-    local appdir
-    appdir="$(mktemp -d "${TMPDIR:-/tmp}/voxtype-appimage.XXXXXX")"
-    trap 'rm -rf "$appdir"' RETURN
-
-    mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
-
-    cp "$onnx_rocm" "$appdir/usr/lib/voxtype/voxtype-onnx-rocm"
-    chmod 755 "$appdir/usr/lib/voxtype/voxtype-onnx-rocm"
-    ln -s ../lib/voxtype/voxtype-onnx-rocm "$appdir/usr/bin/voxtype"
-
-    cp "$APPIMAGE_DIR/AppRun" "$appdir/"
-    chmod 755 "$appdir/AppRun"
-
-    populate_shared_files "$appdir"
-    build_appimage "$appdir" "voxtype-${VERSION}-onnx-rocm-x86_64.AppImage"
 }
 
 # Main
@@ -305,28 +267,20 @@ case "$VARIANT" in
     whisper)
         build_whisper || failed=1
         ;;
-    vulkan)
-        build_vulkan || failed=1
-        ;;
     onnx)
         build_onnx || failed=1
         ;;
     onnx-cuda)
         build_onnx_cuda || failed=1
         ;;
-    onnx-rocm)
-        build_onnx_rocm || failed=1
-        ;;
     all)
         build_whisper || failed=1
-        build_vulkan || failed=1
         build_onnx || failed=1
         build_onnx_cuda || failed=1
-        build_onnx_rocm || failed=1
         ;;
     *)
         echo "Error: Unknown variant '$VARIANT'" >&2
-        echo "Valid variants: whisper, vulkan, onnx, onnx-cuda, onnx-rocm, all" >&2
+        echo "Valid variants: whisper, onnx, onnx-cuda, all" >&2
         exit 1
         ;;
 esac

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+# Build AppImage packages for voxtype
+# Uses pre-built release binaries from releases/{version}/
+#
+# Usage:
+#   ./scripts/build-appimage.sh [options] VERSION
+#   ./scripts/build-appimage.sh 0.6.5
+#   ./scripts/build-appimage.sh --variant whisper 0.6.5
+#   ./scripts/build-appimage.sh --variant all --skip-build 0.6.5
+#
+# Options:
+#   --variant NAME   whisper, vulkan, onnx, onnx-cuda, onnx-rocm, all (default: all)
+#   --skip-build     Use existing binaries (default, binaries must exist)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Defaults
+VARIANT="all"
+VERSION=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --variant)
+            VARIANT="$2"
+            shift 2
+            ;;
+        --skip-build)
+            # Accepted for compatibility with package.sh, but build-appimage
+            # always uses pre-built binaries
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--variant NAME] VERSION"
+            echo ""
+            echo "Variants: whisper, vulkan, onnx, onnx-cuda, onnx-rocm, all"
+            echo ""
+            echo "Requires appimagetool (auto-downloaded if missing)"
+            exit 0
+            ;;
+        *)
+            VERSION="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: VERSION is required" >&2
+    echo "Usage: $0 [--variant NAME] VERSION" >&2
+    exit 1
+fi
+
+RELEASE_DIR="$PROJECT_DIR/releases/$VERSION"
+APPIMAGE_DIR="$PROJECT_DIR/packaging/appimage"
+
+if [[ ! -d "$RELEASE_DIR" ]]; then
+    echo "Error: Release directory not found: $RELEASE_DIR" >&2
+    echo "Build binaries first or check the version number." >&2
+    exit 1
+fi
+
+# Find or download appimagetool
+find_appimagetool() {
+    if command -v appimagetool >/dev/null 2>&1; then
+        echo "appimagetool"
+        return
+    fi
+
+    local cached="$HOME/.local/bin/appimagetool"
+    if [[ -x "$cached" ]]; then
+        echo "$cached"
+        return
+    fi
+
+    echo "  Downloading appimagetool..." >&2
+    mkdir -p "$HOME/.local/bin"
+    curl -fsSL -o "$cached" \
+        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+    chmod +x "$cached"
+    echo "$cached"
+}
+
+APPIMAGETOOL="$(find_appimagetool)"
+echo "Using appimagetool: $APPIMAGETOOL"
+
+# Populate shared files (docs, completions, config) into an AppDir
+populate_shared_files() {
+    local appdir="$1"
+
+    mkdir -p "$appdir/usr/share/doc/voxtype"
+    cp "$PROJECT_DIR/README.md" "$appdir/usr/share/doc/voxtype/"
+    cp "$PROJECT_DIR/LICENSE" "$appdir/usr/share/doc/voxtype/"
+
+    # Default config
+    mkdir -p "$appdir/etc/voxtype"
+    cp "$PROJECT_DIR/config/default.toml" "$appdir/etc/voxtype/config.toml"
+
+    # Shell completions
+    mkdir -p "$appdir/usr/share/bash-completion/completions"
+    mkdir -p "$appdir/usr/share/zsh/site-functions"
+    mkdir -p "$appdir/usr/share/fish/vendor_completions.d"
+    cp "$PROJECT_DIR/packaging/completions/voxtype.bash" "$appdir/usr/share/bash-completion/completions/voxtype"
+    cp "$PROJECT_DIR/packaging/completions/voxtype.zsh" "$appdir/usr/share/zsh/site-functions/_voxtype"
+    cp "$PROJECT_DIR/packaging/completions/voxtype.fish" "$appdir/usr/share/fish/vendor_completions.d/voxtype.fish"
+
+    # Man pages (if available from a prior cargo build --release)
+    local man_dir
+    man_dir=$(find "$PROJECT_DIR/target/release/build" -name "man" -type d -path "*/voxtype-*/out/man" 2>/dev/null | head -1)
+    if [[ -n "$man_dir" && -d "$man_dir" ]]; then
+        mkdir -p "$appdir/usr/share/man/man1"
+        cp "$man_dir"/*.1 "$appdir/usr/share/man/man1/"
+    fi
+
+    # Desktop entry and icon at AppDir root (AppImage spec)
+    cp "$APPIMAGE_DIR/voxtype.desktop" "$appdir/"
+    cp "$APPIMAGE_DIR/voxtype.svg" "$appdir/"
+}
+
+# Build a single AppImage from a prepared AppDir
+build_appimage() {
+    local appdir="$1"
+    local output_name="$2"
+    local output_path="$RELEASE_DIR/$output_name"
+
+    echo "  Building $output_name..."
+    ARCH=x86_64 "$APPIMAGETOOL" "$appdir" "$output_path" 2>&1 | tail -1
+    chmod +x "$output_path"
+    echo "  Created: $output_path ($(du -h "$output_path" | cut -f1))"
+}
+
+# Build Whisper CPU AppImage (avx2 + avx512 with wrapper)
+build_whisper() {
+    echo ""
+    echo "Building Whisper CPU AppImage..."
+
+    local avx2="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-avx2"
+    local avx512="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-avx512"
+
+    if [[ ! -f "$avx2" ]]; then
+        echo "  Skipping: $avx2 not found" >&2
+        return 1
+    fi
+
+    local appdir
+    appdir="$(mktemp -d "${TMPDIR:-/tmp}/voxtype-appimage.XXXXXX")"
+    trap 'rm -rf "$appdir"' RETURN
+
+    mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
+
+    # CPU-adaptive wrapper as the main binary
+    cp "$SCRIPT_DIR/voxtype-wrapper.sh" "$appdir/usr/bin/voxtype"
+    chmod 755 "$appdir/usr/bin/voxtype"
+
+    # Tiered binaries
+    cp "$avx2" "$appdir/usr/lib/voxtype/voxtype-avx2"
+    chmod 755 "$appdir/usr/lib/voxtype/voxtype-avx2"
+    if [[ -f "$avx512" ]]; then
+        cp "$avx512" "$appdir/usr/lib/voxtype/voxtype-avx512"
+        chmod 755 "$appdir/usr/lib/voxtype/voxtype-avx512"
+    fi
+
+    # AppRun entry point
+    cp "$APPIMAGE_DIR/AppRun" "$appdir/"
+    chmod 755 "$appdir/AppRun"
+
+    populate_shared_files "$appdir"
+    build_appimage "$appdir" "voxtype-${VERSION}-x86_64.AppImage"
+}
+
+# Build Vulkan GPU AppImage (single binary)
+build_vulkan() {
+    echo ""
+    echo "Building Vulkan GPU AppImage..."
+
+    local vulkan="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-vulkan"
+
+    if [[ ! -f "$vulkan" ]]; then
+        echo "  Skipping: $vulkan not found" >&2
+        return 1
+    fi
+
+    local appdir
+    appdir="$(mktemp -d "${TMPDIR:-/tmp}/voxtype-appimage.XXXXXX")"
+    trap 'rm -rf "$appdir"' RETURN
+
+    mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
+
+    cp "$vulkan" "$appdir/usr/lib/voxtype/voxtype-vulkan"
+    chmod 755 "$appdir/usr/lib/voxtype/voxtype-vulkan"
+    ln -s ../lib/voxtype/voxtype-vulkan "$appdir/usr/bin/voxtype"
+
+    cp "$APPIMAGE_DIR/AppRun" "$appdir/"
+    chmod 755 "$appdir/AppRun"
+
+    populate_shared_files "$appdir"
+    build_appimage "$appdir" "voxtype-${VERSION}-vulkan-x86_64.AppImage"
+}
+
+# Build ONNX CPU AppImage (onnx-avx2 + onnx-avx512 with wrapper)
+build_onnx() {
+    echo ""
+    echo "Building ONNX CPU AppImage..."
+
+    local onnx_avx2="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-avx2"
+    local onnx_avx512="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-avx512"
+
+    if [[ ! -f "$onnx_avx2" ]]; then
+        echo "  Skipping: $onnx_avx2 not found" >&2
+        return 1
+    fi
+
+    local appdir
+    appdir="$(mktemp -d "${TMPDIR:-/tmp}/voxtype-appimage.XXXXXX")"
+    trap 'rm -rf "$appdir"' RETURN
+
+    mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
+
+    # ONNX-specific CPU-adaptive wrapper
+    cp "$APPIMAGE_DIR/voxtype-onnx-wrapper.sh" "$appdir/usr/bin/voxtype"
+    chmod 755 "$appdir/usr/bin/voxtype"
+
+    cp "$onnx_avx2" "$appdir/usr/lib/voxtype/voxtype-onnx-avx2"
+    chmod 755 "$appdir/usr/lib/voxtype/voxtype-onnx-avx2"
+    if [[ -f "$onnx_avx512" ]]; then
+        cp "$onnx_avx512" "$appdir/usr/lib/voxtype/voxtype-onnx-avx512"
+        chmod 755 "$appdir/usr/lib/voxtype/voxtype-onnx-avx512"
+    fi
+
+    cp "$APPIMAGE_DIR/AppRun" "$appdir/"
+    chmod 755 "$appdir/AppRun"
+
+    populate_shared_files "$appdir"
+    build_appimage "$appdir" "voxtype-${VERSION}-onnx-x86_64.AppImage"
+}
+
+# Build ONNX CUDA AppImage (single binary)
+build_onnx_cuda() {
+    echo ""
+    echo "Building ONNX CUDA AppImage..."
+
+    local onnx_cuda="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-cuda"
+
+    if [[ ! -f "$onnx_cuda" ]]; then
+        echo "  Skipping: $onnx_cuda not found" >&2
+        return 1
+    fi
+
+    local appdir
+    appdir="$(mktemp -d "${TMPDIR:-/tmp}/voxtype-appimage.XXXXXX")"
+    trap 'rm -rf "$appdir"' RETURN
+
+    mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
+
+    cp "$onnx_cuda" "$appdir/usr/lib/voxtype/voxtype-onnx-cuda"
+    chmod 755 "$appdir/usr/lib/voxtype/voxtype-onnx-cuda"
+    ln -s ../lib/voxtype/voxtype-onnx-cuda "$appdir/usr/bin/voxtype"
+
+    cp "$APPIMAGE_DIR/AppRun" "$appdir/"
+    chmod 755 "$appdir/AppRun"
+
+    populate_shared_files "$appdir"
+    build_appimage "$appdir" "voxtype-${VERSION}-onnx-cuda-x86_64.AppImage"
+}
+
+# Build ONNX ROCm AppImage (single binary)
+build_onnx_rocm() {
+    echo ""
+    echo "Building ONNX ROCm AppImage..."
+
+    local onnx_rocm="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-rocm"
+
+    if [[ ! -f "$onnx_rocm" ]]; then
+        echo "  Skipping: $onnx_rocm not found" >&2
+        return 1
+    fi
+
+    local appdir
+    appdir="$(mktemp -d "${TMPDIR:-/tmp}/voxtype-appimage.XXXXXX")"
+    trap 'rm -rf "$appdir"' RETURN
+
+    mkdir -p "$appdir/usr/bin" "$appdir/usr/lib/voxtype"
+
+    cp "$onnx_rocm" "$appdir/usr/lib/voxtype/voxtype-onnx-rocm"
+    chmod 755 "$appdir/usr/lib/voxtype/voxtype-onnx-rocm"
+    ln -s ../lib/voxtype/voxtype-onnx-rocm "$appdir/usr/bin/voxtype"
+
+    cp "$APPIMAGE_DIR/AppRun" "$appdir/"
+    chmod 755 "$appdir/AppRun"
+
+    populate_shared_files "$appdir"
+    build_appimage "$appdir" "voxtype-${VERSION}-onnx-rocm-x86_64.AppImage"
+}
+
+# Main
+echo "Building voxtype AppImage packages v${VERSION}"
+echo "Release dir: $RELEASE_DIR"
+
+failed=0
+
+case "$VARIANT" in
+    whisper)
+        build_whisper || failed=1
+        ;;
+    vulkan)
+        build_vulkan || failed=1
+        ;;
+    onnx)
+        build_onnx || failed=1
+        ;;
+    onnx-cuda)
+        build_onnx_cuda || failed=1
+        ;;
+    onnx-rocm)
+        build_onnx_rocm || failed=1
+        ;;
+    all)
+        build_whisper || failed=1
+        build_vulkan || failed=1
+        build_onnx || failed=1
+        build_onnx_cuda || failed=1
+        build_onnx_rocm || failed=1
+        ;;
+    *)
+        echo "Error: Unknown variant '$VARIANT'" >&2
+        echo "Valid variants: whisper, vulkan, onnx, onnx-cuda, onnx-rocm, all" >&2
+        exit 1
+        ;;
+esac
+
+echo ""
+if [[ "$failed" -eq 0 ]]; then
+    echo "AppImage builds complete."
+else
+    echo "Some AppImage builds were skipped (missing binaries)."
+fi
+
+# List generated AppImages
+echo ""
+echo "Generated AppImages:"
+ls -lh "$RELEASE_DIR"/*.AppImage 2>/dev/null || echo "  (none)"

--- a/scripts/voxtype-wrapper.sh
+++ b/scripts/voxtype-wrapper.sh
@@ -4,6 +4,12 @@
 
 VOXTYPE_LIB="${VOXTYPE_LIB:-/usr/lib/voxtype}"
 
+# GPU mode: use Vulkan binary if available and requested
+# Set VOXTYPE_GPU=1 to prefer the Vulkan binary
+if [ "$VOXTYPE_GPU" = "1" ] && [ -x "$VOXTYPE_LIB/voxtype-vulkan" ]; then
+    exec "$VOXTYPE_LIB/voxtype-vulkan" "$@"
+fi
+
 # Detect AVX-512 support (Linux-specific)
 if [ -f /proc/cpuinfo ] && grep -q avx512f /proc/cpuinfo 2>/dev/null; then
     # Prefer AVX-512 binary if available

--- a/scripts/voxtype-wrapper.sh
+++ b/scripts/voxtype-wrapper.sh
@@ -2,7 +2,7 @@
 # Voxtype CPU-adaptive wrapper script
 # Detects CPU capabilities and executes the appropriate binary variant
 
-VOXTYPE_LIB="/usr/lib/voxtype"
+VOXTYPE_LIB="${VOXTYPE_LIB:-/usr/lib/voxtype}"
 
 # Detect AVX-512 support (Linux-specific)
 if [ -f /proc/cpuinfo ] && grep -q avx512f /proc/cpuinfo 2>/dev/null; then

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -84,6 +84,12 @@ pub fn get_voxtype_path() -> String {
 /// so backend switching only requires a service restart rather than regenerating
 /// the service file.
 pub fn get_voxtype_service_path() -> String {
+    // AppImage: use the .AppImage file path directly
+    // The APPIMAGE env var is set automatically by the AppImage runtime
+    if let Ok(appimage_path) = std::env::var("APPIMAGE") {
+        return appimage_path;
+    }
+
     const VOXTYPE_BIN: &str = "/usr/bin/voxtype";
 
     // If /usr/bin/voxtype exists (either as symlink or binary), use it


### PR DESCRIPTION
## Summary

- Add `scripts/build-appimage.sh` to build AppImages from existing release binaries using `appimagetool`
- Add `packaging/appimage/` with desktop entry, icon, AppRun entry point, and ONNX CPU dispatch wrapper
- Make `scripts/voxtype-wrapper.sh` respect `VOXTYPE_LIB` env var (backward-compatible, defaults to `/usr/lib/voxtype`)
- Make `get_voxtype_service_path()` detect `APPIMAGE` env var so `voxtype setup service install` generates correct systemd service files for AppImage users
- Add AppImage installation instructions to README

Five variant AppImages match the existing binary release model:

| AppImage | Contents |
|----------|----------|
| `voxtype-{ver}-x86_64.AppImage` | Whisper CPU (avx2 + avx512) |
| `voxtype-{ver}-vulkan-x86_64.AppImage` | Whisper Vulkan GPU |
| `voxtype-{ver}-onnx-x86_64.AppImage` | ONNX CPU (avx2 + avx512) |
| `voxtype-{ver}-onnx-cuda-x86_64.AppImage` | ONNX CUDA |
| `voxtype-{ver}-onnx-rocm-x86_64.AppImage` | ONNX ROCm |

## Test plan

- [x] `cargo test` passes (25/25)
- [x] `cargo clippy` clean (no new warnings)
- [ ] Build a test AppImage: `./scripts/build-appimage.sh --variant whisper --skip-build $VERSION`
- [ ] Verify AppImage runs: `./voxtype-$VERSION-x86_64.AppImage --version`
- [ ] Verify `setup service install` uses AppImage path in ExecStart