### PR TITLE
Fall back to /etc/voxtype/config.toml when no user config exists (#337)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1980,10 +1980,38 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Get the default config file path
+    /// System-wide config path used as a fallback when no user config exists.
+    pub const SYSTEM_PATH: &'static str = "/etc/voxtype/config.toml";
+
+    /// Get the default user config file path (XDG)
     pub fn default_path() -> Option<PathBuf> {
         directories::ProjectDirs::from("", "", "voxtype")
             .map(|dirs| dirs.config_dir().join("config.toml"))
+    }
+
+    /// Get the system-wide config file path.
+    pub fn system_path() -> PathBuf {
+        PathBuf::from(Self::SYSTEM_PATH)
+    }
+
+    /// Resolve which config file should actually be loaded, in priority order:
+    /// 1. User config (`~/.config/voxtype/config.toml`)
+    /// 2. System-wide config (`/etc/voxtype/config.toml`)
+    ///
+    /// Returns `None` if neither exists, in which case the caller should fall
+    /// back to built-in defaults. This does not consider the `--config` CLI
+    /// flag; callers handle that explicitly.
+    pub fn resolve_existing_path() -> Option<PathBuf> {
+        if let Some(user) = Self::default_path() {
+            if user.exists() {
+                return Some(user);
+            }
+        }
+        let system = Self::system_path();
+        if system.exists() {
+            return Some(system);
+        }
+        None
     }
 
     /// Get the runtime directory for ephemeral files (state, sockets)
@@ -2150,8 +2178,12 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     // Start with defaults
     let mut config = Config::default();
 
-    // Determine config file path
-    let config_path = path.map(PathBuf::from).or_else(Config::default_path);
+    // Determine config file path. If --config wasn't passed, walk the
+    // documented lookup chain: user config -> /etc/voxtype/config.toml.
+    let config_path = match path {
+        Some(p) => Some(PathBuf::from(p)),
+        None => Config::resolve_existing_path(),
+    };
 
     // Load from file if it exists
     if let Some(ref path) = config_path {
@@ -2165,6 +2197,10 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         } else {
             tracing::debug!("Config file not found at {:?}, using defaults", path);
         }
+    } else {
+        tracing::debug!(
+            "No config file found at user or system path, using built-in defaults"
+        );
     }
 
     // Override from environment variables
@@ -3885,5 +3921,43 @@ mod tests {
 
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.hotkey.profile_modifiers.is_empty());
+    }
+
+    #[test]
+    fn test_system_path_constant() {
+        assert_eq!(Config::system_path(), PathBuf::from("/etc/voxtype/config.toml"));
+        assert_eq!(Config::SYSTEM_PATH, "/etc/voxtype/config.toml");
+    }
+
+    #[test]
+    fn test_load_config_explicit_path() {
+        // Explicit --config should always be used regardless of fallback.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+                [hotkey]
+                key = "F12"
+
+                [audio]
+                device = "default"
+                sample_rate = 16000
+                max_duration_secs = 30
+
+                [whisper]
+                model = "tiny.en"
+                language = "en"
+
+                [output]
+                mode = "clipboard"
+            "#,
+        )
+        .unwrap();
+
+        let config = load_config(Some(&config_path)).unwrap();
+        assert_eq!(config.hotkey.key, "F12");
+        assert_eq!(config.whisper.model, "tiny.en");
+        assert_eq!(config.output.mode, OutputMode::Clipboard);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,13 @@ async fn main() -> anyhow::Result<()> {
             .init();
     }
 
-    // Load configuration
-    let config_path = cli.config.clone().or_else(config::Config::default_path);
+    // Load configuration. config_path tracks the file we actually loaded (or
+    // would load), so subprocess transcribers can reuse the same source.
+    let config_path = cli
+        .config
+        .clone()
+        .or_else(config::Config::resolve_existing_path)
+        .or_else(config::Config::default_path);
     let mut config = config::load_config(cli.config.as_deref())?;
 
     // Apply CLI overrides
@@ -1438,10 +1443,14 @@ async fn show_config(config: &config::Config) -> anyhow::Result<()> {
     setup::print_output_chain_status(&output_status);
 
     println!("\n---");
-    println!(
-        "Config file: {:?}",
-        config::Config::default_path().unwrap_or_else(|| PathBuf::from("(not found)"))
-    );
+    match config::Config::resolve_existing_path() {
+        Some(path) => println!("Config file: {:?} (loaded)", path),
+        None => println!(
+            "Config file: {:?} (not found, using defaults; system fallback {:?} also missing)",
+            config::Config::default_path().unwrap_or_else(|| PathBuf::from("(unknown)")),
+            config::Config::system_path()
+        ),
+    }
     println!("Models dir: {:?}", config::Config::models_dir());
 
     Ok(())


### PR DESCRIPTION
## Summary

- Implements the documented `/etc/voxtype/config.toml` fallback in `load_config`
- Adds `Config::system_path()` and `Config::resolve_existing_path()` so the lookup chain has one source of truth
- Updates `voxtype status` to show which config file actually got loaded (or both paths that were tried)

## Why

Reported in #337: the docs say voxtype falls through to `/etc/voxtype/config.toml` when no user config exists, but `load_config` only ever consulted `~/.config/voxtype/config.toml`. Users following the docs (notably NixOS with a system-managed config) silently got built-in defaults.

## Behavior

Lookup order (unchanged docs, now matches reality):

1. `--config` / `-c` flag (explicit always wins)
2. `~/.config/voxtype/config.toml`
3. `/etc/voxtype/config.toml`
4. Built-in defaults

`config_path` threaded through to subprocess transcribers reflects whichever file actually got loaded, so GPU-isolation workers read the same source.

## Test plan

- [x] `cargo test --lib` (640 passed; 1 pre-existing environmental failure unrelated to this change)
- [x] New test: `test_load_config_explicit_path` - regression for `--config` path handling
- [x] New test: `test_system_path_constant`
- [ ] Manual: move `~/.config/voxtype/config.toml` to `/etc/voxtype/config.toml`, run voxtype, confirm config is loaded
- [ ] Manual: `voxtype status` shows the loaded path correctly in each case

Closes #337