### PR TITLE
Add Quickshell waveform OSD with scrolling envelope and peak meter

### DIFF
--- a/quickshell/OsdSurface.qml
+++ b/quickshell/OsdSurface.qml
@@ -1,0 +1,252 @@
+// Voxtype on-screen display surface (Quickshell frontend).
+//
+// Renders a glassy card with:
+//   - State icon + tint (recording / streaming / transcribing)
+//   - Scrolling waveform of recent mic peaks (3-second window, 100 Hz)
+//   - Peak meter bar with held-peak tick (-60 dB floor, color zones at
+//     -12 and -3 dBFS to match the GTK4 and native frontends)
+//
+// Driven entirely from a parent-provided AudioBridge: the parent is
+// expected to subscribe to AudioBridge once and pass it in via the
+// `audio` property so the OsdSurface, EnginePicker, and MeetingControls
+// share one sidecar process rather than each spawning their own.
+//
+// Visibility follows `daemonState`: hidden when idle/empty, shown
+// otherwise. The component is layered as a WlrLayer.Overlay surface so
+// it floats above all other windows without taking input focus.
+
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import "voxtype-shared" as VT
+
+PanelWindow {
+    id: panel
+
+    /// Current daemon state: idle / recording / streaming / transcribing.
+    /// Wired by the parent (typically from VT.StateReader.state).
+    property string daemonState: "idle"
+
+    /// The audio bridge instance whose frameReceived signal drives the
+    /// waveform. Passed in by the parent so it's shared with sibling
+    /// widgets that also want VAD / peak data.
+    property var audio: null
+
+    visible: daemonState !== "idle" && daemonState !== ""
+    anchors {
+        top: true
+        bottom: true
+        left: true
+        right: true
+    }
+    color: "transparent"
+
+    WlrLayershell.namespace: "voxtype-osd"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+    exclusionMode: ExclusionMode.Ignore
+
+    // Per-state tint, shared by icon + card border so a Hyprland user
+    // can read the daemon's state from screen-edge color alone.
+    readonly property color stateColor:
+        daemonState === "recording"    ? VT.Theme.recordingColor
+      : daemonState === "streaming"    ? VT.Theme.streamingColor
+      : daemonState === "transcribing" ? VT.Theme.transcribingColor
+      :                                  VT.Theme.idleColor
+
+    // Ring of recent per-frame peaks (0.0..1.0). Capacity = 3 s @ 100 Hz.
+    // Stored as a plain array; we shift() when full to keep newest-on-right.
+    readonly property int waveformColumns: Math.round(VT.Theme.waveformWindowSecs * 100)
+    property var ring: []
+
+    // Peak meter state (kept in dBFS so the held-peak decay math matches
+    // src/osd/visual.rs's PeakHold verbatim).
+    property real currentPeakDbfs: -120
+    property real heldDbfs: -120
+    property real lastFrameTsMs: 0
+
+    function _resetMeters() {
+        ring = [];
+        currentPeakDbfs = -120;
+        heldDbfs = -120;
+        lastFrameTsMs = 0;
+        waveCanvas.requestPaint();
+        meterCanvas.requestPaint();
+    }
+
+    Connections {
+        target: panel.audio
+        enabled: panel.audio !== null
+        function onFrameReceived(peak, rms, vad, tsMs) {
+            // Push the new peak onto the ring; drop the oldest when full.
+            const r = panel.ring.slice();
+            r.push(peak);
+            while (r.length > panel.waveformColumns) {
+                r.shift();
+            }
+            panel.ring = r;
+
+            // dBFS from linear peak. Floor at -120 to match visual.rs's
+            // PeakHold::held_dbfs sentinel for "effectively silent".
+            const dbfs = peak > 0.0 ? 20 * Math.log10(peak) : -120;
+            panel.currentPeakDbfs = dbfs;
+
+            // Held-peak: snap up on a louder peak, otherwise decay at
+            // peakDecayDbPerSec. dt comes from the frame timestamps so
+            // a paused daemon (no frames) doesn't unrealistically decay
+            // before we receive the next frame.
+            const dtMs = panel.lastFrameTsMs > 0
+                ? Math.max(0, tsMs - panel.lastFrameTsMs)
+                : 10;
+            panel.lastFrameTsMs = tsMs;
+            const dt = dtMs / 1000;
+            if (dbfs > panel.heldDbfs) {
+                panel.heldDbfs = dbfs;
+            } else {
+                const decayed = panel.heldDbfs - VT.Theme.peakDecayDbPerSec * dt;
+                panel.heldDbfs = decayed < -120 ? -120 : decayed;
+            }
+
+            waveCanvas.requestPaint();
+            meterCanvas.requestPaint();
+        }
+        function onDisconnected() {
+            panel._resetMeters();
+        }
+    }
+
+    // Clear when the daemon's state moves out of recording so the
+    // waveform doesn't show stale audio from the previous recording on
+    // the next one.
+    onDaemonStateChanged: {
+        if (daemonState === "idle" || daemonState === "") {
+            _resetMeters();
+        }
+    }
+
+    Rectangle {
+        id: card
+        width: VT.Theme.defaultWidthPx
+        height: 72
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 72
+        radius: VT.Theme.cornerRadius
+        color: VT.Theme.bgColor
+        border.width: 2
+        border.color: panel.stateColor
+        opacity: (panel.daemonState === "recording" && panel.audio && panel.audio.running && !panel.audio.vad)
+                 ? 0.78 : 1.0
+        Behavior on opacity { NumberAnimation { duration: 120 } }
+
+        Row {
+            anchors.fill: parent
+            anchors.leftMargin: VT.Theme.padding
+            anchors.rightMargin: VT.Theme.padding
+            spacing: 10
+
+            Text {
+                width: 28
+                anchors.verticalCenter: parent.verticalCenter
+                horizontalAlignment: Text.AlignHCenter
+                text: panel.daemonState === "recording"    ? "󰍬"
+                   : panel.daemonState === "streaming"     ? "󰜟"
+                   : panel.daemonState === "transcribing"  ? "󰔟"
+                   :                                          "󰍬"
+                font.family: "JetBrainsMono Nerd Font"
+                font.pixelSize: 26
+                color: panel.stateColor
+            }
+
+            Column {
+                width: card.width - 28 - 2 * VT.Theme.padding - 10
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 4
+
+                Canvas {
+                    id: waveCanvas
+                    width: parent.width
+                    height: 36
+
+                    onPaint: {
+                        const ctx = getContext("2d");
+                        ctx.clearRect(0, 0, width, height);
+                        const r = panel.ring;
+                        if (r.length === 0) {
+                            return;
+                        }
+
+                        const cy = height / 2;
+                        const maxHalf = height / 2 - 1;
+                        const cols = panel.waveformColumns;
+                        const colW = width / cols;
+                        // Empty columns on the left when the ring isn't
+                        // full yet, so newest data lands flush against
+                        // the right edge.
+                        const startIdx = cols - r.length;
+
+                        ctx.strokeStyle = VT.Theme.waveformColor;
+                        ctx.lineWidth = Math.max(1, colW);
+                        ctx.lineCap = "butt";
+                        ctx.beginPath();
+                        for (let i = 0; i < r.length; i++) {
+                            const x = (startIdx + i) * colW + colW / 2;
+                            const halfH = Math.min(
+                                maxHalf,
+                                r[i] * maxHalf * VT.Theme.waveformGain
+                            );
+                            ctx.moveTo(x, cy - halfH);
+                            ctx.lineTo(x, cy + halfH);
+                        }
+                        ctx.stroke();
+                    }
+                }
+
+                Canvas {
+                    id: meterCanvas
+                    width: parent.width
+                    height: 6
+
+                    onPaint: {
+                        const ctx = getContext("2d");
+                        ctx.clearRect(0, 0, width, height);
+
+                        const floor = VT.Theme.meterFloorDbfs;
+                        const span = -floor;
+
+                        // Current peak → fill width
+                        let fill = 0;
+                        if (panel.currentPeakDbfs > floor) {
+                            const clipped = Math.min(panel.currentPeakDbfs, 0);
+                            fill = Math.max(0, Math.min(1, (clipped - floor) / span));
+                        }
+
+                        // Zone color matches src/osd/visual.rs::MeterZone.
+                        let zone = VT.Theme.meterLowColor;
+                        if (panel.currentPeakDbfs >= -3) {
+                            zone = VT.Theme.meterHighColor;
+                        } else if (panel.currentPeakDbfs >= -12) {
+                            zone = VT.Theme.meterMidColor;
+                        }
+
+                        ctx.fillStyle = zone;
+                        ctx.fillRect(0, 0, width * fill, height);
+
+                        // Held-peak tick. Skip if floor or below so the
+                        // tick doesn't pin to the left edge during silence.
+                        if (panel.heldDbfs > floor) {
+                            const clippedHeld = Math.min(panel.heldDbfs, 0);
+                            const heldFill = Math.max(0, Math.min(1,
+                                (clippedHeld - floor) / span));
+                            ctx.fillStyle = VT.Theme.waveformPeakColor;
+                            ctx.fillRect(
+                                Math.max(0, width * heldFill - 1),
+                                0, 2, height
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/quickshell/shell.qml
+++ b/quickshell/shell.qml
@@ -5,109 +5,37 @@
 //
 // Quickshell treats this file as the entry of a config directory. The
 // shared theme/state/audio modules live at `voxtype-shared/` (sibling
-// dir) so the relative import below resolves inside Quickshell's qrc
-// virtual fs; an earlier layout placed shell.qml in a subdirectory and
-// the `../voxtype-shared` traversal landed in `qrc:/qs-blackhole`.
+// dir).
 //
-// Wave 2 components (engine picker, meeting controls) will be added as
-// additional .qml files in this same directory and composed into
-// `ShellRoot` below.
+// This file is intentionally thin: each Wave 2 feature is its own QML
+// component (OsdSurface, EnginePicker, MeetingControls) and `ShellRoot`
+// is just the composition root that wires the shared state and audio
+// bridges into each one. Adding a new widget = drop a new .qml file in
+// this directory and instantiate it below.
 //
-// Reads the daemon's state file at $XDG_RUNTIME_DIR/voxtype/state, which
-// contains exactly one of: idle, recording, streaming, transcribing.
+// State is sourced from the daemon's state file at
+// $XDG_RUNTIME_DIR/voxtype/state. Audio frames are sourced from the
+// `voxtype-audio-bridge` sidecar which reads
+// $XDG_RUNTIME_DIR/voxtype/audio.sock and emits NDJSON on stdout.
 
 import QtQuick
 import Quickshell
-import Quickshell.Wayland
 import "voxtype-shared" as VT
 
 ShellRoot {
     id: shell
 
-    // State is sourced from the shared StateReader so the engine picker
-    // and meeting-controls frontends can subscribe to the same source.
     VT.StateReader {
         id: stateReader
     }
 
-    // Wire the audio bridge even though the POC doesn't render a
-    // waveform yet — letting the indicator pulse on VAD makes
-    // "recording but silent" visually distinct from "recording with
-    // voice", which is a nice quality-of-life cue before the full
-    // waveform lands in Wave 2.
     VT.AudioBridge {
         id: audio
     }
 
-    // The OSD surface itself. Hidden when state is idle; visible otherwise.
-    PanelWindow {
-        id: panel
-        visible: stateReader.state !== "idle" && stateReader.state !== ""
-        anchors { top: true; bottom: true; left: true; right: true }
-        color: "transparent"
-
-        WlrLayershell.namespace: "voxtype-osd"
-        WlrLayershell.layer: WlrLayer.Overlay
-        WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
-        exclusionMode: ExclusionMode.Ignore
-
-        Rectangle {
-            id: card
-            width: 220
-            height: 56
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: 72
-            radius: VT.Theme.cornerRadius
-            color: VT.Theme.bgColor
-            border.width: 2
-
-            // Per-state border tint so a Hyprland user can glance at the
-            // edge of a screen and know whether voxtype is recording vs
-            // streaming vs transcribing without reading the label.
-            border.color: stateReader.state === "recording"    ? VT.Theme.recordingColor
-                       : stateReader.state === "streaming"     ? VT.Theme.streamingColor
-                       : stateReader.state === "transcribing"  ? VT.Theme.transcribingColor
-                       :                                         VT.Theme.idleColor
-
-            // Subtle opacity pulse on VAD=1 while recording. When the
-            // bridge isn't running yet (or the daemon hasn't opened
-            // the audio socket) we fall back to full opacity so the
-            // indicator never disappears unexpectedly.
-            opacity: (stateReader.state === "recording" && audio.running && !audio.vad) ? 0.78 : 1.0
-            Behavior on opacity { NumberAnimation { duration: 120 } }
-
-            Row {
-                anchors.fill: parent
-                anchors.leftMargin: VT.Theme.padding
-                anchors.rightMargin: VT.Theme.padding
-                spacing: 12
-
-                Text {
-                    width: 28
-                    anchors.verticalCenter: parent.verticalCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    text: stateReader.state === "recording"    ? "󰍬"
-                       : stateReader.state === "streaming"     ? "󰜟"
-                       : stateReader.state === "transcribing"  ? "󰔟"
-                       :                                          "󰍬"
-                    font.family: "JetBrainsMono Nerd Font"
-                    font.pixelSize: 26
-                    color: card.border.color
-                }
-
-                Text {
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: stateReader.state === "recording"    ? "Recording"
-                       : stateReader.state === "streaming"     ? "Streaming live"
-                       : stateReader.state === "transcribing"  ? "Transcribing"
-                       :                                         stateReader.state
-                    font.family: "JetBrainsMono Nerd Font"
-                    font.bold: true
-                    font.pixelSize: 14
-                    color: VT.Theme.textColor
-                }
-            }
-        }
+    OsdSurface {
+        id: osd
+        daemonState: stateReader.state
+        audio: audio
     }
 }

--- a/quickshell/voxtype-shared/Theme.qml
+++ b/quickshell/voxtype-shared/Theme.qml
@@ -54,6 +54,16 @@ QtObject {
     /// instantaneous peak is visible against the envelope.
     property color waveformPeakColor: "#FCFBF8"
 
+    /// Peak meter "safe" zone (-inf..-12 dBFS). Mirrors the GTK4/native
+    /// OSD's MeterZone::Low.
+    property color meterLowColor: Qt.rgba(0.30, 0.85, 0.45, 1.0)
+
+    /// Peak meter "warning" zone (-12..-3 dBFS). Mirrors MeterZone::Mid.
+    property color meterMidColor: Qt.rgba(0.95, 0.80, 0.30, 1.0)
+
+    /// Peak meter "danger" zone (-3..0 dBFS). Mirrors MeterZone::High.
+    property color meterHighColor: Qt.rgba(0.95, 0.35, 0.30, 1.0)
+
     /// Corner radius for cards/panels. 12px matches the radius used by
     /// swayosd so voxtype's OSD blends with the rest of an Omarchy
     /// user's notification stack.
@@ -78,4 +88,20 @@ QtObject {
     /// Visible waveform window in seconds. Mirrors
     /// OsdConfig::waveform_window_secs.
     property real waveformWindowSecs: 3.0
+
+    /// Held-peak decay rate (dB/sec). Mirrors
+    /// OsdConfig::peak_decay_db_per_sec; the held tick on the peak
+    /// meter snaps up to the current peak then linearly decays at this
+    /// rate while the signal sits below it.
+    property real peakDecayDbPerSec: 6.0
+
+    /// Visual gain applied to per-frame peak before drawing the
+    /// waveform envelope. Mic-level voice peaks around 0.1..0.3 of
+    /// full-scale, so the gain scales the envelope up to fill the
+    /// available canvas height. Mirrors OsdConfig::waveform_gain.
+    property real waveformGain: 10.0
+
+    /// dBFS floor for the peak meter. Anything quieter renders as an
+    /// empty bar. -60 dB matches the GTK4/native frontends.
+    property real meterFloorDbfs: -60.0
 }


### PR DESCRIPTION
W2-A of the v0.7.3 Quickshell wave. Extracts the OSD surface from \`shell.qml\` into its own \`OsdSurface.qml\` component and adds the scrolling waveform + peak meter visualizer that the GTK4 and native frontends already ship.

## What it draws

The OSD card now shows three things side by side:

1. **State icon** in the per-state tint (existing).
2. **Scrolling waveform.** 3-second window at 100 Hz (300 columns). Each column is a vertical line from \`-peak\` to \`+peak\` around the canvas centerline. Newest-on-right; empty columns pad the left while the ring fills.
3. **Peak meter bar** with held-peak tick. Same dBFS floor (-60), same zone boundaries (-12 / -3 dBFS), same colors as \`src/osd/visual.rs::MeterZone\`. Held-peak snaps up instantly and decays at 6 dB/sec, matching \`PeakHold::update\` verbatim. \`dt\` comes from the bridge's \`ts_ms\` so a paused daemon doesn't drain the held peak unrealistically between frames.

## Why the QML uses peak instead of min/max

\`src/osd/visual.rs::project_envelope\` reads min/max per audio frame. The audio bridge sidecar (W1-A) only exposes \`peak\`, \`rms\`, and \`vad\` on its NDJSON output, so the QML side draws a symmetric envelope (\`-peak..+peak\` around the centerline) rather than asymmetric min/max. For voice signals these are visually equivalent and the QML doesn't have to do audio-decoding math. If we later expose true min/max on the wire it's a one-line change to the canvas paint loop.

## Theme additions

\`Theme.qml\` gains:
- \`meterLowColor\`, \`meterMidColor\`, \`meterHighColor\` (the three zone colors)
- \`peakDecayDbPerSec\` (default 6.0)
- \`waveformGain\` (default 10.0)
- \`meterFloorDbfs\` (default -60.0)

All defaults mirror \`src/osd/visual.rs\` and \`src/osd/config.rs\` so the QML frontend lands at parity with the GTK4/native ones. Future Omarchy theme-color loader can override any of them.

## Composition refactor

\`shell.qml\` is now the composition root only:

\`\`\`qml
ShellRoot {
    VT.StateReader { id: stateReader }
    VT.AudioBridge { id: audio }
    OsdSurface {
        daemonState: stateReader.state
        audio: audio
    }
}
\`\`\`

This keeps the entry point readable as more widgets land. The MeetingControls (#380) and the deferred EnginePicker will follow the same property-injection pattern, so all three widgets share one StateReader and one AudioBridge.

## Smoke

\`qs -p quickshell\` runs clean for 4+ seconds with no ERROR / WARN. \`cargo fmt\`, \`cargo clippy --all-targets --no-deps -- -D warnings\`, and the \`osd::config\` test suite all pass.

Refs the v0.7.3 Quickshell scope (memory note); closes nothing on its own.