### PR TITLE
Add NixOS build validation to CI

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -1,0 +1,63 @@
+name: Build (Nix)
+
+# Validates that the flake.nix produces working derivations before release.
+# Voxtype is maintained on non-NixOS hosts, so this CI is the only check that
+# catches flake regressions (e.g. missing `ort` example dep that broke
+# `nix switch` in v0.7.1, see #352). Targets `.#default` (CPU Whisper) and
+# `.#onnx` (CPU ONNX engines) — these cover the two most common install paths
+# for NixOS users. GPU variants (cuda/migraphx) are excluded because they
+# require unfree allowlists and/or hardware-specific runtime deps that
+# GitHub-hosted runners don't expose.
+
+on:
+  push:
+    branches: [main, dev, 'rc/*']
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-rc*'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: cpu
+            package: default
+          - label: onnx
+            package: onnx
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: nix build .#${{ matrix.package }}
+        run: nix build .#${{ matrix.package }} --print-build-logs --no-link
+
+  # Aggregator job — branch protection only needs to require `nix-success`.
+  # The matrix job is named `build` so `needs: [build]` covers every matrix
+  # entry automatically; adding a new entry doesn't require touching the
+  # protection rule.
+  nix-success:
+    name: nix-success
+    needs: [build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        run: |
+          set -e
+          build='${{ needs.build.result }}'
+          echo "build: $build"
+          if [[ "$build" != success ]]; then
+            echo "::error::One or more required jobs failed"
+            exit 1
+          fi
+          echo "All required jobs succeeded."


### PR DESCRIPTION
## Summary

Adds `.github/workflows/build-nix.yml` to validate that `flake.nix` actually produces working derivations on every PR and push to `dev`/`main`/`rc/*`. Voxtype is maintained on non-NixOS hosts, so without CI the flake only gets exercised when a user runs `nix switch` and either succeeds or files a bug.

The workflow runs `nix build` against two outputs:
- `.#default` — CPU Whisper, the canonical install path
- `.#onnx` — CPU ONNX engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual)

GPU variants (`onnx-cuda`, `onnx-migraphx`) are intentionally excluded — they need unfree allowlists and GPU hardware that GitHub-hosted runners don't have. The CPU paths still catch the same class of dep-graph and `cargoLock` regressions.

Mirrors the `ci.yml` aggregator pattern: a single `nix-success` job depends on the `build` matrix so branch protection only needs to require one check, and adding new matrix entries doesn't force a protection-rule update.

## Why now

- Closes #369 (the explicit ask for a NixOS GitHub builder)
- Would have caught the v0.7.1 surprise in #352 (missing `ort` example dep silently broke `nix switch`) before release
- May surface the issue tracked in #253

## Test plan

- [ ] Workflow triggers on this PR and `nix-success` reports green
- [ ] Both matrix entries (`cpu`, `onnx`) complete `nix build` successfully
- [ ] After merge, maintainer adds `nix-success` to the `main` branch protection rule alongside `ci-success`, `linux-ci-success`, `macos-ci-success`

## Handoff

Branch protection is **not** updated by this PR. After merge, add `nix-success` to the required-checks list on `main` via the repo settings.