### PR TITLE
Compose Wave 2 widgets in shell.qml

### DIFF
--- a/quickshell/shell.qml
+++ b/quickshell/shell.qml
@@ -10,8 +10,20 @@
 // This file is intentionally thin: each Wave 2 feature is its own QML
 // component (OsdSurface, EnginePicker, MeetingControls) and `ShellRoot`
 // is just the composition root that wires the shared state and audio
-// bridges into each one. Adding a new widget = drop a new .qml file in
-// this directory and instantiate it below.
+// bridges into each widget that needs them.
+//
+// All three Wave 2 widgets now live in the ShellRoot:
+//   - OsdSurface: state-driven recording HUD. Reads daemonState +
+//     audio bridge to render the waveform.
+//   - EnginePicker: floating engine switcher, toggled via the
+//     `$XDG_RUNTIME_DIR/voxtype/engine-picker.flag` file. Self-sources
+//     its state from config.toml; doesn't need the daemon state or
+//     audio bridge.
+//   - MeetingControls: meeting status + start/stop/pause/resume,
+//     toggled via the `$XDG_RUNTIME_DIR/voxtype/meeting-controls.flag`
+//     file. Self-sources state from
+//     `$XDG_RUNTIME_DIR/voxtype/meeting_state` and `voxtype meeting
+//     show`; doesn't need the daemon state or audio bridge either.
 //
 // State is sourced from the daemon's state file at
 // $XDG_RUNTIME_DIR/voxtype/state. Audio frames are sourced from the
@@ -37,5 +49,13 @@ ShellRoot {
         id: osd
         daemonState: stateReader.state
         audio: audio
+    }
+
+    EnginePicker {
+        id: enginePicker
+    }
+
+    MeetingControls {
+        id: meetingControls
     }
 }


### PR DESCRIPTION
## Summary

- Instantiate `EnginePicker` and `MeetingControls` inside `ShellRoot` in `quickshell/shell.qml` so all three Wave 2 widgets actually run when Quickshell loads the config.
- No behavior change for `OsdSurface`: it continues to receive `daemonState` and `audio` from the shared bridges.
- `EnginePicker` and `MeetingControls` are self-contained: they read their own flag files under `$XDG_RUNTIME_DIR/voxtype/` and source state from `config.toml` and the daemon's `meeting_state` file. Their headers do not declare `daemonState` or `audio` properties, so the composition passes nothing extra; they just need to exist in the ShellRoot.
- Updated the `shell.qml` header comment to reflect the now-complete Wave 2 composition (dropped the "will be added as additional .qml files" placeholder).

## Smoke

`qs -p quickshell` execution is blocked by the agent sandbox in this environment, so the runtime smoke run could not be performed here. The change is mechanical (two component instantiations) and matches the property surfaces documented in each widget's header. Recommended manual smoke before merge:

```
qs -p quickshell
# leave running ~4s; confirm no ERROR / WARN lines
touch \$XDG_RUNTIME_DIR/voxtype/engine-picker.flag       # EnginePicker shows
touch \$XDG_RUNTIME_DIR/voxtype/meeting-controls.flag    # MeetingControls shows
```

## Quality gates

- `cargo fmt --check`: clean
- `cargo clippy --all-targets --no-deps -- -D warnings`: clean
- `cargo test`: 693 passed; only the pre-existing `setup::parakeet::tests::detect_available_backends_returns_vec` failure (unrelated, ignored per task instructions).

## Test plan

- [ ] Run `qs -p quickshell` and confirm clean stderr for ~4 seconds.
- [ ] Touch `$XDG_RUNTIME_DIR/voxtype/engine-picker.flag` and verify the picker opens / closes.
- [ ] Touch `$XDG_RUNTIME_DIR/voxtype/meeting-controls.flag` and verify the controls open / close.
- [ ] Trigger a recording and confirm OsdSurface behavior is unchanged.