### PR TITLE
Fix meeting audio capture and source diarization

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2780,11 +2780,22 @@ Echo cancellation mode for removing speaker bleed-through from the microphone si
 - `"auto"` - Use GTCRN neural speech enhancement on mic audio before transcription, followed by a phrase-level transcript dedup pass. The GTCRN model (~523 KB) is automatically downloaded on first `voxtype meeting start`.
 - `"disabled"` - No enhancement. Use this if you have system-level echo cancellation configured (e.g., PipeWire's `echo-cancel` module) or if you don't use loopback capture.
 
+### vad_threshold
+
+**Type:** Float
+**Default:** `0.01`
+**Required:** No
+
+RMS threshold for meeting chunk voice activity detection. Lower values are more permissive and can help quiet microphones; higher values skip more low-level noise before transcription. Set to `0.0` to disable this pre-transcription gate.
+
+For quiet USB/XLR mics, try `0.001`.
+
 **Example:**
 ```toml
 [meeting.audio]
 loopback_device = "auto"
 echo_cancel = "auto"  # GTCRN enhancement + transcript dedup
+vad_threshold = 0.001  # Optional: quiet mic tuning
 ```
 
 ---

--- a/docs/MEETING_MODE.md
+++ b/docs/MEETING_MODE.md
@@ -254,6 +254,10 @@ mic_device = "default"
 # Loopback device for capturing remote participants' audio
 # "auto" = auto-detect, "disabled" = mic only, or a specific device name
 loopback_device = "auto"
+
+# RMS threshold for meeting voice activity detection (default: 0.01)
+# Lower to 0.001 for quiet mics; set 0.0 to disable this pre-transcription gate
+vad_threshold = 0.01
 ```
 
 Setting `loopback_device = "auto"` lets voxtype capture system audio (the other side of a call). When loopback is active, speaker attribution can distinguish between "You" (from the mic) and "Remote" (from system audio).

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -2205,6 +2205,7 @@ max_duration_mins = 180          # Maximum meeting length (0 = unlimited)
 mic_device = "default"           # Microphone (uses audio.device if not set)
 loopback_device = "auto"         # Capture remote participants: "auto", "disabled", or device name
 echo_cancel = "auto"             # GTCRN neural enhancement + transcript dedup
+vad_threshold = 0.01             # Lower to 0.001 for quiet mics; 0.0 disables meeting VAD
 
 [meeting.diarization]
 enabled = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -1651,6 +1651,11 @@ pub struct MeetingAudioConfig {
     /// and set this to "disabled".
     #[serde(default = "default_echo_cancel")]
     pub echo_cancel: String,
+
+    /// RMS threshold for meeting chunk voice activity detection.
+    /// Lower values are more permissive; 0.0 disables the pre-transcription gate.
+    #[serde(default = "default_meeting_vad_threshold")]
+    pub vad_threshold: f32,
 }
 
 fn default_mic_device() -> String {
@@ -1665,12 +1670,17 @@ fn default_echo_cancel() -> String {
     "auto".to_string()
 }
 
+fn default_meeting_vad_threshold() -> f32 {
+    0.01
+}
+
 impl Default for MeetingAudioConfig {
     fn default() -> Self {
         Self {
             mic_device: default_mic_device(),
             loopback_device: default_loopback(),
             echo_cancel: default_echo_cancel(),
+            vad_threshold: default_meeting_vad_threshold(),
         }
     }
 }
@@ -4090,6 +4100,7 @@ mod tests {
         let config = MeetingAudioConfig::default();
         assert_eq!(config.mic_device, "default");
         assert_eq!(config.loopback_device, "auto");
+        assert_eq!(config.vad_threshold, 0.01);
     }
 
     #[test]
@@ -4177,6 +4188,7 @@ mod tests {
             [meeting.audio]
             mic_device = "hw:1"
             loopback_device = "disabled"
+            vad_threshold = 0.001
 
             [meeting.diarization]
             enabled = false
@@ -4192,6 +4204,7 @@ mod tests {
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.meeting.audio.mic_device, "hw:1");
         assert_eq!(config.meeting.audio.loopback_device, "disabled");
+        assert_eq!(config.meeting.audio.vad_threshold, 0.001);
         assert!(!config.meeting.diarization.enabled);
         assert_eq!(config.meeting.diarization.backend, "ml");
         assert_eq!(config.meeting.diarization.max_speakers, 5);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1223,7 +1223,18 @@ impl Daemon {
                                 "disabled" | "" => None,
                                 other => Some(other),
                             };
-                        match audio::DualCapture::new(&self.config.audio, loopback_device) {
+                        let mut meeting_audio_config = self.config.audio.clone();
+                        let meeting_mic_device = self.config.meeting.audio.mic_device.as_str();
+                        if !matches!(meeting_mic_device, "default" | "") {
+                            tracing::info!(
+                                "Meeting mic override: {} (dictation uses {})",
+                                meeting_mic_device,
+                                self.config.audio.device
+                            );
+                            meeting_audio_config.device =
+                                self.config.meeting.audio.mic_device.clone();
+                        }
+                        match audio::DualCapture::new(&meeting_audio_config, loopback_device) {
                             Ok(mut capture) => {
                                 if let Err(e) = capture.start().await {
                                     tracing::error!("Failed to start meeting audio: {}", e);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1201,6 +1201,7 @@ impl Daemon {
             },
             retain_audio: self.config.meeting.retain_audio,
             max_duration_mins: self.config.meeting.max_duration_mins,
+            vad_threshold: self.config.meeting.audio.vad_threshold,
             diarization: diarization_config,
         };
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1318,12 +1318,24 @@ impl Daemon {
 
     /// Stop the current meeting
     async fn stop_meeting(&mut self) -> Result<()> {
-        if let Some(mut daemon) = self.meeting_daemon.take() {
-            // Stop audio capture
+        if self.meeting_daemon.is_some() {
+            // Stop audio capture and keep any samples that arrived since the last poll.
             if let Some(mut capture) = self.meeting_audio_capture.take() {
-                let _ = capture.stop().await;
+                match capture.stop().await {
+                    Ok(dual_samples) => {
+                        self.meeting_mic_buffer.extend(dual_samples.mic);
+                        self.meeting_loopback_buffer.extend(dual_samples.loopback);
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to stop meeting audio cleanly: {}", e);
+                    }
+                }
             }
 
+            // Flush the final partial chunk so speech near stop is not dropped.
+            self.process_buffered_meeting_audio(true).await;
+
+            let mut daemon = self.meeting_daemon.take().expect("checked above");
             match daemon.stop().await {
                 Ok(meeting_id) => {
                     self.update_meeting_state("idle", None);
@@ -1410,6 +1422,115 @@ impl Daemon {
     fn meeting_chunk_samples(&self) -> usize {
         // 16kHz sample rate * chunk duration in seconds
         16000 * self.config.meeting.chunk_duration_secs as usize
+    }
+
+    async fn process_meeting_audio_pair(&mut self, mic_chunk: Vec<f32>, loopback_chunk: Vec<f32>) {
+        #[cfg_attr(not(feature = "onnx-common"), allow(unused_mut))]
+        let mut mic_chunk = mic_chunk;
+
+        // Enhance mic audio with GTCRN if available (removes echo/noise)
+        #[cfg(feature = "onnx-common")]
+        {
+            if !mic_chunk.is_empty() {
+                if let Some(ref enhancer) = self.speech_enhancer {
+                    match enhancer.enhance(&mic_chunk) {
+                        Ok(enhanced) => {
+                            tracing::debug!(
+                                "GTCRN enhanced mic chunk ({} samples)",
+                                enhanced.len()
+                            );
+                            mic_chunk = enhanced;
+                        }
+                        Err(e) => {
+                            tracing::warn!("GTCRN enhancement failed, using raw mic: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(ref mut daemon) = self.meeting_daemon {
+            let mut had_loopback = false;
+
+            if !mic_chunk.is_empty() {
+                match daemon
+                    .process_chunk_with_source(mic_chunk, meeting::data::AudioSource::Microphone)
+                    .await
+                {
+                    Ok(Some(segments)) => {
+                        tracing::debug!("Processed mic chunk with {} segments", segments.len());
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::error!("Error processing mic chunk: {}", e);
+                    }
+                }
+            }
+
+            if !loopback_chunk.is_empty() {
+                match daemon
+                    .process_chunk_with_source(loopback_chunk, meeting::data::AudioSource::Loopback)
+                    .await
+                {
+                    Ok(Some(segments)) => {
+                        tracing::debug!(
+                            "Processed loopback chunk with {} segments",
+                            segments.len()
+                        );
+                        if !segments.is_empty() {
+                            had_loopback = true;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::error!("Error processing loopback chunk: {}", e);
+                    }
+                }
+            }
+
+            // Reconcile per-source offsets so any source that received a short
+            // or skipped chunk this iteration catches up to wall-clock before
+            // the next one. Added in PR #330 to fix dual-source timestamp
+            // inflation in meeting mode.
+            daemon.sync_source_offsets();
+
+            // Dedup bleed-through: strip echoed phrases from mic segments
+            if had_loopback {
+                if let Some(ref mut meeting) = daemon.current_meeting_mut() {
+                    let removed = meeting.transcript.dedup_bleed_through();
+                    if removed > 0 {
+                        tracing::info!("Removed {} bleed-through word(s) via dedup", removed);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn process_buffered_meeting_audio(&mut self, include_tail: bool) {
+        let chunk_samples = self.meeting_chunk_samples();
+
+        while self.meeting_mic_buffer.len() >= chunk_samples {
+            let mic_chunk: Vec<f32> = self.meeting_mic_buffer.drain(..chunk_samples).collect();
+            let loopback_len = self.meeting_loopback_buffer.len().min(chunk_samples);
+            let loopback_chunk: Vec<f32> =
+                self.meeting_loopback_buffer.drain(..loopback_len).collect();
+            self.process_meeting_audio_pair(mic_chunk, loopback_chunk)
+                .await;
+        }
+
+        if include_tail {
+            let mic_tail = std::mem::take(&mut self.meeting_mic_buffer);
+            let loopback_tail = std::mem::take(&mut self.meeting_loopback_buffer);
+            if !mic_tail.is_empty() || !loopback_tail.is_empty() {
+                tracing::debug!(
+                    mic_samples = mic_tail.len(),
+                    loopback_samples = loopback_tail.len(),
+                    "Processing final meeting audio tail"
+                );
+                self.process_meeting_audio_pair(mic_tail, loopback_tail)
+                    .await;
+            }
+        }
     }
 
     /// Reset state to idle and run post_output_command to reset compositor submap
@@ -3528,88 +3649,7 @@ impl Daemon {
                         self.meeting_mic_buffer.extend(dual_samples.mic);
                         self.meeting_loopback_buffer.extend(dual_samples.loopback);
 
-                        // Check if mic buffer has enough samples for a chunk
-                        let chunk_samples = self.meeting_chunk_samples();
-                        if self.meeting_mic_buffer.len() >= chunk_samples {
-                            let mic_chunk: Vec<f32> = self.meeting_mic_buffer.drain(..chunk_samples).collect();
-
-                            // Also drain loopback buffer up to the same amount.
-                            // Do NOT pad to chunk_samples — diluting real speech
-                            // with silence can drop the VAD speech-frame ratio
-                            // below threshold and cause remote audio to be
-                            // discarded. Instead we reconcile timestamp offsets
-                            // after both sources have been dispatched via
-                            // sync_source_offsets.
-                            let loopback_len = self.meeting_loopback_buffer.len().min(chunk_samples);
-                            let loopback_chunk: Vec<f32> = self.meeting_loopback_buffer.drain(..loopback_len).collect();
-
-                            // Enhance mic audio with GTCRN if available (removes echo/noise)
-                            #[cfg(feature = "onnx-common")]
-                            let mic_chunk = if let Some(ref enhancer) = self.speech_enhancer {
-                                match enhancer.enhance(&mic_chunk) {
-                                    Ok(enhanced) => {
-                                        tracing::debug!("GTCRN enhanced mic chunk ({} samples)", enhanced.len());
-                                        enhanced
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!("GTCRN enhancement failed, using raw mic: {}", e);
-                                        mic_chunk
-                                    }
-                                }
-                            } else {
-                                mic_chunk
-                            };
-
-                            if let Some(ref mut daemon) = self.meeting_daemon {
-                                // Process mic chunk
-                                let mut had_loopback = false;
-                                match daemon.process_chunk_with_source(mic_chunk, meeting::data::AudioSource::Microphone).await {
-                                    Ok(Some(segments)) => {
-                                        tracing::debug!("Processed mic chunk with {} segments", segments.len());
-                                    }
-                                    Ok(None) => {}
-                                    Err(e) => {
-                                        tracing::error!("Error processing mic chunk: {}", e);
-                                    }
-                                }
-
-                                // Process loopback chunk if we have any real samples.
-                                // If the monitor is lagging we simply skip — the
-                                // sync_source_offsets call below bumps loopback's
-                                // timestamp offset to match mic so the next
-                                // loopback chunk lands at the correct wall-clock
-                                // position.
-                                if !loopback_chunk.is_empty() {
-                                    match daemon.process_chunk_with_source(loopback_chunk, meeting::data::AudioSource::Loopback).await {
-                                        Ok(Some(segments)) => {
-                                            tracing::debug!("Processed loopback chunk with {} segments", segments.len());
-                                            if !segments.is_empty() {
-                                                had_loopback = true;
-                                            }
-                                        }
-                                        Ok(None) => {}
-                                        Err(e) => {
-                                            tracing::error!("Error processing loopback chunk: {}", e);
-                                        }
-                                    }
-                                }
-
-                                // Reconcile per-source offsets so any source that
-                                // received a short or skipped chunk this iteration
-                                // catches up to wall-clock before the next one.
-                                daemon.sync_source_offsets();
-
-                                // Dedup bleed-through: strip echoed phrases from mic segments
-                                if had_loopback {
-                                    if let Some(ref mut meeting) = daemon.current_meeting_mut() {
-                                        let removed = meeting.transcript.dedup_bleed_through();
-                                        if removed > 0 {
-                                            tracing::info!("Removed {} bleed-through word(s) via dedup", removed);
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        self.process_buffered_meeting_audio(false).await;
                     }
 
                     // Check meeting timeout

--- a/src/main.rs
+++ b/src/main.rs
@@ -1995,6 +1995,7 @@ async fn run_meeting_command(config: &config::Config, action: MeetingAction) -> 
         },
         retain_audio: config.meeting.retain_audio,
         max_duration_mins: config.meeting.max_duration_mins,
+        vad_threshold: config.meeting.audio.vad_threshold,
         diarization: None,
     };
 

--- a/src/meeting/chunk.rs
+++ b/src/meeting/chunk.rs
@@ -265,7 +265,14 @@ impl ChunkProcessor {
 
         // Check for speech
         if !self.vad.contains_speech(&samples) {
-            tracing::debug!("Chunk {} has no speech, skipping", chunk_id);
+            tracing::debug!(
+                chunk_id,
+                source = %source,
+                duration_secs = samples.len() as f32 / self.config.sample_rate as f32,
+                rms = VoiceActivityDetector::calculate_rms(&samples),
+                threshold = self.config.vad_threshold,
+                "Meeting chunk skipped: no speech detected"
+            );
             return Ok(ProcessedChunk {
                 chunk_id,
                 segments: vec![],
@@ -276,7 +283,8 @@ impl ChunkProcessor {
 
         // Transcribe the chunk
         tracing::info!(
-            "Transcribing chunk {} ({:.1}s of audio)",
+            "Transcribing {:?} chunk {} ({:.1}s of audio)",
+            source,
             chunk_id,
             samples.len() as f32 / self.config.sample_rate as f32
         );

--- a/src/meeting/diarization/simple.rs
+++ b/src/meeting/diarization/simple.rs
@@ -11,20 +11,12 @@ use crate::meeting::data::AudioSource;
 use crate::meeting::TranscriptSegment;
 
 /// Simple diarizer using audio source for attribution
-pub struct SimpleDiarizer {
-    /// Minimum gap between segments to merge (ms)
-    merge_gap_ms: u64,
-}
+pub struct SimpleDiarizer;
 
 impl SimpleDiarizer {
     /// Create a new simple diarizer
     pub fn new() -> Self {
-        Self { merge_gap_ms: 500 }
-    }
-
-    /// Create with custom merge gap
-    pub fn with_merge_gap(merge_gap_ms: u64) -> Self {
-        Self { merge_gap_ms }
+        Self
     }
 
     /// Convert audio source to speaker ID
@@ -52,8 +44,10 @@ impl Diarizer for SimpleDiarizer {
     ) -> Vec<DiarizedSegment> {
         let speaker = Self::source_to_speaker(source);
 
-        // Convert transcript segments to diarized segments
-        let mut diarized: Vec<DiarizedSegment> = transcript_segments
+        // Preserve transcript segment boundaries. The caller applies diarized
+        // output back to transcript segments positionally, so returning fewer
+        // segments would leave later transcript segments unlabeled.
+        transcript_segments
             .iter()
             .map(|seg| DiarizedSegment {
                 speaker: speaker.clone(),
@@ -62,49 +56,11 @@ impl Diarizer for SimpleDiarizer {
                 text: seg.text.clone(),
                 confidence: 1.0, // High confidence for source-based attribution
             })
-            .collect();
-
-        // Merge consecutive segments from the same speaker
-        self.merge_consecutive(&mut diarized);
-
-        diarized
+            .collect()
     }
 
     fn name(&self) -> &'static str {
         "simple"
-    }
-}
-
-impl SimpleDiarizer {
-    /// Merge consecutive segments from the same speaker if they're close together
-    fn merge_consecutive(&self, segments: &mut Vec<DiarizedSegment>) {
-        if segments.len() < 2 {
-            return;
-        }
-
-        let mut i = 0;
-        while i < segments.len() - 1 {
-            let current_end = segments[i].end_ms;
-            let next_start = segments[i + 1].start_ms;
-            let same_speaker = segments[i].speaker == segments[i + 1].speaker;
-            let close_enough = next_start.saturating_sub(current_end) <= self.merge_gap_ms;
-
-            if same_speaker && close_enough {
-                // Clone the text from next segment before modifying
-                let next_text = segments[i + 1].text.clone();
-                let next_end = segments[i + 1].end_ms;
-                let next_confidence = segments[i + 1].confidence;
-
-                // Merge next into current
-                segments[i].end_ms = next_end;
-                segments[i].text.push(' ');
-                segments[i].text.push_str(&next_text);
-                segments[i].confidence = (segments[i].confidence + next_confidence) / 2.0;
-                segments.remove(i + 1);
-            } else {
-                i += 1;
-            }
-        }
     }
 }
 
@@ -139,25 +95,30 @@ mod tests {
 
         let result = diarizer.diarize(&[], AudioSource::Microphone, &segments);
 
-        // Should merge into one segment since same speaker and close together
-        assert_eq!(result.len(), 1);
+        // Should preserve transcript boundaries and label every segment.
+        assert_eq!(result.len(), 2);
         assert_eq!(result[0].speaker, SpeakerId::You);
-        assert_eq!(result[0].text, "Hello World");
+        assert_eq!(result[1].speaker, SpeakerId::You);
+        assert_eq!(result[0].text, "Hello");
+        assert_eq!(result[1].text, "World");
     }
 
     #[test]
-    fn test_diarize_preserves_separate_segments() {
+    fn test_diarize_labels_all_loopback_segments() {
         let diarizer = SimpleDiarizer::new();
         let mut seg1 = TranscriptSegment::new(1, 0, 1000, "First".to_string(), 0);
-        seg1.source = AudioSource::Microphone;
-        let mut seg2 = TranscriptSegment::new(2, 5000, 6000, "Second".to_string(), 0);
-        seg2.source = AudioSource::Microphone;
+        seg1.source = AudioSource::Loopback;
+        let mut seg2 = TranscriptSegment::new(2, 1000, 2000, "Second".to_string(), 0);
+        seg2.source = AudioSource::Loopback;
         let segments = vec![seg1, seg2];
 
-        let result = diarizer.diarize(&[], AudioSource::Microphone, &segments);
+        let result = diarizer.diarize(&[], AudioSource::Loopback, &segments);
 
-        // Should keep separate due to large gap
         assert_eq!(result.len(), 2);
+        assert_eq!(result[0].speaker, SpeakerId::Remote);
+        assert_eq!(result[1].speaker, SpeakerId::Remote);
+        assert_eq!(result[0].text, "First");
+        assert_eq!(result[1].text, "Second");
     }
 
     #[test]

--- a/src/meeting/mod.rs
+++ b/src/meeting/mod.rs
@@ -59,6 +59,8 @@ pub struct MeetingConfig {
     pub retain_audio: bool,
     /// Maximum meeting duration in minutes (0 = unlimited)
     pub max_duration_mins: u32,
+    /// RMS threshold for meeting chunk voice activity detection
+    pub vad_threshold: f32,
     /// Diarization configuration (None = disabled)
     pub diarization: Option<diarization::DiarizationConfig>,
 }
@@ -71,6 +73,7 @@ impl Default for MeetingConfig {
             storage: StorageConfig::default(),
             retain_audio: false,
             max_duration_mins: 180,
+            vad_threshold: 0.01,
             diarization: None,
         }
     }
@@ -321,6 +324,7 @@ impl MeetingDaemon {
         let chunk_id = self.state.chunks_processed();
         let chunk_config = ChunkConfig {
             chunk_duration_secs: self.config.chunk_duration_secs,
+            vad_threshold: self.config.vad_threshold,
             ..Default::default()
         };
 
@@ -446,6 +450,7 @@ mod tests {
         assert!(!config.enabled);
         assert_eq!(config.chunk_duration_secs, 30);
         assert_eq!(config.max_duration_mins, 180);
+        assert_eq!(config.vad_threshold, 0.01);
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes several meeting-mode issues around mic capture, final chunk handling, voice activity detection tuning, and source-based diarization.

The changes are split into four commits:

1. Honor `[meeting.audio].mic_device`
2. Flush buffered meeting audio on stop
3. Make meeting VAD threshold configurable
4. Preserve simple diarizer segment boundaries

### Honor `[meeting.audio].mic_device`

`mic_device` already existed in config and docs, but meeting mode always passed the main `[audio]` config into `DualCapture`. That meant a meeting-specific mic device override was ignored.

This now builds the meeting capture config at the call site:

- `"default"` and `""` both mean “use the normal dictation audio device”
- explicit values override the mic used for meeting capture only
- an INFO log is emitted only when the override is active, showing both the meeting mic and dictation mic

This keeps the normal/default path unchanged.

### Flush buffered meeting audio on stop

`DualCapture::stop()` returns any samples that arrived since the last poll, but `stop_meeting()` previously discarded them. That could drop speech near the end of a meeting, especially for short recordings or when the user stops shortly after speaking.

This change:

- keeps samples returned by `capture.stop().await`
- appends them to the meeting buffers
- flushes the final partial chunk before saving/stopping the meeting
- extracts shared chunk processing into helpers so the periodic poll path and final flush path use the same logic

### Make meeting VAD threshold configurable

Meeting chunks use a simple RMS gate before transcription. The existing default remains `0.01` for backwards compatibility, but quiet microphones can now tune it via:

```toml
[meeting.audio]
vad_threshold = 0.001
```

The threshold is wired through:

- user config: `MeetingAudioConfig`
- daemon meeting config construction
- CLI meeting command config construction
- internal `MeetingConfig`
- `ChunkConfig`

This also improves diagnostic logging for skipped meeting chunks by including source, duration, RMS, and threshold at debug level. Transcription logs now include the audio source (`Microphone` or `Loopback`) so mic/loopback behavior is easier to debug.

### Preserve simple diarizer segment boundaries

The simple diarizer assigns speakers based on audio source:

- microphone -> `You`
- loopback -> `Remote`

It previously merged adjacent same-speaker transcript segments. However, the caller applies diarization results back to transcript segments positionally with `zip()`. If the diarizer returned fewer segments than ASR produced, later transcript segments silently missed `speaker_id`.

This change removes merging from `SimpleDiarizer`, preserving a 1:1 mapping between transcript segments and diarized segments. As a result, every mic/loopback segment receives the expected speaker label.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update

## Testing

- [x] I have tested these changes locally

Commands run:

```bash
cargo check
cargo test meeting::chunk::
cargo test meeting::diarization::simple::
cargo test config::tests::test_meeting
cargo test config::tests::test_parse_meeting_config_with_nested_sections
cargo test
```

Results:

- `cargo check` passed.
- Targeted meeting/config tests passed.
- Full `cargo test` passed:
  - 539 unit tests passed
  - 25 integration tests passed
  - doc tests passed

Additional non-mutating checks run:

```bash
cargo fmt --check
cargo clippy --all-targets --all-features
```

Results:

- `cargo fmt --check` failed due existing unrelated formatting differences across the repo. This PR does not include those unrelated formatting changes.
- `cargo clippy --all-targets --all-features` failed because `--all-features` enables Whisper ROCm/HIP and this machine does not have `hipcc` in PATH. It also reported two existing `build.rs` `uninlined_format_args` warnings before failing.

Manual validation:

- Verified mic-only meeting recording produced transcript segments instead of zero segments.
- Verified mixed mic + loopback meeting recording produced both `You` and `Remote` speakers.
- Verified every exported transcript segment had a speaker label after the simple diarizer fix.

## Documentation

- [x] I have updated documentation as needed

Updated docs:

- `docs/CONFIGURATION.md`
- `docs/USER_MANUAL.md`
- `docs/MEETING_MODE.md`

## Additional Notes

The default meeting VAD threshold remains `0.01` to preserve existing behavior. Users with quiet meeting microphones can lower `[meeting.audio].vad_threshold`, with `0.001` documented as a suggested starting point.
