### PR TITLE
Drop line anchors in onnx-cuda-13 sm_120 gate

### DIFF
--- a/Dockerfile.onnx-cuda-13
+++ b/Dockerfile.onnx-cuda-13
@@ -92,9 +92,12 @@ RUN set -eux; \
     test -f "${ORT_DIR}/lib/libonnxruntime_providers_shared.so"; \
     # Fail loudly at build time if a future Microsoft release ever drops
     # Blackwell. This is the gate that should have existed for the pyke
-    # prebuilt before #386 reached a 5090 user.
+    # prebuilt before #386 reached a 5090 user. The sm_120 token appears
+    # in `strings` output as a substring of compiler directives like
+    # `-arch sm_120a -m 64 -w` and `.target sm_120`, never as a whole
+    # line, so the pattern can't be line-anchored.
     strings "${ORT_DIR}/lib/libonnxruntime_providers_cuda.so" \
-      | grep -qE '^sm_120(a)?$' \
+      | grep -qE '(\.target sm_120|sm_120a)\b' \
       || { echo "FAIL: Microsoft ORT ${ORT_VERSION} cu13 EP lacks sm_120 — bundle layout changed upstream."; exit 1; }; \
     echo "Microsoft ORT ${ORT_VERSION} cu13 staged at ${ORT_DIR} (sm_70..sm_120a)."
 


### PR DESCRIPTION
The CI run on rc/0.7.3 caught a bug in the sm_120 gate I added in #398: \`strings\` output for \`libonnxruntime_providers_cuda.so\` never has \`sm_120\` on its own line — the token appears inside compiler-arg strings like \`-arch sm_120a -m 64 -w\` and \`.target sm_120\`. The \`^sm_120(a)?\$\`-anchored pattern from #398 matched nothing, so the gate failed itself instead of catching a real regression.

Switched to a pattern that matches the directive forms directly: \`(\.target sm_120|sm_120a)\b\`.

Verified locally against the same artifacts:

| EP source | Matches |
|---|---|
| Microsoft ORT 1.24.4 cu13 (what we ship) | 66 (gate passes) |
| Pyke ORT 1.24.4 cu13 (what 0.7.2 shipped) | 0 (gate would fail — correct, that's the regression we're guarding against) |

Targets \`rc/0.7.3\` so the v0.7.3 hotfix sequence stays linear: this PR → rc/0.7.3, then PR #402 merges rc/0.7.3 → main.