### PR TITLE
Add shared Quickshell QML modules for voxtype OSD

### DIFF
--- a/quickshell/voxtype-osd/shell.qml
+++ b/quickshell/voxtype-osd/shell.qml
@@ -10,38 +10,38 @@
 //
 // Reads the daemon's state file at $XDG_RUNTIME_DIR/voxtype/state, which
 // contains exactly one of: idle, recording, streaming, transcribing.
+//
+// Shared theme, state-file reader, and audio bridge wrapper live under
+// `quickshell/voxtype-shared/`; this file is intentionally thin so that
+// it stays readable as the entry point for the Wave 2 waveform work.
 
 import QtQuick
 import Quickshell
-import Quickshell.Io
 import Quickshell.Wayland
+import "../voxtype-shared" as VT
 
 ShellRoot {
     id: shell
 
-    property string runtimeDir: Quickshell.env("XDG_RUNTIME_DIR")
-                                  || "/run/user/" + Quickshell.env("UID")
-    property string statePath: runtimeDir + "/voxtype/state"
-    property string state: "idle"
+    // State is sourced from the shared StateReader so the engine picker
+    // and meeting-controls frontends can subscribe to the same source.
+    VT.StateReader {
+        id: stateReader
+    }
 
-    // Watch the daemon's state file. Quickshell's FileView reads the
-    // contents into `text()` on demand; we trigger re-reads via reload()
-    // whenever the underlying file changes so the OSD follows the daemon's
-    // state machine transitions (idle → recording → transcribing → idle).
-    FileView {
-        id: stateFile
-        path: shell.statePath
-        watchChanges: true
-        printErrors: false
-        onLoaded: shell.state = (text() || "idle").trim()
-        onLoadFailed: shell.state = "idle"
-        onFileChanged: reload()
+    // Wire the audio bridge even though the POC doesn't render a
+    // waveform yet — letting the indicator pulse on VAD makes
+    // "recording but silent" visually distinct from "recording with
+    // voice", which is a nice quality-of-life cue before the full
+    // waveform lands in Wave 2.
+    VT.AudioBridge {
+        id: audio
     }
 
     // The OSD surface itself. Hidden when state is idle; visible otherwise.
     PanelWindow {
         id: panel
-        visible: shell.state !== "idle" && shell.state !== ""
+        visible: stateReader.state !== "idle" && stateReader.state !== ""
         anchors { top: true; bottom: true; left: true; right: true }
         color: "transparent"
 
@@ -57,32 +57,39 @@ ShellRoot {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 72
-            radius: 8
-            color: Qt.rgba(0.08, 0.08, 0.10, 0.95)
+            radius: VT.Theme.cornerRadius
+            color: VT.Theme.bgColor
             border.width: 2
 
             // Per-state border tint so a Hyprland user can glance at the
             // edge of a screen and know whether voxtype is recording vs
             // streaming vs transcribing without reading the label.
-            border.color: shell.state === "recording"    ? "#e06c75"
-                       : shell.state === "streaming"     ? "#61afef"
-                       : shell.state === "transcribing"  ? "#e5c07b"
-                       :                                   "#abb2bf"
+            border.color: stateReader.state === "recording"    ? VT.Theme.recordingColor
+                       : stateReader.state === "streaming"     ? VT.Theme.streamingColor
+                       : stateReader.state === "transcribing"  ? VT.Theme.transcribingColor
+                       :                                         VT.Theme.idleColor
+
+            // Subtle opacity pulse on VAD=1 while recording. When the
+            // bridge isn't running yet (or the daemon hasn't opened
+            // the audio socket) we fall back to full opacity so the
+            // indicator never disappears unexpectedly.
+            opacity: (stateReader.state === "recording" && audio.running && !audio.vad) ? 0.78 : 1.0
+            Behavior on opacity { NumberAnimation { duration: 120 } }
 
             Row {
                 anchors.fill: parent
-                anchors.leftMargin: 14
-                anchors.rightMargin: 14
+                anchors.leftMargin: VT.Theme.padding
+                anchors.rightMargin: VT.Theme.padding
                 spacing: 12
 
                 Text {
                     width: 28
                     anchors.verticalCenter: parent.verticalCenter
                     horizontalAlignment: Text.AlignHCenter
-                    text: shell.state === "recording"    ? "󰍬"
-                       : shell.state === "streaming"     ? "󰜟"
-                       : shell.state === "transcribing"  ? "󰔟"
-                       :                                   "󰍬"
+                    text: stateReader.state === "recording"    ? "󰍬"
+                       : stateReader.state === "streaming"     ? "󰜟"
+                       : stateReader.state === "transcribing"  ? "󰔟"
+                       :                                          "󰍬"
                     font.family: "JetBrainsMono Nerd Font"
                     font.pixelSize: 26
                     color: card.border.color
@@ -90,14 +97,14 @@ ShellRoot {
 
                 Text {
                     anchors.verticalCenter: parent.verticalCenter
-                    text: shell.state === "recording"    ? "Recording"
-                       : shell.state === "streaming"     ? "Streaming live"
-                       : shell.state === "transcribing"  ? "Transcribing"
-                       :                                   shell.state
+                    text: stateReader.state === "recording"    ? "Recording"
+                       : stateReader.state === "streaming"     ? "Streaming live"
+                       : stateReader.state === "transcribing"  ? "Transcribing"
+                       :                                         stateReader.state
                     font.family: "JetBrainsMono Nerd Font"
                     font.bold: true
                     font.pixelSize: 14
-                    color: "#dcdfe4"
+                    color: VT.Theme.textColor
                 }
             }
         }

--- a/quickshell/voxtype-shared/AudioBridge.qml
+++ b/quickshell/voxtype-shared/AudioBridge.qml
@@ -1,0 +1,157 @@
+// Voxtype audio-bridge wrapper.
+//
+// Spawns the `voxtype-audio-bridge` sidecar binary as a child Process and
+// parses one NDJSON object per line of stdout. The sidecar reads from
+// the daemon's audio Unix socket (`$XDG_RUNTIME_DIR/voxtype/audio.sock`)
+// and emits frames in this locked protocol:
+//
+//   {"peak":0.421,"rms":0.180,"vad":1,"ts_ms":1234567}
+//   {"status":"connected"}
+//   {"status":"disconnected"}
+//
+// Usage:
+//
+//   import "voxtype-shared" as VT
+//   VT.AudioBridge {
+//       id: audio
+//       onFrameReceived: function(peak, rms, vad, tsMs) {
+//           // Push into a ring buffer, drive an animation, etc.
+//       }
+//       onDisconnected: console.warn("daemon audio socket dropped")
+//   }
+//
+// Quickshell.Io.Process restarts automatically when `running` is true
+// and the child exits, so a crash of the bridge binary heals on its
+// own after `restartDelayMs` milliseconds.
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+Item {
+    id: root
+
+    /// Path or PATH-resolvable name of the audio-bridge binary. The
+    /// AUR/.deb/.rpm packages install it as `voxtype-audio-bridge` in
+    /// `/usr/bin`, so the default works for end-user installs. For
+    /// development, override with the cargo target path:
+    ///
+    ///   VT.AudioBridge {
+    ///       bridgeBinary: "/path/to/target/release/voxtype-audio-bridge"
+    ///   }
+    property string bridgeBinary: "voxtype-audio-bridge"
+
+    /// Additional command-line arguments to pass to the bridge.
+    /// Defaults to empty; the bridge auto-discovers
+    /// `$XDG_RUNTIME_DIR/voxtype/audio.sock`.
+    property var bridgeArgs: []
+
+    /// Milliseconds to wait before respawning the bridge after it
+    /// exits. Stops a wedged binary from pegging the CPU in a tight
+    /// restart loop while still recovering quickly under normal
+    /// conditions.
+    property int restartDelayMs: 1000
+
+    /// True once the bridge process has emitted at least one frame.
+    /// Distinct from `process.running`, which only reflects whether
+    /// the OS process exists. A bridge that's connected to the daemon
+    /// but waiting for audio will have `process.running == true` and
+    /// `running == false`.
+    property bool running: false
+
+    /// Latest peak amplitude, 0.0..=1.0.
+    property real peak: 0.0
+
+    /// Latest RMS amplitude, 0.0..=1.0.
+    property real rms: 0.0
+
+    /// Latest voice-activity-detection result.
+    property bool vad: false
+
+    /// Latest frame timestamp in milliseconds (monotonic clock from
+    /// the daemon).
+    property var tsMs: 0
+
+    /// Emitted on every parsed audio frame. Consumers that need the
+    /// full history (waveform renderer) should push to their own ring
+    /// buffer in this handler.
+    signal frameReceived(real peak, real rms, bool vad, var tsMs)
+
+    /// Emitted on `{"status":"connected"}` lines from the bridge,
+    /// indicating the audio socket is open.
+    signal connected()
+
+    /// Emitted on `{"status":"disconnected"}` lines or when the
+    /// bridge process exits.
+    signal disconnected()
+
+    function _handleLine(line) {
+        const trimmed = (line || "").trim();
+        if (trimmed.length === 0) return;
+        let obj;
+        try {
+            obj = JSON.parse(trimmed);
+        } catch (e) {
+            // Non-JSON line from the bridge (e.g. an unexpected log
+            // print to stdout). Swallow rather than crash the OSD.
+            console.warn("voxtype audio-bridge: non-JSON stdout line:", trimmed);
+            return;
+        }
+        if (obj.status === "connected") {
+            root.connected();
+            return;
+        }
+        if (obj.status === "disconnected") {
+            if (root.running) {
+                root.running = false;
+            }
+            root.disconnected();
+            return;
+        }
+        if (typeof obj.peak === "number" && typeof obj.rms === "number") {
+            root.peak = obj.peak;
+            root.rms = obj.rms;
+            root.vad = !!obj.vad;
+            root.tsMs = obj.ts_ms !== undefined ? obj.ts_ms : 0;
+            if (!root.running) {
+                root.running = true;
+            }
+            root.frameReceived(root.peak, root.rms, root.vad, root.tsMs);
+        }
+    }
+
+    Process {
+        id: process
+        command: [root.bridgeBinary].concat(root.bridgeArgs)
+        running: true
+
+        stdout: SplitParser {
+            splitMarker: "\n"
+            onRead: function(data) { root._handleLine(data); }
+        }
+
+        // Restart the bridge when it exits. Quickshell's Process with
+        // `running: true` would respawn instantly; the small delay
+        // keeps a crash-looping binary from hammering the CPU.
+        onRunningChanged: {
+            if (!process.running) {
+                if (root.running) {
+                    root.running = false;
+                    root.disconnected();
+                }
+                restartTimer.restart();
+            }
+        }
+    }
+
+    Timer {
+        id: restartTimer
+        interval: root.restartDelayMs
+        repeat: false
+        onTriggered: {
+            if (!process.running) {
+                process.running = true;
+            }
+        }
+    }
+}

--- a/quickshell/voxtype-shared/README.md
+++ b/quickshell/voxtype-shared/README.md
@@ -1,0 +1,109 @@
+# voxtype-shared
+
+Shared Quickshell QML modules used by every voxtype QML frontend: the
+OSD card, the engine picker menu, and (eventually) the meeting controls
+canvas. Extracted so the frontends don't each ship their own copy of
+theme constants, state file watcher, and audio bridge wrapper.
+
+## Modules
+
+### `Theme` (singleton)
+
+Color palette and sizing defaults mirrored from `src/osd/visual.rs`
+(`Palette::fallback`) and `src/osd/config.rs` (`OsdConfig::default`).
+
+Public properties:
+
+| Property            | Default                                | Purpose                                  |
+|---------------------|----------------------------------------|------------------------------------------|
+| `bgColor`           | rgba(0.10, 0.10, 0.12, 0.85)           | Translucent card background              |
+| `accentColor`       | rgba(0.40, 0.78, 1.00, 1.0)            | Waveform fill, primary action            |
+| `idleColor`         | `#abb2bf`                              | Idle-state indicator                     |
+| `recordingColor`    | `#e06c75`                              | Recording-state indicator                |
+| `streamingColor`    | `#61afef`                              | Streaming-state indicator                |
+| `transcribingColor` | `#e5c07b`                              | Transcribing-state indicator             |
+| `textColor`         | `#dcdfe4`                              | Foreground text                          |
+| `waveformColor`     | bound to `accentColor`                 | Waveform body                            |
+| `waveformPeakColor` | `#FCFBF8`                              | Waveform held-peak tick                  |
+| `cornerRadius`      | `12`                                   | Card radius (swayosd parity)             |
+| `padding`           | `14`                                   | Inner padding for OSD cards              |
+| `marginPx`          | `24`                                   | Distance from screen edge                |
+| `defaultWidthPx`    | `400`                                  | Mirrors `OsdConfig::width_px`            |
+| `defaultHeightPx`   | `48`                                   | Mirrors `OsdConfig::height_px`           |
+| `defaultOpacity`    | `0.95`                                 | Mirrors `OsdConfig::opacity`             |
+| `waveformWindowSecs`| `3.0`                                  | Mirrors `OsdConfig::waveform_window_secs`|
+
+### `StateReader`
+
+Watches `$XDG_RUNTIME_DIR/voxtype/state` for changes and exposes the
+current daemon state.
+
+Public properties:
+
+| Property    | Default                                  | Purpose                              |
+|-------------|------------------------------------------|--------------------------------------|
+| `statePath` | `$XDG_RUNTIME_DIR/voxtype/state`         | Override for tests / custom setups   |
+| `state`     | `"idle"`                                 | Current daemon state                 |
+
+Signals:
+
+- `stateChanged(string newState)` — fired on every transition.
+
+### `AudioBridge`
+
+Wraps the `voxtype-audio-bridge` sidecar binary. The bridge reads the
+daemon's audio Unix socket and emits NDJSON to stdout; this component
+parses each line into properties + signals.
+
+Public properties:
+
+| Property         | Default                  | Purpose                                                            |
+|------------------|--------------------------|--------------------------------------------------------------------|
+| `bridgeBinary`   | `voxtype-audio-bridge`   | Path or PATH-resolvable name of the sidecar                        |
+| `bridgeArgs`     | `[]`                     | Additional CLI args for the bridge                                 |
+| `restartDelayMs` | `1000`                   | Delay between exit and respawn                                     |
+| `running`        | `false`                  | True once frames are arriving                                      |
+| `peak`           | `0.0`                    | Latest peak amplitude (0.0..=1.0)                                  |
+| `rms`            | `0.0`                    | Latest RMS amplitude (0.0..=1.0)                                   |
+| `vad`            | `false`                  | Latest voice-activity-detection result                             |
+| `tsMs`           | `0`                      | Latest frame timestamp in ms (monotonic, from the daemon)          |
+
+Signals:
+
+- `frameReceived(real peak, real rms, bool vad, var tsMs)` — emitted on every audio frame.
+- `connected()` — emitted on `{"status":"connected"}`.
+- `disconnected()` — emitted on `{"status":"disconnected"}` or when the bridge process exits.
+
+## Minimal import
+
+```qml
+import "voxtype-shared" as VT
+
+Rectangle {
+    color: VT.Theme.bgColor
+
+    VT.StateReader {
+        id: state
+        onStateChanged: console.log("state:", newState)
+    }
+
+    VT.AudioBridge {
+        onFrameReceived: function(peak, rms, vad, tsMs) {
+            // push into a ring buffer for the waveform renderer
+        }
+    }
+}
+```
+
+The directory is structured as a QML module (`qmldir` registers
+`Theme` as a singleton plus the two `Item` subclasses), so the import
+above resolves when Quickshell is launched from the parent
+`quickshell/` directory or when the module is symlinked into the
+user's Quickshell config tree.
+
+## Scope
+
+These modules are the foundation for v0.7.3 Wave 2 work: the waveform
+OSD, the engine picker menu, and the meeting controls panel. None of
+those frontends ship yet; this commit only lands the shared modules
+plus a refactor of the existing OSD proof-of-concept to consume them.

--- a/quickshell/voxtype-shared/StateReader.qml
+++ b/quickshell/voxtype-shared/StateReader.qml
@@ -1,0 +1,84 @@
+// Voxtype daemon state file watcher.
+//
+// Wraps Quickshell.Io.FileView around the daemon's state file at
+// $XDG_RUNTIME_DIR/voxtype/state. The file contains exactly one of
+// `idle`, `recording`, `streaming`, `transcribing` and is rewritten by
+// the daemon on every state machine transition.
+//
+// Usage:
+//
+//   import "voxtype-shared" as VT
+//   VT.StateReader {
+//       id: stateReader
+//       onStateChanged: function(newState) {
+//           console.log("voxtype is now", newState);
+//       }
+//   }
+//
+// The component exposes `state` as a bindable property so consumers
+// don't have to listen for the signal:
+//
+//   border.color: stateReader.state === "recording" ? "red" : "gray"
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+Item {
+    id: root
+
+    /// Filesystem path to the daemon state file. Defaults to
+    /// `$XDG_RUNTIME_DIR/voxtype/state` with a `/run/user/$UID`
+    /// fallback for environments that don't export XDG_RUNTIME_DIR.
+    property string statePath: {
+        const xdg = Quickshell.env("XDG_RUNTIME_DIR");
+        if (xdg && xdg.length > 0) {
+            return xdg + "/voxtype/state";
+        }
+        const uid = Quickshell.env("UID");
+        if (uid && uid.length > 0) {
+            return "/run/user/" + uid + "/voxtype/state";
+        }
+        // Last-resort fallback: assume UID 1000. Better than an empty
+        // path that would silently never resolve.
+        return "/run/user/1000/voxtype/state";
+    }
+
+    /// Current daemon state. One of: idle, recording, streaming,
+    /// transcribing. Defaults to "idle" when the file is missing or
+    /// unreadable so consumers can always render a sensible default.
+    property string state: "idle"
+
+    /// Emitted whenever the daemon writes a new state to disk.
+    /// `newState` is the freshly read value with surrounding whitespace
+    /// trimmed.
+    signal stateChanged(string newState)
+
+    // FileView re-reads on file changes when watchChanges is true.
+    // We re-set the `state` property inside onLoaded so the binding-
+    // based consumers also update, then fire the signal for imperative
+    // consumers (e.g. animation triggers).
+    FileView {
+        id: stateFile
+        path: root.statePath
+        watchChanges: true
+        printErrors: false
+
+        onLoaded: {
+            const next = (text() || "idle").trim();
+            if (next !== root.state) {
+                root.state = next;
+                root.stateChanged(next);
+            }
+        }
+
+        onLoadFailed: {
+            if (root.state !== "idle") {
+                root.state = "idle";
+                root.stateChanged("idle");
+            }
+        }
+
+        onFileChanged: reload()
+    }
+}

--- a/quickshell/voxtype-shared/Theme.qml
+++ b/quickshell/voxtype-shared/Theme.qml
@@ -1,0 +1,81 @@
+pragma Singleton
+
+// Voxtype Quickshell theme singleton.
+//
+// Mirrors the fallback palette from src/osd/visual.rs (Palette::fallback)
+// and the OSD's sizing defaults from src/osd/config.rs (OsdConfig::default).
+// Consumers can override any of these properties at runtime to match the
+// active Omarchy theme or a user-provided palette:
+//
+//   import "voxtype-shared" as VT
+//   VT.Theme.accentColor = "#6E89C2"
+//
+// Wave 2 will add a loader that reads
+// `~/.config/omarchy/current/theme/colors.toml` and maps `accent`,
+// `background`, `color1`/`2`/`3` onto these properties.
+
+import QtQuick
+
+QtObject {
+    id: theme
+
+    /// Window / card background. Translucent dark, alpha matches the
+    /// Rust fallback (0.85) so the OSD reads as a glassy overlay rather
+    /// than a solid panel.
+    property color bgColor: Qt.rgba(0.10, 0.10, 0.12, 0.85)
+
+    /// Theme accent. Used for the waveform fill and any "primary action"
+    /// indicators. Default mirrors Palette::fallback().accent.
+    property color accentColor: Qt.rgba(0.40, 0.78, 1.00, 1.0)
+
+    /// Idle-state indicator color (when the OSD is visible but the
+    /// daemon isn't actively recording). Matches the existing POC.
+    property color idleColor: "#abb2bf"
+
+    /// Recording-state indicator color. Voxtype's signature
+    /// red/orange used for "we are capturing your voice right now."
+    property color recordingColor: "#e06c75"
+
+    /// Streaming-state indicator color (live partial-token output).
+    property color streamingColor: "#61afef"
+
+    /// Transcribing-state indicator color (model is processing the
+    /// final audio buffer).
+    property color transcribingColor: "#e5c07b"
+
+    /// Foreground text color. Matches the OSD card label.
+    property color textColor: "#dcdfe4"
+
+    /// Waveform body color. Defaults to accent so a single tweak
+    /// re-themes both the indicator and the meter.
+    property color waveformColor: theme.accentColor
+
+    /// Waveform held-peak tick color. Brighter than the body so the
+    /// instantaneous peak is visible against the envelope.
+    property color waveformPeakColor: "#FCFBF8"
+
+    /// Corner radius for cards/panels. 12px matches the radius used by
+    /// swayosd so voxtype's OSD blends with the rest of an Omarchy
+    /// user's notification stack.
+    property int cornerRadius: 12
+
+    /// Inner padding for OSD cards (px between border and content).
+    property int padding: 14
+
+    /// Distance from the screen edge (px). Mirrors OsdConfig::margin_px.
+    property int marginPx: 24
+
+    /// Default OSD surface width (px). Mirrors OsdConfig::width_px so
+    /// the QML frontend lands at the same size as the GTK4/wgpu ones.
+    property int defaultWidthPx: 400
+
+    /// Default OSD surface height (px). Mirrors OsdConfig::height_px.
+    property int defaultHeightPx: 48
+
+    /// Default background opacity. Mirrors OsdConfig::opacity.
+    property real defaultOpacity: 0.95
+
+    /// Visible waveform window in seconds. Mirrors
+    /// OsdConfig::waveform_window_secs.
+    property real waveformWindowSecs: 3.0
+}

--- a/quickshell/voxtype-shared/qmldir
+++ b/quickshell/voxtype-shared/qmldir
@@ -1,0 +1,5 @@
+module voxtype-shared
+
+singleton Theme 1.0 Theme.qml
+StateReader 1.0 StateReader.qml
+AudioBridge 1.0 AudioBridge.qml


### PR DESCRIPTION
## Summary

Foundation work for v0.7.3 Wave 2 (waveform OSD, engine picker menu, meeting controls panel). This PR doesn't ship a new frontend on its own; it extracts the three concerns every QML frontend will need into a reusable `voxtype-shared` module:

- **`Theme`** (singleton) — color palette and sizing defaults mirrored from `src/osd/visual.rs` (`Palette::fallback`) and `src/osd/config.rs` (`OsdConfig::default`). All values are properties so consumers can override (e.g. an Omarchy theme loader can set `VT.Theme.accentColor = "#6E89C2"` at startup).
- **`StateReader`** — wraps the `FileView` pattern already in the POC. Watches `\$XDG_RUNTIME_DIR/voxtype/state` (with a `/run/user/\$UID` fallback) and exposes `state` plus a `stateChanged(newState)` signal.
- **`AudioBridge`** — spawns the locked-protocol `voxtype-audio-bridge` sidecar via `Quickshell.Io.Process`, parses one NDJSON object per stdout line into `peak` / `rms` / `vad` / `tsMs` properties, and emits `frameReceived` / `connected` / `disconnected` signals. Auto-restarts on crash with a 1s delay so a wedged bridge can't peg CPU.

The OSD POC at `quickshell/voxtype-osd/shell.qml` is refactored to consume all three. Indicator behavior is preserved (state-driven border tint + icon + label). One small UX bonus while wiring up `AudioBridge`: when the daemon is in `recording` and the bridge is connected, the card pulses to 0.78 opacity on VAD=0 frames so "silence while held" reads visually differently from "voice while held." No waveform yet — that's Wave 2.

A `qmldir` registers the module so consumers can `import \"voxtype-shared\" as VT` and reach `VT.Theme.bgColor`, `VT.StateReader { ... }`, `VT.AudioBridge { ... }`.

## What's not in this PR

- The waveform renderer (Wave 2).
- The `voxtype-audio-bridge` sidecar binary itself (parallel agent's branch). The protocol is locked, so this PR can land first.
- An Omarchy theme loader that populates `Theme` properties from `~/.config/omarchy/current/theme/colors.toml`. Trivial follow-up once the QML frontends start using `Theme` for real.

## Test plan

- [ ] Run `qs -p quickshell/voxtype-osd/shell.qml` and confirm no QML errors on startup.
- [ ] With the daemon idle, confirm the OSD card is hidden.
- [ ] Trigger a recording (`voxtype record start`) and confirm the card appears with the red border and \"Recording\" label.
- [ ] Trigger streaming / transcribing transitions and confirm the border tint follows.
- [ ] With the `voxtype-audio-bridge` sidecar in PATH, confirm the recording card visibly pulses on silence vs voice.
- [ ] Without the sidecar in PATH, confirm the card still renders at full opacity (no crash, no flicker).