### PR TITLE
Detect X session and dispatch to xclip/xsel for clipboard output

### DIFF
--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -664,6 +664,41 @@ sudo mv /usr/bin/wtype.bak /usr/bin/wtype
 sudo mv /usr/bin/dotool.bak /usr/bin/dotool
 ```
 
+## X11 Session Clipboard (xclip/xsel)
+
+Verifies that voxtype dispatches to `xclip` or `xsel` under an X11 session
+instead of the no-op `wl-copy` call. Regression test for GitHub #346.
+
+```bash
+# Requires: an X11 session (e.g. XLibre, Xorg). WAYLAND_DISPLAY must be unset.
+# Install xclip (or xsel) via your package manager:
+#   sudo pacman -S xclip   # Arch / Manjaro
+#   sudo apt install xclip # Debian / Ubuntu
+
+# 1. Confirm session is X11
+echo "WAYLAND_DISPLAY=$WAYLAND_DISPLAY"  # should be empty
+echo "DISPLAY=$DISPLAY"                  # should be set (e.g. :0)
+
+# 2. Force clipboard mode and trigger a recording
+voxtype --mode clipboard record start && sleep 2 && voxtype record stop
+
+# 3. Verify the transcribed text landed in the X11 clipboard
+xclip -selection clipboard -o
+# Expected: the transcribed text (NOT empty, NOT a stale value)
+
+# 4. Verify the log shows the correct dispatch
+journalctl --user -u voxtype --since "30 seconds ago" | grep -iE "xclip|xsel|wl-copy"
+# Expected: "Using xclip for X11 clipboard" (or xsel if xclip is missing)
+# Not expected: "Text copied to clipboard" via wl-copy
+
+# 5. xsel fallback (optional): hide xclip and rerun
+sudo mv /usr/bin/xclip /usr/bin/xclip.bak
+voxtype --mode clipboard record start && sleep 2 && voxtype record stop
+xsel --clipboard --output
+# Expected: transcribed text from xsel
+sudo mv /usr/bin/xclip.bak /usr/bin/xclip
+```
+
 ## Output Chain Verification
 
 Verify the complete fallback chain works:

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,15 @@ pub enum OutputError {
     #[error("xclip not found in PATH. Install xclip via your package manager.")]
     XclipNotFound,
 
+    #[error(
+        "Neither xclip nor xsel is available for X11 clipboard access.\n  \
+         Install one via your package manager:\n    \
+         sudo pacman -S xclip   # Arch / Manjaro\n    \
+         sudo apt install xclip # Debian / Ubuntu\n    \
+         sudo dnf install xclip # Fedora"
+    )]
+    X11ClipboardToolMissing,
+
     #[error("Text injection failed: {0}")]
     InjectionFailed(String),
 

--- a/src/output/clipboard.rs
+++ b/src/output/clipboard.rs
@@ -3,8 +3,12 @@
 //! Uses wl-copy to copy text to the Wayland clipboard.
 //! This is the most reliable fallback as it works on all Wayland compositors.
 //!
+//! Under an X11 session this method is unavailable; the chain falls through
+//! to `XclipOutput` (xclip/xsel) instead.
+//!
 //! Requires: wl-clipboard package installed
 
+use super::session::{detect, DisplaySession};
 use super::TextOutput;
 use crate::error::OutputError;
 use std::process::Stdio;
@@ -80,6 +84,13 @@ impl TextOutput for ClipboardOutput {
     }
 
     async fn is_available(&self) -> bool {
+        // wl-copy is a no-op without a Wayland compositor (the issue from
+        // GitHub #346). Under X11, defer to xclip/xsel via XclipOutput.
+        if detect() != DisplaySession::Wayland {
+            tracing::debug!("clipboard (wl-copy) skipped: not a Wayland session");
+            return false;
+        }
+
         Command::new("which")
             .arg("wl-copy")
             .stdout(Stdio::null())

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -33,6 +33,7 @@ pub mod paste;
 #[cfg(target_os = "macos")]
 pub mod pbcopy;
 pub mod post_process;
+pub mod session;
 pub mod streaming;
 pub mod wtype;
 pub mod xclip;
@@ -617,7 +618,7 @@ mod tests {
         assert!(is_keystroke_method("ydotool"));
         assert!(is_keystroke_method("paste (clipboard + keystroke)"));
         assert!(!is_keystroke_method("clipboard (wl-copy)"));
-        assert!(!is_keystroke_method("clipboard (xclip)"));
+        assert!(!is_keystroke_method("clipboard (xclip/xsel)"));
     }
 
     #[test]

--- a/src/output/paste.rs
+++ b/src/output/paste.rs
@@ -10,9 +10,11 @@
 //!   - eitype: EI protocol, works on GNOME/KDE/Sway with libei
 //!   - ydotool: Works on X11/Wayland/TTY, requires ydotoold daemon
 
+use super::session::{detect, DisplaySession};
 use super::TextOutput;
 use crate::error::OutputError;
 use crate::output::find_ydotool_socket;
+use crate::output::xclip::copy_to_x11_clipboard;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -244,8 +246,16 @@ impl PasteOutput {
         }
     }
 
-    /// Copy text to clipboard using wl-copy
+    /// Copy text to clipboard, dispatching by session type.
+    ///
+    /// Wayland sessions use `wl-copy`; X11 sessions use `xclip` (preferred)
+    /// or `xsel` (fallback). Without this dispatch, X11 users see voxtype
+    /// silently no-op on the clipboard (GitHub #346).
     async fn copy_to_clipboard(&self, text: &str) -> Result<(), OutputError> {
+        if detect() == DisplaySession::X11 {
+            return copy_to_x11_clipboard(text.as_bytes()).await;
+        }
+
         // Spawn wl-copy with stdin pipe
         let mut child = Command::new("wl-copy")
             .stdin(Stdio::piped())
@@ -889,18 +899,44 @@ impl TextOutput for PasteOutput {
     }
 
     async fn is_available(&self) -> bool {
-        // Check if wl-copy exists (required for clipboard)
-        let wl_copy_available = Command::new("which")
-            .arg("wl-copy")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-            .map(|s| s.success())
-            .unwrap_or(false);
+        // Probe the appropriate clipboard tool for the active session.
+        // Wayland needs wl-copy; X11 needs xclip or xsel.
+        let session = detect();
+        let clipboard_available = match session {
+            DisplaySession::Wayland => Command::new("which")
+                .arg("wl-copy")
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .await
+                .map(|s| s.success())
+                .unwrap_or(false),
+            DisplaySession::X11 => {
+                let xclip_ok = Command::new("which")
+                    .arg("xclip")
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()
+                    .await
+                    .map(|s| s.success())
+                    .unwrap_or(false);
+                let xsel_ok = Command::new("which")
+                    .arg("xsel")
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()
+                    .await
+                    .map(|s| s.success())
+                    .unwrap_or(false);
+                xclip_ok || xsel_ok
+            }
+        };
 
-        if !wl_copy_available {
-            tracing::debug!("paste mode unavailable: wl-copy not found");
+        if !clipboard_available {
+            tracing::debug!(
+                "paste mode unavailable: no clipboard tool for {:?} session",
+                session
+            );
             return false;
         }
 

--- a/src/output/session.rs
+++ b/src/output/session.rs
@@ -1,0 +1,107 @@
+//! Display session detection
+//!
+//! Detects whether the user is running under a Wayland compositor or an X11
+//! session so that clipboard tooling can be dispatched correctly.
+//!
+//! Detection order:
+//! 1. `WAYLAND_DISPLAY` is set and non-empty: Wayland
+//! 2. `XDG_SESSION_TYPE` is `wayland` or `x11`: use that
+//! 3. `DISPLAY` is set without `WAYLAND_DISPLAY`: X11
+//! 4. Default to Wayland (matches historical voxtype behavior)
+
+/// The user's display session type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisplaySession {
+    /// Wayland compositor (wl-copy / wl-paste apply)
+    Wayland,
+    /// X11 session (xclip / xsel apply)
+    X11,
+}
+
+/// Detect the active display session from environment variables.
+pub fn detect() -> DisplaySession {
+    if let Ok(val) = std::env::var("WAYLAND_DISPLAY") {
+        if !val.is_empty() {
+            return DisplaySession::Wayland;
+        }
+    }
+
+    if let Ok(session) = std::env::var("XDG_SESSION_TYPE") {
+        match session.as_str() {
+            "wayland" => return DisplaySession::Wayland,
+            "x11" => return DisplaySession::X11,
+            _ => {}
+        }
+    }
+
+    if std::env::var("DISPLAY").is_ok() {
+        return DisplaySession::X11;
+    }
+
+    DisplaySession::Wayland
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper to evaluate detect() with a controlled environment.
+    ///
+    /// These tests mutate process-wide env vars and therefore must not run
+    /// concurrently with anything else that reads them. We serialize by
+    /// running each in its own `#[test]` and clearing all relevant vars at
+    /// the start.
+    fn clear_env() {
+        std::env::remove_var("WAYLAND_DISPLAY");
+        std::env::remove_var("XDG_SESSION_TYPE");
+        std::env::remove_var("DISPLAY");
+    }
+
+    #[test]
+    fn wayland_display_wins() {
+        clear_env();
+        std::env::set_var("WAYLAND_DISPLAY", "wayland-0");
+        std::env::set_var("DISPLAY", ":0");
+        assert_eq!(detect(), DisplaySession::Wayland);
+        clear_env();
+    }
+
+    #[test]
+    fn empty_wayland_display_does_not_win() {
+        clear_env();
+        std::env::set_var("WAYLAND_DISPLAY", "");
+        std::env::set_var("XDG_SESSION_TYPE", "x11");
+        assert_eq!(detect(), DisplaySession::X11);
+        clear_env();
+    }
+
+    #[test]
+    fn xdg_session_type_x11() {
+        clear_env();
+        std::env::set_var("XDG_SESSION_TYPE", "x11");
+        assert_eq!(detect(), DisplaySession::X11);
+        clear_env();
+    }
+
+    #[test]
+    fn xdg_session_type_wayland() {
+        clear_env();
+        std::env::set_var("XDG_SESSION_TYPE", "wayland");
+        assert_eq!(detect(), DisplaySession::Wayland);
+        clear_env();
+    }
+
+    #[test]
+    fn display_only_means_x11() {
+        clear_env();
+        std::env::set_var("DISPLAY", ":0");
+        assert_eq!(detect(), DisplaySession::X11);
+        clear_env();
+    }
+
+    #[test]
+    fn no_env_defaults_to_wayland() {
+        clear_env();
+        assert_eq!(detect(), DisplaySession::Wayland);
+    }
+}

--- a/src/output/xclip.rs
+++ b/src/output/xclip.rs
@@ -1,27 +1,134 @@
-//! xclip-based text output for X11
+//! X11 clipboard output
 //!
-//! Uses xclip to copy text to the X11 clipboard.
-//! This is a fallback for X11 environments where wl-copy isn't available.
+//! Copies text to the X11 CLIPBOARD selection using `xclip` (preferred) or
+//! `xsel` (fallback). Activates only under an X11 session; Wayland sessions
+//! are handled by `ClipboardOutput` (wl-copy).
 //!
-//! Requires: xclip package installed
+//! See GitHub issue #346 for the original report: under XLibre/X11 sessions
+//! voxtype was invoking wl-copy unconditionally, leaving the clipboard
+//! untouched.
+//!
+//! Requires one of: `xclip` or `xsel` installed.
 
+use super::session::{detect, DisplaySession};
 use super::TextOutput;
 use crate::error::OutputError;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
-/// xclip-based text output for X11
+/// X11 clipboard output (xclip with xsel fallback)
 pub struct XclipOutput {
     /// Text to append after transcription
     append_text: Option<String>,
 }
 
 impl XclipOutput {
-    /// Create a new xclip output
+    /// Create a new X11 clipboard output
     pub fn new(append_text: Option<String>) -> Self {
         Self { append_text }
     }
+}
+
+/// Which X11 clipboard tool to invoke.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum X11ClipboardTool {
+    Xclip,
+    Xsel,
+}
+
+impl X11ClipboardTool {
+    fn command(self) -> &'static str {
+        match self {
+            X11ClipboardTool::Xclip => "xclip",
+            X11ClipboardTool::Xsel => "xsel",
+        }
+    }
+
+    fn args(self) -> &'static [&'static str] {
+        match self {
+            X11ClipboardTool::Xclip => &["-selection", "clipboard"],
+            X11ClipboardTool::Xsel => &["--clipboard", "--input"],
+        }
+    }
+}
+
+/// Probe `which $cmd` to see if a binary is on PATH.
+async fn binary_on_path(cmd: &str) -> bool {
+    Command::new("which")
+        .arg(cmd)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Find an installed X11 clipboard tool, preferring xclip.
+async fn find_tool() -> Option<X11ClipboardTool> {
+    if binary_on_path("xclip").await {
+        return Some(X11ClipboardTool::Xclip);
+    }
+    if binary_on_path("xsel").await {
+        return Some(X11ClipboardTool::Xsel);
+    }
+    None
+}
+
+/// Run an X11 clipboard tool, piping `text` to its stdin.
+async fn copy_via(tool: X11ClipboardTool, text: &[u8]) -> Result<(), OutputError> {
+    let mut child = Command::new(tool.command())
+        .args(tool.args())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                match tool {
+                    X11ClipboardTool::Xclip => OutputError::XclipNotFound,
+                    X11ClipboardTool::Xsel => OutputError::X11ClipboardToolMissing,
+                }
+            } else {
+                OutputError::InjectionFailed(e.to_string())
+            }
+        })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(text)
+            .await
+            .map_err(|e| OutputError::InjectionFailed(e.to_string()))?;
+        drop(stdin);
+    }
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| OutputError::InjectionFailed(e.to_string()))?;
+
+    if !status.success() {
+        return Err(OutputError::InjectionFailed(format!(
+            "{} exited with error",
+            tool.command()
+        )));
+    }
+
+    Ok(())
+}
+
+/// Public helper: copy `text` to the X11 clipboard, trying xclip then xsel.
+///
+/// Returns `OutputError::X11ClipboardToolMissing` if neither tool is on PATH.
+/// Used by both `XclipOutput` and `PasteOutput` so they share the same
+/// dispatch logic.
+pub(crate) async fn copy_to_x11_clipboard(text: &[u8]) -> Result<(), OutputError> {
+    let tool = find_tool()
+        .await
+        .ok_or(OutputError::X11ClipboardToolMissing)?;
+    tracing::debug!("Using {} for X11 clipboard", tool.command());
+    copy_via(tool, text).await
 }
 
 #[async_trait::async_trait]
@@ -31,74 +138,29 @@ impl TextOutput for XclipOutput {
             return Ok(());
         }
 
-        // Prepare text with optional append
         let text = if let Some(ref append) = self.append_text {
             std::borrow::Cow::Owned(format!("{}{}", text, append))
         } else {
             std::borrow::Cow::Borrowed(text)
         };
 
-        // Spawn xclip with stdin pipe, targeting the clipboard selection
-        let mut child = Command::new("xclip")
-            .args(["-selection", "clipboard"])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    OutputError::XclipNotFound
-                } else {
-                    OutputError::InjectionFailed(e.to_string())
-                }
-            })?;
-
-        // Write text to stdin
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(text.as_bytes())
-                .await
-                .map_err(|e| OutputError::InjectionFailed(e.to_string()))?;
-
-            // Close stdin to signal EOF
-            drop(stdin);
-        }
-
-        // Wait for completion
-        let status = child
-            .wait()
-            .await
-            .map_err(|e| OutputError::InjectionFailed(e.to_string()))?;
-
-        if !status.success() {
-            return Err(OutputError::InjectionFailed(
-                "xclip exited with error".to_string(),
-            ));
-        }
+        copy_to_x11_clipboard(text.as_bytes()).await?;
 
         tracing::info!("Text copied to X11 clipboard ({} chars)", text.len());
         Ok(())
     }
 
     async fn is_available(&self) -> bool {
-        // Check if xclip is installed and DISPLAY is set (X11 environment)
-        let xclip_installed = Command::new("which")
-            .arg("xclip")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-            .map(|s| s.success())
-            .unwrap_or(false);
-
-        // Only available if X11 DISPLAY is set
-        let display_set = std::env::var("DISPLAY").is_ok();
-
-        xclip_installed && display_set
+        // Only available under an X11 session with at least one tool installed.
+        if detect() != DisplaySession::X11 {
+            tracing::debug!("clipboard (xclip/xsel) skipped: not an X11 session");
+            return false;
+        }
+        find_tool().await.is_some()
     }
 
     fn name(&self) -> &'static str {
-        "clipboard (xclip)"
+        "clipboard (xclip/xsel)"
     }
 }
 
@@ -113,5 +175,13 @@ mod tests {
 
         let output = XclipOutput::new(Some(" ".to_string()));
         assert_eq!(output.append_text, Some(" ".to_string()));
+    }
+
+    #[test]
+    fn test_tool_command_and_args() {
+        assert_eq!(X11ClipboardTool::Xclip.command(), "xclip");
+        assert_eq!(X11ClipboardTool::Xclip.args(), &["-selection", "clipboard"]);
+        assert_eq!(X11ClipboardTool::Xsel.command(), "xsel");
+        assert_eq!(X11ClipboardTool::Xsel.args(), &["--clipboard", "--input"]);
     }
 }


### PR DESCRIPTION
## Summary

- Detect display session (Wayland vs X11) from `WAYLAND_DISPLAY` -> `XDG_SESSION_TYPE` -> `DISPLAY`, defaulting to Wayland when nothing is set.
- `ClipboardOutput` (wl-copy) now returns `is_available() = false` outside Wayland, so the existing `XclipOutput` in the fallback chain takes over under X11.
- `XclipOutput` now tries `xclip -selection clipboard` first, then falls back to `xsel --clipboard --input`. If neither is installed, it returns a thiserror with install instructions for pacman/apt/dnf.
- `PasteOutput::copy_to_clipboard` dispatches through the same X11 helper before sending the paste keystroke, and `PasteOutput::is_available()` probes the right tool for the active session.

## Why

Issue #346: under XLibre/Xorg sessions, voxtype invoked `wl-copy` unconditionally. With no Wayland compositor the call was a no-op, leaving the clipboard untouched. Users with `xsel` or `xclip` installed never saw their transcribed text reach the clipboard.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo test` (only pre-existing `setup::parakeet` failure unrelated to this change)
- [ ] Manual: run voxtype under XLibre / Xorg, trigger a recording, verify `xclip -selection clipboard -o` returns the transcribed text (smoke test entry added in `docs/SMOKE_TESTS.md`).
- [ ] Manual: temporarily move xclip aside and confirm xsel fallback works.

Closes #346