### PR TITLE
fix: remove unnecessary unsafe block around __cpuid in cpu.rs

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -86,7 +86,7 @@ pub fn is_running_in_vm() -> bool {
     // CPUID leaf 1, ECX bit 31 is the hypervisor present bit
     #[cfg(target_arch = "x86_64")]
     {
-        let result = unsafe { std::arch::x86_64::__cpuid(1) };
+        let result = std::arch::x86_64::__cpuid(1);
         (result.ecx & (1 << 31)) != 0
     }
 }


### PR DESCRIPTION
std::arch::x86_64::__cpuid was stabilised as a safe fn in Rust 1.59. The unsafe {} wrapper around the call in is_running_in_vm() triggers

## Related Issue

None. 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [X] I have tested these changes locally
- [ ]XI have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy` with no warnings
- [ ] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [X] No documentation changes are needed