### PR TITLE
Daemonize qs by default in voxtype-osd-quickshell (closes #395)

### DIFF
--- a/src/bin/voxtype_osd.rs
+++ b/src/bin/voxtype_osd.rs
@@ -24,6 +24,19 @@
 //! frontend (including `--config`, which the GTK4 and native frontends
 //! consume on their own to read the rest of the `[osd]` section; the
 //! Quickshell frontend reads the same config via its launcher).
+//!
+//! ## Supervisor opt-out for Quickshell daemonize
+//!
+//! `voxtype-osd-quickshell` passes `-d` to `qs` by default so that
+//! hotkey/CLI invocations survive a short-lived parent shell (see issue
+//! #395). The daemon's OSD supervisor in `src/osd/supervisor.rs` needs
+//! the opposite behavior: it uses `kill_on_drop(true)` to kill the OSD
+//! on shutdown, which only works if qs stays attached to its child slot.
+//!
+//! The supervisor sets `VOXTYPE_OSD_SUPERVISED=1` on the dispatcher's
+//! environment. When this dispatcher sees that env var AND it's about to
+//! exec the Quickshell launcher, it appends `--no-daemonize` to the
+//! launcher's args so qs stays in the foreground.
 
 use std::env;
 use std::os::unix::process::CommandExt;
@@ -96,10 +109,18 @@ fn main() -> ExitCode {
         );
     }
 
+    // Build the final argv. If the supervisor invoked us AND we're
+    // dispatching to the Quickshell launcher, append `--no-daemonize` so
+    // qs stays attached to its child slot for `kill_on_drop`.
+    let supervised = env::var("VOXTYPE_OSD_SUPERVISED")
+        .map(|v| v == "1")
+        .unwrap_or(false);
+    let final_args = build_child_args(chosen.frontend, supervised, &rest);
+
     // Hand off. exec replaces this process so the child inherits stdin,
     // stdout, stderr, signals, and process group cleanly. There's no return
     // path on success.
-    let err = Command::new(&chosen.path).args(&rest).exec();
+    let err = Command::new(&chosen.path).args(&final_args).exec();
     eprintln!(
         "voxtype-osd: failed to exec '{}': {err}",
         chosen.path.display()
@@ -183,6 +204,21 @@ fn parse_frontend_and_config(
         }
     }
     (frontend, config, rest)
+}
+
+/// Build the argv we hand to the chosen frontend. Currently only the
+/// Quickshell launcher needs special handling: when the daemon
+/// supervisor invokes us we append `--no-daemonize` so qs stays attached
+/// to its child slot for `kill_on_drop`. We append (rather than prepend)
+/// so the user's own `--daemonize`/`--no-daemonize` in `rest` always
+/// loses to the supervisor's intent. The Quickshell launcher uses
+/// last-wins flag resolution.
+fn build_child_args(frontend: OsdFrontend, supervised: bool, rest: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = rest.to_vec();
+    if supervised && frontend == OsdFrontend::Quickshell {
+        out.push("--no-daemonize".into());
+    }
+    out
 }
 
 /// Load the `[osd] frontend` value from the voxtype config file, falling
@@ -304,6 +340,44 @@ mod tests {
                 "400".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn build_child_args_appends_no_daemonize_when_supervised_quickshell() {
+        let rest = vec!["--width-px".to_string(), "400".to_string()];
+        let out = build_child_args(OsdFrontend::Quickshell, true, &rest);
+        assert_eq!(
+            out,
+            vec![
+                "--width-px".to_string(),
+                "400".to_string(),
+                "--no-daemonize".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_child_args_no_op_for_quickshell_unsupervised() {
+        let rest = vec!["--width-px".to_string(), "400".to_string()];
+        let out = build_child_args(OsdFrontend::Quickshell, false, &rest);
+        assert_eq!(out, rest);
+    }
+
+    #[test]
+    fn build_child_args_no_op_for_gtk4_supervised() {
+        // The supervisor flag must not bleed into the GTK4 or Native
+        // frontends — they have no `--no-daemonize` flag and would
+        // error out on an unknown arg.
+        let rest = vec!["--width-px".to_string(), "400".to_string()];
+        let out = build_child_args(OsdFrontend::Gtk4, true, &rest);
+        assert_eq!(out, rest);
+    }
+
+    #[test]
+    fn build_child_args_no_op_for_native_supervised() {
+        let rest = vec!["--width-px".to_string(), "400".to_string()];
+        let out = build_child_args(OsdFrontend::Native, true, &rest);
+        assert_eq!(out, rest);
     }
 
     #[test]

--- a/src/bin/voxtype_osd_quickshell.rs
+++ b/src/bin/voxtype_osd_quickshell.rs
@@ -1,11 +1,28 @@
 //! `voxtype-osd-quickshell` — a tiny launcher that finds voxtype's Quickshell
-//! shell directory (containing `shell.qml`) and execs `qs -p <dir>`.
+//! shell directory (containing `shell.qml`) and execs `qs -d -p <dir>`.
 //!
 //! Quickshell (`qs`) treats the directory as a config root and loads
 //! `shell.qml` from it. We pass the directory rather than the file so that
 //! sibling QML imports (`import "voxtype-shared" as VT`) resolve through
 //! Quickshell's virtual filesystem; passing the file directly traps `..`
 //! traversals in `qrc:/qs-blackhole`.
+//!
+//! ## Daemonize by default
+//!
+//! The launcher passes `-d` to `qs` by default. Without `-d`, qs stays
+//! attached to its controlling terminal and dies via SIGHUP when its
+//! parent process exits — which is exactly what happens when users invoke
+//! the launcher from a hotkey, a short-lived shell, or `voxtype setup
+//! quickshell` smoke tests (see issue #395). Passing `-d` forks qs into
+//! its own session so the OSD survives.
+//!
+//! The daemon's OSD supervisor needs the opposite behavior: it spawns
+//! `voxtype-osd` (the dispatcher) via `tokio::process::Command` with
+//! `kill_on_drop(true)` so the OSD child is killed on daemon shutdown. If
+//! qs daemonizes, the supervisor's child slot exits immediately, the
+//! supervisor thinks qs died, and it respawns in a loop. To opt out, the
+//! supervisor sets `VOXTYPE_OSD_SUPERVISED=1` and the dispatcher then
+//! passes `--no-daemonize` through to this launcher.
 //!
 //! The launcher resolves the shell directory in this order:
 //!
@@ -53,7 +70,7 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    let (cli_qml_path, rest) = parse_qml_path(&raw_args);
+    let (cli_qml_path, daemonize, rest) = parse_args(&raw_args);
 
     let shell_dir = match resolve_shell_dir(cli_qml_path) {
         Some(p) => p,
@@ -92,10 +109,14 @@ fn main() -> ExitCode {
 
     tracing::info!(
         shell_dir = %shell_dir.display(),
+        daemonize,
         "launching Quickshell OSD"
     );
 
     let mut cmd = Command::new(QS_BIN);
+    if daemonize {
+        cmd.arg("-d");
+    }
     cmd.arg("-p").arg(&shell_dir).args(&rest);
     let err = cmd.exec();
     eprintln!(
@@ -116,10 +137,21 @@ fn print_help() {
              --qml-path <PATH>    Override the Quickshell config directory.\n\
                                   Accepts either the directory containing\n\
                                   shell.qml or the shell.qml file itself.\n    \
+             --daemonize          Pass `-d` to qs (default). qs forks and\n\
+                                  detaches from the controlling terminal so\n\
+                                  the OSD survives a short-lived parent\n\
+                                  shell or hotkey invocation.\n    \
+             --no-daemonize       Do NOT pass `-d` to qs. Use this when a\n\
+                                  supervisor wants to keep qs attached to a\n\
+                                  child-process slot (e.g. the daemon's OSD\n\
+                                  supervisor relies on this so kill_on_drop\n\
+                                  reaches qs on shutdown).\n    \
              -h, --help           Show this message.\n    \
              -V, --version        Show version.\n\
          \n\
-         All other arguments are forwarded to `qs` after `-p <dir>`.\n\
+         If both --daemonize and --no-daemonize appear, the last one wins.\n\
+         \n\
+         All other arguments are forwarded to `qs` after `-d -p <dir>`.\n\
          \n\
          ENV:\n    \
              VOXTYPE_OSD_QML_PATH   Same as --qml-path.\n",
@@ -127,10 +159,19 @@ fn print_help() {
     );
 }
 
-/// Strip `--qml-path X`/`--qml-path=X` out of `args`. Anything left over
-/// is passed through to `qs` unchanged.
-fn parse_qml_path(args: &[String]) -> (Option<PathBuf>, Vec<String>) {
+/// Strip our own flags out of `args`:
+///
+/// - `--qml-path X` / `--qml-path=X`: resolve to a `PathBuf`.
+/// - `--daemonize` / `--no-daemonize`: set the daemonize flag. Last one
+///   wins so callers can override an upstream default by appending the
+///   opposite flag at the end (the dispatcher relies on this when it
+///   appends `--no-daemonize` to the user's argv).
+///
+/// Anything left over is passed through to `qs` unchanged. The returned
+/// `daemonize` defaults to `true` (the bug-fix in #395).
+fn parse_args(args: &[String]) -> (Option<PathBuf>, bool, Vec<String>) {
     let mut qml: Option<PathBuf> = None;
+    let mut daemonize = true;
     let mut rest: Vec<String> = Vec::with_capacity(args.len());
     let mut i = 0;
     while i < args.len() {
@@ -146,12 +187,18 @@ fn parse_qml_path(args: &[String]) -> (Option<PathBuf>, Vec<String>) {
         } else if let Some(v) = a.strip_prefix("--qml-path=") {
             qml = Some(PathBuf::from(v));
             i += 1;
+        } else if a == "--daemonize" {
+            daemonize = true;
+            i += 1;
+        } else if a == "--no-daemonize" {
+            daemonize = false;
+            i += 1;
         } else {
             rest.push(a.clone());
             i += 1;
         }
     }
-    (qml, rest)
+    (qml, daemonize, rest)
 }
 
 /// Normalize a user-supplied path into the directory containing
@@ -222,36 +269,85 @@ mod tests {
     #[test]
     fn parse_qml_path_space_form() {
         let args = vec!["--qml-path".into(), "/tmp/x".into(), "extra".into()];
-        let (q, rest) = parse_qml_path(&args);
+        let (q, d, rest) = parse_args(&args);
         assert_eq!(q.as_deref(), Some(Path::new("/tmp/x")));
+        assert!(d, "daemonize defaults to true");
         assert_eq!(rest, vec!["extra".to_string()]);
     }
 
     #[test]
     fn parse_qml_path_equals_form() {
         let args = vec!["--qml-path=/tmp/y".into(), "extra".into()];
-        let (q, rest) = parse_qml_path(&args);
+        let (q, d, rest) = parse_args(&args);
         assert_eq!(q.as_deref(), Some(Path::new("/tmp/y")));
+        assert!(d);
         assert_eq!(rest, vec!["extra".to_string()]);
     }
 
     #[test]
     fn parse_qml_path_absent() {
         let args = vec!["--width-px".into(), "400".into()];
-        let (q, rest) = parse_qml_path(&args);
+        let (q, d, rest) = parse_args(&args);
         assert!(q.is_none());
+        assert!(d, "daemonize defaults to true");
         assert_eq!(rest, vec!["--width-px".to_string(), "400".to_string()]);
     }
 
     #[test]
     fn parse_qml_path_dangling_flag() {
         let args = vec!["--qml-path".into()];
-        let (q, rest) = parse_qml_path(&args);
+        let (q, d, rest) = parse_args(&args);
         // Dangling `--qml-path` with no value is passed through so the
         // child (which won't recognise it) errors out clearly rather than
         // being silently dropped.
         assert!(q.is_none());
+        assert!(d);
         assert_eq!(rest, vec!["--qml-path".to_string()]);
+    }
+
+    #[test]
+    fn parse_daemonize_default_true() {
+        // No flag at all → daemonize stays true (the v0.7.3 default).
+        let args: Vec<String> = vec!["--width-px".into(), "400".into()];
+        let (_, d, rest) = parse_args(&args);
+        assert!(d);
+        // The pass-through arg is preserved verbatim for qs.
+        assert_eq!(rest, vec!["--width-px".to_string(), "400".to_string()]);
+    }
+
+    #[test]
+    fn parse_no_daemonize_strips_flag_and_clears_default() {
+        let args = vec!["--no-daemonize".into(), "extra".into()];
+        let (_, d, rest) = parse_args(&args);
+        assert!(!d, "--no-daemonize must turn off daemonize");
+        assert_eq!(
+            rest,
+            vec!["extra".to_string()],
+            "--no-daemonize must be stripped from the pass-through args"
+        );
+    }
+
+    #[test]
+    fn parse_daemonize_explicit_flag_stripped() {
+        let args = vec!["--daemonize".into(), "extra".into()];
+        let (_, d, rest) = parse_args(&args);
+        assert!(d);
+        assert_eq!(rest, vec!["extra".to_string()]);
+    }
+
+    #[test]
+    fn parse_daemonize_flags_last_wins() {
+        // --daemonize then --no-daemonize → no-daemonize wins.
+        let args = vec!["--daemonize".into(), "--no-daemonize".into()];
+        let (_, d, rest) = parse_args(&args);
+        assert!(!d, "last flag wins: --no-daemonize at the end");
+        assert!(rest.is_empty());
+
+        // Reverse: --no-daemonize then --daemonize → daemonize wins.
+        let args = vec!["--no-daemonize".into(), "--daemonize".into()];
+        let (_, d, rest) = parse_args(&args);
+        assert!(d, "last flag wins: --daemonize at the end");
+        assert!(rest.is_empty());
     }
 
     #[test]

--- a/src/osd/supervisor.rs
+++ b/src/osd/supervisor.rs
@@ -16,6 +16,17 @@
 //! aborted, which is fine for the OSD: it owns no daemon-shared state and
 //! the frontend's own `--reconnect-secs` loop handles a clean re-attach
 //! after `systemctl --user restart voxtype`.
+//!
+//! ### `VOXTYPE_OSD_SUPERVISED`
+//!
+//! We set `VOXTYPE_OSD_SUPERVISED=1` on the child's environment so the
+//! dispatcher (`voxtype-osd`) knows it was spawned by the daemon rather
+//! than invoked interactively. When dispatching to the Quickshell
+//! launcher the dispatcher then appends `--no-daemonize`, which tells
+//! the launcher to skip `qs -d`. Without this, qs would fork off into
+//! its own session, the supervisor's child slot would exit immediately,
+//! `kill_on_drop` would have nothing to kill, and the supervisor would
+//! respawn in a loop thinking the child died (see issue #395).
 
 use std::time::{Duration, Instant};
 use tokio::process::Command;
@@ -44,6 +55,11 @@ async fn supervise() {
         let started = Instant::now();
         let mut cmd = Command::new(OSD_BINARY);
         cmd.kill_on_drop(true);
+        // Tell the dispatcher this child is supervised. The dispatcher
+        // uses this to suppress qs's daemonize fork when handing off to
+        // the Quickshell launcher (otherwise kill_on_drop has nothing
+        // to kill — see #395).
+        cmd.env("VOXTYPE_OSD_SUPERVISED", "1");
 
         let mut child = match cmd.spawn() {
             Ok(c) => c,


### PR DESCRIPTION
## Summary

- The Quickshell launcher now passes `-d` to `qs` by default, so OSDs launched from hotkeys, short-lived shells, or `voxtype setup quickshell` smoke tests survive SIGHUP from their dying parent.
- Adds `--daemonize` / `--no-daemonize` flags to `voxtype-osd-quickshell`. Default is daemonize; last flag wins so an override can be appended.
- The daemon's OSD supervisor sets `VOXTYPE_OSD_SUPERVISED=1` on the dispatcher's environment. The dispatcher (`voxtype-osd`) reads it and, when dispatching to the Quickshell launcher specifically, appends `--no-daemonize` so qs stays attached to the supervisor's child slot and `kill_on_drop(true)` still works on shutdown.
- GTK4 and Native frontends are not touched: the dispatcher only appends `--no-daemonize` when the chosen frontend is Quickshell, so those launchers never see an unknown flag.

Closes #395.

## Approach

**Launcher flag parsing.** `voxtype-osd-quickshell` learns `--daemonize` and `--no-daemonize` in `parse_args` (renamed from `parse_qml_path`). Default is `true`, last flag wins. Both flags are stripped from the pass-through args so `qs` never sees them.

**Dispatcher opt-out.** `voxtype-osd` adds `build_child_args(frontend, supervised, &rest)` which appends `--no-daemonize` only when `frontend == Quickshell && supervised`. Append-not-prepend so the supervisor wins last-write over any user-supplied flag.

**Supervisor.** `src/osd/supervisor.rs` adds `cmd.env("VOXTYPE_OSD_SUPERVISED", "1")` before spawn. No structural changes; `kill_on_drop(true)` keeps working because qs no longer forks away.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --bin voxtype-osd --bin voxtype-osd-quickshell` (20 tests pass)
- [x] Full `cargo test` (only pre-existing parakeet backend test fails, unrelated)
- [ ] Manual: invoke `voxtype-osd-quickshell` from a `bash -c` one-shot and confirm qs survives parent exit
- [ ] Manual: restart the daemon and confirm `journalctl --user -u voxtype` doesn't show a respawn loop for the Quickshell OSD child
- [ ] Manual: `systemctl --user stop voxtype` and confirm the qs process is killed (kill_on_drop reaches it)

## Notes

The supervisor opt-out path is covered by unit tests (env-driven dispatcher behavior), but the end-to-end "supervisor actually kills the child" path is not exercised in CI - that's a live Hyprland/Wayland test on a machine with `qs` installed. Worth a smoke run before tagging v0.7.3.