### PR TITLE
feat: Tag models directory with `CACHEDIR.TAG`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cachedir"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5268,6 +5277,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytemuck",
+ "cachedir",
  "cairo-rs 0.22.0",
  "calloop",
  "calloop-wayland-source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 directories = "5"
 dirs = "5"
+cachedir = "0.3"
 
 # Logging
 tracing = "0.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2127,6 +2127,8 @@ impl Config {
         let models_dir = Self::models_dir();
         std::fs::create_dir_all(&models_dir)?;
         tracing::debug!("Ensured models directory exists: {:?}", models_dir);
+        cachedir::ensure_tag(&models_dir)
+            .unwrap_or_else(|e| tracing::warn!("could not tag models dir: {e}"));
 
         Ok(())
     }


### PR DESCRIPTION
Adds the cachedir crate and calls `cachedir::ensure_tag()` after creating the models directory in `Config::ensure_directories()`. This writes a `CACHEDIR.TAG` file so backup tools skip the models directory if they are configured to do so per https://bford.info/cachedir/

The tag write is non-fatal - a failure logs a warning and does not block startup.

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [X] I have tested these changes locally
- [X] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy` with no warnings
- [X] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [X] No documentation changes are needed