### PR TITLE
Run gpu_isolation worker spawn off the async event loop

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -496,6 +496,10 @@ pub struct Daemon {
             std::result::Result<Arc<dyn Transcriber>, crate::error::TranscribeError>,
         >,
     >,
+    // Background task that spawns and prepares the gpu_isolation subprocess
+    // worker. Awaited before transcription so audio capture can start
+    // immediately while the worker loads its model in parallel.
+    whisper_prepare_task: Option<tokio::task::JoinHandle<()>>,
     // Background task for transcription (allows cancel during transcription)
     transcription_task: Option<tokio::task::JoinHandle<TranscriptionResult>>,
     // Background tasks for eager chunk transcriptions (chunk_index, task)
@@ -606,6 +610,7 @@ impl Daemon {
             last_dictation: None,
             model_manager: None,
             model_load_task: None,
+            whisper_prepare_task: None,
             transcription_task: None,
             eager_chunk_tasks: Vec::new(),
             vad,
@@ -703,6 +708,15 @@ impl Daemon {
                     }
                 }
                 crate::config::TranscriptionEngine::Whisper => {
+                    // Wait for the gpu_isolation worker to finish preparing
+                    // (model load) before we hand the transcriber to the
+                    // recording stop path. Otherwise transcribe() would race
+                    // with the in-flight prepare and spawn a second worker.
+                    if let Some(task) = self.whisper_prepare_task.take() {
+                        if let Err(e) = task.await {
+                            tracing::warn!("Whisper prepare task failed: {}", e);
+                        }
+                    }
                     if let Some(ref mut mm) = self.model_manager {
                         match mm.get_prepared_transcriber(model_override) {
                             Ok(t) => Ok(t),
@@ -1783,8 +1797,13 @@ impl Daemon {
                                     match self.config.engine {
                                         crate::config::TranscriptionEngine::Whisper => {
                                             if let Some(ref mut mm) = self.model_manager {
-                                                if let Err(e) = mm.prepare_model(model_override.as_deref()) {
-                                                    tracing::warn!("Failed to prepare model: {}", e);
+                                                match mm.prepare_model(model_override.as_deref()) {
+                                                    Ok(handle) => {
+                                                        self.whisper_prepare_task = handle;
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::warn!("Failed to prepare model: {}", e);
+                                                    }
                                                 }
                                             }
                                         }
@@ -1974,8 +1993,13 @@ impl Daemon {
                                     match self.config.engine {
                                         crate::config::TranscriptionEngine::Whisper => {
                                             if let Some(ref mut mm) = self.model_manager {
-                                                if let Err(e) = mm.prepare_model(model_override.as_deref()) {
-                                                    tracing::warn!("Failed to prepare model: {}", e);
+                                                match mm.prepare_model(model_override.as_deref()) {
+                                                    Ok(handle) => {
+                                                        self.whisper_prepare_task = handle;
+                                                    }
+                                                    Err(e) => {
+                                                        tracing::warn!("Failed to prepare model: {}", e);
+                                                    }
                                                 }
                                             }
                                         }
@@ -2409,8 +2433,13 @@ impl Daemon {
                             match self.config.engine {
                                 crate::config::TranscriptionEngine::Whisper => {
                                     if let Some(ref mut mm) = self.model_manager {
-                                        if let Err(e) = mm.prepare_model(model_override.as_deref()) {
-                                            tracing::warn!("Failed to prepare model: {}", e);
+                                        match mm.prepare_model(model_override.as_deref()) {
+                                            Ok(handle) => {
+                                                self.whisper_prepare_task = handle;
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!("Failed to prepare model: {}", e);
+                                            }
                                         }
                                     }
                                 }

--- a/src/model_manager.rs
+++ b/src/model_manager.rs
@@ -245,8 +245,16 @@ impl ModelManager {
     /// Prepare a model for transcription (called when recording starts)
     ///
     /// For subprocess mode, this spawns the worker early so it can load
-    /// the model while the user is speaking.
-    pub fn prepare_model(&mut self, model: Option<&str>) -> Result<(), TranscribeError> {
+    /// the model while the user is speaking. The actual worker spawn and
+    /// model load happen on a blocking thread, so the async event loop
+    /// (and audio capture) is not blocked. Returns a JoinHandle that the
+    /// caller must await before invoking transcription, so that we don't
+    /// race against the in-flight prepare and end up spawning a second
+    /// worker.
+    pub fn prepare_model(
+        &mut self,
+        model: Option<&str>,
+    ) -> Result<Option<tokio::task::JoinHandle<()>>, TranscribeError> {
         let model_name = model
             .map(|s| s.to_string())
             .unwrap_or_else(|| self.config.model.clone());
@@ -257,26 +265,30 @@ impl ModelManager {
                 "Cannot prepare unavailable model '{}', will use default",
                 model_name
             );
-            return Ok(());
+            return Ok(None);
         }
 
         // For GPU isolation, spawn subprocess early
         if self.config.gpu_isolation && self.config.effective_mode() == WhisperMode::Local {
-            // Create and prepare subprocess transcriber
             let transcriber = self.create_subprocess_transcriber(&model_name)?;
-            transcriber.prepare();
-            // Store it temporarily for the upcoming transcription
+            // Store the Arc immediately so get_prepared_transcriber can retrieve it.
+            // The worker spawn happens on a blocking thread; the prepared_worker
+            // mutex inside SubprocessTranscriber is populated when ready.
             self.loaded_models.insert(
                 format!("_prepared_{}", model_name),
                 LoadedModel {
-                    transcriber,
+                    transcriber: transcriber.clone(),
                     last_used: Instant::now(),
                     is_primary: false,
                 },
             );
+            let handle = tokio::task::spawn_blocking(move || {
+                transcriber.prepare();
+            });
+            return Ok(Some(handle));
         }
 
-        Ok(())
+        Ok(None)
     }
 
     /// Get a prepared transcriber (if available) or create one


### PR DESCRIPTION
## Summary
- Fixes #331: `gpu_isolation = true` no longer blocks audio capture for ~2s while the Whisper worker subprocess loads its model.
- `ModelManager::prepare_model` now offloads the slow `transcriber.prepare()` call (worker spawn + model load) onto `tokio::task::spawn_blocking` and returns a `JoinHandle`. The subprocess `Arc` is stored in `loaded_models` synchronously so `get_prepared_transcriber` can still retrieve it.
- `Daemon` tracks the handle in a new `whisper_prepare_task` field and awaits it inside `get_transcriber_for_recording`, ensuring the in-flight prepare completes before transcription (avoids spawning a duplicate worker).

This matches the existing Parakeet/Moonshine path, where `prepare()` already runs via `spawn_blocking`, and aligns with the design comment "model loaded while recording" in `subprocess.rs`.

## Test plan
- [x] `cargo build --release` passes.
- [x] `cargo test --lib` passes (539 tests).
- [ ] Manual: with `gpu_isolation = true`, press hotkey and verify audio capture starts immediately while logs show the worker preparing in the background.
- [ ] Manual: confirm transcription on hotkey release still works (no duplicate worker spawn) on both short and long recordings.
- [ ] Manual: regression check with `gpu_isolation = false` to make sure the non-isolation path is unchanged.