### PR TITLE
Bound Vulkan/CI ISA floor at x86_64-v3 to fix Kaby Lake SIGILL [#393]

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -211,17 +211,42 @@ jobs:
             exit 1
           fi
 
-      - name: Verify AVX-512 absence (AVX2 and Vulkan variants only)
+      - name: Verify ISA floor (Haswell / x86_64-v3) on AVX2 and Vulkan variants
         if: matrix.check_no_avx512
         run: |
           set -euo pipefail
           VERSION='${{ steps.version.outputs.version }}'
           BIN="releases/${VERSION}/voxtype-${VERSION}-linux-${{ matrix.arch }}-${{ matrix.variant }}"
-          ZMM=$(objdump -d "${BIN}" | grep -c zmm || true)
-          echo "AVX-512 zmm register count: ${ZMM}"
-          if [[ "${ZMM}" -ne 0 ]]; then
-            echo "FAIL: ${{ matrix.variant }} binary contains ${ZMM} AVX-512 zmm references."
-            echo "It will SIGILL on pre-AVX-512 CPUs (Zen 3, Haswell, etc.)."
+          # The "no AVX-512" variants must run on every x86_64-v3 CPU: Haswell,
+          # Kaby Lake, Zen 2, Zen 3, etc. That floor excludes AVX-512, GFNI,
+          # AVX-VNNI, and SSE4a (AMD-only). The previous gate only checked zmm
+          # registers — Zen 3 lacks AVX-512 but still has SSE4a's `insertq`,
+          # which is what crashed Kaby Lake daemons in issue #393. NOTE:
+          # SHA-NI, VAES (ymm), and VPCLMULQDQ (ymm) are NOT checked because
+          # the sha2/aes crates emit them behind cpufeatures-dispatched
+          # runtime CPUID guards; they show up in every working binary.
+          DUMP=$(objdump -d "${BIN}")
+          ZMM=$(echo "$DUMP" | grep -c zmm || true)
+          EVEX=$(echo "$DUMP" | grep -cE 'vpternlog|vpermt2|vpermi2|vpblendm|valign[dq]|vpcompress|vpexpand' || true)
+          BCAST=$(echo "$DUMP" | grep -c '{1to' || true)
+          GFNI=$(echo "$DUMP" | grep -cE '\b(vgf2p8|gf2p8)' || true)
+          SSE4A=$(echo "$DUMP" | grep -cE '\b(insertq|extrq)\b' || true)
+          AVXVNNI=$(echo "$DUMP" | grep -cE '\bvpdpbus(d|ds)|vpdpwss(d|ds)' || true)
+          printf '  zmm registers:     %s\n' "$ZMM"
+          printf '  AVX-512 EVEX:      %s\n' "$EVEX"
+          printf '  AVX-512 broadcast: %s\n' "$BCAST"
+          printf '  GFNI:              %s\n' "$GFNI"
+          printf '  SSE4a (AMD-only):  %s\n' "$SSE4A"
+          printf '  AVX-VNNI:          %s\n' "$AVXVNNI"
+          fail=0
+          for n in "$ZMM" "$EVEX" "$BCAST" "$GFNI" "$SSE4A" "$AVXVNNI"; do
+            [[ "${n:-0}" -gt 0 ]] && fail=1
+          done
+          if [[ "$fail" -ne 0 ]]; then
+            echo "FAIL: ${{ matrix.variant }} binary contains out-of-floor instructions."
+            echo "It will SIGILL on x86_64-v3 CPUs (Kaby Lake, Zen 2/3, Haswell, etc.)."
+            echo "Most likely cause: RUSTFLAGS uses target-cpu=native or GGML_NATIVE=ON"
+            echo "on a build host whose CPU has features the floor doesn't allow."
             exit 1
           fi
 

--- a/Dockerfile.vulkan
+++ b/Dockerfile.vulkan
@@ -55,11 +55,22 @@ ENV CARGO_BUILD_JOBS=1
 ENV CMAKE_BUILD_PARALLEL_LEVEL=1
 ENV MAKEFLAGS="-j1"
 
-# Build flags - use native CPU (i9-9900K has no AVX-512, so no leakage possible)
-# Disable LTO to prevent linking hangs
-ENV RUSTFLAGS="-C target-cpu=native -C lto=off -C codegen-units=8"
-# whisper.cpp/ggml flags - let it detect native CPU features
-ENV GGML_NATIVE=ON
+# Build flags: bound the ISA floor at Haswell so the binary runs on every
+# x86_64-v3 CPU (Kaby Lake, Zen 2/3, etc.). target-cpu=native was safe when
+# this built on a pre-AVX-512 host (i9-9900K, Coffee Lake), but the GitHub
+# Actions ubuntu-24.04 runner is Zen 3 with SHA Extensions / VAES / AES-NI,
+# and those instructions SIGILL on Kaby Lake — see issue #393.
+# Disable LTO to prevent linking hangs.
+ENV RUSTFLAGS="-C target-cpu=haswell -C target-feature=-avx512f,-avx512bw,-avx512cd,-avx512dq,-avx512vl,-gfni,-sse4a,-avxvnni -C lto=off -C codegen-units=8"
+# whisper.cpp/ggml flags: match Dockerfile.build's Haswell bound. NATIVE=ON
+# inherits -march=native from CMake's host detection, which on a Zen 3 runner
+# emits the same forbidden instructions the SIGILL handler ends up catching.
+ENV GGML_NATIVE=OFF
+ENV GGML_AVX512=OFF
+ENV GGML_AVX_VNNI=OFF
+ENV GGML_AVX512_VNNI=OFF
+ENV CMAKE_C_FLAGS="-mno-avx512f -mno-avx512vl -mno-avx512bw -mno-avx512dq -mno-avx512cd -mno-gfni -mno-avxvnni -mno-sha -mno-vaes -mno-vpclmulqdq"
+ENV CMAKE_CXX_FLAGS="-mno-avx512f -mno-avx512vl -mno-avx512bw -mno-avx512dq -mno-avx512cd -mno-gfni -mno-avxvnni -mno-sha -mno-vaes -mno-vpclmulqdq"
 
 # Build Vulkan binary (verbose to show progress)
 # Override Cargo.toml's LTO settings to prevent linking hangs
@@ -69,18 +80,34 @@ RUN cargo build --release --features gpu-vulkan \
     -vv 2>&1 | tee /tmp/build.log \
     && cp target/release/voxtype /tmp/voxtype-vulkan
 
-# Verify no AVX-512 or GFNI instructions
-RUN echo "=== Verifying Vulkan binary ===" \
-    && zmm_count=$(objdump -d /tmp/voxtype-vulkan | grep -c zmm || true) \
-    && avx512_count=$(objdump -d /tmp/voxtype-vulkan | grep -cE 'vpternlog|vpermt2|vpblendm' || true) \
-    && broadcast_count=$(objdump -d /tmp/voxtype-vulkan | grep -c '{1to' || true) \
-    && gfni_count=$(objdump -d /tmp/voxtype-vulkan | grep -cE 'vgf2p8|gf2p8' || true) \
-    && echo "  zmm registers: $zmm_count" \
-    && echo "  AVX-512 EVEX: $avx512_count" \
-    && echo "  Broadcast: $broadcast_count" \
-    && echo "  GFNI: $gfni_count" \
-    && if [ "${zmm_count:-0}" -gt 0 ] || [ "${avx512_count:-0}" -gt 0 ] || [ "${broadcast_count:-0}" -gt 0 ] || [ "${gfni_count:-0}" -gt 0 ]; then \
-         echo "ERROR: Vulkan binary contains forbidden instructions!" && exit 1; \
+# Verify no out-of-floor instructions leaked in. The ISA floor is x86_64-v3
+# (Haswell): AVX2 + BMI1/2 + FMA, no AVX-512, no GFNI, no AVX-VNNI, and no
+# SSE4a (AMD-only — would SIGILL on Intel). NOTE: SHA-NI / VAES (ymm) /
+# VPCLMULQDQ (ymm) are deliberately NOT checked here — those instructions
+# appear in every binary as part of the sha2/aes crates' cpufeatures-dispatched
+# runtime paths, and are guarded by CPUID checks at the library level. Adding
+# them to this gate would produce false positives. Instead we constrain the
+# Rust compiler's own emission via target-cpu=haswell + target-feature
+# disables above, which is what stops issue-#393-style leaks.
+RUN echo "=== Verifying Vulkan binary ISA floor (x86_64-v3 / Haswell, no SSE4a) ===" \
+    && DUMP=$(objdump -d /tmp/voxtype-vulkan) \
+    && zmm_count=$(echo "$DUMP" | grep -c zmm || true) \
+    && avx512_count=$(echo "$DUMP" | grep -cE 'vpternlog|vpermt2|vpermi2|vpblendm|valign[dq]|vpcompress|vpexpand' || true) \
+    && broadcast_count=$(echo "$DUMP" | grep -c '{1to' || true) \
+    && gfni_count=$(echo "$DUMP" | grep -cE '\b(vgf2p8|gf2p8)' || true) \
+    && sse4a_count=$(echo "$DUMP" | grep -cE '\b(insertq|extrq)\b' || true) \
+    && avxvnni_count=$(echo "$DUMP" | grep -cE '\bvpdpbus(d|ds)|vpdpwss(d|ds)' || true) \
+    && echo "  zmm registers:     $zmm_count" \
+    && echo "  AVX-512 EVEX:      $avx512_count" \
+    && echo "  AVX-512 broadcast: $broadcast_count" \
+    && echo "  GFNI:              $gfni_count" \
+    && echo "  SSE4a (AMD-only):  $sse4a_count" \
+    && echo "  AVX-VNNI:          $avxvnni_count" \
+    && if [ "${zmm_count:-0}" -gt 0 ] || [ "${avx512_count:-0}" -gt 0 ] \
+         || [ "${broadcast_count:-0}" -gt 0 ] || [ "${gfni_count:-0}" -gt 0 ] \
+         || [ "${sse4a_count:-0}" -gt 0 ] || [ "${avxvnni_count:-0}" -gt 0 ]; then \
+         echo "ERROR: Vulkan binary contains out-of-floor instructions — will SIGILL on Intel Kaby Lake, Zen 1, etc." \
+         && exit 1; \
        fi \
     && echo "✓ Vulkan binary is clean"
 


### PR DESCRIPTION
## Summary

- **Dockerfile.vulkan**: replace `RUSTFLAGS="-C target-cpu=native"` + `GGML_NATIVE=ON` with the Haswell-bounded flag set `Dockerfile.build` already uses, and add `-sse4a` to the disabled features so the Rust compiler never emits AMD-only `insertq`/`extrq` even when the build host is a Zen CPU.
- **.github/workflows/build-linux.yml**: broaden the `Verify AVX-512 absence` step into a general ISA-floor check that also fails on AVX-512 EVEX mnemonics, broadcast operands, GFNI, AVX-VNNI, and SSE4a.

## Root cause for #393

`Dockerfile.vulkan` carried the comment

> `# Build flags - use native CPU (i9-9900K has no AVX-512, so no leakage possible)`

from commit `401b0a1` (2025-12-20). That assumption held on the TrueNAS Coffee Lake builder, but the v0.7.2 pipeline moved onto the GitHub Actions `ubuntu-24.04` runner (AMD EPYC 7763 / Zen 3). `target-cpu=native` on Zen 3 enables **SSE4a** — an AMD-only extension Intel never adopted. The Rust compiler emitted three `insertq` instructions in the v0.7.2 vulkan binary, and they SIGILL on Intel Kaby Lake (the i7-7700HQ in #393).

```
$ objdump -d voxtype-0.7.2-linux-x86_64-vulkan | grep -E '\b(insertq|extrq)\b'
 2728613: f2 0f 78 d0 08 38  insertq $0x38,$0x8,%xmm0,%xmm2
 2728750: f2 0f 78 ca 20 18  insertq $0x18,$0x20,%xmm2,%xmm1
 272877a: f2 0f 78 c2 20 18  insertq $0x18,$0x20,%xmm2,%xmm0
```

Same class as #356 — `target-cpu=native` is only safe when the build host's ISA is bounded below the lowest-supported CPU. The build host moved; the Dockerfile didn't.

## Why the CI gate missed it

The existing `Verify AVX-512 absence` step only ran `grep -c zmm`. Zen 3 has no AVX-512, so the check passed cleanly while SSE4a walked through. The expanded gate validates against the published 0.7.2 binaries:

| variant | zmm | EVEX | bcast | GFNI | SSE4a | AVX-VNNI |
|---|---|---|---|---|---|---|
| `0.7.2-vulkan` | 0 | 0 | 0 | 0 | **3** | 0 → **FAIL** |
| `0.7.2-avx2` | 0 | 0 | 0 | 0 | 0 | 0 → PASS |

## What the gate intentionally does NOT check

SHA-NI, VAES (ymm), and VPCLMULQDQ (ymm) are deliberately excluded. The `sha2` and `aes` crates emit those behind cpufeatures-dispatched runtime CPUID guards, so they appear in every working binary (the same 32 `sha256rnds2` and 136 `vaesenc %ymm…` sites appear in the 0.7.2 vulkan, avx2, and avx512 binaries). Absolute-presence checks would generate false positives. The Rust compiler's own emission is bounded via `target-feature` instead.

## Test plan
- [ ] Re-run the workflow on tag `v0.7.3-rc1` (or `workflow_dispatch`); confirm the new ISA-floor step passes on a freshly built vulkan binary
- [ ] Confirm `objdump -d` of the new vulkan binary shows zero hits for `insertq|extrq`
- [ ] Smoke test the resulting vulkan binary on the i7-7700HQ in #393 (Pete to coordinate with @iTuiTu, or use a Kaby Lake VM/box) — daemon startup must not SIGILL
- [ ] Verify the gate still passes the avx2, onnx-avx2, and other matrix variants (none should regress)

Closes #393.