### PR TITLE
v0.7.3 hotfix: Kaby Lake Vulkan SIGILL + RTX 5090 CUDA Blackwell

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -92,7 +92,11 @@ jobs:
             runner: ubuntu-24.04
             glibc_cap: '2.39'
             check_no_avx512: false
-            companion_libs: 'libonnxruntime_providers_cuda.so libonnxruntime_providers_shared.so'
+            # cuda-13 dlopens ORT via ort/load-dynamic so the runtime ships
+            # alongside the binary (Microsoft's prebuilt is the only 1.24.4
+            # build with sm_120 Blackwell coverage, and it's distributed as
+            # .so only — see Dockerfile.onnx-cuda-13 header).
+            companion_libs: 'libonnxruntime.so.1.24.4 libonnxruntime_providers_cuda.so libonnxruntime_providers_shared.so'
             timeout_minutes: 120
           - variant: onnx-migraphx
             arch: x86_64

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -211,17 +211,42 @@ jobs:
             exit 1
           fi
 
-      - name: Verify AVX-512 absence (AVX2 and Vulkan variants only)
+      - name: Verify ISA floor (Haswell / x86_64-v3) on AVX2 and Vulkan variants
         if: matrix.check_no_avx512
         run: |
           set -euo pipefail
           VERSION='${{ steps.version.outputs.version }}'
           BIN="releases/${VERSION}/voxtype-${VERSION}-linux-${{ matrix.arch }}-${{ matrix.variant }}"
-          ZMM=$(objdump -d "${BIN}" | grep -c zmm || true)
-          echo "AVX-512 zmm register count: ${ZMM}"
-          if [[ "${ZMM}" -ne 0 ]]; then
-            echo "FAIL: ${{ matrix.variant }} binary contains ${ZMM} AVX-512 zmm references."
-            echo "It will SIGILL on pre-AVX-512 CPUs (Zen 3, Haswell, etc.)."
+          # The "no AVX-512" variants must run on every x86_64-v3 CPU: Haswell,
+          # Kaby Lake, Zen 2, Zen 3, etc. That floor excludes AVX-512, GFNI,
+          # AVX-VNNI, and SSE4a (AMD-only). The previous gate only checked zmm
+          # registers — Zen 3 lacks AVX-512 but still has SSE4a's `insertq`,
+          # which is what crashed Kaby Lake daemons in issue #393. NOTE:
+          # SHA-NI, VAES (ymm), and VPCLMULQDQ (ymm) are NOT checked because
+          # the sha2/aes crates emit them behind cpufeatures-dispatched
+          # runtime CPUID guards; they show up in every working binary.
+          DUMP=$(objdump -d "${BIN}")
+          ZMM=$(echo "$DUMP" | grep -c zmm || true)
+          EVEX=$(echo "$DUMP" | grep -cE 'vpternlog|vpermt2|vpermi2|vpblendm|valign[dq]|vpcompress|vpexpand' || true)
+          BCAST=$(echo "$DUMP" | grep -c '{1to' || true)
+          GFNI=$(echo "$DUMP" | grep -cE '\b(vgf2p8|gf2p8)' || true)
+          SSE4A=$(echo "$DUMP" | grep -cE '\b(insertq|extrq)\b' || true)
+          AVXVNNI=$(echo "$DUMP" | grep -cE '\bvpdpbus(d|ds)|vpdpwss(d|ds)' || true)
+          printf '  zmm registers:     %s\n' "$ZMM"
+          printf '  AVX-512 EVEX:      %s\n' "$EVEX"
+          printf '  AVX-512 broadcast: %s\n' "$BCAST"
+          printf '  GFNI:              %s\n' "$GFNI"
+          printf '  SSE4a (AMD-only):  %s\n' "$SSE4A"
+          printf '  AVX-VNNI:          %s\n' "$AVXVNNI"
+          fail=0
+          for n in "$ZMM" "$EVEX" "$BCAST" "$GFNI" "$SSE4A" "$AVXVNNI"; do
+            [[ "${n:-0}" -gt 0 ]] && fail=1
+          done
+          if [[ "$fail" -ne 0 ]]; then
+            echo "FAIL: ${{ matrix.variant }} binary contains out-of-floor instructions."
+            echo "It will SIGILL on x86_64-v3 CPUs (Kaby Lake, Zen 2/3, Haswell, etc.)."
+            echo "Most likely cause: RUSTFLAGS uses target-cpu=native or GGML_NATIVE=ON"
+            echo "on a build host whose CPU has features the floor doesn't allow."
             exit 1
           fi
 

--- a/Dockerfile.onnx-cuda-13
+++ b/Dockerfile.onnx-cuda-13
@@ -5,6 +5,27 @@
 # voxtype-onnx-cuda is symlinked to whichever variant matches the host's
 # CUDA runtime (see voxtype setup gpu --enable).
 #
+# Linking model (cu13 only — differs from cu12):
+#   Unlike Dockerfile.onnx-cuda-12, this binary does NOT statically link
+#   ORT into voxtype. We use `ort/load-dynamic` and dlopen Microsoft's
+#   official `libonnxruntime.so.1.24.4` at runtime. The reason is that
+#   the pyke-distributed ORT 1.24.4 cu13 prebuilt (which ort-sys would
+#   otherwise download and link statically) ships a CUDA EP with arch
+#   coverage sm_30..sm_90a — no Blackwell (sm_120) SASS or PTX — so any
+#   RTX 50-series GPU fails the first transcription with
+#   `cudaErrorNoKernelImageForDevice` (see issue #386, RTX 5090). Upstream
+#   pyke has closed Blackwell support requests as "not planned", and as of
+#   2026-05 ort 2.0.0-rc.12 is still the newest crate on crates.io.
+#
+#   Microsoft's official ORT 1.24.4 cu13 prebuilt covers sm_70..sm_120a
+#   across both the main runtime and the CUDA EP, so this Dockerfile
+#   pivots to that prebuilt entirely (main runtime + EP + shared EP),
+#   linked dynamically. At runtime ort looks for `libonnxruntime.so` in
+#   the directory containing the executable (see ort src/lib.rs:96-109),
+#   so scripts/package.sh and the AUR PKGBUILD install all three files
+#   into /usr/lib/voxtype/cuda-13/ alongside the binary — no RPATH or
+#   LD_LIBRARY_PATH plumbing required.
+#
 # Usage:
 #   docker build -f Dockerfile.onnx-cuda-13 -t voxtype-onnx-cuda-13-builder .
 #   docker run --rm -v $(pwd)/releases:/output voxtype-onnx-cuda-13-builder
@@ -13,8 +34,9 @@
 #   - NVIDIA GPU with CUDA 13.x runtime
 #   - NVIDIA driver 580 or newer (CUDA 13 minimum)
 #   - libcudart.so.13 and cuDNN 9 at runtime (or via LD_LIBRARY_PATH)
-#   - The bundled libonnxruntime_providers_cuda.so and *_shared.so
-#     installed alongside the binary (handled by scripts/package.sh)
+#   - The bundled libonnxruntime.so.1.24.4 + libonnxruntime_providers_cuda.so
+#     + libonnxruntime_providers_shared.so co-located with the binary
+#     (handled by scripts/package.sh and the AUR voxtype-bin PKGBUILD)
 #
 FROM nvidia/cuda:13.0.3-cudnn-devel-ubuntu24.04
 
@@ -53,40 +75,95 @@ WORKDIR /build
 # Copy source code
 COPY . .
 
-# ONNX Runtime CUDA 13 settings
-# ort-sys reads ORT_CUDA_VERSION at build time to choose the cu12 or cu13
-# prebuilt. The base image's NV_CUDA_CUDART_VERSION would also yield cu13,
-# but setting ORT_CUDA_VERSION explicitly is unambiguous and survives any
-# upstream changes to NVIDIA's image env vars.
-ENV ORT_STRATEGY=download
-ENV ORT_CUDA_VERSION=13
+# Fetch Microsoft's ORT 1.24.4 cu13 prebuilt. We bundle it verbatim into
+# the release; ort/load-dynamic dlopens it at runtime. Pinned to match the
+# api-24 ABI surface ort 2.0.0-rc.12 expects; bump in lockstep when the
+# ort crate version moves.
+ENV ORT_VERSION=1.24.4
+ENV ORT_DIR=/opt/onnxruntime
+RUN set -eux; \
+    curl -fsSL -o /tmp/ort-msft.tgz \
+      "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-gpu_cuda13-${ORT_VERSION}.tgz"; \
+    mkdir -p "${ORT_DIR}"; \
+    tar -xzf /tmp/ort-msft.tgz --strip-components=1 -C "${ORT_DIR}"; \
+    rm /tmp/ort-msft.tgz; \
+    test -f "${ORT_DIR}/lib/libonnxruntime.so.${ORT_VERSION}"; \
+    test -f "${ORT_DIR}/lib/libonnxruntime_providers_cuda.so"; \
+    test -f "${ORT_DIR}/lib/libonnxruntime_providers_shared.so"; \
+    # Fail loudly at build time if a future Microsoft release ever drops
+    # Blackwell. This is the gate that should have existed for the pyke
+    # prebuilt before #386 reached a 5090 user.
+    strings "${ORT_DIR}/lib/libonnxruntime_providers_cuda.so" \
+      | grep -qE '^sm_120(a)?$' \
+      || { echo "FAIL: Microsoft ORT ${ORT_VERSION} cu13 EP lacks sm_120 — bundle layout changed upstream."; exit 1; }; \
+    echo "Microsoft ORT ${ORT_VERSION} cu13 staged at ${ORT_DIR} (sm_70..sm_120a)."
 
-# Build with all ONNX engines + CUDA 13 support for NVIDIA GPUs
-# Disable LTO for faster builds
-RUN cargo build --release --features parakeet-cuda,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,ml-diarization \
-    --config 'profile.release.lto=false' \
-    --config 'profile.release.codegen-units=8' \
+# Build voxtype with all ONNX engines + CUDA EP, linked dynamically.
+#
+# Feature breakdown:
+#   - parakeet-cuda          → parakeet-rs/cuda  (registers CUDA EP for Parakeet)
+#   - parakeet-load-dynamic  → parakeet-rs/load-dynamic  (dlopen ORT in parakeet-rs)
+#   - {moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere}-cuda
+#                            → onnx-cuda-enabled = ort/cuda  (CUDA EP type)
+#   - onnx-load-dynamic      → ort/load-dynamic  (dlopen ORT crate-wide)
+#   - ml-diarization         → ort (no EP gates needed)
+#
+# `ort/cuda` and `ort/load-dynamic` compose: ort/src/execution_providers/cuda.rs
+# gates the CUDA EP under `any(load-dynamic, cuda)`, and load-dynamic just
+# changes how libonnxruntime is reached, not whether the EP exists.
+#
+# Disable LTO for faster builds; same as the rest of the matrix.
+RUN cargo build --release \
+        --features parakeet-cuda,parakeet-load-dynamic,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,onnx-load-dynamic,ml-diarization \
+        --config 'profile.release.lto=false' \
+        --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-cuda-13
 
-# Bundle the CUDA EP companion shared libs (see Dockerfile.onnx-cuda-12 for rationale)
-RUN mkdir -p /tmp/onnx-cuda-13-libs \
-    && find /build/target/release -maxdepth 2 -name 'libonnxruntime_providers_cuda.so' -exec cp -L {} /tmp/onnx-cuda-13-libs/ \; \
-    && find /build/target/release -maxdepth 2 -name 'libonnxruntime_providers_shared.so' -exec cp -L {} /tmp/onnx-cuda-13-libs/ \; \
-    && test -f /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so \
-    && test -f /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so
+# Stage the bundled libs alongside the binary. Three files ship:
+#   - libonnxruntime.so.${ORT_VERSION}  (real file with Blackwell SASS)
+#   - libonnxruntime.so                 (symlink → libonnxruntime.so.${ORT_VERSION})
+#                                       ort/load-dynamic dlopens this exact name
+#                                       relative to /proc/self/exe.
+#   - libonnxruntime_providers_cuda.so  (Blackwell CUDA EP, dlopened by main)
+#   - libonnxruntime_providers_shared.so (EP support shim)
+RUN set -eux; \
+    mkdir -p /tmp/onnx-cuda-13-libs; \
+    cp -L "${ORT_DIR}/lib/libonnxruntime.so.${ORT_VERSION}" \
+        "/tmp/onnx-cuda-13-libs/libonnxruntime.so.${ORT_VERSION}"; \
+    ln -sf "libonnxruntime.so.${ORT_VERSION}" \
+        "/tmp/onnx-cuda-13-libs/libonnxruntime.so"; \
+    cp -L "${ORT_DIR}/lib/libonnxruntime_providers_cuda.so" \
+        /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so; \
+    cp -L "${ORT_DIR}/lib/libonnxruntime_providers_shared.so" \
+        /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so; \
+    test -L /tmp/onnx-cuda-13-libs/libonnxruntime.so; \
+    test -f /tmp/onnx-cuda-13-libs/libonnxruntime.so.${ORT_VERSION}; \
+    test -f /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so; \
+    test -f /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so
 
 # Verify binary
 RUN echo "=== Verifying ONNX CUDA 13 binary ===" \
     && /tmp/voxtype-onnx-cuda-13 --version \
     && echo "=== Binary size ===" \
     && ls -lh /tmp/voxtype-onnx-cuda-13 \
-    && echo "=== Companion .so files ===" \
-    && ls -lh /tmp/onnx-cuda-13-libs/
+    && echo "=== Bundled libs ===" \
+    && ls -lh /tmp/onnx-cuda-13-libs/ \
+    && echo "=== CUDA arch coverage in bundled EP ===" \
+    && strings /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so | grep -oE 'sm_[0-9]+[a-z]?' | sort -u \
+    && echo "=== Confirm binary does NOT need libonnxruntime.so.1 at startup ===" \
+    && ! objdump -p /tmp/voxtype-onnx-cuda-13 | grep -q 'NEEDED.*libonnxruntime' \
+    || { echo "FAIL: voxtype has libonnxruntime in NEEDED — load-dynamic feature didn't take effect."; exit 1; }
 
-# Output stage: copy binary and companion .so files
+# Output stage: copy binary and bundled libs. Names follow the existing
+# release convention (`<binary>.<companion>`) so scripts/package.sh and
+# the AUR PKGBUILD can pick them up by predictable filenames.
 CMD mkdir -p /output \
     && cp /tmp/voxtype-onnx-cuda-13 /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13 \
-    && cp /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_cuda.so \
-    && cp /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_shared.so \
+    && cp /tmp/onnx-cuda-13-libs/libonnxruntime.so.${ORT_VERSION} \
+        /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime.so.${ORT_VERSION} \
+    && cp /tmp/onnx-cuda-13-libs/libonnxruntime_providers_cuda.so \
+        /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_cuda.so \
+    && cp /tmp/onnx-cuda-13-libs/libonnxruntime_providers_shared.so \
+        /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_shared.so \
     && echo "Output:" \
     && ls -la /output/voxtype-${VERSION}-linux-x86_64-onnx-cuda-13*

--- a/Dockerfile.onnx-cuda-13
+++ b/Dockerfile.onnx-cuda-13
@@ -92,9 +92,12 @@ RUN set -eux; \
     test -f "${ORT_DIR}/lib/libonnxruntime_providers_shared.so"; \
     # Fail loudly at build time if a future Microsoft release ever drops
     # Blackwell. This is the gate that should have existed for the pyke
-    # prebuilt before #386 reached a 5090 user.
+    # prebuilt before #386 reached a 5090 user. The sm_120 token appears
+    # in `strings` output as a substring of compiler directives like
+    # `-arch sm_120a -m 64 -w` and `.target sm_120`, never as a whole
+    # line, so the pattern can't be line-anchored.
     strings "${ORT_DIR}/lib/libonnxruntime_providers_cuda.so" \
-      | grep -qE '^sm_120(a)?$' \
+      | grep -qE '(\.target sm_120|sm_120a)\b' \
       || { echo "FAIL: Microsoft ORT ${ORT_VERSION} cu13 EP lacks sm_120 — bundle layout changed upstream."; exit 1; }; \
     echo "Microsoft ORT ${ORT_VERSION} cu13 staged at ${ORT_DIR} (sm_70..sm_120a)."
 

--- a/Dockerfile.vulkan
+++ b/Dockerfile.vulkan
@@ -55,11 +55,22 @@ ENV CARGO_BUILD_JOBS=1
 ENV CMAKE_BUILD_PARALLEL_LEVEL=1
 ENV MAKEFLAGS="-j1"
 
-# Build flags - use native CPU (i9-9900K has no AVX-512, so no leakage possible)
-# Disable LTO to prevent linking hangs
-ENV RUSTFLAGS="-C target-cpu=native -C lto=off -C codegen-units=8"
-# whisper.cpp/ggml flags - let it detect native CPU features
-ENV GGML_NATIVE=ON
+# Build flags: bound the ISA floor at Haswell so the binary runs on every
+# x86_64-v3 CPU (Kaby Lake, Zen 2/3, etc.). target-cpu=native was safe when
+# this built on a pre-AVX-512 host (i9-9900K, Coffee Lake), but the GitHub
+# Actions ubuntu-24.04 runner is Zen 3 with SHA Extensions / VAES / AES-NI,
+# and those instructions SIGILL on Kaby Lake — see issue #393.
+# Disable LTO to prevent linking hangs.
+ENV RUSTFLAGS="-C target-cpu=haswell -C target-feature=-avx512f,-avx512bw,-avx512cd,-avx512dq,-avx512vl,-gfni,-sse4a,-avxvnni -C lto=off -C codegen-units=8"
+# whisper.cpp/ggml flags: match Dockerfile.build's Haswell bound. NATIVE=ON
+# inherits -march=native from CMake's host detection, which on a Zen 3 runner
+# emits the same forbidden instructions the SIGILL handler ends up catching.
+ENV GGML_NATIVE=OFF
+ENV GGML_AVX512=OFF
+ENV GGML_AVX_VNNI=OFF
+ENV GGML_AVX512_VNNI=OFF
+ENV CMAKE_C_FLAGS="-mno-avx512f -mno-avx512vl -mno-avx512bw -mno-avx512dq -mno-avx512cd -mno-gfni -mno-avxvnni -mno-sha -mno-vaes -mno-vpclmulqdq"
+ENV CMAKE_CXX_FLAGS="-mno-avx512f -mno-avx512vl -mno-avx512bw -mno-avx512dq -mno-avx512cd -mno-gfni -mno-avxvnni -mno-sha -mno-vaes -mno-vpclmulqdq"
 
 # Build Vulkan binary (verbose to show progress)
 # Override Cargo.toml's LTO settings to prevent linking hangs
@@ -69,18 +80,34 @@ RUN cargo build --release --features gpu-vulkan \
     -vv 2>&1 | tee /tmp/build.log \
     && cp target/release/voxtype /tmp/voxtype-vulkan
 
-# Verify no AVX-512 or GFNI instructions
-RUN echo "=== Verifying Vulkan binary ===" \
-    && zmm_count=$(objdump -d /tmp/voxtype-vulkan | grep -c zmm || true) \
-    && avx512_count=$(objdump -d /tmp/voxtype-vulkan | grep -cE 'vpternlog|vpermt2|vpblendm' || true) \
-    && broadcast_count=$(objdump -d /tmp/voxtype-vulkan | grep -c '{1to' || true) \
-    && gfni_count=$(objdump -d /tmp/voxtype-vulkan | grep -cE 'vgf2p8|gf2p8' || true) \
-    && echo "  zmm registers: $zmm_count" \
-    && echo "  AVX-512 EVEX: $avx512_count" \
-    && echo "  Broadcast: $broadcast_count" \
-    && echo "  GFNI: $gfni_count" \
-    && if [ "${zmm_count:-0}" -gt 0 ] || [ "${avx512_count:-0}" -gt 0 ] || [ "${broadcast_count:-0}" -gt 0 ] || [ "${gfni_count:-0}" -gt 0 ]; then \
-         echo "ERROR: Vulkan binary contains forbidden instructions!" && exit 1; \
+# Verify no out-of-floor instructions leaked in. The ISA floor is x86_64-v3
+# (Haswell): AVX2 + BMI1/2 + FMA, no AVX-512, no GFNI, no AVX-VNNI, and no
+# SSE4a (AMD-only — would SIGILL on Intel). NOTE: SHA-NI / VAES (ymm) /
+# VPCLMULQDQ (ymm) are deliberately NOT checked here — those instructions
+# appear in every binary as part of the sha2/aes crates' cpufeatures-dispatched
+# runtime paths, and are guarded by CPUID checks at the library level. Adding
+# them to this gate would produce false positives. Instead we constrain the
+# Rust compiler's own emission via target-cpu=haswell + target-feature
+# disables above, which is what stops issue-#393-style leaks.
+RUN echo "=== Verifying Vulkan binary ISA floor (x86_64-v3 / Haswell, no SSE4a) ===" \
+    && DUMP=$(objdump -d /tmp/voxtype-vulkan) \
+    && zmm_count=$(echo "$DUMP" | grep -c zmm || true) \
+    && avx512_count=$(echo "$DUMP" | grep -cE 'vpternlog|vpermt2|vpermi2|vpblendm|valign[dq]|vpcompress|vpexpand' || true) \
+    && broadcast_count=$(echo "$DUMP" | grep -c '{1to' || true) \
+    && gfni_count=$(echo "$DUMP" | grep -cE '\b(vgf2p8|gf2p8)' || true) \
+    && sse4a_count=$(echo "$DUMP" | grep -cE '\b(insertq|extrq)\b' || true) \
+    && avxvnni_count=$(echo "$DUMP" | grep -cE '\bvpdpbus(d|ds)|vpdpwss(d|ds)' || true) \
+    && echo "  zmm registers:     $zmm_count" \
+    && echo "  AVX-512 EVEX:      $avx512_count" \
+    && echo "  AVX-512 broadcast: $broadcast_count" \
+    && echo "  GFNI:              $gfni_count" \
+    && echo "  SSE4a (AMD-only):  $sse4a_count" \
+    && echo "  AVX-VNNI:          $avxvnni_count" \
+    && if [ "${zmm_count:-0}" -gt 0 ] || [ "${avx512_count:-0}" -gt 0 ] \
+         || [ "${broadcast_count:-0}" -gt 0 ] || [ "${gfni_count:-0}" -gt 0 ] \
+         || [ "${sse4a_count:-0}" -gt 0 ] || [ "${avxvnni_count:-0}" -gt 0 ]; then \
+         echo "ERROR: Vulkan binary contains out-of-floor instructions — will SIGILL on Intel Kaby Lake, Zen 1, etc." \
+         && exit 1; \
        fi \
     && echo "✓ Vulkan binary is clean"
 

--- a/packaging/arch-bin-rc/PKGBUILD
+++ b/packaging/arch-bin-rc/PKGBUILD
@@ -79,6 +79,12 @@ source=(
     "voxtype-${pkgname}-${pkgver}-onnx-cuda-13.asc::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-cuda-13.asc"
     "voxtype-${pkgname}-${pkgver}-onnx-cuda-13.libonnxruntime_providers_cuda.so::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_cuda.so"
     "voxtype-${pkgname}-${pkgver}-onnx-cuda-13.libonnxruntime_providers_shared.so::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-cuda-13.libonnxruntime_providers_shared.so"
+    # cuda-13 dlopens ORT at runtime (Microsoft's prebuilt is the only
+    # 1.24.4 build with Blackwell sm_120 coverage, and it's distributed
+    # as .so only). The runtime ships alongside the binary; the install
+    # step below symlinks libonnxruntime.so → this versioned name so
+    # ort/load-dynamic finds it via /proc/self/exe's directory.
+    "voxtype-${pkgname}-${pkgver}-onnx-cuda-13.libonnxruntime.so.1.24.4::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-cuda-13.libonnxruntime.so.1.24.4"
     # ONNX MIGraphX binary + companion shared libs
     "voxtype-${pkgname}-${pkgver}-onnx-migraphx::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-migraphx"
     "voxtype-${pkgname}-${pkgver}-onnx-migraphx.asc::${_github}/voxtype-${_upstream_ver}-linux-x86_64-onnx-migraphx.asc"
@@ -130,6 +136,7 @@ sha256sums=(
     'SKIP'  # voxtype-onnx-cuda-13.asc
     'SKIP'  # voxtype-onnx-cuda-13.libonnxruntime_providers_cuda.so
     'SKIP'  # voxtype-onnx-cuda-13.libonnxruntime_providers_shared.so
+    'SKIP'  # voxtype-onnx-cuda-13.libonnxruntime.so.1.24.4
     # ONNX MIGraphX
     'SKIP'  # voxtype-onnx-migraphx
     'SKIP'  # voxtype-onnx-migraphx.asc
@@ -190,6 +197,13 @@ package() {
         "$pkgdir/usr/lib/voxtype/cuda-13/libonnxruntime_providers_cuda.so"
     install -Dm644 "${src}-onnx-cuda-13.libonnxruntime_providers_shared.so" \
         "$pkgdir/usr/lib/voxtype/cuda-13/libonnxruntime_providers_shared.so"
+    # cuda-13 dlopens ORT at runtime. Install Microsoft's libonnxruntime
+    # under its SONAME (libonnxruntime.so.1.24.4) and symlink the bare
+    # name ort/load-dynamic expects (libonnxruntime.so).
+    install -Dm644 "${src}-onnx-cuda-13.libonnxruntime.so.1.24.4" \
+        "$pkgdir/usr/lib/voxtype/cuda-13/libonnxruntime.so.1.24.4"
+    ln -sf "libonnxruntime.so.1.24.4" \
+        "$pkgdir/usr/lib/voxtype/cuda-13/libonnxruntime.so"
     ln -sf "cuda-13/voxtype-onnx-cuda-13" \
         "$pkgdir/usr/lib/voxtype/voxtype-onnx-cuda-13"
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -408,6 +408,13 @@ if [[ "$TARGET_ARCH" == "x86_64" ]]; then
     install_onnx_gpu_variant() {
         local variant="$1"      # cuda-12, cuda-13, migraphx
         local ep_lib="$2"       # cuda or migraphx
+        # When set, $3 is the libonnxruntime.so.X.Y.Z basename the variant
+        # bundles alongside the binary. The cuda-13 build links ORT
+        # dynamically (load-dynamic) because Microsoft's prebuilt is the
+        # only ORT 1.24.4 build that ships Blackwell sm_120 kernels, and
+        # Microsoft only distributes .so (no .a). cuda-12 and migraphx
+        # keep their static-linked layouts; pass empty for those.
+        local libort_versioned="${3:-}"
         local src="${RELEASE_DIR}/voxtype-${VERSION}-linux-x86_64-onnx-${variant}"
         if [[ ! -f "$src" ]]; then
             return 0
@@ -420,6 +427,14 @@ if [[ "$TARGET_ARCH" == "x86_64" ]]; then
             "$subdir/libonnxruntime_providers_${ep_lib}.so"
         cp "${src}.libonnxruntime_providers_shared.so" \
             "$subdir/libonnxruntime_providers_shared.so"
+        if [[ -n "$libort_versioned" ]]; then
+            # Real file + symlink. ort/load-dynamic dlopens the unversioned
+            # name (`libonnxruntime.so`) relative to /proc/self/exe (see
+            # ort src/lib.rs:96-109); the SONAME symlink lets that resolve
+            # without env vars or RPATH plumbing.
+            cp "${src}.${libort_versioned}" "$subdir/${libort_versioned}"
+            ln -sf "${libort_versioned}" "$subdir/libonnxruntime.so"
+        fi
         # Convenience symlink at the top level so existing tooling (the
         # voxtype-wrapper.sh, voxtype setup gpu, ParakeetBackend detection)
         # finds the binary by its short name.
@@ -427,7 +442,7 @@ if [[ "$TARGET_ARCH" == "x86_64" ]]; then
             "$STAGING/usr/lib/voxtype/voxtype-onnx-${variant}"
     }
     install_onnx_gpu_variant cuda-12 cuda
-    install_onnx_gpu_variant cuda-13 cuda
+    install_onnx_gpu_variant cuda-13 cuda libonnxruntime.so.1.24.4
     install_onnx_gpu_variant migraphx migraphx
     # Legacy compat symlink for users with scripts referencing the old
     # voxtype-onnx-rocm name. The AMD GPU EP changed from ROCm to MIGraphX


### PR DESCRIPTION
Merges the two hotfixes that landed on \`rc/0.7.3\` back to \`main\` ahead of cutting \`v0.7.3\`.

## What's in this merge

| PR | Fix | Issue |
|---|---|---|
| #394 | Bound Vulkan/CI ISA floor at x86_64-v3 — stops SSE4a (\`insertq\`) leaking into the GitHub Actions \`vulkan\` build via \`target-cpu=native\` on a Zen 3 runner | #393 (Kaby Lake i7-7700HQ SIGILL) |
| #398 | Switch \`onnx-cuda-13\` to Microsoft's ORT 1.24.4 prebuilt via \`ort/load-dynamic\` — Microsoft's CUDA EP covers sm_70..sm_120a, pyke's stops at sm_90a and upstream marked Blackwell support \"not planned\" | #386 (RTX 5090 \`cudaErrorNoKernelImageForDevice\`) |

Both PRs ship with build-time gates against regression of their root cause:

- The CI \`Verify ISA floor\` step now fails the build on AVX-512 EVEX/zmm/broadcast, GFNI, AVX-VNNI, and SSE4a — not just zmm registers. The zmm-only check is what let the SSE4a leak through on the Zen 3 runner.
- The cuda-13 Dockerfile asserts \`sm_120\` is present in the bundled \`libonnxruntime_providers_cuda.so\` via \`strings\`, and asserts the built binary has no \`NEEDED libonnxruntime.so.1\` (load-dynamic didn't silently drop out).

## What does NOT change

- cuda-12, migraphx, avx2, avx512, and onnx-avx2/avx512 binaries are untouched (different Dockerfiles, different ISA floors, different ORT linkage).
- No source code changes in \`src/\`. All changes are in Dockerfiles, the CI workflow, \`scripts/package.sh\`, and \`packaging/arch-bin-rc/PKGBUILD\`.

## Release path after merge

1. Tag \`v0.7.3\` on the resulting main commit; the Linux build matrix kicks off automatically.
2. Verify the new ISA-floor gate passes on \`vulkan\` and \`avx2\` artifacts.
3. Verify the cuda-13 artifact bundles \`libonnxruntime.so.1.24.4\` + \`libonnxruntime.so\` symlink + EP \`.so\` files, and that \`strings\` confirms sm_120 coverage.
4. Update the stable \`voxtype-bin\` AUR PKGBUILD with the same source/install delta that \`voxtype-bin-rc\` already has on this branch (the \`aur-publish\` skill knows how).
5. Smoke test on a Kaby Lake CPU (Vulkan) and an RTX 5090 (cuda-13 transcription) before promoting from \`v0.7.3-rc1\` to \`v0.7.3\`.

## Test plan
- [ ] Tag a \`v0.7.3-rc1\` after merge and confirm all matrix variants build and pass their gates
- [ ] Kaby Lake smoke test (reporter: @iTuiTu on i7-7700HQ): \`voxtype-vulkan daemon\` must start without SIGILL
- [ ] RTX 5090 smoke test (reporter: @tyvsmith): \`voxtype-onnx-cuda-13 daemon\` + one Parakeet transcription must succeed without \`cudaErrorNoKernelImageForDevice\`
- [ ] Non-Blackwell NVIDIA smoke test (4090/3090) on \`onnx-cuda-13\` to confirm the load-dynamic swap doesn't regress existing GPUs