### PR TITLE
Switch onnx-cuda-13 to Microsoft ORT via load-dynamic for Blackwell [#386]

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -92,7 +92,11 @@ jobs:
             runner: ubuntu-24.04
             glibc_cap: '2.39'
             check_no_avx512: false
-            companion_libs: 'libonnxruntime_providers_cuda.so libonnxruntime_providers_shared.so'
+            # cuda-13 dlopens ORT via ort/load-dynamic so the runtime ships
+            # alongside the binary (Microsoft's prebuilt is the only 1.24.4
+            # build with sm_120 Blackwell coverage, and it's distributed as
+            # .so only — see Dockerfile.onnx-cuda-13 header).
+            companion_libs: 'libonnxruntime.so.1.24.4 libonnxruntime_providers_cuda.so libonnxruntime_providers_shared.so'
             timeout_minutes: 120
           - variant: onnx-migraphx
             arch: x86_64

--- a/Dockerfile.onnx-cuda-13
+++ b/Dockerfile.onnx-cuda-13
@@ -5,6 +5,27 @@
 # voxtype-onnx-cuda is symlinked to whichever variant matches the host's
 # CUDA runtime (see voxtype setup gpu --enable).
 #
+# Linking model (cu13 only — differs from cu12):
+#   Unlike Dockerfile.onnx-cuda-12, this binary does NOT statically link
+#   ORT into voxtype. We use `ort/load-dynamic` and dlopen Microsoft's
+#   official `libonnxruntime.so.1.24.4` at runtime. The reason is that
+#   the pyke-distributed ORT 1.24.4 cu13 prebuilt (which ort-sys would
+#   otherwise download and link statically) ships a CUDA EP with arch
+#   coverage sm_30..sm_90a — no Blackwell (sm_120) SASS or PTX — so any
+#   RTX 50-series GPU fails the first transcription with
+#   `cudaErrorNoKernelImageForDevice` (see issue #386, RTX 5090). Upstream
+#   pyke has closed Blackwell support requests as "not planned", and as of
+#   2026-05 ort 2.0.0-rc.12 is still the newest crate on crates.io.
+#
+#   Microsoft's official ORT 1.24.4 cu13 prebuilt covers sm_70..sm_120a
+#   across both the main runtime and the CUDA EP, so this Dockerfile
+#   pivots to that prebuilt entirely (main runtime + EP + shared EP),
+#   linked dynamically. At runtime ort looks for `libonnxruntime.so` in
+#   the directory containing the executable (see ort src/lib.rs:96-109),
+#   so scripts/package.sh and the AUR PKGBUILD install all three files
+#   into /usr/lib/voxtype/cuda-13/ alongside the binary — no RPATH or
+#   LD_LIBRARY_PATH plumbing required.
+#
 # Usage:
 #   docker build -f Dockerfile.onnx-cuda-13 -t voxtype-onnx-cuda-13-builder .
 #   docker run --rm -v $(pwd)/releases:/output voxtype-onnx-cuda-13-builder
@@ -13,8 +34,9 @@
 #   - NVIDIA GPU with CUDA 13.x runtime
 #   - NVIDIA driver 580 or newer (CUDA 13 minimum)
 #   - libcudart.so.13 and cuDNN 9 at runtime (or via LD_LIBRARY_PATH)
-#   - The bundled libonnxruntime_providers_cuda.so and *_shared.so
-#     installed alongside the binary (handled by scripts/package.sh)
+#   - The bundled libonnxruntime.so.1.24.4 + libonnxruntime_providers_cuda.so
+#     + libonnxruntime_providers_shared.so co-located with the binary
+#     (handled by scripts/package.sh and the AUR voxtype-bin PKGBUILD)
 #
 FROM nvidia/cuda:13.0.3-cudnn-devel-ubuntu24.04
 
@@ -53,40 +75,95 @@ WORKDIR /build
 # Copy source code
 COPY . .
 
-# ONNX Runtime CUDA 13 settings
-# ort-sys reads ORT_CUDA_VERSION at build time to choose the cu12 or cu13
-# prebuilt. The base image's NV_CUDA_CUDART_VERSION would also yield cu13,
-# but setting ORT_CUDA_VERSION explicitly is unambiguous and survives any
-# upstream changes to NVIDIA's image env vars.
-ENV ORT_STRATEGY=download
-ENV ORT_CUDA_VERSION=13
+# Fetch Microsoft's ORT 1.24.4 cu13 prebuilt. We bundle it verbatim into
+# the release; ort/load-dynamic dlopens it at runtime. Pinned to match the
+# api-24 ABI surface ort 2.0.0-rc.12 expects; bump in lockstep when the
+# ort crate version moves.
+ENV ORT_VERSION=1.24.4
+ENV ORT_DIR=/opt/onnxruntime
+RUN set -eux; \
+    curl -fsSL -o /tmp/ort-msft.tgz \
+      "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-gpu_cuda13-${ORT_VERSION}.tgz"; \
+    mkdir -p "${ORT_DIR}"; \
+    tar -xzf /tmp/ort-msft.tgz --strip-components=1 -C "${ORT_DIR}"; \
+    rm /tmp/ort-msft.tgz; \
+    test -f "${ORT_DIR}/lib/libonnxruntime.so.${ORT_VERSION}"; \
+    test -f "${ORT_DIR}/lib/libonnxruntime_providers_cuda.so"; \
+    test -f "${ORT_DIR}/lib/libonnxruntime_providers_shared.so"; \
+    # Fail loudly at build time if a future Microsoft release ever drops
+    # Blackwell. This is the gate that should have existed for the pyke
+    # prebuilt before #386 reached a 5090 user.
+    strings "${ORT_DIR}/lib/libonnxruntime_providers_cuda.so" \
+      | grep -qE '^sm_120(a)?$' \
+      || { echo "FAIL: Microsoft ORT ${ORT_VERSION} cu13 EP lacks sm_120 — bundle layout changed upstream."; exit 1; }; \
+    echo "Microsoft ORT ${ORT_VERSION} cu13 staged at ${ORT_DIR} (sm_70..sm_120a)."
 
-# Build with all ONNX engines + CUDA 13 support for NVIDIA GPUs
-# Disable LTO for faster builds
-RUN cargo build --release --features parakeet-cuda,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,ml-diarization \
-    --config 'profile.release.lto=false' \
-    --config 'profile.release.codegen-units=8' \
+# Build voxtype with all ONNX engines + CUDA EP, linked dynamically.
+#
+# Feature breakdown:
+#   - parakeet-cuda          → parakeet-rs/cuda  (registers CUDA EP for Parakeet)
+#   - parakeet-load-dynamic  → parakeet-rs/load-dynamic  (dlopen ORT in parakeet-rs)
+#   - {moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere}-cuda
+#                            → onnx-cuda-enabled = ort/cuda  (CUDA EP type)
+#   - onnx-load-dynamic      → ort/load-dynamic  (dlopen ORT crate-wide)
+#   - ml-diarization         → ort (no EP gates needed)
+#
+# `ort/cuda` and `ort/load-dynamic` compose: ort/src/execution_providers/cuda.rs
+# gates the CUDA EP under `any(load-dynamic, cuda)`, and load-dynamic just
+# changes how libonnxruntime is reached, not whether the EP exists.
+#
+# Disable LTO for faster builds; same as the rest of the matrix.
+RUN cargo build --release \
+        --features parakeet-cuda,parakeet-load-dynamic,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,onnx-load-dynamic,ml-diarization \
+        --config 'profile.release.lto=false' \
+        --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-cuda-13
 
-# Bundle the CUDA EP companion shared libs (see Dockerfile.onnx-cuda-12 for rationale)
-RUN mkdir -p /tmp/onnx-cuda-13-libs \
-    && find /build/target/release -maxdepth 2 -name 'libonnxruntime_providers_cuda.so' -exec cp -L {} /tmp/onnx-cuda-13-libs/ \; \
-    && find /build/target/release -maxdepth 2 -name 'libonnxruntime_providers_shared.so' -exec cp -L {} /tmp/onnx-cuda-13-libs/ \; \
-    && test -f /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so \
-    && test -f /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so
+# Stage the bundled libs alongside the binary. Three files ship:
+#   - libonnxruntime.so.${ORT_VERSION}  (real file with Blackwell SASS)
+#   - libonnxruntime.so                 (symlink → libonnxruntime.so.${ORT_VERSION})
+#                                       ort/load-dynamic dlopens this exact name
+#                                       relative to /proc/self/exe.
+#   - libonnxruntime_providers_cuda.so  (Blackwell CUDA EP, dlopened by main)
+#   - libonnxruntime_providers_shared.so (EP support shim)
+RUN set -eux; \
+    mkdir -p /tmp/onnx-cuda-13-libs; \
+    cp -L "${ORT_DIR}/lib/libonnxruntime.so.${ORT_VERSION}" \
+        "/tmp/onnx-cuda-13-libs/libonnxruntime.so.${ORT_VERSION}"; \
+    ln -sf "libonnxruntime.so.${ORT_VERSION}" \
+        "/tmp/onnx-cuda-13-libs/libonnxruntime.so"; \
+    cp -L "${ORT_DIR}/lib/libonnxruntime_providers_cuda.so" \
+        /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so; \
+    cp -L "${ORT_DIR}/lib/libonnxruntime_providers_shared.so" \
+        /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so; \
+    test -L /tmp/onnx-cuda-13-libs/libonnxruntime.so; \
+    test -f /tmp/onnx-cuda-13-libs/libonnxruntime.so.${ORT_VERSION}; \
+    test -f /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so; \
+    test -f /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so
 
 # Verify binary
 RUN echo "=== Verifying ONNX CUDA 13 binary ===" \
     && /tmp/voxtype-onnx-cuda-13 --version \
     && echo "=== Binary size ===" \
     && ls -lh /tmp/voxtype-onnx-cuda-13 \
-    && echo "=== Companion .so files ===" \
-    && ls -lh /tmp/onnx-cuda-13-libs/
+    && echo "=== Bundled libs ===" \
+    && ls -lh /tmp/onnx-cuda-13-libs/ \
+    && echo "=== CUDA arch coverage in bundled EP ===" \
+    && strings /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so | grep -oE 'sm_[0-9]+[a-z]?' | sort -u \
+    && echo "=== Confirm binary does NOT need libonnxruntime.so.1 at startup ===" \
+    && ! objdump -p /tmp/voxtype-onnx-cuda-13 | grep -q 'NEEDED.*libonnxruntime' \
+    || { echo "FAIL: voxtype has libonnxruntime in NEEDED — load-dynamic feature didn't take effect."; exit 1; }
 
-# Output stage: copy binary and companion .so files
+# Output stage: copy binary and bundled libs. Names follow the existing
+# release convention (`<binary>.<companion>`) so scripts/package.sh and
+# the AUR PKGBUILD can pick them up by predictable filenames.
 CMD mkdir -p /output \
     && cp /tmp/voxtype-onnx-cuda-13 /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13 \
-    && cp /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_cuda.so \
-    && cp /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_shared.so \
+    && cp /tmp/onnx-cuda-13-libs/libonnxruntime.so.${ORT_VERSION} \
+        /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime.so.${ORT_VERSION} \
+    && cp /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so \
+        /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_cuda.so \
+    && cp /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so \
+        /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_shared.so \
     && echo "Output:" \
     && ls -la /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13*

--- a/packaging/arch-bin-rc/PKGBUILD
+++ b/packaging/arch-bin-rc/PKGBUILD
@@ -79,6 +79,12 @@ source=(
     "voxtype-${pkgname}-${pkgver}-onnx-cuda-13.asc::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-cuda-13.asc"
     "voxtype-${pkgname}-${pkgver}-onnx-cuda-13.libonnxruntime_providers_cuda.so::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_cuda.so"
     "voxtype-${pkgname}-${pkgver}-onnx-cuda-13.libonnxruntime_providers_shared.so::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_shared.so"
+    # cuda-13 dlopens ORT at runtime (Microsoft's prebuilt is the only
+    # 1.24.4 build with Blackwell sm_120 coverage, and it's distributed
+    # as .so only). The runtime ships alongside the binary; the install
+    # step below symlinks libonnxruntime.so → this versioned name so
+    # ort/load-dynamic finds it via /proc/self/exe's directory.
+    "voxtype-${pkgname}-${pkgver}-onnx-cuda-13.libonnxruntime.so.1.24.4::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-cuda-13.libonnxruntime.so.1.24.4"
     # ONNX MIGraphX binary + companion shared libs
     "voxtype-${pkgname}-${pkgver}-onnx-migraphx::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-migraphx"
     "voxtype-${pkgname}-${pkgver}-onnx-migraphx.asc::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-migraphx.asc"
@@ -130,6 +136,7 @@ sha256sums=(
     'SKIP'  # voxtype-onnx-cuda-13.asc
     'SKIP'  # voxtype-onnx-cuda-13.libonnxruntime_providers_cuda.so
     'SKIP'  # voxtype-onnx-cuda-13.libonnxruntime_providers_shared.so
+    'SKIP'  # voxtype-onnx-cuda-13.libonnxruntime.so.1.24.4
     # ONNX MIGraphX
     'SKIP'  # voxtype-onnx-migraphx
     'SKIP'  # voxtype-onnx-migraphx.asc
@@ -190,6 +197,13 @@ package() {
         "$pkgdir/usr/lib/voxtype/cuda-13/libonnxruntime_providers_cuda.so"
     install -Dm644 "${src}-onnx-cuda-13.libonnxruntime_providers_shared.so" \
         "$pkgdir/usr/lib/voxtype/cuda-13/libonnxruntime_providers_shared.so"
+    # cuda-13 dlopens ORT at runtime. Install Microsoft's libonnxruntime
+    # under its SONAME (libonnxruntime.so.1.24.4) and symlink the bare
+    # name ort/load-dynamic expects (libonnxruntime.so).
+    install -Dm644 "${src}-onnx-cuda-13.libonnxruntime.so.1.24.4" \
+        "$pkgdir/usr/lib/voxtype/cuda-13/libonnxruntime.so.1.24.4"
+    ln -sf "libonnxruntime.so.1.24.4" \
+        "$pkgdir/usr/lib/voxtype/cuda-13/libonnxruntime.so"
     ln -sf "cuda-13/voxtype-onnx-cuda-13" \
         "$pkgdir/usr/lib/voxtype/voxtype-onnx-cuda-13"
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -408,6 +408,13 @@ if [[ "$TARGET_ARCH" == "x86_64" ]]; then
     install_onnx_gpu_variant() {
         local variant="$1"      # cuda-12, cuda-13, migraphx
         local ep_lib="$2"       # cuda or migraphx
+        # When set, $3 is the libonnxruntime.so.X.Y.Z basename the variant
+        # bundles alongside the binary. The cuda-13 build links ORT
+        # dynamically (load-dynamic) because Microsoft's prebuilt is the
+        # only ORT 1.24.4 build that ships Blackwell sm_120 kernels, and
+        # Microsoft only distributes .so (no .a). cuda-12 and migraphx
+        # keep their static-linked layouts; pass empty for those.
+        local libort_versioned="${3:-}"
         local src="${RELEASE_DIR}/voxtype-${VERSION}-linux-x86_64-onnx-${variant}"
         if [[ ! -f "$src" ]]; then
             return 0
@@ -420,6 +427,14 @@ if [[ "$TARGET_ARCH" == "x86_64" ]]; then
             "$subdir/libonnxruntime_providers_${ep_lib}.so"
         cp "${src}.libonnxruntime_providers_shared.so" \
             "$subdir/libonnxruntime_providers_shared.so"
+        if [[ -n "$libort_versioned" ]]; then
+            # Real file + symlink. ort/load-dynamic dlopens the unversioned
+            # name (`libonnxruntime.so`) relative to /proc/self/exe (see
+            # ort src/lib.rs:96-109); the SONAME symlink lets that resolve
+            # without env vars or RPATH plumbing.
+            cp "${src}.${libort_versioned}" "$subdir/${libort_versioned}"
+            ln -sf "${libort_versioned}" "$subdir/libonnxruntime.so"
+        fi
         # Convenience symlink at the top level so existing tooling (the
         # voxtype-wrapper.sh, voxtype setup gpu, ParakeetBackend detection)
         # finds the binary by its short name.
@@ -427,7 +442,7 @@ if [[ "$TARGET_ARCH" == "x86_64" ]]; then
             "$STAGING/usr/lib/voxtype/voxtype-onnx-${variant}"
     }
     install_onnx_gpu_variant cuda-12 cuda
-    install_onnx_gpu_variant cuda-13 cuda
+    install_onnx_gpu_variant cuda-13 cuda libonnxruntime.so.1.24.4
     install_onnx_gpu_variant migraphx migraphx
     # Legacy compat symlink for users with scripts referencing the old
     # voxtype-onnx-rocm name. The AMD GPU EP changed from ROCm to MIGraphX


### PR DESCRIPTION
## Summary

This PR pivots the `voxtype-onnx-cuda-13` build from pyke's prebuilt ORT to Microsoft's official prebuilt, linked dynamically via the `ort/load-dynamic` feature. The full ORT runtime (`libonnxruntime.so.1.24.4`) plus the CUDA EP shared libs ship alongside the binary in `/usr/lib/voxtype/cuda-13/`; `ort/load-dynamic` already resolves the runtime relative to `/proc/self/exe`, so no RPATH or LD_LIBRARY_PATH plumbing is needed.

Targeted at `rc/0.7.3` (hotfix branch); second of two PRs after #394.

## Root cause for #386

`voxtype-onnx-cuda-13 0.7.2` fails on RTX 5090 with:

```
ERROR Non-zero status code returned while running Cast node.
      Name:'/pre_encode/Cast' Status Message: CUDA error
      cudaErrorNoKernelImageForDevice:no kernel image is available
      for execution on the device
```

The 0.7.2 bundled EP confirms it:

| EP source | CUDA arches | PTX |
|---|---|---|
| pyke prebuilt (shipped in 0.7.2) | sm_30, sm_70, sm_75, sm_80, sm_86, sm_89, sm_90a | compute_90a (can't JIT to 12.0) |
| Microsoft 1.24.4 cu13 prebuilt | sm_70, sm_75, sm_80, sm_86, sm_89, sm_90a, sm_100a, **sm_120, sm_120a** | (full coverage) |

The AUR \`voxtype\` source PKGBUILD avoids the bug because it dynamic-loads the distro-built ORT via \`parakeet-load-dynamic\` and the Arch \`onnxruntime\` package is current. Only the binary release path is affected.

## Why not pyke-bump or hybrid swap

- crates.io top version is still \`2.0.0-rc.12\` (March 2025); same as we use. pykeio has closed Blackwell-support issues (#566, #567, #568, #569) as \"Not planned.\"
- An earlier draft of this PR did a minimum-blast-radius EP-only swap (keep pyke's static \`libonnxruntime.a\` + overlay Microsoft's \`libonnxruntime_providers_cuda.so\`). That works in principle — the EP factory ABI is stable across patch versions of the same 1.x line — but mixes two upstreams in one binary. Pivoting to all-Microsoft eliminates the hybrid-ABI bet for the same end-user behavior.

## Why load-dynamic (not from-source static)

Microsoft only distributes \`.so\` files for Linux GPU. Going static requires building ORT ourselves with \`--build_shared_lib=OFF\` and \`CMAKE_CUDA_ARCHITECTURES\` including \`120-real;120-virtual\`, which adds 1–2hr per CI build forever. \`ort/load-dynamic\` matches the runtime model the AUR source build already uses successfully on the user's RTX 5090, and ort's library lookup (\`src/lib.rs:96-109\`) already resolves \`libonnxruntime.so\` relative to \`current_exe()\` — exactly where \`scripts/package.sh\` installs companion .so files today.

## Changes

- **\`Dockerfile.onnx-cuda-13\`**: fetch \`onnxruntime-linux-x64-gpu_cuda13-1.24.4.tgz\` from Microsoft's GitHub release; build voxtype with \`parakeet-cuda,parakeet-load-dynamic,moonshine-cuda,…,onnx-load-dynamic,ml-diarization\`. Bundle \`libonnxruntime.so.1.24.4\` + a \`libonnxruntime.so\` symlink + the CUDA EP shared libs into the output. Two new build-time gates:
  - \`strings | grep '^sm_120'\` fails the build if Microsoft ever ships a tarball without Blackwell (this is what the pyke prebuilt should have been gated on).
  - \`objdump -p | grep 'NEEDED.*libonnxruntime'\` fails the build if \`ort/load-dynamic\` ever silently drops out and the binary regresses to a NEEDED link.

- **\`scripts/package.sh\`**: \`install_onnx_gpu_variant\` gains an optional third arg — the libonnxruntime SONAME. \`cuda-13\` passes \`libonnxruntime.so.1.24.4\` (real file + \`libonnxruntime.so\` symlink). \`cuda-12\` and \`migraphx\` pass empty, keeping their existing static-link layouts.

- **\`.github/workflows/build-linux.yml\`**: \`onnx-cuda-13\` matrix entry's \`companion_libs\` adds \`libonnxruntime.so.1.24.4\` so the Stage step verifies the artifact exists and the artifact-upload glob picks it up.

- **\`packaging/arch-bin-rc/PKGBUILD\`**: add the new artifact to \`source\`, \`sha256sums\` (SKIP placeholder), and install it under \`/usr/lib/voxtype/cuda-13/libonnxruntime.so.1.24.4\` with the \`libonnxruntime.so → libonnxruntime.so.1.24.4\` symlink \`ort/load-dynamic\` needs.

## What's not in this PR

- **\`voxtype-bin\` stable AUR PKGBUILD**: that PKGBUILD lives in its own AUR git repo and is not checked into this tree. The same source/install delta needs to be applied there when v0.7.3 final ships (the \`aur-publish\` skill will pick that up).
- **\`voxtype-bin-rc\` (in-tree)** is updated.
- **cuda-12 + migraphx** are untouched; only RTX 50-series users on cuda-13 actually need this code path. cuda-12 can pivot to the same model later if pyke ever updates their cu12 prebuilt the same way they failed to update cu13.

## Test plan
- [ ] CI build on rc/0.7.3 completes for onnx-cuda-13; both build-time gates (sm_120 strings check + NEEDED-libonnxruntime negative check) pass
- [ ] \`objdump -p\` of the new binary has **no** NEEDED libonnxruntime entry (load-dynamic worked)
- [ ] \`strings\` of the bundled \`libonnxruntime_providers_cuda.so\` includes \`sm_120\` and \`sm_120a\`
- [ ] Local install via \`scripts/package.sh --skip-build 0.7.3-rc1\` produces a deb/rpm with \`/usr/lib/voxtype/cuda-13/{voxtype-onnx-cuda-13, libonnxruntime.so, libonnxruntime.so.1.24.4, libonnxruntime_providers_cuda.so, libonnxruntime_providers_shared.so}\`
- [ ] Smoke test on RTX 5090 (coordinate with @tyvsmith): \`voxtype daemon\` + one Parakeet transcription must succeed without \`cudaErrorNoKernelImageForDevice\`
- [ ] Smoke test on a non-Blackwell NVIDIA card (4090 / 3090) to confirm the load-dynamic swap doesn't regress existing GPUs

Closes #386.