### PR TITLE
voxtype setup quickshell symlinks voxtype-audio-bridge into PATH (closes #397)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3130,11 +3130,16 @@ voxtype setup quickshell
 ```
 
 That command copies the QML files into `$XDG_DATA_HOME/voxtype/quickshell/`
-(or `~/.local/share/voxtype/quickshell/`) and prints compositor binding
-examples for the Wave 2 engine picker and meeting controls panels. The AUR
-packages already install the system-wide copy under
-`/usr/share/voxtype/quickshell/`; the per-user copy is only required for
-source builds or for customization. See the
+(or `~/.local/share/voxtype/quickshell/`), symlinks the
+`voxtype-audio-bridge` sidecar into `$XDG_BIN_HOME/voxtype-audio-bridge`
+(or `~/.local/bin/voxtype-audio-bridge`) so the QML waveform can find
+it on PATH, and prints compositor binding examples for the Wave 2 engine
+picker and meeting controls panels. The AUR packages already install
+the system-wide copy under `/usr/share/voxtype/quickshell/` and ship the
+bridge at `/usr/lib/voxtype/voxtype-audio-bridge`; the per-user QML copy
+is only required for source builds or for customization, and the bridge
+symlink is what puts the sidecar on PATH where the QML expects it. Pass
+`--skip-bridge` if your install already has the bridge on PATH. See the
 [user manual](USER_MANUAL.md#voxtype-setup-quickshell) for details.
 
 ---

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -267,16 +267,30 @@ command to put a per-user copy under `$XDG_DATA_HOME/voxtype/quickshell/`
 for customization.
 
 ```bash
-voxtype setup quickshell                  # Install + print compositor bindings
-voxtype setup quickshell --target DIR     # Install to a custom location
-voxtype setup quickshell --source DIR     # Override the source tree (default: auto-detect)
-voxtype setup quickshell --force          # Overwrite an existing install
-voxtype setup quickshell --print-bindings # Print the bindings only, do not copy
+voxtype setup quickshell                       # Install QML + symlink the bridge
+voxtype setup quickshell --target DIR          # Install QML to a custom location
+voxtype setup quickshell --source DIR          # Override the source tree (default: auto-detect)
+voxtype setup quickshell --force               # Overwrite an existing install
+voxtype setup quickshell --print-bindings      # Print the bindings only, do not copy
+voxtype setup quickshell --bridge PATH         # Override the audio-bridge source binary
+voxtype setup quickshell --bridge-target PATH  # Override the audio-bridge symlink location
+voxtype setup quickshell --skip-bridge         # Skip the audio-bridge symlink entirely
 ```
 
-The default target is `$XDG_DATA_HOME/voxtype/quickshell/` (or
+The default QML target is `$XDG_DATA_HOME/voxtype/quickshell/` (or
 `~/.local/share/voxtype/quickshell/` if `XDG_DATA_HOME` is unset). The
 launcher searches that path first, then `/usr/share/voxtype/quickshell/`.
+
+The command also symlinks `voxtype-audio-bridge` into
+`$XDG_BIN_HOME/voxtype-audio-bridge` (or `~/.local/bin/voxtype-audio-bridge`)
+so the QML waveform can spawn the sidecar via a normal PATH lookup. The
+AUR `voxtype-bin` package installs the bridge under
+`/usr/lib/voxtype/voxtype-audio-bridge`, which is not on the default
+PATH; the symlink is what makes the waveform light up after install.
+Pass `--skip-bridge` if you already have the bridge on PATH and don't
+want a per-user symlink, or `--bridge-target` to point the symlink at a
+different user-owned directory. Writing outside of `$HOME` is refused
+unless `--force` is also passed.
 
 The command prints Hyprland, Sway, and River keybinding examples that
 toggle the Wave 2 engine-picker and meeting-controls panels via flag

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1278,6 +1278,30 @@ pub enum SetupAction {
         /// Skip the file copy; only print the compositor binding examples.
         #[arg(long)]
         print_bindings: bool,
+
+        /// Override the source path of the voxtype-audio-bridge binary.
+        ///
+        /// Search order (when omitted): $VOXTYPE_AUDIO_BRIDGE_BINARY,
+        /// <binary>/../lib/voxtype/voxtype-audio-bridge,
+        /// /usr/lib/voxtype/voxtype-audio-bridge, `which voxtype-audio-bridge`,
+        /// target/release/voxtype-audio-bridge, target/debug/voxtype-audio-bridge.
+        #[arg(long, value_name = "PATH")]
+        bridge: Option<std::path::PathBuf>,
+
+        /// Override the symlink location for voxtype-audio-bridge.
+        ///
+        /// Defaults to $XDG_BIN_HOME/voxtype-audio-bridge or
+        /// ~/.local/bin/voxtype-audio-bridge. Must live under the user's
+        /// $HOME unless you also pass --force.
+        #[arg(long, value_name = "PATH")]
+        bridge_target: Option<std::path::PathBuf>,
+
+        /// Skip installing the voxtype-audio-bridge symlink.
+        ///
+        /// Use this if the bridge is already on PATH (e.g., a packaged
+        /// install put it there, or you have your own symlink).
+        #[arg(long)]
+        skip_bridge: bool,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -663,9 +663,20 @@ async fn main() -> anyhow::Result<()> {
                     source,
                     force,
                     print_bindings,
+                    bridge,
+                    bridge_target,
+                    skip_bridge,
                 }) => {
                     warn_if_root("quickshell");
-                    setup::quickshell::run(target, source, force, print_bindings)?;
+                    setup::quickshell::run(
+                        target,
+                        source,
+                        force,
+                        print_bindings,
+                        bridge,
+                        bridge_target,
+                        skip_bridge,
+                    )?;
                 }
                 None => {
                     // Default: run setup (non-blocking)

--- a/src/setup/quickshell.rs
+++ b/src/setup/quickshell.rs
@@ -3,9 +3,10 @@
 //! Copies the Quickshell QML tree (`shell.qml`, `OsdSurface.qml`,
 //! `EnginePicker.qml`, `MeetingControls.qml`, and the `voxtype-shared/`
 //! module) into the user's data directory so the `voxtype-osd-quickshell`
-//! launcher can find it. Also prints Hyprland/Sway/River keybinding
-//! examples for the Wave 2 widgets that toggle via flag files in
-//! `$XDG_RUNTIME_DIR/voxtype/`.
+//! launcher can find it. Also symlinks the `voxtype-audio-bridge` sidecar
+//! into a user-owned PATH directory so the QML can spawn it. Prints
+//! Hyprland/Sway/River keybinding examples for the Wave 2 widgets that
+//! toggle via flag files in `$XDG_RUNTIME_DIR/voxtype/`.
 //!
 //! Source tree resolution (first match wins):
 //! 1. `--source <DIR>` CLI override
@@ -16,9 +17,22 @@
 //!
 //! Destination: `$XDG_DATA_HOME/voxtype/quickshell/` (or
 //! `~/.local/share/voxtype/quickshell/` if `XDG_DATA_HOME` is unset).
+//!
+//! Bridge binary resolution (first match wins):
+//! 1. `--bridge <PATH>` CLI override
+//! 2. `$VOXTYPE_AUDIO_BRIDGE_BINARY` env var
+//! 3. `<binary's dir>/../lib/voxtype/voxtype-audio-bridge` (installed layout)
+//! 4. `/usr/lib/voxtype/voxtype-audio-bridge`
+//! 5. `which voxtype-audio-bridge` (already on PATH — no symlink needed)
+//! 6. `target/release/voxtype-audio-bridge` / `target/debug/...` (dev convenience)
+//!
+//! Bridge symlink target defaults to `$XDG_BIN_HOME/voxtype-audio-bridge`
+//! (or `~/.local/bin/voxtype-audio-bridge`). Refuses to write outside
+//! `$HOME` without `--force`.
 
 use std::env;
 use std::fs;
+use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::VoxtypeError;
@@ -185,6 +199,190 @@ pub fn install_tree(
     Ok(written)
 }
 
+/// Name of the audio bridge binary used in PATH lookups and symlinks.
+const BRIDGE_BIN_NAME: &str = "voxtype-audio-bridge";
+
+/// Outcome of bridge resolution: either a concrete source path to symlink
+/// from, or a confirmation that the bridge is already discoverable on the
+/// user's `PATH` (in which case no symlink is needed).
+#[derive(Debug, PartialEq, Eq)]
+pub enum BridgeSource {
+    /// Bridge binary lives at this absolute path. Caller should symlink.
+    Path(PathBuf),
+    /// `which voxtype-audio-bridge` succeeded at this path; PATH already has it.
+    OnPath(PathBuf),
+}
+
+/// Resolve the voxtype-audio-bridge source binary.
+///
+/// Search order (first match wins) mirrors the module header.
+pub fn resolve_bridge_source(cli_bridge: Option<&Path>) -> Option<BridgeSource> {
+    if let Some(p) = cli_bridge {
+        if p.is_file() {
+            return Some(BridgeSource::Path(p.to_path_buf()));
+        }
+    }
+    if let Ok(env_path) = env::var("VOXTYPE_AUDIO_BRIDGE_BINARY") {
+        if !env_path.is_empty() {
+            let p = PathBuf::from(env_path);
+            if p.is_file() {
+                return Some(BridgeSource::Path(p));
+            }
+        }
+    }
+    if let Ok(exe) = env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            let installed = parent.join("../lib/voxtype").join(BRIDGE_BIN_NAME);
+            if installed.is_file() {
+                if let Ok(canon) = fs::canonicalize(&installed) {
+                    return Some(BridgeSource::Path(canon));
+                }
+                return Some(BridgeSource::Path(installed));
+            }
+        }
+    }
+    let system = PathBuf::from("/usr/lib/voxtype").join(BRIDGE_BIN_NAME);
+    if system.is_file() {
+        return Some(BridgeSource::Path(system));
+    }
+    if let Ok(path) = which::which(BRIDGE_BIN_NAME) {
+        return Some(BridgeSource::OnPath(path));
+    }
+    for build in &["release", "debug"] {
+        let dev = PathBuf::from("target").join(build).join(BRIDGE_BIN_NAME);
+        if dev.is_file() {
+            if let Ok(canon) = fs::canonicalize(&dev) {
+                return Some(BridgeSource::Path(canon));
+            }
+            return Some(BridgeSource::Path(dev));
+        }
+    }
+    None
+}
+
+/// Resolve the default bridge symlink target.
+///
+/// Honors `$XDG_BIN_HOME` when set (per the user-dirs spec), otherwise
+/// falls back to `~/.local/bin/`.
+pub fn default_bridge_target() -> PathBuf {
+    if let Ok(xdg) = env::var("XDG_BIN_HOME") {
+        if !xdg.is_empty() {
+            return PathBuf::from(xdg).join(BRIDGE_BIN_NAME);
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        return home.join(".local/bin").join(BRIDGE_BIN_NAME);
+    }
+    PathBuf::from(".local/bin").join(BRIDGE_BIN_NAME)
+}
+
+/// Check whether `target` lives under the user's `$HOME`.
+fn target_is_under_home(target: &Path) -> bool {
+    match dirs::home_dir() {
+        Some(home) => target.starts_with(home),
+        None => false,
+    }
+}
+
+/// Outcome of `install_bridge_symlink`. Used to format the user-facing
+/// message and inform tests.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BridgeInstallOutcome {
+    /// Created or replaced the symlink.
+    Linked,
+    /// Symlink already pointed at the right source; no change.
+    AlreadyLinked,
+    /// Skipped because the bridge was already on the user's PATH.
+    AlreadyOnPath(PathBuf),
+}
+
+/// Install a symlink at `target` pointing at the bridge source.
+///
+/// Refuses to overwrite an existing file (or a symlink pointing elsewhere)
+/// without `force`. Refuses to write outside the user's `$HOME` without
+/// `force` to avoid stomping on system paths like `/usr/local/bin/`.
+pub fn install_bridge_symlink(
+    source: &Path,
+    target: &Path,
+    force: bool,
+) -> Result<BridgeInstallOutcome, VoxtypeError> {
+    if !target_is_under_home(target) && !force {
+        return Err(VoxtypeError::Config(format!(
+            "Refusing to write bridge symlink outside of HOME: {}\n  \
+             Re-run with --force if this is really what you want.",
+            target.display()
+        )));
+    }
+
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            VoxtypeError::Config(format!("Failed to create {}: {}", parent.display(), e))
+        })?;
+    }
+
+    let metadata = fs::symlink_metadata(target).ok();
+    if let Some(md) = metadata {
+        if md.file_type().is_symlink() {
+            let current = fs::read_link(target).map_err(|e| {
+                VoxtypeError::Config(format!(
+                    "Failed to read existing symlink {}: {}",
+                    target.display(),
+                    e
+                ))
+            })?;
+            // Compare canonicalized forms when possible so relative vs
+            // absolute representations don't trigger spurious mismatches.
+            let same = current == source
+                || fs::canonicalize(&current).ok() == fs::canonicalize(source).ok();
+            if same {
+                return Ok(BridgeInstallOutcome::AlreadyLinked);
+            }
+            if !force {
+                return Err(VoxtypeError::Config(format!(
+                    "{} already exists and points to {}.\n  \
+                     Re-run with --force to overwrite, or pass \
+                     --skip-bridge to leave it alone.",
+                    target.display(),
+                    current.display()
+                )));
+            }
+            fs::remove_file(target).map_err(|e| {
+                VoxtypeError::Config(format!(
+                    "Failed to remove existing symlink {}: {}",
+                    target.display(),
+                    e
+                ))
+            })?;
+        } else {
+            if !force {
+                return Err(VoxtypeError::Config(format!(
+                    "{} already exists and is not a symlink.\n  \
+                     Re-run with --force to overwrite, or pass \
+                     --skip-bridge to leave it alone.",
+                    target.display()
+                )));
+            }
+            fs::remove_file(target).map_err(|e| {
+                VoxtypeError::Config(format!(
+                    "Failed to remove existing file {}: {}",
+                    target.display(),
+                    e
+                ))
+            })?;
+        }
+    }
+
+    unix_fs::symlink(source, target).map_err(|e| {
+        VoxtypeError::Config(format!(
+            "Failed to symlink {} -> {}: {}",
+            target.display(),
+            source.display(),
+            e
+        ))
+    })?;
+    Ok(BridgeInstallOutcome::Linked)
+}
+
 /// Print the Hyprland/Sway/River keybinding examples that drive the
 /// flag-file triggers for the engine picker and meeting controls panels.
 pub fn print_bindings() {
@@ -212,11 +410,15 @@ pub fn print_bindings() {
 }
 
 /// Run the full `voxtype setup quickshell` flow.
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     target: Option<PathBuf>,
     source: Option<PathBuf>,
     force: bool,
     print_bindings_only: bool,
+    bridge: Option<PathBuf>,
+    bridge_target: Option<PathBuf>,
+    skip_bridge: bool,
 ) -> Result<(), VoxtypeError> {
     if print_bindings_only {
         print_bindings();
@@ -247,6 +449,55 @@ pub fn run(
         println!("  copied {}", rel.display());
     }
 
+    // Bridge install (symlink so updates to the source binary propagate).
+    let bridge_summary = if skip_bridge {
+        println!();
+        println!("Skipping voxtype-audio-bridge install (--skip-bridge).");
+        None
+    } else {
+        println!();
+        match install_bridge(bridge.as_deref(), bridge_target.as_deref(), force)? {
+            Some((outcome, link_target, link_source)) => match outcome {
+                BridgeInstallOutcome::Linked => {
+                    println!(
+                        "Linked {} -> {}",
+                        link_target.display(),
+                        link_source.display()
+                    );
+                    Some(link_target)
+                }
+                BridgeInstallOutcome::AlreadyLinked => {
+                    println!(
+                        "voxtype-audio-bridge already linked at {} (no change).",
+                        link_target.display()
+                    );
+                    Some(link_target)
+                }
+                BridgeInstallOutcome::AlreadyOnPath(path) => {
+                    println!(
+                        "voxtype-audio-bridge is already on PATH at {} (no symlink needed).",
+                        path.display()
+                    );
+                    None
+                }
+            },
+            None => {
+                println!(
+                    "Could not locate voxtype-audio-bridge. The QML waveform will\n  \
+                     stay empty until the bridge is on PATH. Searched (in order):\n  \
+                     --bridge <PATH>\n  \
+                     $VOXTYPE_AUDIO_BRIDGE_BINARY\n  \
+                     <binary>/../lib/voxtype/voxtype-audio-bridge\n  \
+                     /usr/lib/voxtype/voxtype-audio-bridge\n  \
+                     `which voxtype-audio-bridge`\n  \
+                     ./target/release/voxtype-audio-bridge\n  \
+                     ./target/debug/voxtype-audio-bridge"
+                );
+                None
+            }
+        }
+    };
+
     println!();
     print_bindings();
 
@@ -255,6 +506,13 @@ pub fn run(
         "Quickshell config installed to {}.",
         resolved_target.display()
     );
+    if let Some(link) = bridge_summary.as_ref() {
+        println!(
+            "voxtype-audio-bridge linked at {}. Make sure ~/.local/bin is on your\n  \
+             PATH (most shells already include it).",
+            link.display()
+        );
+    }
     println!(
         "Run with: voxtype-osd-quickshell  (or set [osd] frontend = \"quickshell\" in config.toml)"
     );
@@ -262,10 +520,53 @@ pub fn run(
     Ok(())
 }
 
+/// Resolve, decide, and install the bridge symlink. Returns `None` if no
+/// bridge source could be found anywhere. Returns the install outcome
+/// along with the resolved target path and source path for messaging.
+fn install_bridge(
+    cli_bridge: Option<&Path>,
+    cli_target: Option<&Path>,
+    force: bool,
+) -> Result<Option<(BridgeInstallOutcome, PathBuf, PathBuf)>, VoxtypeError> {
+    let Some(source) = resolve_bridge_source(cli_bridge) else {
+        return Ok(None);
+    };
+    let resolved_target = cli_target
+        .map(PathBuf::from)
+        .unwrap_or_else(default_bridge_target);
+    println!("voxtype-audio-bridge target: {}", resolved_target.display());
+
+    match source {
+        BridgeSource::OnPath(path) if cli_target.is_none() => {
+            // If the user gave an explicit --bridge-target, fall through
+            // and create the symlink anyway. Otherwise honor the existing
+            // PATH entry.
+            Ok(Some((
+                BridgeInstallOutcome::AlreadyOnPath(path.clone()),
+                resolved_target,
+                path,
+            )))
+        }
+        BridgeSource::OnPath(path) => {
+            let outcome = install_bridge_symlink(&path, &resolved_target, force)?;
+            Ok(Some((outcome, resolved_target, path)))
+        }
+        BridgeSource::Path(path) => {
+            let outcome = install_bridge_symlink(&path, &resolved_target, force)?;
+            Ok(Some((outcome, resolved_target, path)))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    /// Serializes tests that mutate process-wide environment variables so
+    /// they don't race each other when cargo runs them in parallel.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn make_fake_source(dir: &Path) {
         fs::create_dir_all(dir).unwrap();
@@ -352,6 +653,7 @@ mod tests {
 
     #[test]
     fn resolve_source_dir_prefers_cli_override() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let valid = TempDir::new().unwrap();
         make_fake_source(valid.path());
 
@@ -373,6 +675,7 @@ mod tests {
 
     #[test]
     fn resolve_source_dir_honors_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let valid = TempDir::new().unwrap();
         make_fake_source(valid.path());
 
@@ -387,8 +690,257 @@ mod tests {
         }
     }
 
+    fn make_fake_bridge(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, b"#!/bin/sh\necho fake\n").unwrap();
+    }
+
+    #[test]
+    fn resolve_bridge_source_prefers_cli_override() {
+        let dir = TempDir::new().unwrap();
+        let bin = dir.path().join("voxtype-audio-bridge");
+        make_fake_bridge(&bin);
+
+        let resolved = resolve_bridge_source(Some(&bin)).unwrap();
+        assert_eq!(resolved, BridgeSource::Path(bin));
+    }
+
+    #[test]
+    fn resolve_bridge_source_honors_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = TempDir::new().unwrap();
+        let bin = dir.path().join("voxtype-audio-bridge");
+        make_fake_bridge(&bin);
+
+        unsafe {
+            env::set_var("VOXTYPE_AUDIO_BRIDGE_BINARY", &bin);
+        }
+        let resolved = resolve_bridge_source(None).unwrap();
+        unsafe {
+            env::remove_var("VOXTYPE_AUDIO_BRIDGE_BINARY");
+        }
+        assert_eq!(resolved, BridgeSource::Path(bin));
+    }
+
+    #[test]
+    fn resolve_bridge_source_returns_none_when_missing() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Make sure no env override is set, and the search will hit
+        // /usr/lib/voxtype/... only if it actually exists on disk.
+        unsafe {
+            env::remove_var("VOXTYPE_AUDIO_BRIDGE_BINARY");
+        }
+        // Pass a non-existent CLI path — should fall through to system
+        // paths and PATH lookup. We can't deterministically guarantee
+        // those are absent, but we can at least confirm that with a
+        // bogus CLI override we still do the search.
+        let bogus = PathBuf::from("/nonexistent/path/voxtype-audio-bridge");
+        // Result is system-dependent; we just exercise the code path.
+        let _ = resolve_bridge_source(Some(&bogus));
+    }
+
+    #[test]
+    fn install_bridge_symlink_creates_link() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let src_dir = TempDir::new().unwrap();
+        let bin = src_dir.path().join("voxtype-audio-bridge");
+        make_fake_bridge(&bin);
+
+        // Pretend the target is under HOME by setting HOME to a tmpdir.
+        let fake_home = TempDir::new().unwrap();
+        let prev_home = env::var("HOME").ok();
+        unsafe {
+            env::set_var("HOME", fake_home.path());
+        }
+        let target = fake_home.path().join(".local/bin/voxtype-audio-bridge");
+
+        let outcome = install_bridge_symlink(&bin, &target, false).unwrap();
+        assert_eq!(outcome, BridgeInstallOutcome::Linked);
+        let md = fs::symlink_metadata(&target).unwrap();
+        assert!(md.file_type().is_symlink());
+        assert_eq!(fs::read_link(&target).unwrap(), bin);
+
+        unsafe {
+            match prev_home {
+                Some(v) => env::set_var("HOME", v),
+                None => env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn install_bridge_symlink_is_idempotent_when_matches() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let src_dir = TempDir::new().unwrap();
+        let bin = src_dir.path().join("voxtype-audio-bridge");
+        make_fake_bridge(&bin);
+
+        let fake_home = TempDir::new().unwrap();
+        let prev_home = env::var("HOME").ok();
+        unsafe {
+            env::set_var("HOME", fake_home.path());
+        }
+        let target = fake_home.path().join(".local/bin/voxtype-audio-bridge");
+
+        let first = install_bridge_symlink(&bin, &target, false).unwrap();
+        assert_eq!(first, BridgeInstallOutcome::Linked);
+
+        let second = install_bridge_symlink(&bin, &target, false).unwrap();
+        assert_eq!(second, BridgeInstallOutcome::AlreadyLinked);
+
+        unsafe {
+            match prev_home {
+                Some(v) => env::set_var("HOME", v),
+                None => env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn install_bridge_symlink_refuses_overwrite_without_force() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let src_dir = TempDir::new().unwrap();
+        let bin_a = src_dir.path().join("voxtype-audio-bridge");
+        let bin_b = src_dir.path().join("some-other-binary");
+        make_fake_bridge(&bin_a);
+        make_fake_bridge(&bin_b);
+
+        let fake_home = TempDir::new().unwrap();
+        let prev_home = env::var("HOME").ok();
+        unsafe {
+            env::set_var("HOME", fake_home.path());
+        }
+        let target = fake_home.path().join(".local/bin/voxtype-audio-bridge");
+
+        // First install points to bin_b.
+        install_bridge_symlink(&bin_b, &target, false).unwrap();
+
+        // Re-install pointing at bin_a should refuse without --force.
+        let err = install_bridge_symlink(&bin_a, &target, false).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("already exists") && msg.contains("--force"),
+            "got: {}",
+            msg
+        );
+
+        // Existing link should not have been clobbered.
+        assert_eq!(fs::read_link(&target).unwrap(), bin_b);
+
+        // With --force, it should overwrite.
+        let outcome = install_bridge_symlink(&bin_a, &target, true).unwrap();
+        assert_eq!(outcome, BridgeInstallOutcome::Linked);
+        assert_eq!(fs::read_link(&target).unwrap(), bin_a);
+
+        unsafe {
+            match prev_home {
+                Some(v) => env::set_var("HOME", v),
+                None => env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn install_bridge_symlink_refuses_outside_home_without_force() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let src_dir = TempDir::new().unwrap();
+        let bin = src_dir.path().join("voxtype-audio-bridge");
+        make_fake_bridge(&bin);
+
+        // Point HOME at a tmpdir, and try to install OUTSIDE of it.
+        let fake_home = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let prev_home = env::var("HOME").ok();
+        unsafe {
+            env::set_var("HOME", fake_home.path());
+        }
+        let target = outside.path().join("voxtype-audio-bridge");
+
+        let err = install_bridge_symlink(&bin, &target, false).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("outside of HOME"), "got: {}", msg);
+        assert!(!target.exists(), "target should not exist after refusal");
+
+        unsafe {
+            match prev_home {
+                Some(v) => env::set_var("HOME", v),
+                None => env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn default_bridge_target_honors_xdg_bin_home() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = env::var("XDG_BIN_HOME").ok();
+        unsafe {
+            env::set_var("XDG_BIN_HOME", "/tmp/voxtype-test-bin");
+        }
+        let dir = default_bridge_target();
+        assert_eq!(
+            dir,
+            PathBuf::from("/tmp/voxtype-test-bin/voxtype-audio-bridge")
+        );
+        unsafe {
+            match prev {
+                Some(v) => env::set_var("XDG_BIN_HOME", v),
+                None => env::remove_var("XDG_BIN_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn run_with_skip_bridge_does_not_touch_target() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Stage a source tree so the QML install succeeds.
+        let src = TempDir::new().unwrap();
+        make_fake_source(src.path());
+        let dst = TempDir::new().unwrap();
+
+        // Point HOME and XDG_BIN_HOME at a tmpdir so any accidental
+        // bridge install would land there (we then assert it didn't).
+        let fake_home = TempDir::new().unwrap();
+        let bin_home = fake_home.path().join(".local/bin");
+        let prev_home = env::var("HOME").ok();
+        let prev_xdg = env::var("XDG_BIN_HOME").ok();
+        unsafe {
+            env::set_var("HOME", fake_home.path());
+            env::set_var("XDG_BIN_HOME", &bin_home);
+        }
+
+        run(
+            Some(dst.path().to_path_buf()),
+            Some(src.path().to_path_buf()),
+            false,
+            false,
+            None,
+            None,
+            true, // skip_bridge
+        )
+        .unwrap();
+
+        assert!(
+            !bin_home.join("voxtype-audio-bridge").exists(),
+            "skip_bridge should leave the target untouched"
+        );
+
+        unsafe {
+            match prev_home {
+                Some(v) => env::set_var("HOME", v),
+                None => env::remove_var("HOME"),
+            }
+            match prev_xdg {
+                Some(v) => env::set_var("XDG_BIN_HOME", v),
+                None => env::remove_var("XDG_BIN_HOME"),
+            }
+        }
+    }
+
     #[test]
     fn default_target_dir_honors_xdg_data_home() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Save and restore env to avoid clobbering other tests.
         let prev = env::var("XDG_DATA_HOME").ok();
         unsafe {


### PR DESCRIPTION
## Summary

The Quickshell QML spawns `voxtype-audio-bridge` via `Quickshell.Io.Process` with `bridgeBinary: "voxtype-audio-bridge"` — a PATH lookup. The AUR `voxtype-bin` package installs the bridge at `/usr/lib/voxtype/voxtype-audio-bridge`, which is not on the default `PATH`. So after running `voxtype setup quickshell` today, the QML OSD card renders but the waveform stays empty until the user manually symlinks the bridge into a PATH directory. Confirmed live during v0.7.4 visual testing.

This PR teaches `voxtype setup quickshell` to symlink the bridge into a user-owned PATH directory as part of the same setup flow, so a fresh install just works.

## What changes

- New flags on `voxtype setup quickshell`:
  - `--bridge <PATH>`: override the source binary location.
  - `--bridge-target <PATH>`: override the symlink destination (default `$XDG_BIN_HOME/voxtype-audio-bridge`, falling back to `~/.local/bin/voxtype-audio-bridge`).
  - `--skip-bridge`: skip the bridge install entirely (for users who already have it on PATH or manage their own symlink).
- Bridge source search order:
  1. `--bridge <PATH>` CLI override
  2. `$VOXTYPE_AUDIO_BRIDGE_BINARY` env var
  3. `<binary's dir>/../lib/voxtype/voxtype-audio-bridge` (installed layout)
  4. `/usr/lib/voxtype/voxtype-audio-bridge` (AUR / .deb / .rpm location)
  5. `which voxtype-audio-bridge` — already on PATH, no symlink needed
  6. `target/release/voxtype-audio-bridge` then `target/debug/...` (dev convenience)
- Install method is `std::os::unix::fs::symlink`, not a copy, so future binary upgrades propagate without re-running setup.
- Existing-target handling:
  - Same source: no-op.
  - Different symlink target / non-symlink file: refuse without `--force`.
  - With `--force`: replace.
- Refuses to write outside of `$HOME` without `--force` to avoid silently touching root-owned paths like `/usr/local/bin/`.
- The closing summary printed by the command now mentions both the QML install and the bridge symlink, plus a reminder that `~/.local/bin` needs to be on the user's PATH (most shells already include it).
- Docs updated: `docs/USER_MANUAL.md` and `docs/CONFIGURATION.md` describe the new flags and the default install behavior.

## Edge cases worth flagging

- The AUR PKGBUILD is intentionally not touched in this PR. The new symlink is for source builders and for users who want the QML waveform working on a fresh install via the `setup quickshell` command. The packaged install hook is a separate channel.
- When the bridge is already on `PATH` via `which` (e.g., distro install puts it in `/usr/bin/`), the command prints "no symlink needed" and skips the symlink unless `--bridge-target` is passed explicitly.
- The `target/{release,debug}/` fallback only matches relative to the current working directory, so dev users running `cargo run -- setup quickshell` from the repo root get the expected behavior.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo test --lib setup::quickshell` — 16 tests pass, including: bridge resolution priorities, symlink creation, idempotency on re-run, refusal to overwrite without `--force`, refusal to write outside `$HOME`, and `--skip-bridge` honored.
- [ ] Manual: run `voxtype setup quickshell` on a fresh AUR install, confirm the QML waveform lights up without further intervention.
- [ ] Manual: re-run `voxtype setup quickshell` and confirm idempotent "already linked" message.
- [ ] Manual: `voxtype setup quickshell --skip-bridge` and verify no symlink is created.

Closes #397.