### PR TITLE
Make session-detection tests hermetic (fix display_only_means_x11)

### DIFF
--- a/src/output/session.rs
+++ b/src/output/session.rs
@@ -18,15 +18,36 @@ pub enum DisplaySession {
     X11,
 }
 
-/// Detect the active display session from environment variables.
+/// Detect the active display session from the process environment.
+///
+/// Production callers should use this. Tests should call
+/// [`detect_with_env`] with an explicit lookup closure so that the
+/// process-wide environment (which the test runner inherits from the
+/// developer's interactive session) cannot leak in.
 pub fn detect() -> DisplaySession {
-    if let Ok(val) = std::env::var("WAYLAND_DISPLAY") {
+    detect_with_env(|name| std::env::var(name).ok())
+}
+
+/// Detect the display session using a caller-supplied env lookup.
+///
+/// Returns `None` from the closure for "unset"; returns `Some(String)` for
+/// any value (including the empty string, which has special meaning for
+/// `WAYLAND_DISPLAY`).
+///
+/// This indirection exists so unit tests can run hermetically without
+/// mutating `std::env`, which is process-global and racy under parallel
+/// test execution.
+fn detect_with_env<F>(get: F) -> DisplaySession
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if let Some(val) = get("WAYLAND_DISPLAY") {
         if !val.is_empty() {
             return DisplaySession::Wayland;
         }
     }
 
-    if let Ok(session) = std::env::var("XDG_SESSION_TYPE") {
+    if let Some(session) = get("XDG_SESSION_TYPE") {
         match session.as_str() {
             "wayland" => return DisplaySession::Wayland,
             "x11" => return DisplaySession::X11,
@@ -34,7 +55,7 @@ pub fn detect() -> DisplaySession {
         }
     }
 
-    if std::env::var("DISPLAY").is_ok() {
+    if get("DISPLAY").is_some() {
         return DisplaySession::X11;
     }
 
@@ -44,64 +65,68 @@ pub fn detect() -> DisplaySession {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
-    /// Helper to evaluate detect() with a controlled environment.
+    /// Build an env lookup from a small literal map.
     ///
-    /// These tests mutate process-wide env vars and therefore must not run
-    /// concurrently with anything else that reads them. We serialize by
-    /// running each in its own `#[test]` and clearing all relevant vars at
-    /// the start.
-    fn clear_env() {
-        std::env::remove_var("WAYLAND_DISPLAY");
-        std::env::remove_var("XDG_SESSION_TYPE");
-        std::env::remove_var("DISPLAY");
+    /// These tests used to mutate `std::env` via `set_var` / `remove_var`,
+    /// but that approach has two problems:
+    ///
+    /// 1. The cargo test harness runs tests in parallel by default, so
+    ///    one test's `set_var("WAYLAND_DISPLAY", ...)` could be observed
+    ///    by another test running concurrently.
+    /// 2. `clear_env()` only removed the three vars the tests cared about,
+    ///    but the test runner itself inherits `WAYLAND_DISPLAY` from the
+    ///    developer's interactive shell on most laptop dev environments.
+    ///    A test that "cleared" the env and then expected detect() to
+    ///    return X11 would still see the inherited Wayland value if
+    ///    another test had set it back, or if the clear ran before that
+    ///    other test's set. The failure mode was order-dependent and
+    ///    hard to reproduce, which is exactly what bit PR #372.
+    ///
+    /// The fix is to pass a hermetic `Fn(&str) -> Option<String>` into
+    /// the detection logic and never touch the process env in tests.
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |name| map.get(name).cloned()
     }
 
     #[test]
     fn wayland_display_wins() {
-        clear_env();
-        std::env::set_var("WAYLAND_DISPLAY", "wayland-0");
-        std::env::set_var("DISPLAY", ":0");
-        assert_eq!(detect(), DisplaySession::Wayland);
-        clear_env();
+        let get = env(&[("WAYLAND_DISPLAY", "wayland-0"), ("DISPLAY", ":0")]);
+        assert_eq!(detect_with_env(get), DisplaySession::Wayland);
     }
 
     #[test]
     fn empty_wayland_display_does_not_win() {
-        clear_env();
-        std::env::set_var("WAYLAND_DISPLAY", "");
-        std::env::set_var("XDG_SESSION_TYPE", "x11");
-        assert_eq!(detect(), DisplaySession::X11);
-        clear_env();
+        let get = env(&[("WAYLAND_DISPLAY", ""), ("XDG_SESSION_TYPE", "x11")]);
+        assert_eq!(detect_with_env(get), DisplaySession::X11);
     }
 
     #[test]
     fn xdg_session_type_x11() {
-        clear_env();
-        std::env::set_var("XDG_SESSION_TYPE", "x11");
-        assert_eq!(detect(), DisplaySession::X11);
-        clear_env();
+        let get = env(&[("XDG_SESSION_TYPE", "x11")]);
+        assert_eq!(detect_with_env(get), DisplaySession::X11);
     }
 
     #[test]
     fn xdg_session_type_wayland() {
-        clear_env();
-        std::env::set_var("XDG_SESSION_TYPE", "wayland");
-        assert_eq!(detect(), DisplaySession::Wayland);
-        clear_env();
+        let get = env(&[("XDG_SESSION_TYPE", "wayland")]);
+        assert_eq!(detect_with_env(get), DisplaySession::Wayland);
     }
 
     #[test]
     fn display_only_means_x11() {
-        clear_env();
-        std::env::set_var("DISPLAY", ":0");
-        assert_eq!(detect(), DisplaySession::X11);
-        clear_env();
+        let get = env(&[("DISPLAY", ":0")]);
+        assert_eq!(detect_with_env(get), DisplaySession::X11);
     }
 
     #[test]
     fn no_env_defaults_to_wayland() {
-        clear_env();
-        assert_eq!(detect(), DisplaySession::Wayland);
+        let get = env(&[]);
+        assert_eq!(detect_with_env(get), DisplaySession::Wayland);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a pre-existing test failure on `dev` that's been present since PR #372 (wl-copy-under-X work). Tests in `src/output/session.rs` mutated `std::env` directly, which is process-global and racy under parallel cargo test execution. On Wayland laptop dev environments the test runner also inherits `WAYLAND_DISPLAY` from the user's interactive shell, so `clear_env()` could not actually guarantee a clean slate when another concurrent test had just set the variable back.

The observed failure rotated between `display_only_means_x11` and `empty_wayland_display_does_not_win` depending on test scheduling, which is exactly the signature of an env-leak race.

## Approach

Refactored `detect()` into a thin wrapper around `detect_with_env(F)` where `F: Fn(&str) -> Option<String>`. Production callers (`clipboard.rs`, `paste.rs`, `xclip.rs`) continue calling `detect()` unchanged and pay zero cost: the wrapper just hands `std::env::var(name).ok()` to the same logic. Tests now build a `HashMap`-backed closure and never touch process env.

No production behavior change. A doc comment on the test helper records *why* the indirection exists so this doesn't regress.

## Test plan

- [x] `cargo test --lib output::session` passes all 6 tests
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --lib` overall: only the unrelated pre-existing `setup::parakeet::tests::detect_available_backends_returns_vec` failure remains; this PR does not affect it