### PR TITLE
Add v0.7.3 release news article and bump download URLs

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -318,6 +318,16 @@
             <p class="section-subtitle">Recent releases and what they bring</p>
 
             <div class="news-preview-grid">
+                <a href="news/#v073" class="news-preview-card">
+                    <div class="news-preview-meta">
+                        <time datetime="2026-05-19">May 19, 2026</time>
+                        <span class="news-preview-tag">Release</span>
+                    </div>
+                    <h3>v0.7.3: Kaby Lake Vulkan SIGILL fix, RTX 5090 Blackwell support</h3>
+                    <p>A two-issue hotfix. The Vulkan binary now runs on pre-Cascade-Lake Intel CPUs that lack SSE4a (the bug that crashed the i7-7700HQ). The CUDA 13 binary now ships Microsoft's Blackwell-capable ONNX Runtime so the RTX 5090 transcribes without <code>cudaErrorNoKernelImageForDevice</code>. The CI ISA-floor gate is widened so the same class of regression cannot slip through again.</p>
+                    <span class="news-preview-link">Read more &rarr;</span>
+                </a>
+
                 <a href="news/#v072" class="news-preview-card">
                     <div class="news-preview-meta">
                         <time datetime="2026-05-17">May 17, 2026</time>
@@ -909,11 +919,11 @@ sudo pacman -S wtype wl-clipboard libnotify gtk4-layer-shell</code></pre>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install .deb package</span>
-                            <button class="copy-btn" data-copy="sudo apt install ./voxtype_0.7.2-1_amd64.deb">Copy</button>
+                            <button class="copy-btn" data-copy="sudo apt install ./voxtype_0.7.3-1_amd64.deb">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.2/voxtype_0.7.2-1_amd64.deb
-sudo apt install ./voxtype_0.7.2-1_amd64.deb
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype_0.7.3-1_amd64.deb
+sudo apt install ./voxtype_0.7.3-1_amd64.deb
 
 <span class="comment"># Recommended optional dependencies</span>
 sudo apt install wtype wl-clipboard libnotify-bin pipewire-alsa playerctl</code></pre>
@@ -926,11 +936,11 @@ sudo apt install wtype wl-clipboard libnotify-bin pipewire-alsa playerctl</code>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install RPM package</span>
-                            <button class="copy-btn" data-copy="sudo dnf install ./voxtype-0.7.2-1.x86_64.rpm">Copy</button>
+                            <button class="copy-btn" data-copy="sudo dnf install ./voxtype-0.7.3-1.x86_64.rpm">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.2/voxtype-0.7.2-1.x86_64.rpm
-sudo dnf install ./voxtype-0.7.2-1.x86_64.rpm
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype-0.7.3-1.x86_64.rpm
+sudo dnf install ./voxtype-0.7.3-1.x86_64.rpm
 
 <span class="comment"># Recommended optional dependencies</span>
 sudo dnf install wtype wl-clipboard libnotify pipewire-alsa playerctl</code></pre>
@@ -951,7 +961,7 @@ brew install --cask voxtype
 <span class="comment"># First launch opens a setup wizard that walks you through</span>
 <span class="comment"># Accessibility permissions, model download, and the FN-key hotkey.</span></code></pre>
                     </div>
-                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-0.7.2-macOS-arm64.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
+                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-0.7.3-macOS-arm64.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
                 </div>
 
                 <div id="nixos" class="tab-content">
@@ -959,16 +969,16 @@ brew install --cask voxtype
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install via flake</span>
-                            <button class="copy-btn" data-copy="nix profile install github:peteonrails/voxtype/v0.7.2#vulkan">Copy</button>
+                            <button class="copy-btn" data-copy="nix profile install github:peteonrails/voxtype/v0.7.3#vulkan">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Imperative install</span>
-nix profile install github:peteonrails/voxtype/v0.7.2#vulkan
+nix profile install github:peteonrails/voxtype/v0.7.3#vulkan
 
 <span class="comment"># Available outputs: default, vulkan, cuda, rocm, osdGtk4, osdNative</span>
-nix build github:peteonrails/voxtype/v0.7.2#osdGtk4
+nix build github:peteonrails/voxtype/v0.7.3#osdGtk4
 
 <span class="comment"># Or pin in your flake inputs</span>
-inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.2";</code></pre>
+inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.3";</code></pre>
                     </div>
                     <p class="install-note" style="margin-top: 1rem;"><strong>Next:</strong> <a href="#quick-start">First-run setup</a> below.</p>
                 </div>
@@ -978,15 +988,15 @@ inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.2";</code></pre>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Download and run</span>
-                            <button class="copy-btn" data-copy="chmod +x voxtype-0.7.2-x86_64.AppImage && ./voxtype-0.7.2-x86_64.AppImage">Copy</button>
+                            <button class="copy-btn" data-copy="chmod +x voxtype-0.7.3-x86_64.AppImage && ./voxtype-0.7.3-x86_64.AppImage">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download a variant from the latest release</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.2/voxtype-0.7.2-x86_64.AppImage
-chmod +x voxtype-0.7.2-x86_64.AppImage
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype-0.7.3-x86_64.AppImage
+chmod +x voxtype-0.7.3-x86_64.AppImage
 
 <span class="comment"># Run directly, or move to ~/.local/bin/ for permanent install</span>
-./voxtype-0.7.2-x86_64.AppImage --help
-mv voxtype-0.7.2-x86_64.AppImage ~/.local/bin/voxtype</code></pre>
+./voxtype-0.7.3-x86_64.AppImage --help
+mv voxtype-0.7.3-x86_64.AppImage ~/.local/bin/voxtype</code></pre>
                     </div>
                     <p class="install-note" style="margin-top: 1rem;"><strong>Next:</strong> <a href="#quick-start">First-run setup</a> below.</p>
                 </div>

--- a/website/news/index.html
+++ b/website/news/index.html
@@ -77,6 +77,44 @@
 
             <!-- v0.7.x Era Posts -->
 
+            <article class="news-article" id="v073">
+                <div class="article-meta">
+                    <time datetime="2026-05-19">May 19, 2026</time>
+                    <span class="article-tag">Release</span>
+                </div>
+                <h2>v0.7.3: Kaby Lake Vulkan SIGILL fix, RTX 5090 Blackwell support</h2>
+                <div class="article-body">
+                    <p>A two-issue hotfix. The Vulkan binary regression came in via the move to GitHub-hosted CI runners; the CUDA 13 issue surfaced once RTX 5090 owners hit a transcription. Both fixes also harden the build pipeline so the same class of regression cannot ship again.</p>
+
+                    <h3>Vulkan binary works on Kaby Lake and older Intel CPUs (<a href="https://github.com/peteonrails/voxtype/issues/393">#393</a>)</h3>
+                    <p>The v0.7.2 Vulkan binary failed with SIGILL on Intel CPUs that lack SSE4a, including the i7-7700HQ in the reporter's machine. The instruction came from <code>RUSTFLAGS="-C target-cpu=native"</code> in <code>Dockerfile.vulkan</code>. That flag was safe when the build host was a pre-AVX-512 Coffee Lake server, but the v0.7.2 pipeline moved onto GitHub's <code>ubuntu-24.04</code> runner, which is AMD Zen 3 and has SSE4a. The compiler emitted <code>insertq</code> instructions, and Intel CPUs SIGILL on those.</p>
+
+                    <p><strong>Why use it:</strong> if you have a pre-Cascade-Lake Intel CPU (anything roughly 6th-gen or older) and the Vulkan backend, voxtype 0.7.2 daemons would not start. v0.7.3 boots cleanly on the same hardware.</p>
+
+                    <p>The build now bounds Rust at <code>target-cpu=haswell</code> with <code>-sse4a,-gfni,-avxvnni</code> disables, matches the ggml CMake flags to the same floor, and adds a CI gate that fails the build on any AVX-512 EVEX, GFNI, AVX-VNNI, or SSE4a instruction in the AVX2 or Vulkan variants. The previous gate only checked <code>zmm</code> registers, so SSE4a slipped through unnoticed.</p>
+
+                    <h3>NVIDIA Blackwell (RTX 5090) works on the CUDA 13 binary (<a href="https://github.com/peteonrails/voxtype/issues/386">#386</a>)</h3>
+                    <p><code>voxtype-onnx-cuda-13</code> shipped a CUDA execution provider with kernel coverage up to sm_90a (Hopper). Blackwell needs sm_120, so the RTX 5090 hit the EP and got <code>cudaErrorNoKernelImageForDevice</code> on every transcription. The upstream prebuilt ORT that the <code>ort</code> crate downloads does not include Blackwell, and the maintainer has marked Blackwell support as not planned.</p>
+
+                    <p><strong>Why use it:</strong> if you own an RTX 50-series card, voxtype 0.7.2's CUDA 13 binary would error on every transcription. v0.7.3 transcribes correctly on Blackwell.</p>
+
+                    <p><code>Dockerfile.onnx-cuda-13</code> now pulls Microsoft's official ORT 1.24.4 cu13 prebuilt and links to it with <code>ort/load-dynamic</code>. The bundled CUDA EP covers sm_70 through sm_120a. The runtime ships alongside the binary at <code>/usr/lib/voxtype/cuda-13/libonnxruntime.so.1.24.4</code> plus a <code>libonnxruntime.so</code> symlink, which is exactly where <code>ort/load-dynamic</code> looks first (relative to <code>/proc/self/exe</code>). No environment variable or LD_LIBRARY_PATH setup required.</p>
+
+                    <p>Two build gates went in alongside the fix: a check that <code>sm_120</code> markers are present in the bundled provider library, and a check that the binary did not silently fall back to static linking (which would have brought the old kernel coverage back).</p>
+
+                    <p><code>voxtype-onnx-cuda-12</code> is unchanged. Blackwell requires CUDA 13 and driver 580+, so cuda-12 users are not affected.</p>
+
+                    <h3>Acknowledgments</h3>
+                    <ul>
+                        <li><strong>Piotr Lipski</strong> for reporting the Kaby Lake Vulkan SIGILL with a complete environment dump.</li>
+                        <li><strong>tyvsmith</strong> for the RTX 5090 report including the source-build comparison that confirmed the diagnosis.</li>
+                    </ul>
+
+                    <h3>Downloads</h3>
+                    <p>Full changelog, signed binaries, and SHA256 sums: <a href="https://github.com/peteonrails/voxtype/releases/tag/v0.7.3">v0.7.3 on GitHub</a>.</p>
+                </div>
+            </article>
+
             <article class="news-article" id="v072">
                 <div class="article-meta">
                     <time datetime="2026-05-17">May 17, 2026</time>


### PR DESCRIPTION
Mirrors the [v0.7.3 GitHub release](https://github.com/peteonrails/voxtype/releases/tag/v0.7.3) onto voxtype.io per the release checklist.

- New article in `website/news/index.html` (above v0.7.2): two-issue hotfix narrative — Kaby Lake Vulkan SIGILL (#393), RTX 5090 Blackwell CUDA (#386), plus the CI ISA-floor gate widening.
- New news-preview card at the top of the homepage grid pointing at the new article.
- Download URLs bumped to v0.7.3 across the .deb / .rpm / Nix flake / AppImage code blocks.

Deploys automatically via GitHub Pages once merged.