### PR TITLE
Add Quickshell as a third OSD frontend option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,10 +266,10 @@ name = "voxtype-osd-gtk4"
 path = "src/bin/voxtype_osd_gtk4.rs"
 required-features = ["osd-gtk4"]
 
-# Tiny launcher that picks between voxtype-osd-gtk4 and voxtype-osd-native
-# at runtime based on config/env/CLI. Always built, no GUI deps; falls back
-# to whichever frontend binary it finds on PATH if the preferred one isn't
-# installed.
+# Tiny launcher that picks between voxtype-osd-gtk4, voxtype-osd-native,
+# and voxtype-osd-quickshell at runtime based on config/env/CLI. Always
+# built, no GUI deps; falls back to whichever frontend binary it finds on
+# PATH if the preferred one isn't installed.
 [[bin]]
 name = "voxtype-osd"
 path = "src/bin/voxtype_osd.rs"
@@ -280,6 +280,14 @@ path = "src/bin/voxtype_osd.rs"
 [[bin]]
 name = "voxtype-audio-bridge"
 path = "src/bin/voxtype_audio_bridge.rs"
+
+# Quickshell launcher: finds voxtype's shell.qml and execs `qs -p <path>`.
+# Always built, no GUI deps. Runtime dependency on the system `quickshell`
+# package; the launcher prints a clear remediation message if `qs` is
+# missing.
+[[bin]]
+name = "voxtype-osd-quickshell"
+path = "src/bin/voxtype_osd_quickshell.rs"
 
 [[example]]
 name = "inspect_cohere_onnx"

--- a/src/bin/voxtype_osd.rs
+++ b/src/bin/voxtype_osd.rs
@@ -1,27 +1,29 @@
-//! `voxtype-osd` — a tiny launcher that picks between the `voxtype-osd-gtk4`
-//! and `voxtype-osd-native` frontends and execs the chosen one.
+//! `voxtype-osd` — a tiny launcher that picks between the `voxtype-osd-gtk4`,
+//! `voxtype-osd-native`, and `voxtype-osd-quickshell` frontends and execs
+//! the chosen one.
 //!
 //! The user's preference comes from (in priority order):
 //!
-//! 1. `--frontend gtk4|native` on the command line
-//! 2. `VOXTYPE_OSD_FRONTEND=gtk4|native` env var
-//! 3. `[osd] frontend = "gtk4|native"` in `~/.config/voxtype/config.toml`
+//! 1. `--frontend gtk4|native|quickshell` on the command line
+//! 2. `VOXTYPE_OSD_FRONTEND=gtk4|native|quickshell` env var
+//! 3. `[osd] frontend = "gtk4|native|quickshell"` in `~/.config/voxtype/config.toml`
 //! 4. Default: `gtk4`
 //!
-//! That preference is then reconciled with what's actually installed:
+//! That preference is then reconciled with what's actually installed: the
+//! preferred frontend's binary is searched alongside this launcher and on
+//! `$PATH`; if missing, the launcher tries the other installed frontends
+//! in a fixed fallback order and warns about the substitution. If nothing
+//! is installed at all the launcher exits with a clear error pointing to
+//! the build feature flags.
 //!
-//! - Both binaries available → use the preferred one
-//! - Only one available → use it (warn if it's not the preferred one)
-//! - Neither available → exit with a clear error pointing to the build
-//!   feature flags
-//!
-//! Source builders who only enabled one of `osd-gtk4`/`osd-native` thus
-//! get a working `voxtype-osd` regardless of config — the launcher
-//! adapts to what was actually built.
+//! Source builders who only enabled one of `osd-gtk4`/`osd-native`/
+//! `osd-quickshell` thus get a working `voxtype-osd` regardless of config
+//! — the launcher adapts to what was actually built.
 //!
 //! All other CLI args + env vars pass through unchanged to the chosen
-//! frontend (including `--config`, which both frontends consume on their
-//! own to read the rest of the `[osd]` section).
+//! frontend (including `--config`, which the GTK4 and native frontends
+//! consume on their own to read the rest of the `[osd]` section; the
+//! Quickshell frontend reads the same config via its launcher).
 
 use std::env;
 use std::os::unix::process::CommandExt;
@@ -33,6 +35,7 @@ use voxtype::osd::config::{OsdConfig, OsdFrontend};
 
 const NATIVE_BIN: &str = "voxtype-osd-native";
 const GTK4_BIN: &str = "voxtype-osd-gtk4";
+const QUICKSHELL_BIN: &str = "voxtype-osd-quickshell";
 
 fn main() -> ExitCode {
     tracing_subscriber::fmt()
@@ -70,12 +73,13 @@ fn main() -> ExitCode {
         Some(c) => c,
         None => {
             eprintln!(
-                "voxtype-osd: neither '{NATIVE_BIN}' nor '{GTK4_BIN}' was found on PATH \
-                 or next to this binary.\n\
+                "voxtype-osd: none of '{GTK4_BIN}', '{NATIVE_BIN}', or '{QUICKSHELL_BIN}' \
+                 was found on PATH or next to this binary.\n\
                  \n\
                  If you built from source, enable at least one OSD feature:\n\
-                   cargo build --release --features osd-gtk4    # GTK4 frontend\n\
-                   cargo build --release --features osd-native  # SCTK + wgpu + egui\n\
+                   cargo build --release --features osd-gtk4       # GTK4 frontend\n\
+                   cargo build --release --features osd-native     # SCTK + wgpu + egui\n\
+                   cargo build --release --bin voxtype-osd-quickshell  # Quickshell launcher\n\
                  \n\
                  If you installed a package, the OSD binaries may be a separate\n\
                  optional dependency."
@@ -108,10 +112,11 @@ fn print_help() {
         "voxtype-osd {} — launcher for the on-screen mic visualizer\n\
          \n\
          USAGE:\n    \
-             voxtype-osd [--frontend gtk4|native] [FRONTEND ARGS...]\n\
+             voxtype-osd [--frontend gtk4|native|quickshell] [FRONTEND ARGS...]\n\
          \n\
          OPTIONS:\n    \
-             --frontend <gtk4|native>     Which frontend to launch. Falls back to\n\
+             --frontend <gtk4|native|quickshell>\n    \
+                                          Which frontend to launch. Falls back to\n\
                                           whatever is installed if the preferred\n\
                                           frontend isn't found on PATH.\n    \
              -h, --help                   Show this message.\n    \
@@ -123,7 +128,7 @@ fn print_help() {
          \n\
          CONFIG:\n    \
              [osd]\n    \
-             frontend = \"gtk4\"  # or \"native\"\n\
+             frontend = \"gtk4\"  # or \"native\", \"quickshell\"\n\
          \n\
          ENV:\n    \
              VOXTYPE_OSD_FRONTEND   Same as --frontend.\n    \
@@ -211,22 +216,31 @@ struct ResolvedFrontend {
     path: PathBuf,
 }
 
-/// Find the binary for `preferred`; if missing, fall back to the other
-/// frontend. Returns `None` only if neither binary is installed.
+/// Find the binary for `preferred`; if missing, fall back to the next
+/// available frontend in a fixed order. Quickshell sits at the bottom of
+/// non-Quickshell chains because users who didn't ask for it usually
+/// don't have `qs` installed; conversely a Quickshell user who's missing
+/// their launcher falls back to Gtk4 (the default) before Native.
 fn resolve_installed(preferred: OsdFrontend) -> Option<ResolvedFrontend> {
-    if let Some(path) = find_binary(preferred.binary_name()) {
-        return Some(ResolvedFrontend {
-            frontend: preferred,
-            path,
-        });
-    }
-    let other = match preferred {
-        OsdFrontend::Gtk4 => OsdFrontend::Native,
-        OsdFrontend::Native => OsdFrontend::Gtk4,
+    let chain: [OsdFrontend; 3] = match preferred {
+        OsdFrontend::Gtk4 => [
+            OsdFrontend::Gtk4,
+            OsdFrontend::Native,
+            OsdFrontend::Quickshell,
+        ],
+        OsdFrontend::Native => [
+            OsdFrontend::Native,
+            OsdFrontend::Gtk4,
+            OsdFrontend::Quickshell,
+        ],
+        OsdFrontend::Quickshell => [
+            OsdFrontend::Quickshell,
+            OsdFrontend::Gtk4,
+            OsdFrontend::Native,
+        ],
     };
-    find_binary(other.binary_name()).map(|path| ResolvedFrontend {
-        frontend: other,
-        path,
+    chain.into_iter().find_map(|f| {
+        find_binary(f.binary_name()).map(|path| ResolvedFrontend { frontend: f, path })
     })
 }
 

--- a/src/bin/voxtype_osd_quickshell.rs
+++ b/src/bin/voxtype_osd_quickshell.rs
@@ -1,0 +1,227 @@
+//! `voxtype-osd-quickshell` — a tiny launcher that finds voxtype's Quickshell
+//! OSD entry point (`shell.qml`) and execs `qs -p <path>`.
+//!
+//! Quickshell (`qs`) is the runtime; voxtype ships its QML shell tree
+//! under one of the standard data directories. The launcher resolves
+//! the shell path in this order:
+//!
+//! 1. `--qml-path <PATH>` on the command line
+//! 2. `VOXTYPE_OSD_QML_PATH` env var
+//! 3. `$XDG_DATA_HOME/voxtype/quickshell/voxtype-osd/shell.qml`
+//! 4. `~/.local/share/voxtype/quickshell/voxtype-osd/shell.qml`
+//! 5. `/usr/share/voxtype/quickshell/voxtype-osd/shell.qml`
+//! 6. `quickshell/voxtype-osd/shell.qml` relative to the current directory
+//!    (development convenience when running from the repo root)
+//!
+//! All other CLI arguments pass through to `qs` unchanged.
+//!
+//! Exit codes:
+//! - 2: Quickshell (`qs`) not found on PATH.
+//! - 3: No shell.qml found at any of the resolved paths.
+//! - 1: exec of `qs` failed for some other reason.
+
+use std::env;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+const QS_BIN: &str = "qs";
+const SHELL_FILE: &str = "shell.qml";
+const SHELL_SUBPATH: &str = "voxtype/quickshell/voxtype-osd/shell.qml";
+
+fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let raw_args: Vec<String> = env::args().skip(1).collect();
+    if raw_args.iter().any(|a| a == "--help" || a == "-h") {
+        print_help();
+        return ExitCode::SUCCESS;
+    }
+    if raw_args.iter().any(|a| a == "--version" || a == "-V") {
+        println!("voxtype-osd-quickshell {}", env!("CARGO_PKG_VERSION"));
+        return ExitCode::SUCCESS;
+    }
+
+    let (cli_qml_path, rest) = parse_qml_path(&raw_args);
+
+    let qml_path = match resolve_qml_path(cli_qml_path) {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "voxtype-osd-quickshell: could not find '{SHELL_FILE}' for the Quickshell OSD.\n\
+                 \n\
+                 Searched:\n    \
+                     --qml-path <PATH>\n    \
+                     $VOXTYPE_OSD_QML_PATH\n    \
+                     $XDG_DATA_HOME/{SHELL_SUBPATH}\n    \
+                     ~/.local/share/{SHELL_SUBPATH}\n    \
+                     /usr/share/{SHELL_SUBPATH}\n    \
+                     ./quickshell/voxtype-osd/{SHELL_FILE}\n\
+                 \n\
+                 Install voxtype's Quickshell files (e.g. `voxtype setup quickshell`)\n\
+                 or pass `--qml-path /path/to/shell.qml` explicitly."
+            );
+            return ExitCode::from(3);
+        }
+    };
+
+    if which::which(QS_BIN).is_err() {
+        eprintln!(
+            "voxtype-osd-quickshell: '{QS_BIN}' (Quickshell) is not installed on PATH.\n\
+             \n\
+             Install it from your distro's package manager:\n    \
+                 sudo pacman -S quickshell        # Arch / Omarchy\n    \
+                 nix profile install nixpkgs#quickshell  # NixOS\n\
+             \n\
+             Or switch to a different OSD frontend:\n    \
+                 voxtype config set osd.frontend gtk4"
+        );
+        return ExitCode::from(2);
+    }
+
+    tracing::info!(
+        qml = %qml_path.display(),
+        "launching Quickshell OSD"
+    );
+
+    let mut cmd = Command::new(QS_BIN);
+    cmd.arg("-p").arg(&qml_path).args(&rest);
+    let err = cmd.exec();
+    eprintln!(
+        "voxtype-osd-quickshell: failed to exec '{QS_BIN}' with shell '{}': {err}",
+        qml_path.display()
+    );
+    ExitCode::from(1)
+}
+
+fn print_help() {
+    println!(
+        "voxtype-osd-quickshell {} — launcher for the Quickshell-based voxtype OSD\n\
+         \n\
+         USAGE:\n    \
+             voxtype-osd-quickshell [--qml-path PATH] [QUICKSHELL ARGS...]\n\
+         \n\
+         OPTIONS:\n    \
+             --qml-path <PATH>    Override the shell.qml path. Default is to\n\
+                                  search standard data dirs.\n    \
+             -h, --help           Show this message.\n    \
+             -V, --version        Show version.\n\
+         \n\
+         All other arguments are forwarded to `qs` after `-p <shell.qml>`.\n\
+         \n\
+         ENV:\n    \
+             VOXTYPE_OSD_QML_PATH   Same as --qml-path.\n",
+        env!("CARGO_PKG_VERSION"),
+    );
+}
+
+/// Strip `--qml-path X`/`--qml-path=X` out of `args`. Anything left over
+/// is passed through to `qs` unchanged.
+fn parse_qml_path(args: &[String]) -> (Option<PathBuf>, Vec<String>) {
+    let mut qml: Option<PathBuf> = None;
+    let mut rest: Vec<String> = Vec::with_capacity(args.len());
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        if a == "--qml-path" {
+            if let Some(v) = args.get(i + 1) {
+                qml = Some(PathBuf::from(v));
+                i += 2;
+                continue;
+            }
+            rest.push(a.clone());
+            i += 1;
+        } else if let Some(v) = a.strip_prefix("--qml-path=") {
+            qml = Some(PathBuf::from(v));
+            i += 1;
+        } else {
+            rest.push(a.clone());
+            i += 1;
+        }
+    }
+    (qml, rest)
+}
+
+fn resolve_qml_path(cli: Option<PathBuf>) -> Option<PathBuf> {
+    if let Some(p) = cli.filter(|p| p.is_file()) {
+        return Some(p);
+    }
+    if let Ok(env_path) = env::var("VOXTYPE_OSD_QML_PATH") {
+        let p = PathBuf::from(env_path);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    for base in candidate_data_dirs() {
+        let candidate = base.join(SHELL_SUBPATH);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    // Development convenience: running `cargo run --bin voxtype-osd-quickshell`
+    // from the repo root should find the QML tree without installing.
+    let dev_candidate = Path::new("quickshell/voxtype-osd").join(SHELL_FILE);
+    if dev_candidate.is_file() {
+        return Some(dev_candidate);
+    }
+    None
+}
+
+fn candidate_data_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(xdg) = env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            dirs.push(PathBuf::from(xdg));
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        dirs.push(home.join(".local/share"));
+    }
+    dirs.push(PathBuf::from("/usr/share"));
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_qml_path_space_form() {
+        let args = vec!["--qml-path".into(), "/tmp/x.qml".into(), "extra".into()];
+        let (q, rest) = parse_qml_path(&args);
+        assert_eq!(q.as_deref(), Some(Path::new("/tmp/x.qml")));
+        assert_eq!(rest, vec!["extra".to_string()]);
+    }
+
+    #[test]
+    fn parse_qml_path_equals_form() {
+        let args = vec!["--qml-path=/tmp/y.qml".into(), "extra".into()];
+        let (q, rest) = parse_qml_path(&args);
+        assert_eq!(q.as_deref(), Some(Path::new("/tmp/y.qml")));
+        assert_eq!(rest, vec!["extra".to_string()]);
+    }
+
+    #[test]
+    fn parse_qml_path_absent() {
+        let args = vec!["--width-px".into(), "400".into()];
+        let (q, rest) = parse_qml_path(&args);
+        assert!(q.is_none());
+        assert_eq!(rest, vec!["--width-px".to_string(), "400".to_string()]);
+    }
+
+    #[test]
+    fn parse_qml_path_dangling_flag() {
+        let args = vec!["--qml-path".into()];
+        let (q, rest) = parse_qml_path(&args);
+        // Dangling `--qml-path` with no value is passed through so the
+        // child (which won't recognise it) errors out clearly rather than
+        // being silently dropped.
+        assert!(q.is_none());
+        assert_eq!(rest, vec!["--qml-path".to_string()]);
+    }
+}

--- a/src/osd/config.rs
+++ b/src/osd/config.rs
@@ -23,16 +23,18 @@ pub enum OsdPosition {
 ///
 /// The wrapper treats this as a *preference*: if the chosen frontend's
 /// binary isn't on PATH (e.g. the user built voxtype with only one of
-/// `osd-gtk4`/`osd-native`), the wrapper falls back to whichever it can
-/// find and logs a warning. Default is `Gtk4` because GTK4 ships with
-/// most Hyprland setups already (Omarchy pulls it in via swayosd, walker,
-/// etc.) so there's no extra runtime cost for the typical user.
+/// `osd-gtk4`/`osd-native`/`osd-quickshell`), the wrapper falls back to
+/// whichever it can find and logs a warning. Default is `Gtk4` because
+/// GTK4 ships with most Hyprland setups already (Omarchy pulls it in via
+/// swayosd, walker, etc.) so there's no extra runtime cost for the
+/// typical user.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum OsdFrontend {
     #[default]
     Gtk4,
     Native,
+    Quickshell,
 }
 
 impl OsdFrontend {
@@ -42,6 +44,7 @@ impl OsdFrontend {
         match self {
             OsdFrontend::Gtk4 => "voxtype-osd-gtk4",
             OsdFrontend::Native => "voxtype-osd-native",
+            OsdFrontend::Quickshell => "voxtype-osd-quickshell",
         }
     }
 
@@ -49,6 +52,7 @@ impl OsdFrontend {
         match s.trim().to_ascii_lowercase().as_str() {
             "gtk4" | "gtk" => Some(OsdFrontend::Gtk4),
             "native" | "wgpu" | "egui" => Some(OsdFrontend::Native),
+            "quickshell" | "qml" | "qs" => Some(OsdFrontend::Quickshell),
             _ => None,
         }
     }
@@ -151,6 +155,10 @@ mod tests {
     fn frontend_binary_names() {
         assert_eq!(OsdFrontend::Gtk4.binary_name(), "voxtype-osd-gtk4");
         assert_eq!(OsdFrontend::Native.binary_name(), "voxtype-osd-native");
+        assert_eq!(
+            OsdFrontend::Quickshell.binary_name(),
+            "voxtype-osd-quickshell"
+        );
     }
 
     #[test]
@@ -160,6 +168,12 @@ mod tests {
         assert_eq!(OsdFrontend::parse_str("native"), Some(OsdFrontend::Native));
         assert_eq!(OsdFrontend::parse_str("wgpu"), Some(OsdFrontend::Native));
         assert_eq!(OsdFrontend::parse_str("egui"), Some(OsdFrontend::Native));
+        assert_eq!(
+            OsdFrontend::parse_str("quickshell"),
+            Some(OsdFrontend::Quickshell)
+        );
+        assert_eq!(OsdFrontend::parse_str("qml"), Some(OsdFrontend::Quickshell));
+        assert_eq!(OsdFrontend::parse_str("QS"), Some(OsdFrontend::Quickshell));
         assert_eq!(OsdFrontend::parse_str("nope"), None);
     }
 
@@ -169,6 +183,8 @@ mod tests {
         assert_eq!(v, OsdFrontend::Gtk4);
         let v: OsdFrontend = serde_json::from_str("\"native\"").unwrap();
         assert_eq!(v, OsdFrontend::Native);
+        let v: OsdFrontend = serde_json::from_str("\"quickshell\"").unwrap();
+        assert_eq!(v, OsdFrontend::Quickshell);
     }
 
     #[test]


### PR DESCRIPTION
Foundation piece for the v0.7.3 Quickshell-native OSD work (Wave 1 of Part B in the v0.7.3 plan). Adds a third variant to `OsdFrontend` and ships a tiny launcher binary that finds voxtype's `shell.qml` and execs `qs -p <path>`.

## What changed

- `src/osd/config.rs` — new `OsdFrontend::Quickshell` variant. `parse_str` accepts `quickshell`, `qml`, `qs`. Tests cover the new aliases.
- `src/bin/voxtype_osd_quickshell.rs` — new launcher. Searches for `shell.qml` via `--qml-path`, `VOXTYPE_OSD_QML_PATH`, `$XDG_DATA_HOME/voxtype/quickshell/voxtype-osd/`, `~/.local/share/...`, `/usr/share/...`, then `./quickshell/voxtype-osd/` (dev convenience). Prints a clear remediation message if `qs` isn't installed.
- `src/bin/voxtype_osd.rs` — top-level dispatcher learns about the third frontend. Fallback chains: Quickshell → Gtk4 → Native, Gtk4 → Native → Quickshell, Native → Gtk4 → Quickshell. Quickshell sits last for non-Quickshell users so existing installs are unaffected.
- `Cargo.toml` — `[[bin]]` entry for `voxtype-osd-quickshell`. Always built, no GUI dependency.

## Notes

- The QML shell tree itself ships in follow-up PRs (shared modules — separate PR in flight; waveform OSD — Wave 2).
- No config file migration is needed: existing `[osd] frontend = "gtk4"` users stay on GTK4. Setting `frontend = "quickshell"` requires both the launcher (this PR) and the QML tree (later PRs) installed.
- Runtime dependency on the system `quickshell` package; the launcher exits with code 2 and a helpful message if `qs` is missing on PATH.

Part of the v0.7.3 Quickshell agenda. Refs the v0.7.3 project notes; closes nothing on its own.