### PR TITLE
fix(transcribe): zero constant mel columns in cohere fbank CMVN

### DIFF
--- a/src/transcribe/cohere_fbank.rs
+++ b/src/transcribe/cohere_fbank.rs
@@ -137,6 +137,16 @@ fn per_feature_normalize(features: &mut Array2<f32>) {
     }
     let n = num_frames as f32;
     for mel in 0..num_mels {
+        // Constant mel bins can acquire tiny nonzero variance from f32 rounding
+        // during two-pass CMVN, which amplifies normalization artifacts.
+        // Detect identical columns early and emit zeros directly.
+        let first = features[[0, mel]];
+        if (1..num_frames).all(|f| features[[f, mel]] == first) {
+            for frame in 0..num_frames {
+                features[[frame, mel]] = 0.0;
+            }
+            continue;
+        }
         let mut sum = 0.0_f32;
         for frame in 0..num_frames {
             sum += features[[frame, mel]];


### PR DESCRIPTION
Encountered this error during the test phase:

```
voxtype-vulkan> failures:
voxtype-vulkan>
voxtype-vulkan> ---- transcribe::cohere_fbank::tests::fbank_normalization_zero_mean_unit_std stdout ----
voxtype-vulkan>
voxtype-vulkan> thread 'transcribe::cohere_fbank::tests::fbank_normalization_zero_mean_unit_std' (12522) panicked at src/transcribe/cohere_fbank.rs:231:13:
voxtype-vulkan> mel 0 mean 0.6772196
```

This branch enhances the test case.

## Related Issue

None.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [X] I have tested these changes locally
- [X] I have run `cargo test` and all tests pass
- [X] I have run `cargo clippy` with no warnings
- [X] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [X] No documentation changes are needed
