### PR TITLE
Clear MeetingButton.enabled QML warning (closes #396)

### DIFF
--- a/quickshell/MeetingControls.qml
+++ b/quickshell/MeetingControls.qml
@@ -596,8 +596,12 @@ PanelWindow {
         id: btn
         property string label: ""
         property string shortcut: ""
-        property bool enabled: true
         signal clicked()
+
+        // `enabled` is inherited from Item. Qt's built-in property already
+        // controls visual disabled state and gates input events on children
+        // (including the MouseArea below), so a redeclaration would only
+        // shadow it and trigger a QML propertyCache warning.
 
         Layout.fillWidth: true
         Layout.preferredHeight: 36


### PR DESCRIPTION
## Summary

Drops the `property bool enabled: true` redeclaration on the inline `MeetingButton` component in `quickshell/MeetingControls.qml`. Qt logged this on every shell load:

```
WARN qt.qml.propertyCache.append:
  Member enabled of the object MeetingButton overrides a member of the base object.
  Consider renaming it or adding final or override specifier
```

## Option A (drop the redeclaration) - reasoning

`MeetingButton` inherits from `Rectangle`, which inherits `enabled` from `Item`. The redeclaration was semantically identical to the inherited property:

- Both default to `true`.
- Both gate the visual disabled state (the bindings already use `btn.enabled`, which now resolves to the inherited property).
- Qt's built-in `enabled` also gates input events on child items, so the `MouseArea` is automatically suppressed when `enabled` is false. The existing `if (btn.enabled) btn.clicked()` guard in `MouseArea.onClicked` continues to work as belt-and-suspenders.

There was no semantic distinction that would have justified renaming (Option B). The four call sites in the button row keep writing `enabled: card._startEnabled` etc.; they now bind to the inherited property instead of the shadowed one.

Closes #396.

## Test plan

- [ ] `qs -p quickshell -d` no longer logs the `propertyCache.append` warning (verified via static review here; sandbox blocked running `qs`).
- [ ] Open the meeting controls panel (touch the flag file) and confirm Start/Stop/Pause/Resume enable/disable in sync with the daemon's meeting state (`idle` -> Start only; `recording` -> Stop+Pause; `paused` -> Stop+Resume).
- [ ] Disabled buttons still render with reduced opacity, idle-color border, and arrow cursor; clicks do nothing.
- [ ] `cargo fmt --check`, `cargo clippy --all-targets --no-deps -- -D warnings` clean. `cargo test` matches dev (one pre-existing unrelated failure in `setup::parakeet::tests::detect_available_backends_returns_vec`, environmental).