### PR TITLE
Pass keyboard layout hints to eitype based on detected language

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1576,6 +1576,95 @@ dotool_xkb_layout = "de"
 dotool_xkb_variant = "nodeadkeys"  # German without dead keys
 ```
 
+### eitype_xkb_layout
+
+**Type:** String (optional)
+**Default:** None
+**Required:** No
+
+Keyboard layout passed to eitype as `-l <layout>`. Use this when your
+transcribed language does not match the active system layout (issue #180).
+
+When unset, voxtype derives the layout from the transcriber's detected
+language using [language_to_layout](#language_to_layout). Setting this field
+explicitly disables that auto-detection and forces the chosen layout.
+
+**Example: pin eitype to US regardless of what voxtype detects**
+```toml
+[output]
+mode = "type"
+driver_order = ["eitype"]
+eitype_xkb_layout = "us"
+```
+
+### eitype_xkb_variant
+
+**Type:** String (optional)
+**Default:** None
+**Required:** No
+
+Layout variant passed to eitype as `--variant <variant>` (e.g., `dvorak`,
+`colemak`, `nodeadkeys`).
+
+```toml
+[output]
+eitype_xkb_layout = "de"
+eitype_xkb_variant = "nodeadkeys"
+```
+
+### language_to_layout
+
+**Type:** Table (map of two-letter language code to XKB layout)
+**Default:** Built-in map covering common languages
+
+Maps detected language codes (ISO 639-1, e.g. `en`, `ru`, `de`) to XKB
+keyboard layout codes (e.g. `us`, `ru`, `de`). When a transcriber reports the
+language used for a transcription and neither `eitype_xkb_layout` nor
+`dotool_xkb_layout` is set, voxtype looks the language up in this map and
+passes the resulting layout to eitype/dotool for that transcription only.
+
+This is what makes the multi-language case from issue #180 work
+end-to-end: with `language = ["en", "ru"]` and `driver_order = ["eitype"]`,
+voxtype detects the spoken language, looks it up here, and tells eitype
+to type with the right keyboard layout.
+
+**Built-in defaults include:**
+- `en = "us"` (English)
+- `ru = "ru"`, `de = "de"`, `fr = "fr"`, `es = "es"`, `it = "it"`
+- `pl = "pl"`, `uk = "uk"`, `cs = "cs"`, `sk = "sk"`
+- `sv = "sv"`, `no = "no"`, `fi = "fi"`, `da = "da"`, `nl = "nl"`
+- `pt = "pt"`, `tr = "tr"`, `gr = "gr"`, `hu = "hu"`, `ro = "ro"`
+- `bg = "bg"`, `hr = "hr"`, `sr = "sr"`, `sl = "sl"`
+- `lt = "lt"`, `lv = "lv"`, `et = "et"`, `is = "is"`
+- `ca = "ca"`, `eu = "eu"`
+- `el = "gr"` (Greek uses "gr")
+- `ja = "jp"`, `ko = "kr"`
+
+Languages without a mapping fall through with no layout hint (eitype uses
+the system layout).
+
+**Replacing the defaults.** Providing the `[output.language_to_layout]`
+section in your config replaces the entire built-in map (TOML does not
+merge tables). If you want to add a single entry while keeping the
+defaults, copy the entries you need.
+
+**Example: Brazilian Portuguese and Dvorak English**
+```toml
+[output.language_to_layout]
+en = "dvorak"   # English on Dvorak
+pt = "br"       # Brazilian Portuguese layout
+ru = "ru"       # Russian (kept from defaults)
+de = "de"       # German (kept from defaults)
+```
+
+**Disabling auto layout selection.** Set the map to empty to skip layout
+inference entirely; eitype/dotool will use whatever explicit
+`*_xkb_layout` you set (or the system layout):
+```toml
+[output.language_to_layout]
+# (empty)
+```
+
 ### file_path
 
 **Type:** String (path)
@@ -2766,6 +2855,9 @@ Any config file setting can be overridden via environment variable. These are ap
 | `VOXTYPE_FALLBACK_TO_CLIPBOARD` | bool | `output.fallback_to_clipboard` |
 | `VOXTYPE_PASTE_KEYS` | string | `output.paste_keys` |
 | `VOXTYPE_DOTOOL_XKB_LAYOUT` | string | `output.dotool_xkb_layout` |
+| `VOXTYPE_DOTOOL_XKB_VARIANT` | string | `output.dotool_xkb_variant` |
+| `VOXTYPE_EITYPE_XKB_LAYOUT` | string | `output.eitype_xkb_layout` |
+| `VOXTYPE_EITYPE_XKB_VARIANT` | string | `output.eitype_xkb_variant` |
 | `VOXTYPE_SPOKEN_PUNCTUATION` | bool | `text.spoken_punctuation` |
 | `VOXTYPE_SMART_AUTO_SUBMIT` | bool | `text.smart_auto_submit` |
 | `VOXTYPE_FILTER_FILLERS` | bool | `text.filter_filler_words` |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -683,6 +683,57 @@ mode = "paste"
 
 ---
 
+### eitype: "Character not found in keymap" or wrong characters when transcribing a second language
+
+**Symptom:** With `language = ["en", "ru"]` and `driver_order = ["eitype"]`,
+transcribing Russian on a US system layout fails with eitype reporting
+`Character not found in keymap`, or prints garbled text. English
+transcriptions work fine.
+
+**Cause:** Before voxtype v0.7.3, the daemon did not pass a layout hint to
+the `eitype` binary. eitype fell back to the system's active XKB layout,
+which lacked the keycodes for Cyrillic (or any non-system language) and so
+either errored or typed the wrong characters. This is issue #180.
+
+**Solution:** Upgrade to voxtype v0.7.3 or later. The daemon now reads the
+language Whisper picked for each transcription and passes it to eitype as
+`-l <layout>`, switching the layout for that call only.
+
+Verify:
+
+```bash
+voxtype daemon -vv  # debug logs
+# After a Russian transcription you should see:
+# DEBUG Auto layout for eitype: language='ru' -> layout='ru'
+```
+
+**Forcing a specific layout.** To pin eitype to a fixed layout regardless of
+the detected language, set it explicitly:
+
+```toml
+[output]
+driver_order = ["eitype"]
+eitype_xkb_layout = "us"          # or "de", "ru", etc.
+# eitype_xkb_variant = "dvorak"   # optional
+```
+
+**Customizing the language-to-layout map.** Voxtype ships built-in defaults
+(`en→us`, `ru→ru`, `de→de`, etc.). Layouts that don't match the language code
+(e.g. Brazilian Portuguese uses `br`, not `pt`) need an override in config:
+
+```toml
+[output.language_to_layout]
+en = "us"
+pt = "br"
+ru = "ru"
+```
+
+See `docs/CONFIGURATION.md` for the full list of built-in defaults and merge
+semantics (the user table replaces the defaults, so copy the entries you
+want to keep).
+
+---
+
 ### "ydotool daemon not running"
 
 **Cause:** ydotool systemd service not started.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -356,6 +356,25 @@ pub struct Cli {
     )]
     pub dotool_xkb_variant: Option<String>,
 
+    /// Keyboard layout for eitype (e.g., de, ru, us). Passed as `-l <LAYOUT>`.
+    /// Overrides any layout derived from the transcribed language.
+    #[arg(
+        long,
+        value_name = "LAYOUT",
+        help_heading = "Output",
+        hide_short_help = true
+    )]
+    pub eitype_xkb_layout: Option<String>,
+
+    /// Keyboard layout variant for eitype (e.g., dvorak, colemak)
+    #[arg(
+        long,
+        value_name = "VARIANT",
+        help_heading = "Output",
+        hide_short_help = true
+    )]
+    pub eitype_xkb_variant: Option<String>,
+
     /// Command to run before typing output (e.g., compositor submap switch)
     #[arg(
         long,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1892,6 +1892,34 @@ pub struct OutputConfig {
     #[serde(default)]
     pub dotool_xkb_variant: Option<String>,
 
+    /// Keyboard layout for eitype (e.g., "de" for German, "ru" for Russian).
+    /// Passed to eitype as `-l <layout>`. Overrides the system XKB layout
+    /// while eitype is typing, then restores it when eitype exits.
+    /// Required when the transcribed language does not match the active
+    /// system layout (see issue #180).
+    #[serde(default)]
+    pub eitype_xkb_layout: Option<String>,
+
+    /// Keyboard layout variant for eitype (e.g., "dvorak", "colemak").
+    /// Passed to eitype as `--variant <variant>`.
+    #[serde(default)]
+    pub eitype_xkb_variant: Option<String>,
+
+    /// Mapping from detected language code (two-letter ISO 639-1) to XKB
+    /// keyboard layout. When voxtype's transcriber reports a language for the
+    /// current transcription and no explicit `eitype_xkb_layout` /
+    /// `dotool_xkb_layout` is set, the layout is looked up here.
+    ///
+    /// Built-in defaults cover the common cases (en→us, ru→ru, de→de, ...);
+    /// see [`default_language_to_layout`]. Users can override or extend the
+    /// map in config to handle layouts that differ from the language code
+    /// (e.g. `pt = "br"` for Brazilian Portuguese).
+    ///
+    /// Set to an empty map (or remove all entries) to disable automatic
+    /// layout selection from the detected language.
+    #[serde(default = "default_language_to_layout")]
+    pub language_to_layout: std::collections::HashMap<String, String>,
+
     /// File path for file output mode (required when mode = "file")
     /// Also used as default path for --output-file CLI flag
     #[serde(default)]
@@ -1932,6 +1960,34 @@ pub struct OutputConfig {
 
 fn default_modifier_release_timeout_ms() -> u64 {
     750
+}
+
+/// Built-in mapping from two-letter ISO 639-1 language codes to XKB layout
+/// codes. Used when the transcriber reports a detected language and the user
+/// has not set an explicit `eitype_xkb_layout` / `dotool_xkb_layout`.
+///
+/// Covers the most common cases where layout code matches language code
+/// (en→us is the notable exception). Users can extend or override this map
+/// in config under `[output] language_to_layout`. To disable automatic
+/// layout selection entirely, set `language_to_layout = {}` in config.
+pub fn default_language_to_layout() -> std::collections::HashMap<String, String> {
+    let mut m = std::collections::HashMap::new();
+    // English uses "us" by convention, not "en".
+    m.insert("en".to_string(), "us".to_string());
+    // Other common languages where layout name matches ISO 639-1.
+    for code in [
+        "ru", "de", "fr", "es", "it", "pl", "uk", "cs", "sk", "sv", "no", "fi", "da", "nl", "pt",
+        "tr", "gr", "hu", "ro", "bg", "hr", "sr", "sl", "lt", "lv", "et", "is", "ca", "eu",
+    ] {
+        m.insert(code.to_string(), code.to_string());
+    }
+    // Greek uses "gr" not "el".
+    m.insert("el".to_string(), "gr".to_string());
+    // Japanese, Korean, Chinese typically need IMEs rather than XKB layouts,
+    // but voxtype passes the hint through so users can map them as they wish.
+    m.insert("ja".to_string(), "jp".to_string());
+    m.insert("ko".to_string(), "kr".to_string());
+    m
 }
 
 impl OutputConfig {
@@ -2101,6 +2157,9 @@ impl Default for Config {
                 paste_keys: None,
                 dotool_xkb_layout: None,
                 dotool_xkb_variant: None,
+                eitype_xkb_layout: None,
+                eitype_xkb_variant: None,
+                language_to_layout: default_language_to_layout(),
                 file_path: None,
                 file_mode: FileMode::default(),
                 restore_clipboard: false,
@@ -2467,6 +2526,15 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     }
     if let Ok(layout) = std::env::var("VOXTYPE_DOTOOL_XKB_LAYOUT") {
         config.output.dotool_xkb_layout = Some(layout);
+    }
+    if let Ok(variant) = std::env::var("VOXTYPE_DOTOOL_XKB_VARIANT") {
+        config.output.dotool_xkb_variant = Some(variant);
+    }
+    if let Ok(layout) = std::env::var("VOXTYPE_EITYPE_XKB_LAYOUT") {
+        config.output.eitype_xkb_layout = Some(layout);
+    }
+    if let Ok(variant) = std::env::var("VOXTYPE_EITYPE_XKB_VARIANT") {
+        config.output.eitype_xkb_variant = Some(variant);
     }
 
     // Remote whisper
@@ -4111,5 +4179,102 @@ mod tests {
         assert_eq!(config.hotkey.key, "F12");
         assert_eq!(config.whisper.model, "tiny.en");
         assert_eq!(config.output.mode, OutputMode::Clipboard);
+    }
+
+    #[test]
+    fn test_default_language_to_layout_common_cases() {
+        let map = default_language_to_layout();
+        // English maps to "us", the XKB convention.
+        assert_eq!(map.get("en"), Some(&"us".to_string()));
+        // Russian, German, French, Spanish are direct passthroughs.
+        assert_eq!(map.get("ru"), Some(&"ru".to_string()));
+        assert_eq!(map.get("de"), Some(&"de".to_string()));
+        assert_eq!(map.get("fr"), Some(&"fr".to_string()));
+        assert_eq!(map.get("es"), Some(&"es".to_string()));
+        // Greek uses "gr", not "el".
+        assert_eq!(map.get("el"), Some(&"gr".to_string()));
+        // Japanese / Korean map to common XKB names.
+        assert_eq!(map.get("ja"), Some(&"jp".to_string()));
+        assert_eq!(map.get("ko"), Some(&"kr".to_string()));
+    }
+
+    #[test]
+    fn test_output_config_default_includes_language_layout_map() {
+        let cfg = Config::default();
+        assert!(!cfg.output.language_to_layout.is_empty());
+        assert_eq!(
+            cfg.output.language_to_layout.get("en"),
+            Some(&"us".to_string())
+        );
+        // New eitype layout fields are unset by default; the layout is
+        // inferred from the detected language only when both fields are
+        // empty (see daemon::handle_transcription_result).
+        assert!(cfg.output.eitype_xkb_layout.is_none());
+        assert!(cfg.output.eitype_xkb_variant.is_none());
+    }
+
+    #[test]
+    fn test_parse_eitype_layout_from_toml() {
+        let toml_str = r#"
+            [hotkey]
+            key = "PAUSE"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = "en"
+
+            [output]
+            mode = "type"
+            eitype_xkb_layout = "ru"
+            eitype_xkb_variant = "phonetic"
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.output.eitype_xkb_layout, Some("ru".to_string()));
+        assert_eq!(
+            config.output.eitype_xkb_variant,
+            Some("phonetic".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_language_to_layout_override() {
+        // User can override individual mappings (e.g. Brazilian Portuguese
+        // typically needs the `br` layout, not `pt`). Providing the field
+        // replaces the built-in defaults; users are expected to copy
+        // entries they want to keep (documented in CONFIGURATION.md).
+        let toml_str = r#"
+            [hotkey]
+            key = "PAUSE"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = "en"
+
+            [output]
+            mode = "type"
+
+            [output.language_to_layout]
+            pt = "br"
+            en = "dvorak"
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.output.language_to_layout.get("pt"),
+            Some(&"br".to_string())
+        );
+        assert_eq!(
+            config.output.language_to_layout.get("en"),
+            Some(&"dvorak".to_string())
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -580,6 +580,11 @@ pub struct Daemon {
     whisper_prepare_task: Option<tokio::task::JoinHandle<()>>,
     // Background task for transcription (allows cancel during transcription)
     transcription_task: Option<tokio::task::JoinHandle<TranscriptionResult>>,
+    // Transcriber Arc used for the in-flight transcription_task. Held so the
+    // result handler can query language metadata (e.g. detected language for
+    // keyboard-layout hints to eitype/dotool, see issue #180) after the task
+    // completes. Cleared when transcription_task is taken.
+    active_transcriber: Option<Arc<dyn Transcriber>>,
     // Background tasks for eager chunk transcriptions (chunk_index, task)
     eager_chunk_tasks: Vec<(
         usize,
@@ -693,6 +698,7 @@ impl Daemon {
             model_load_task: None,
             whisper_prepare_task: None,
             transcription_task: None,
+            active_transcriber: None,
             eager_chunk_tasks: Vec::new(),
             vad,
             meeting_daemon: None,
@@ -1639,6 +1645,11 @@ impl Daemon {
 
                     // Spawn transcription task (non-blocking)
                     if let Some(t) = transcriber {
+                        // Hold an Arc clone so the result handler can query
+                        // post-transcription metadata (e.g. detected language
+                        // for layout hints, issue #180) without re-fetching
+                        // the transcriber.
+                        self.active_transcriber = Some(t.clone());
                         self.transcription_task =
                             Some(tokio::task::spawn_blocking(move || t.transcribe(&samples)));
                         true
@@ -1667,6 +1678,11 @@ impl Daemon {
         state: &mut State,
         result: std::result::Result<TranscriptionResult, tokio::task::JoinError>,
     ) {
+        // Take ownership of the transcriber Arc we cloned at spawn time so it
+        // is dropped on every exit path (success, transcription error, or
+        // task error). The Ok(Ok(_)) branch consults it for the language
+        // layout hint before letting it drop.
+        let active_transcriber = self.active_transcriber.take();
         match result {
             Ok(Ok(text)) => {
                 if text.is_empty() {
@@ -1892,6 +1908,45 @@ impl Daemon {
                     // If smart auto-submit triggered, enable auto_submit for this cycle
                     if smart_submit {
                         output_config.auto_submit = true;
+                    }
+
+                    // Inject a keyboard-layout hint derived from the
+                    // transcriber's detected language (issue #180). Skipped
+                    // when the user has already set an explicit
+                    // `eitype_xkb_layout` / `dotool_xkb_layout`, so static
+                    // configuration wins over auto-detection. Only the
+                    // `language_to_layout` map is consulted; if the language
+                    // isn't mapped, no hint is applied (eitype/dotool fall
+                    // back to the system layout).
+                    if let Some(ref transcriber) = active_transcriber {
+                        if let Some(lang) = transcriber.last_detected_language() {
+                            if let Some(layout) =
+                                self.config.output.language_to_layout.get(&lang).cloned()
+                            {
+                                if output_config.eitype_xkb_layout.is_none() {
+                                    tracing::debug!(
+                                        "Auto layout for eitype: language='{}' -> layout='{}'",
+                                        lang,
+                                        layout
+                                    );
+                                    output_config.eitype_xkb_layout = Some(layout.clone());
+                                }
+                                if output_config.dotool_xkb_layout.is_none() {
+                                    tracing::debug!(
+                                        "Auto layout for dotool: language='{}' -> layout='{}'",
+                                        lang,
+                                        layout
+                                    );
+                                    output_config.dotool_xkb_layout = Some(layout);
+                                }
+                            } else {
+                                tracing::debug!(
+                                    "No layout mapping for detected language '{}'; \
+                                     not setting a layout hint",
+                                    lang
+                                );
+                            }
+                        }
                     }
 
                     let output_chain = output::create_output_chain(&output_config);
@@ -2744,6 +2799,9 @@ impl Daemon {
                                 if let Some(task) = self.transcription_task.take() {
                                     task.abort();
                                 }
+                                // Drop the cloned transcriber Arc so it isn't
+                                // held until the next transcription.
+                                self.active_transcriber = None;
 
                                 cleanup_output_mode_override();
                                 cleanup_model_override();
@@ -3256,6 +3314,9 @@ impl Daemon {
                         if let Some(task) = self.transcription_task.take() {
                             task.abort();
                         }
+                        // Drop the cloned transcriber Arc so it isn't held
+                        // until the next transcription.
+                        self.active_transcriber = None;
 
                         cleanup_output_mode_override();
                         cleanup_model_override();
@@ -3522,6 +3583,7 @@ impl Daemon {
         if let Some(task) = self.transcription_task.take() {
             task.abort();
         }
+        self.active_transcriber = None;
 
         // Abort any pending eager chunk tasks
         for (_, task) in self.eager_chunk_tasks.drain(..) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,6 +311,12 @@ async fn main() -> anyhow::Result<()> {
     if let Some(variant) = cli.dotool_xkb_variant {
         config.output.dotool_xkb_variant = Some(variant);
     }
+    if let Some(layout) = cli.eitype_xkb_layout {
+        config.output.eitype_xkb_layout = Some(layout);
+    }
+    if let Some(variant) = cli.eitype_xkb_variant {
+        config.output.eitype_xkb_variant = Some(variant);
+    }
     if let Some(path) = cli.file_path {
         config.output.file_path = Some(path);
     }

--- a/src/output/eitype.rs
+++ b/src/output/eitype.rs
@@ -25,6 +25,14 @@ pub struct EitypeOutput {
     pre_type_delay_ms: u32,
     /// Convert newlines to Shift+Enter (for apps where Enter submits)
     shift_enter_newlines: bool,
+    /// XKB keyboard layout to pass via `-l <layout>` (e.g., "us", "de", "ru").
+    /// Overrides eitype's view of the system layout for the call. Required
+    /// when the transcribed language does not match the active layout, see
+    /// issue #180.
+    xkb_layout: Option<String>,
+    /// XKB layout variant passed via `--variant <variant>` (e.g.,
+    /// "dvorak", "colemak", "nodeadkeys").
+    xkb_variant: Option<String>,
 }
 
 impl EitypeOutput {
@@ -35,13 +43,34 @@ impl EitypeOutput {
         type_delay_ms: u32,
         pre_type_delay_ms: u32,
         shift_enter_newlines: bool,
+        xkb_layout: Option<String>,
+        xkb_variant: Option<String>,
     ) -> Self {
+        if let Some(ref layout) = xkb_layout {
+            tracing::debug!("eitype: using keyboard layout '{}'", layout);
+        }
         Self {
             auto_submit,
             append_text,
             type_delay_ms,
             pre_type_delay_ms,
             shift_enter_newlines,
+            xkb_layout,
+            xkb_variant,
+        }
+    }
+
+    /// Append `-l <layout>` / `--variant <variant>` flags to a Command and
+    /// the debug_args vec, if configured. Centralized so type_text and the
+    /// key-press helpers stay in sync.
+    fn apply_layout_args(&self, cmd: &mut Command, debug_args: &mut Vec<String>) {
+        if let Some(ref layout) = self.xkb_layout {
+            cmd.arg("-l").arg(layout);
+            debug_args.push(format!("-l {}", layout));
+        }
+        if let Some(ref variant) = self.xkb_variant {
+            cmd.arg("--variant").arg(variant);
+            debug_args.push(format!("--variant {}", variant));
         }
     }
 
@@ -67,6 +96,9 @@ impl EitypeOutput {
             cmd.arg("-d").arg(self.type_delay_ms.to_string());
             debug_args.push(format!("-d {}", self.type_delay_ms));
         }
+
+        // Apply layout hint (e.g. -l ru when transcribing Russian on a US layout).
+        self.apply_layout_args(&mut cmd, &mut debug_args);
 
         debug_args.push(format!("\"{}\"", text.chars().take(20).collect::<String>()));
         tracing::debug!("Running: {}", debug_args.join(" "));
@@ -204,36 +236,100 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let output = EitypeOutput::new(false, None, 0, 0, false);
+        let output = EitypeOutput::new(false, None, 0, 0, false, None, None);
         assert!(!output.auto_submit);
         assert_eq!(output.type_delay_ms, 0);
         assert_eq!(output.pre_type_delay_ms, 0);
         assert!(!output.shift_enter_newlines);
+        assert!(output.xkb_layout.is_none());
+        assert!(output.xkb_variant.is_none());
     }
 
     #[test]
     fn test_new_with_enter() {
-        let output = EitypeOutput::new(true, None, 0, 0, false);
+        let output = EitypeOutput::new(true, None, 0, 0, false, None, None);
         assert!(output.auto_submit);
     }
 
     #[test]
     fn test_new_with_type_delay() {
-        let output = EitypeOutput::new(false, None, 50, 0, false);
+        let output = EitypeOutput::new(false, None, 50, 0, false, None, None);
         assert_eq!(output.type_delay_ms, 50);
         assert_eq!(output.pre_type_delay_ms, 0);
     }
 
     #[test]
     fn test_new_with_pre_type_delay() {
-        let output = EitypeOutput::new(false, None, 0, 200, false);
+        let output = EitypeOutput::new(false, None, 0, 200, false, None, None);
         assert_eq!(output.type_delay_ms, 0);
         assert_eq!(output.pre_type_delay_ms, 200);
     }
 
     #[test]
     fn test_new_with_shift_enter_newlines() {
-        let output = EitypeOutput::new(false, None, 0, 0, true);
+        let output = EitypeOutput::new(false, None, 0, 0, true, None, None);
         assert!(output.shift_enter_newlines);
+    }
+
+    #[test]
+    fn test_new_with_layout() {
+        let output = EitypeOutput::new(false, None, 0, 0, false, Some("ru".to_string()), None);
+        assert_eq!(output.xkb_layout, Some("ru".to_string()));
+        assert!(output.xkb_variant.is_none());
+    }
+
+    #[test]
+    fn test_new_with_layout_and_variant() {
+        let output = EitypeOutput::new(
+            false,
+            None,
+            0,
+            0,
+            false,
+            Some("de".to_string()),
+            Some("nodeadkeys".to_string()),
+        );
+        assert_eq!(output.xkb_layout, Some("de".to_string()));
+        assert_eq!(output.xkb_variant, Some("nodeadkeys".to_string()));
+    }
+
+    /// Resolve layout/variant against the standard cases covered by config:
+    /// - explicit layout, no variant
+    /// - layout + variant
+    /// - neither
+    #[test]
+    fn test_apply_layout_args_includes_layout_when_set() {
+        let output = EitypeOutput::new(false, None, 0, 0, false, Some("ru".to_string()), None);
+        let mut cmd = Command::new("eitype");
+        let mut debug_args: Vec<String> = vec![];
+        output.apply_layout_args(&mut cmd, &mut debug_args);
+        assert!(debug_args.iter().any(|s| s == "-l ru"));
+    }
+
+    #[test]
+    fn test_apply_layout_args_includes_variant_when_set() {
+        let output = EitypeOutput::new(
+            false,
+            None,
+            0,
+            0,
+            false,
+            Some("de".to_string()),
+            Some("nodeadkeys".to_string()),
+        );
+        let mut cmd = Command::new("eitype");
+        let mut debug_args: Vec<String> = vec![];
+        output.apply_layout_args(&mut cmd, &mut debug_args);
+        assert!(debug_args.iter().any(|s| s == "-l de"));
+        assert!(debug_args.iter().any(|s| s == "--variant nodeadkeys"));
+    }
+
+    #[test]
+    fn test_apply_layout_args_noop_when_unset() {
+        let output = EitypeOutput::new(false, None, 0, 0, false, None, None);
+        let mut cmd = Command::new("eitype");
+        let mut debug_args: Vec<String> = vec![];
+        output.apply_layout_args(&mut cmd, &mut debug_args);
+        assert!(debug_args.is_empty());
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -277,6 +277,8 @@ fn create_driver_output(
             config.type_delay_ms,
             pre_type_delay_ms,
             config.shift_enter_newlines,
+            config.eitype_xkb_layout.clone(),
+            config.eitype_xkb_variant.clone(),
         )),
         OutputDriver::Dotool => Box::new(dotool::DotoolOutput::new(
             config.type_delay_ms,

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -131,6 +131,22 @@ pub trait Transcriber: Send + Sync {
     fn as_streaming(&self) -> Option<&dyn StreamingTranscriber> {
         None
     }
+
+    /// Two-letter language code detected (or selected) for the most recent
+    /// transcription, if the backend tracks it.
+    ///
+    /// This is used by output methods that benefit from a layout hint
+    /// (notably [`crate::output::eitype::EitypeOutput`] and
+    /// [`crate::output::dotool::DotoolOutput`]). It is set by backends with
+    /// language auto-detection or explicit single-language mode; backends
+    /// without language awareness return `None`.
+    ///
+    /// The default implementation returns `None`. Backends override this when
+    /// they track the language used for the previous call to
+    /// [`Self::transcribe`].
+    fn last_detected_language(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Factory function to create transcriber based on configured engine

--- a/src/transcribe/subprocess.rs
+++ b/src/transcribe/subprocess.rs
@@ -33,6 +33,11 @@ struct WorkerResponse {
     text: Option<String>,
     #[serde(default)]
     error: Option<String>,
+    /// Two-letter language code chosen for this transcription, if the worker
+    /// tracked it. Used by output methods that benefit from a layout hint.
+    /// Older workers that do not emit this field deserialize to `None`.
+    #[serde(default)]
+    language: Option<String>,
 }
 
 /// A prepared worker process ready to receive audio
@@ -57,6 +62,10 @@ pub struct SubprocessTranscriber {
     config_path: Option<std::path::PathBuf>,
     /// Pre-spawned worker (from prepare())
     prepared_worker: Mutex<Option<PreparedWorker>>,
+    /// Last language reported by the worker, if any. Mirrors
+    /// `WhisperTranscriber::last_language` so the daemon can derive a layout
+    /// hint after transcription. See [`Transcriber::last_detected_language`].
+    last_language: Mutex<Option<String>>,
 }
 
 impl SubprocessTranscriber {
@@ -69,6 +78,7 @@ impl SubprocessTranscriber {
             config: config.clone(),
             config_path,
             prepared_worker: Mutex::new(None),
+            last_language: Mutex::new(None),
         })
     }
 
@@ -286,6 +296,15 @@ impl Transcriber for SubprocessTranscriber {
             start.elapsed().as_secs_f32()
         );
 
+        // Record reported language for layout-aware output methods. Missing
+        // (older worker) leaves the previous value untouched-by-success
+        // semantics: clear it on every successful call so stale language
+        // hints don't leak across transcriptions when the user switches
+        // engines or recordings.
+        if let Ok(mut guard) = self.last_language.lock() {
+            *guard = response.language.clone();
+        }
+
         // Handle response
         if response.ok {
             response.text.ok_or_else(|| {
@@ -299,6 +318,10 @@ impl Transcriber for SubprocessTranscriber {
             ))
         }
     }
+
+    fn last_detected_language(&self) -> Option<String> {
+        self.last_language.lock().ok().and_then(|g| g.clone())
+    }
 }
 
 #[cfg(test)]
@@ -311,10 +334,20 @@ mod tests {
             serde_json::from_str(r#"{"ok": true, "text": "Hello world"}"#).unwrap();
         assert!(success.ok);
         assert_eq!(success.text, Some("Hello world".to_string()));
+        // Backward compat: older workers don't emit "language".
+        assert_eq!(success.language, None);
 
         let error: WorkerResponse =
             serde_json::from_str(r#"{"ok": false, "error": "Model not found"}"#).unwrap();
         assert!(!error.ok);
         assert_eq!(error.error, Some("Model not found".to_string()));
+    }
+
+    #[test]
+    fn test_worker_response_parsing_with_language() {
+        let success: WorkerResponse =
+            serde_json::from_str(r#"{"ok": true, "text": "Privet", "language": "ru"}"#).unwrap();
+        assert!(success.ok);
+        assert_eq!(success.language, Some("ru".to_string()));
     }
 }

--- a/src/transcribe/whisper.rs
+++ b/src/transcribe/whisper.rs
@@ -11,6 +11,7 @@ use super::Transcriber;
 use crate::config::{Config, LanguageConfig, WhisperConfig};
 use crate::error::TranscribeError;
 use std::path::PathBuf;
+use std::sync::Mutex;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
 /// Whisper-based transcriber
@@ -27,6 +28,12 @@ pub struct WhisperTranscriber {
     context_window_optimization: bool,
     /// Initial prompt to provide context for transcription
     initial_prompt: Option<String>,
+    /// Two-letter code for the language used during the most recent
+    /// `transcribe()` call. Populated for single-language and constrained
+    /// auto-detection modes; left empty for unconstrained auto-detection
+    /// (since whisper-rs does not currently expose the chosen language
+    /// from the full() pipeline). Read via [`Transcriber::last_detected_language`].
+    last_language: Mutex<Option<String>>,
 }
 
 impl WhisperTranscriber {
@@ -66,6 +73,7 @@ impl WhisperTranscriber {
             threads,
             context_window_optimization: config.context_window_optimization,
             initial_prompt: config.initial_prompt.clone(),
+            last_language: Mutex::new(None),
         })
     }
 
@@ -170,6 +178,15 @@ impl Transcriber for WhisperTranscriber {
             Some(lang)
         };
 
+        // Record the language for output methods that benefit from a layout
+        // hint (e.g. eitype --layout, dotool DOTOOL_XKB_LAYOUT). See
+        // `Transcriber::last_detected_language`. Unconstrained auto-detect
+        // leaves this as `None`; whisper-rs does not expose the language
+        // chosen inside `full()` so we cannot recover it after the fact.
+        if let Ok(mut guard) = self.last_language.lock() {
+            *guard = selected_language.clone();
+        }
+
         // Configure parameters
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
 
@@ -251,6 +268,10 @@ impl Transcriber for WhisperTranscriber {
         );
 
         Ok(result)
+    }
+
+    fn last_detected_language(&self) -> Option<String> {
+        self.last_language.lock().ok().and_then(|g| g.clone())
     }
 }
 

--- a/src/transcribe/worker.rs
+++ b/src/transcribe/worker.rs
@@ -27,13 +27,29 @@ pub const READY_SIGNAL: &str = "READY";
 #[derive(Debug, serde::Serialize)]
 #[serde(untagged)]
 pub enum WorkerResponse {
-    Success { ok: bool, text: String },
-    Error { ok: bool, error: String },
+    Success {
+        ok: bool,
+        text: String,
+        /// Two-letter language code chosen for this transcription, if the
+        /// worker tracked one. The parent reads this so layout-aware output
+        /// methods (eitype, dotool) can switch keyboard layouts. Older
+        /// parents that ignore the field simply skip the hint.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        language: Option<String>,
+    },
+    Error {
+        ok: bool,
+        error: String,
+    },
 }
 
 impl WorkerResponse {
-    pub fn success(text: String) -> Self {
-        WorkerResponse::Success { ok: true, text }
+    pub fn success(text: String, language: Option<String>) -> Self {
+        WorkerResponse::Success {
+            ok: true,
+            text,
+            language,
+        }
     }
 
     pub fn error(msg: impl Into<String>) -> Self {
@@ -150,7 +166,12 @@ pub fn run_worker(config: &WhisperConfig) -> anyhow::Result<()> {
                 transcribe_start.elapsed().as_secs_f32(),
                 text.len()
             );
-            write_response_to(&mut stdout_lock, WorkerResponse::success(text));
+            // Capture the chosen language so the parent can hint output
+            // methods (eitype --layout, dotool DOTOOL_XKB_LAYOUT) about
+            // what keyboard layout to use. Field is omitted from the JSON
+            // if no language was tracked.
+            let language = transcriber.last_detected_language();
+            write_response_to(&mut stdout_lock, WorkerResponse::success(text, language));
         }
         Err(e) => {
             eprintln!("[worker] Transcription failed: {}", e);
@@ -175,15 +196,25 @@ mod tests {
 
     #[test]
     fn test_worker_response_serialization() {
-        let success = WorkerResponse::success("Hello world".to_string());
+        let success = WorkerResponse::success("Hello world".to_string(), None);
         let json = serde_json::to_string(&success).unwrap();
         assert!(json.contains(r#""ok":true"#));
         assert!(json.contains(r#""text":"Hello world""#));
+        // No language present: serialized form omits the field entirely.
+        assert!(!json.contains(r#""language""#));
 
         let error = WorkerResponse::error("Something went wrong");
         let json = serde_json::to_string(&error).unwrap();
         assert!(json.contains(r#""ok":false"#));
         assert!(json.contains(r#""error":"Something went wrong""#));
+    }
+
+    #[test]
+    fn test_worker_response_serialization_with_language() {
+        let success = WorkerResponse::success("Привет".to_string(), Some("ru".to_string()));
+        let json = serde_json::to_string(&success).unwrap();
+        assert!(json.contains(r#""ok":true"#));
+        assert!(json.contains(r#""language":"ru""#));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Voxtype now passes a keyboard layout hint to `eitype` (and `dotool`) for each transcription, derived from the language the transcriber actually used. With `language = ["en", "ru"]` and `driver_order = ["eitype"]`, Russian transcriptions now type Cyrillic correctly even when the system layout is US.
- Adds `eitype_xkb_layout` / `eitype_xkb_variant` config fields, matching `VOXTYPE_EITYPE_XKB_LAYOUT` / `VOXTYPE_EITYPE_XKB_VARIANT` env vars, and `--eitype-xkb-layout` / `--eitype-xkb-variant` CLI flags. Explicit values win over auto-detection.
- Adds a `[output.language_to_layout]` map with sensible built-in defaults (e.g. `en→us`, `ru→ru`, `de→de`, `el→gr`, `ja→jp`, `ko→kr`). Users can override or extend it.

## How it works

1. `Transcriber::last_detected_language()` is a new optional trait method (default `None`). `WhisperTranscriber` stores the chosen language inside `transcribe()` and exposes it. `SubprocessTranscriber` reads a new optional `language` field from the worker's JSON response; older workers omitting the field deserialize cleanly.
2. The daemon clones the transcriber `Arc` at spawn time so the result handler can query the language without contention.
3. Before the output chain is built per transcription, the daemon looks the language up in `language_to_layout` and injects the layout into `output_config.eitype_xkb_layout` / `dotool_xkb_layout` only when those fields are unset. Static config wins.
4. `EitypeOutput::type_text` passes the layout as `-l <layout>` and the variant as `--variant <variant>`.

## Backwards compatibility

- New trait method has a default impl, so external transcribers compile unchanged.
- Worker JSON `language` field is `#[serde(skip_serializing_if = "Option::is_none")]` on emit and `#[serde(default)]` on receive, so old workers and old parents interoperate.
- All new config fields default to `None` / built-in map.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --lib`: 676 pass, 1 pre-existing failure unrelated to this change (`setup::parakeet::detect_available_backends_returns_vec` fails on `main` too)
- [x] New unit tests cover: layout/variant flag construction, default `language_to_layout` contents, TOML parse of new fields, language override map parsing, worker JSON round-trip with and without language
- [ ] Manual test on multi-language setup: `language = ["en", "ru"]`, `driver_order = ["eitype"]`, alternate English/Russian dictation, verify both type correctly without "Character not found in keymap"
- [ ] Manual test that explicit `eitype_xkb_layout = "us"` pins the layout regardless of detected language

Closes #180