### PR TITLE
fix(error): drop Whisper-specific prefix from shared InitFailed variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -77,7 +77,7 @@ pub enum TranscribeError {
     #[error("Model not found: {0}\n  Run 'voxtype setup' to download models.")]
     ModelNotFound(String),
 
-    #[error("Whisper initialization failed: {0}")]
+    #[error("Transcriber initialization failed: {0}")]
     InitFailed(String),
 
     #[error("Transcription failed: {0}")]


### PR DESCRIPTION
Whilst debugging the Cohere engine, I got an error message that said:

```
Whisper initialization failed: Failed to load Cohere encoder
```

...which was really confusing. This changes the string to be engine-neutral.

## Related Issue

None.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [X] I have tested these changes locally
- [X] I have run `cargo test` and all tests pass
- [X] I have run `cargo clippy` with no warnings
- [X] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [X] No documentation changes are needed