### PR TITLE
Make notification urgency configurable (#335)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1480,6 +1480,24 @@ on_recording_stop = true    # Notify when transcribing
 on_transcription = true     # Show transcribed text
 ```
 
+### urgency
+
+**Type:** String (`"low"`, `"normal"`, or `"critical"`)
+**Default:** `"normal"`
+**Required:** No
+
+Sets the urgency level passed to `notify-send` for all voxtype notifications.
+
+On GNOME, notifications with `"low"` urgency are delivered to the notification drawer without showing as a popup banner. Use `"normal"` (the default) if you want notifications to pop up on screen. Use `"critical"` if you want notifications that persist until dismissed.
+
+Unknown values fall back to `"normal"`.
+
+**Example:**
+```toml
+[output.notification]
+urgency = "normal"  # "low" | "normal" | "critical"
+```
+
 ### type_delay_ms
 
 **Type:** Integer

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,6 +239,11 @@ on_recording_stop = false
 # Show notification with transcribed text after transcription completes
 on_transcription = true
 
+# Notification urgency level: "low", "normal", or "critical".
+# On GNOME, "low" notifications are delivered to the drawer without a popup banner.
+# Use "normal" (default) to ensure notifications appear as banners.
+# urgency = "normal"
+
 # [text]
 # Text processing options (word replacements, spoken punctuation)
 #
@@ -1504,6 +1509,15 @@ pub struct NotificationConfig {
     /// Show engine icon in notification title (🦜 for Parakeet, 🗣️ for Whisper)
     #[serde(default)]
     pub show_engine_icon: bool,
+
+    /// Notification urgency level: "low", "normal", or "critical".
+    /// On GNOME, "low" notifications go straight to the drawer without a popup banner.
+    #[serde(default = "default_notification_urgency")]
+    pub urgency: String,
+}
+
+fn default_notification_urgency() -> String {
+    "normal".to_string()
 }
 
 impl Default for NotificationConfig {
@@ -1513,6 +1527,7 @@ impl Default for NotificationConfig {
             on_recording_stop: false,
             on_transcription: true,
             show_engine_icon: false,
+            urgency: default_notification_urgency(),
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,6 +30,7 @@ async fn send_notification(
     body: &str,
     show_engine_icon: bool,
     engine: crate::config::TranscriptionEngine,
+    urgency: &str,
 ) {
     let title = if show_engine_icon {
         format!("{} {}", crate::output::engine_icon(engine), title)
@@ -37,8 +38,15 @@ async fn send_notification(
         title.to_string()
     };
 
+    let urgency_arg = format!("--urgency={}", crate::output::sanitize_urgency(urgency));
     let _ = Command::new("notify-send")
-        .args(["--app-name=Voxtype", "--expire-time=2000", &title, body])
+        .args([
+            "--app-name=Voxtype",
+            &urgency_arg,
+            "--expire-time=2000",
+            &title,
+            body,
+        ])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -852,6 +860,7 @@ impl Daemon {
                                 &format!("ID: {}", meeting_id),
                                 false,
                                 self.config.engine,
+                                &self.config.output.notification.urgency,
                             )
                             .await;
                         }
@@ -892,6 +901,7 @@ impl Daemon {
                             &format!("ID: {}", meeting_id),
                             false,
                             self.config.engine,
+                            &self.config.output.notification.urgency,
                         )
                         .await;
                     }
@@ -923,6 +933,7 @@ impl Daemon {
                     "Recording paused",
                     false,
                     self.config.engine,
+                    &self.config.output.notification.urgency,
                 )
                 .await;
             }
@@ -944,6 +955,7 @@ impl Daemon {
                     "Recording resumed",
                     false,
                     self.config.engine,
+                    &self.config.output.notification.urgency,
                 )
                 .await;
             }
@@ -1206,6 +1218,7 @@ impl Daemon {
                 "Transcribing...",
                 self.config.output.notification.show_engine_icon,
                 self.config.engine,
+                &self.config.output.notification.urgency,
             )
             .await;
         }
@@ -1520,6 +1533,7 @@ impl Daemon {
                                 &final_text,
                                 self.config.output.notification.show_engine_icon,
                                 self.config.engine,
+                                &self.config.output.notification.urgency,
                             )
                             .await;
                         }
@@ -1749,7 +1763,7 @@ impl Daemon {
 
                                 // Send notification if enabled
                                 if self.config.output.notification.on_recording_start {
-                                    send_notification("Push to Talk Active", "Recording...", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                                    send_notification("Push to Talk Active", "Recording...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                                 }
 
                                 // Prepare model for transcription
@@ -1886,7 +1900,7 @@ impl Daemon {
                                 self.play_feedback(SoundEvent::RecordingStop);
 
                                 if self.config.output.notification.on_recording_stop {
-                                    send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                                    send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                                 }
 
                                 // Stop audio capture and get remaining samples
@@ -1940,7 +1954,7 @@ impl Daemon {
                                 tracing::info!("Recording started (toggle mode)");
 
                                 if self.config.output.notification.on_recording_start {
-                                    send_notification("Recording Started", "Press hotkey again to stop", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                                    send_notification("Recording Started", "Press hotkey again to stop", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                                 }
 
                                 // Prepare model for transcription
@@ -2070,7 +2084,7 @@ impl Daemon {
                                 self.play_feedback(SoundEvent::RecordingStop);
 
                                 if self.config.output.notification.on_recording_stop {
-                                    send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                                    send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                                 }
 
                                 // Stop audio capture and get remaining samples
@@ -2150,7 +2164,7 @@ impl Daemon {
                                 }
 
                                 if self.config.output.notification.on_recording_stop {
-                                    send_notification("Cancelled", "Recording discarded", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                                    send_notification("Cancelled", "Recording discarded", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                                 }
                             } else if matches!(state, State::Transcribing { .. }) {
                                 tracing::info!("Transcription cancelled via hotkey");
@@ -2176,7 +2190,7 @@ impl Daemon {
                                 }
 
                                 if self.config.output.notification.on_recording_stop {
-                                    send_notification("Cancelled", "Transcription aborted", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                                    send_notification("Cancelled", "Transcription aborted", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                                 }
                             } else {
                                 tracing::trace!("Cancel ignored - not recording or transcribing");
@@ -2237,7 +2251,7 @@ impl Daemon {
                         }
 
                         if self.config.output.notification.on_recording_stop {
-                            send_notification("Cancelled", "Recording discarded", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                            send_notification("Cancelled", "Recording discarded", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                         }
 
                         continue;
@@ -2376,7 +2390,7 @@ impl Daemon {
                         tracing::info!("Recording started (external trigger), model_override = {:?}", model_override);
 
                         if self.config.output.notification.on_recording_start {
-                            send_notification("Recording Started", "External trigger", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                            send_notification("Recording Started", "External trigger", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                         }
 
                         // Prepare model for transcription
@@ -2508,7 +2522,7 @@ impl Daemon {
                         self.play_feedback(SoundEvent::RecordingStop);
 
                         if self.config.output.notification.on_recording_stop {
-                            send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                            send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                         }
 
                         // Stop audio capture and get remaining samples
@@ -2582,7 +2596,7 @@ impl Daemon {
                         }
 
                         if self.config.output.notification.on_recording_stop {
-                            send_notification("Cancelled", "Transcription aborted", self.config.output.notification.show_engine_icon, self.config.engine).await;
+                            send_notification("Cancelled", "Transcription aborted", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1292,6 +1292,7 @@ async fn show_config(config: &config::Config) -> anyhow::Result<()> {
         "  on_transcription = {}",
         config.output.notification.on_transcription
     );
+    println!("  urgency = {:?}", config.output.notification.urgency);
 
     println!("\n[status]");
     println!("  icon_theme = {:?}", config.status.icon_theme);

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -160,11 +160,22 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
     }
 }
 
+/// Validate notification urgency, falling back to "normal" for unknown values.
+///
+/// notify-send only accepts "low", "normal", or "critical".
+pub fn sanitize_urgency(urgency: &str) -> &str {
+    match urgency {
+        "low" | "normal" | "critical" => urgency,
+        _ => "normal",
+    }
+}
+
 /// Send a transcription notification with optional engine icon
 pub async fn send_transcription_notification(
     text: &str,
     show_engine_icon: bool,
     engine: crate::config::TranscriptionEngine,
+    urgency: &str,
 ) {
     // Truncate preview for notification (use chars() to handle multi-byte UTF-8)
     let preview = if text.chars().count() > 80 {
@@ -179,10 +190,11 @@ pub async fn send_transcription_notification(
         "Transcribed".to_string()
     };
 
+    let urgency_arg = format!("--urgency={}", sanitize_urgency(urgency));
     let _ = Command::new("notify-send")
         .args([
             "--app-name=Voxtype",
-            "--urgency=low",
+            &urgency_arg,
             "--expire-time=3000",
             &title,
             &preview,
@@ -509,5 +521,20 @@ mod tests {
         std::env::remove_var("YDOTOOL_SOCKET");
 
         assert_eq!(result, Some(sock_path));
+    }
+
+    #[test]
+    fn test_sanitize_urgency_valid() {
+        assert_eq!(sanitize_urgency("low"), "low");
+        assert_eq!(sanitize_urgency("normal"), "normal");
+        assert_eq!(sanitize_urgency("critical"), "critical");
+    }
+
+    #[test]
+    fn test_sanitize_urgency_invalid_falls_back_to_normal() {
+        assert_eq!(sanitize_urgency(""), "normal");
+        assert_eq!(sanitize_urgency("LOW"), "normal");
+        assert_eq!(sanitize_urgency("urgent"), "normal");
+        assert_eq!(sanitize_urgency("--rm -rf /"), "normal");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `urgency` to `[output.notification]` (`"low"` / `"normal"` / `"critical"`, default `"normal"`)
- Applies the urgency to every `notify-send` call (recording start/stop, transcription, meeting events, cancellation)
- Removes the hardcoded `--urgency=low` from the transcription notification, which on GNOME 49 routed the popup straight to the notification drawer

## Why

Reported in #335: on Ubuntu 25.10 / GNOME 49 Wayland with `output.mode = "clipboard"`, the "Transcribed" notification never shows as a banner because GNOME suppresses popups for low-urgency notifications. Other voxtype notifications used `notify-send`'s default (normal) and worked, so only this one path was affected.

Defaulting to `"normal"` matches the behavior of recording start/stop notifications and is what users expect from "all my other apps' notifications pop normally." Users who liked the quiet behavior can set `urgency = "low"`.

Unknown values fall back to `"normal"` via `sanitize_urgency` so a config typo can't break `notify-send`.

## Test plan

- [x] `cargo test --lib` (541 passed)
- [x] `cargo build` clean
- [x] `cargo clippy` no new warnings on changed files
- [ ] Manual: trigger transcription on GNOME, confirm banner appears
- [ ] Manual: set `urgency = "low"`, confirm notification goes to drawer only
- [ ] Manual: set `urgency = "garbage"`, confirm it still works (fallback to normal)

Closes #335