### PR TITLE
Fix compiled_features() under-reporting ONNX engines (#383)

### DIFF
--- a/src/setup/binary.rs
+++ b/src/setup/binary.rs
@@ -626,11 +626,50 @@ fn variant_gpu_available(v: Variant, g: &Gpus) -> bool {
     }
 }
 
+/// Enumerate Cargo features compiled into the running binary.
+///
+/// Drives the "Features:" line in `voxtype info variants`, the same field
+/// in the TUI's General and Engine inventory panes, and the source-build
+/// engine-validation warning at `src/tui/engine.rs::refresh_binary_match`.
+///
+/// **When adding a new engine or capability feature, add it here too.**
+/// The previous version of this function only enumerated `parakeet` and
+/// the four GPU backends; the six ONNX engines and `ml-diarization`
+/// silently disappeared from every display, and the source-build engine
+/// validator emitted a spurious "rebuild voxtype with the corresponding
+/// Cargo feature for this engine" warning when a user picked an engine
+/// that was actually compiled in (#383).
 pub fn compiled_features() -> Vec<&'static str> {
     let mut f = Vec::new();
+    // ASR engines. Whisper is unconditional and not a Cargo feature, so
+    // it never appears here; only optional engines are listed.
     if cfg!(feature = "parakeet") {
         f.push("parakeet");
     }
+    if cfg!(feature = "moonshine") {
+        f.push("moonshine");
+    }
+    if cfg!(feature = "sensevoice") {
+        f.push("sensevoice");
+    }
+    if cfg!(feature = "paraformer") {
+        f.push("paraformer");
+    }
+    if cfg!(feature = "dolphin") {
+        f.push("dolphin");
+    }
+    if cfg!(feature = "omnilingual") {
+        f.push("omnilingual");
+    }
+    if cfg!(feature = "cohere") {
+        f.push("cohere");
+    }
+    // Meeting-mode capability: ML-based speaker diarization (ECAPA-TDNN).
+    // When absent, meeting mode falls back to source-based attribution.
+    if cfg!(feature = "ml-diarization") {
+        f.push("ml-diarization");
+    }
+    // GPU acceleration backends
     if cfg!(feature = "gpu-vulkan") {
         f.push("gpu-vulkan");
     }
@@ -642,6 +681,15 @@ pub fn compiled_features() -> Vec<&'static str> {
     }
     if cfg!(feature = "gpu-metal") {
         f.push("gpu-metal");
+    }
+    // OSD frontends. Affects whether `voxtype-osd-gtk4` and
+    // `voxtype-osd-native` are present in the build. (The Quickshell
+    // launcher binary is unconditional and has no Cargo feature.)
+    if cfg!(feature = "osd-native") {
+        f.push("osd-native");
+    }
+    if cfg!(feature = "osd-gtk4") {
+        f.push("osd-gtk4");
     }
     f
 }
@@ -908,5 +956,47 @@ mod tests {
             InstallKind::Package | InstallKind::Source
         ));
         let _ = inv.recommendation;
+    }
+
+    /// Regression test for #383: `compiled_features()` previously omitted
+    /// the six ONNX engines and `ml-diarization`. The bug was visible to
+    /// users in `voxtype info variants` and the TUI inventory panes, and
+    /// caused the source-build engine validator to spuriously warn about
+    /// engines that were actually compiled in.
+    ///
+    /// This test asserts the contract: every Cargo feature checked below
+    /// must appear in the returned vec when its `cfg!` is true at test
+    /// compile time. CI runs the test under several feature sets so a
+    /// future omission shows up immediately.
+    #[test]
+    fn compiled_features_enumerates_all_optional_features() {
+        let f = compiled_features();
+        macro_rules! require_feature_listed {
+            ($name:literal) => {
+                if cfg!(feature = $name) {
+                    assert!(
+                        f.contains(&$name),
+                        "compiled_features() omitted `{}` (regression of #383); \
+                         add the corresponding `if cfg!(feature = \"{}\")` arm",
+                        $name,
+                        $name
+                    );
+                }
+            };
+        }
+        require_feature_listed!("parakeet");
+        require_feature_listed!("moonshine");
+        require_feature_listed!("sensevoice");
+        require_feature_listed!("paraformer");
+        require_feature_listed!("dolphin");
+        require_feature_listed!("omnilingual");
+        require_feature_listed!("cohere");
+        require_feature_listed!("ml-diarization");
+        require_feature_listed!("gpu-vulkan");
+        require_feature_listed!("gpu-cuda");
+        require_feature_listed!("gpu-hipblas");
+        require_feature_listed!("gpu-metal");
+        require_feature_listed!("osd-native");
+        require_feature_listed!("osd-gtk4");
     }
 }


### PR DESCRIPTION
Closes #383.

\`src/setup/binary.rs::compiled_features()\` only enumerated \`parakeet\` and the four GPU backends. The six ONNX engines (moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere) and \`ml-diarization\` were silently dropped from every display + the source-build engine validator.

## Verification on \`voxtype-onnx-migraphx\` (before this PR)

\`\`\`
Voxtype install
  Binary:        /usr/lib/voxtype/migraphx/voxtype-onnx-migraphx
  Install kind:  package
  Features:      parakeet
\`\`\`

Six ONNX engines and ml-diarization compiled in — none listed.

## What's in the fix

- Extend the helper to enumerate parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, ml-diarization, all four \`gpu-*\` backends, and the two \`osd-*\` frontends.
- Add a regression test (\`compiled_features_enumerates_all_optional_features\`) that asserts every feature checked by the helper appears in the returned vec when its \`cfg!\` is true at test compile time. CI's per-variant builds enable feature subsets, so a future omission shows up immediately.
- Add a function-level doc comment naming this as the source of truth and pointing future contributors to add new features here.

## What this DOESN'T touch

- \`src/tui/engine.rs::refresh_binary_match\` still uses \`inv.compiled_features.contains(...)\`. With this fix, the lookup now returns the right answer; the spurious "rebuild for engine X" warning on source builds is gone as a side effect.
- The \`voxtype config set engine\` CLI in #382 continues to use \`cfg!(feature = ...)\` directly. It's correct either way and avoids depending on the inventory module from CLI code.