### PR TITLE
Add Soniox cloud streaming STT backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +279,15 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block2"
@@ -782,6 +797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +878,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cursor-icon"
@@ -946,6 +980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1033,16 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1492,6 +1542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1561,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -1654,14 +1711,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1671,9 +1740,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2228,10 +2299,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -2443,6 +2596,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2769,6 +2928,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lzma-rust2"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,6 +3035,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -3782,6 +3963,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4050,6 +4286,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4176,6 +4452,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4326,6 +4603,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4556,6 +4856,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4752,6 +5061,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4841,6 +5165,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4967,6 +5317,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5060,6 +5455,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5067,6 +5488,18 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.1",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -5293,6 +5726,7 @@ dependencies = [
  "egui",
  "egui-wgpu",
  "evdev",
+ "futures-util",
  "glib 0.22.7",
  "gtk4",
  "gtk4-layer-shell",
@@ -5313,6 +5747,7 @@ dependencies = [
  "raw-window-handle",
  "rdev",
  "regex",
+ "reqwest",
  "rodio",
  "rusqlite",
  "rustfft",
@@ -5325,6 +5760,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokenizers 0.20.4",
  "tokio",
+ "tokio-tungstenite",
  "toml 0.8.23",
  "toml_edit 0.22.27",
  "tracing",
@@ -5349,6 +5785,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,12 @@ hound = "3"  # WAV file reading/writing
 # HTTP client for remote transcription
 ureq = { version = "2", features = ["json"] }
 
+# WebSocket client for Soniox streaming backend (optional)
+tokio-tungstenite = { version = "0.24", optional = true, features = ["rustls-tls-webpki-roots"] }
+futures-util = { version = "0.3", optional = true }
+# Async HTTP client for Soniox async transcription API (multipart upload + poll)
+reqwest = { version = "0.12", optional = true, default-features = false, features = ["json", "multipart", "rustls-tls"] }
+
 # JSON parsing (for CLI backend)
 serde_json = "1"
 
@@ -224,6 +230,8 @@ omnilingual-tensorrt = ["omnilingual", "onnx-tensorrt-enabled"]
 cohere = ["onnx-common", "dep:half", "dep:tokenizers"]
 cohere-cuda = ["cohere", "onnx-cuda-enabled"]
 cohere-tensorrt = ["cohere", "onnx-tensorrt-enabled"]
+# Soniox cloud streaming WebSocket STT backend (no local model, just a network client)
+soniox = ["dep:tokio-tungstenite", "dep:futures-util", "dep:reqwest"]
 # No cohere-migraphx feature: MIGraphX 7.2 still fails on the
 # onnx-community q4 export. Original blocker was MatMulNBits bits=8
 # (cstr int8); q4 has bits=4 which is supported, but its zero_points

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1384,6 +1384,208 @@ The prebuilt `voxtype-*-onnx-*` release binaries already include `cohere`, so us
 
 ---
 
+## [soniox]
+
+Configuration for the Soniox cloud streaming WebSocket STT engine. This section is only used when `engine = "soniox"`.
+
+Soniox is a paid cloud STT provider with 60+ languages, per-token finality flags, and server-side endpoint detection. Unlike voxtype's other engines, no model runs on your machine — audio streams to Soniox's servers over WebSocket and tokens stream back.
+
+**Privacy:** Audio is sent to a third-party service. Use the local engines (Whisper, Parakeet, etc.) if you cannot send dictation off-device.
+
+### api_key
+
+**Type:** String (optional)
+**Default:** unset (falls back to `SONIOX_API_KEY` env var)
+**Required:** Yes (via this field or env var)
+
+Soniox API key. Get one at https://console.soniox.com.
+
+Prefer the env var so the key never lands in shell history or a checked-in config file:
+
+```bash
+export SONIOX_API_KEY="your-key-here"
+```
+
+### model
+
+**Type:** String
+**Default:** `"stt-rt-v4"`
+**Required:** No
+
+Soniox model identifier. The current realtime model is `stt-rt-v4`.
+
+### language_hints
+
+**Type:** Array of strings
+**Default:** `["hu", "en"]`
+**Required:** No
+
+ISO 639-1 codes hinting which languages to prefer. Use an empty array for full auto-detect across all 60+ supported languages.
+
+```toml
+[soniox]
+language_hints = ["en"]            # English only
+# or
+language_hints = ["hu", "en", "de"] # Hungarian, English, German
+# or
+language_hints = []                 # auto-detect everything
+```
+
+### language_hints_strict
+
+**Type:** Boolean
+**Default:** `true`
+**Required:** No
+
+When `true`, the model is strongly biased to produce output only in the languages listed in `language_hints`. When `false`, the model may occasionally produce other languages it detects with high confidence. Ignored when `language_hints` is empty.
+
+Strict mode is the right default for bilingual setups (`["hu", "en"]` etc.): without it, partials can briefly drift to a third language before snapping back when a final lands, causing unnecessary tail revisions. Turn it off only when you genuinely expect input in languages outside the hint list. See [Soniox language-restrictions docs](https://soniox.com/docs/stt/concepts/language-restrictions).
+
+```toml
+[soniox]
+language_hints = ["hu", "en"]
+language_hints_strict = false   # allow occasional third-language tokens
+```
+
+### streaming
+
+**Type:** Boolean
+**Default:** `true`
+**Required:** No
+
+Activation mode for the Soniox backend:
+
+- `true` — Live WebSocket session. Tokens stream back during recording and are typed at the cursor as they arrive (or only on finalization if `type_partials = false`). **Requires `[hotkey] mode = "toggle"`.** Push-to-talk is auto-promoted to toggle for the running session with a warning, because typing characters while the PTT key is still held clobbers libinput's held-key state on Hyprland/Sway/River.
+- `false` — Batch mode. Audio buffered while the hotkey is held; on release one WebSocket session opens, the entire buffer is sent + finalized, and the resulting transcript is typed in one shot. Push-to-talk compatible. Loses live partials but keeps Soniox's accuracy.
+
+### type_partials
+
+**Type:** Boolean
+**Default:** `true`
+**Required:** No
+
+Only used when `streaming = true`. When `true`, non-final tokens are typed at the cursor as they arrive (lower perceived latency). When `false`, only finalized segments are typed — partials still appear in `voxtype status --follow` but never touch the cursor.
+
+Soniox guarantees stable finals; non-finals can be revised. In practice revisions are rare and short. If you see occasional churn at the cursor, set `type_partials = false`.
+
+### context
+
+**Type:** String (optional)
+**Default:** unset
+**Required:** No
+
+Free-form domain context. Mapped to `context.text` in Soniox's init frame. Use for short prose describing the dictation domain — `"medical consultation"`, `"Rust async runtime podcast"`. Leave unset unless you have a clearly bounded vocabulary worth biasing the model toward. See [Soniox context docs](https://soniox.com/docs/stt/concepts/context).
+
+### terms
+
+**Type:** Array of strings (optional)
+**Default:** unset
+**Required:** No
+
+Inline vocabulary boost terms. Mapped to `context.terms` in Soniox's init frame. Use for proper names, jargon, product names — entries the generic model wouldn't get right. Combined with `terms_file` (deduplicated, order preserved).
+
+```toml
+[soniox]
+terms = ["Voxtype", "Hyprland", "tokio-tungstenite"]
+```
+
+### terms_file
+
+**Type:** Path (optional)
+**Default:** unset
+**Required:** No
+
+Path to a JSON file containing a list of vocabulary boost terms — `["term1", "term2", ...]`. Loaded once at daemon startup and merged into `context.terms`. Useful for sharing a corrections list across multiple voxtype config snapshots or projects.
+
+```toml
+[soniox]
+terms_file = "/home/me/dotfiles/voxtype-terms.json"
+```
+
+### async_api
+
+**Type:** Boolean
+**Default:** `false`
+**Required:** No
+
+Use the Soniox **async transcription API** (file upload + poll) instead of the realtime WebSocket. Different model (`stt-async-v4`), different accuracy profile, batch only — no live partials, no flicker, push-to-talk compatible.
+
+When `true`:
+- Audio buffered while recording. On release, voxtype uploads the WAV to `https://api.soniox.com/v1/files`, creates a transcription job, polls until complete, fetches the transcript, then types it at the cursor in one shot.
+- `streaming` and `type_partials` are ignored.
+- `model` defaults to `stt-async-v4` (override only if you know what you're doing).
+- Push-to-talk is **not** auto-promoted to toggle (no live cursor typing means no compositor-state clobbering).
+
+Latency: typical 15s recording → ~1s upload + 2-5s processing = 3-6s total wait after release. Compare to realtime which streams partials as you speak.
+
+**Accuracy:** the async model (`stt-async-v4`) is marketed as higher accuracy than the realtime model (`stt-rt-v4`). In practice quality varies by language and content — benchmark both for your use case before committing.
+
+### async_max_wait_secs
+
+**Type:** Integer
+**Default:** `120`
+**Required:** No
+
+Maximum total wait time (seconds) for an async API job to complete. If exceeded, voxtype cleans up the server-side job and surfaces an error. Only used when `async_api = true`.
+
+### Configuration Summary
+
+| Option | CLI Flag | Environment Variable | Default | Description |
+|--------|----------|---------------------|---------|-------------|
+| `api_key` | `--soniox-api-key` | `SONIOX_API_KEY` | none (required) | Soniox API key |
+| `model` | - | - | `"stt-rt-v4"` | Soniox model (`stt-async-v4` when `async_api = true`) |
+| `language_hints` | - | - | `["hu", "en"]` | Language preference |
+| `language_hints_strict` | - | - | `true` | Restrict output to hinted languages (ignored if empty) |
+| `streaming` | - | - | `true` | Live WebSocket vs batch-on-release (realtime only) |
+| `type_partials` | - | - | `true` | Type non-final tokens at cursor (realtime only) |
+| `context` | - | - | none | Free-form domain context (`context.text`) |
+| `terms` | - | - | none | Inline boost terms array (`context.terms`) |
+| `terms_file` | - | - | none | JSON file path with boost terms |
+| `async_api` | - | - | `false` | Use async REST API instead of realtime WS |
+| `async_max_wait_secs` | - | - | `120` | Async job total timeout |
+
+### Complete Example — Realtime (with live partials)
+
+```toml
+engine = "soniox"
+
+[hotkey]
+mode = "toggle"   # Required when [soniox] streaming = true
+
+[soniox]
+language_hints = ["hu", "en"]
+streaming = true
+type_partials = true
+# api_key set via SONIOX_API_KEY env var
+```
+
+### Complete Example — Async (PTT-compatible, batch-only)
+
+```toml
+engine = "soniox"
+
+[hotkey]
+mode = "push_to_talk"   # Works with async_api; no toggle promotion
+
+[soniox]
+async_api = true
+language_hints = ["hu", "en"]
+# model defaults to stt-async-v4 when async_api = true
+# api_key set via SONIOX_API_KEY env var
+```
+
+### Building from Source
+
+Source builds need the `soniox` Cargo feature:
+
+```bash
+cargo build --release --features soniox
+```
+
+The `soniox` feature is independent of the other engine features and adds a small WebSocket client (tokio-tungstenite + rustls) plus an async HTTP client (reqwest) for the async API. It can be combined with any local engine feature, e.g. `--features "soniox parakeet"` for a binary that runs Parakeet locally and Soniox in the cloud depending on the `engine` setting.
+
+---
+
 ## [output]
 
 Controls how transcribed text is delivered.
@@ -1520,9 +1722,9 @@ Custom order of output drivers to try when `mode = "type"`. Each driver is tried
 
 **Available drivers:**
 - `wtype` - Wayland virtual keyboard protocol (best CJK/Unicode support, wlroots compositors only)
-- `eitype` - Wayland via libei/EI protocol (works on GNOME, KDE, and compositors with libei support)
-- `dotool` - uinput-based typing (supports keyboard layouts, works on X11/Wayland/TTY)
-- `ydotool` - uinput-based typing (requires daemon, X11/Wayland/TTY)
+- `eitype` - Wayland via libei/EI protocol (works on GNOME, KDE, and compositors with libei support). On KDE Plasma 6, each invocation briefly registers via the XDG RemoteDesktop portal, which can cause a system-tray icon to flicker during streaming dictation (many fast typing calls). Prefer `dotool` for streaming if you're on KDE.
+- `dotool` - uinput-based typing (supports keyboard layouts, works on X11/Wayland/TTY). For streaming backends (Parakeet, Soniox), run `dotoold` to make this **much** faster — see [Streaming performance: dotoold fast path](#streaming-performance-dotoold-fast-path) below.
+- `ydotool` - uinput-based typing (requires `ydotoold` daemon, X11/Wayland/TTY). Fast spawn, but **does not support keyboard layouts** — sends raw US keycodes. Wrong output on non-US layouts (e.g. Hungarian Z/Y swap).
 - `clipboard` - Wayland clipboard via wl-copy
 - `xclip` - X11 clipboard via xclip
 
@@ -1554,6 +1756,58 @@ voxtype --driver=ydotool,clipboard daemon
 ```
 
 **Note:** When `driver_order` is set, `fallback_to_clipboard` is ignored—the driver list explicitly defines what's tried.
+
+#### Streaming performance: dotoold fast path
+
+Streaming backends (Parakeet, Soniox) call the output driver many times per session — once for every partial token batch. With direct `dotool` invocations each call spawns a fresh dotool process that pays the kernel uinput device setup cost (**~700-800ms** on most systems). For 60+ partials per session this stacks into 40+ seconds of typing latency — unusable.
+
+dotool ships a daemon/client pair (`dotoold` + `dotoolc`) specifically for this case. When `dotoold` is running, voxtype auto-detects its FIFO at `/tmp/dotool-pipe` and routes every typing call through `dotoolc`, which simply relays commands to the long-lived daemon. The uinput device is registered **once** at daemon startup, not on every typed segment. Sub-10ms per call.
+
+**Strongly recommended** if you use `dotool` as your primary typing driver with any streaming backend.
+
+**Setup as a systemd user unit (persistent across reboots):**
+
+```bash
+mkdir -p ~/.config/systemd/user
+
+cat > ~/.config/systemd/user/dotoold.service <<'EOF'
+[Unit]
+Description=dotool daemon for low-latency keyboard injection
+After=default.target
+
+[Service]
+ExecStart=/usr/bin/dotoold
+# Set DOTOOL_XKB_LAYOUT here (NOT in voxtype) — layout applies to the
+# daemon, not the per-call client. voxtype's dotool_xkb_layout config
+# is ignored when routing through dotoolc.
+Environment=DOTOOL_XKB_LAYOUT=hu
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user enable --now dotoold
+```
+
+Replace `hu` with your XKB layout (`de`, `fr`, `us`, etc.).
+
+**Manual test:**
+```bash
+DOTOOL_XKB_LAYOUT=hu dotoold &
+ls -la /tmp/dotool-pipe   # confirm FIFO exists
+```
+
+**Verifying voxtype is using the fast path:**
+
+After dictating a session, check the daemon log:
+```bash
+journalctl --user -u voxtype --since "5 min ago" | grep "typed via"
+```
+- `Text typed via dotoolc (N chars)` — fast path active
+- `Text typed via dotool (N chars)` — daemon not running, slow per-call spawn
+
+**Important caveat:** Keyboard layout (`DOTOOL_XKB_LAYOUT` / `DOTOOL_XKB_VARIANT`) applies to **the daemon, not the client**. When dotoold is running, voxtype's `dotool_xkb_layout` config setting has no effect — set the env var in dotoold's unit file or shell instead.
 
 ### dotool_xkb_layout
 

--- a/docs/MODEL_SELECTION_GUIDE.md
+++ b/docs/MODEL_SELECTION_GUIDE.md
@@ -17,6 +17,9 @@ Voxtype has seven transcription engines. Two are bundled with the standard binar
 | **Paraformer** | zh, en | Encoder-predictor-decoder | 220 - 487 MB | Fast | No | ONNX |
 | **Dolphin** | 40+ langs, 22 Chinese dialects | CTC E-Branchformer | 198 MB | Fast | No | ONNX |
 | **Omnilingual** | 1600+ | CTC wav2vec2 | 3.9 GB | Moderate | No | ONNX |
+| **Soniox** (cloud) | 60+ | Cloud (WebSocket / REST) | n/a (no local model) | Cloud-bound | Yes | Soniox feature |
+
+**Soniox** is different from the others — it's a paid cloud service over WebSocket / REST. No local model, no GPU. Sub-second partial latency. Strong for non-English languages where local Whisper-based engines struggle on lower-end hardware. Requires `cargo build --features soniox` and a `SONIOX_API_KEY`. See [SONIOX.md](SONIOX.md) for the full story.
 
 ---
 
@@ -53,6 +56,18 @@ What language(s) do you speak?
 │
 └─ Rare or uncommon language
     └─ → Omnilingual (1600+ languages) or Whisper
+
+OR — independently of language:
+
+├─ Want sub-second live partials at the cursor?
+│   ├─ English + GPU available?           → Parakeet TDT (streaming, local)
+│   └─ Any of 60+ languages, paid OK?     → Soniox (cloud, sub-100ms partials)
+│
+├─ Want highest accuracy and don't mind a few seconds of wait?
+│   └─ Soniox async API (cloud, stt-async-v4)
+│
+└─ Cannot send audio off-device (privacy-sensitive)?
+    └─ Pick any *local* engine above. Never Soniox.
 ```
 
 ---

--- a/docs/SONIOX.md
+++ b/docs/SONIOX.md
@@ -1,0 +1,198 @@
+# Soniox Backend
+
+Voxtype supports [Soniox](https://soniox.com) as a cloud streaming speech-to-text backend. Unlike voxtype's other engines (Whisper, Parakeet, Moonshine, etc.), nothing runs on your machine — audio streams to Soniox's servers over WebSocket and tokens stream back.
+
+## What is Soniox?
+
+Soniox is a paid cloud STT provider offering:
+
+- **60+ languages** including strong Hungarian, English, German, French, Spanish, etc.
+- **Per-token finality** — server marks each token as `is_final: true` or `false`, with stable-final guarantees
+- **Sub-second latency** for partial tokens
+- **Server-side endpoint detection** — automatic finalization at utterance boundaries
+- **Two API modes** — realtime WebSocket (`stt-rt-v4`) and async REST (`stt-async-v4`)
+- **Domain context** — bias the model toward your vocabulary
+
+## Privacy
+
+Audio is sent to a third-party service over TLS. Soniox processes the audio server-side and discards it according to their [data retention policy](https://soniox.com). **Use a local engine (Whisper, Parakeet) instead if your dictation contains anything you cannot send off-device.**
+
+## Cost
+
+Soniox is paid SaaS. Sign up at [console.soniox.com](https://console.soniox.com) for an API key. New accounts get free credits to evaluate; pay-as-you-go pricing kicks in after that. Check the current [pricing page](https://soniox.com/pricing) before relying on it for high-volume dictation.
+
+## Requirements
+
+- voxtype built with the `soniox` Cargo feature:
+  ```bash
+  cargo build --release --features soniox
+  ```
+- A Soniox API key (free tier credits available)
+- Outbound HTTPS / WebSocket (wss://) access
+
+No local model files. No GPU.
+
+## Quick Start
+
+1. Get an API key at [console.soniox.com](https://console.soniox.com).
+2. Export it:
+   ```bash
+   export SONIOX_API_KEY="your-key-here"
+   ```
+3. Minimal config in `~/.config/voxtype/config.toml`:
+   ```toml
+   engine = "soniox"
+
+   [hotkey]
+   mode = "toggle"           # required when streaming (default)
+   key = "SCROLLLOCK"
+
+   [soniox]
+   language_hints = ["en"]   # adjust for your languages
+   ```
+4. Run voxtype, press the hotkey, dictate, press again to stop.
+
+## Two API Modes
+
+Soniox exposes two distinct backends. Voxtype supports both via `[soniox] async_api`.
+
+### Realtime (default — `async_api = false`)
+
+WebSocket-based. Tokens stream back as you speak.
+
+- **Latency:** partials appear within ~100ms of speech, finals at utterance boundaries.
+- **Model:** `stt-rt-v4`.
+- **Activation:** **toggle only.** Push-to-talk is auto-promoted to toggle for the running session, because typing characters at the cursor while the PTT key is still held breaks libinput's held-key state on Hyprland/Sway/River.
+- **Live typing:** non-final tokens are typed at the cursor as they arrive (`type_partials = true`). Soniox occasionally revises the tail when finalizing; voxtype emits a backspace+retype primitive (`StreamingEvent::Replace`) to patch up the cursor.
+
+```toml
+[hotkey]
+mode = "toggle"
+
+[soniox]
+streaming = true            # default
+type_partials = true        # default; live cursor feedback
+language_hints = ["en"]
+```
+
+To use realtime without live partial typing (only commits at finals):
+
+```toml
+[soniox]
+type_partials = false       # cursor stays still until finals arrive
+```
+
+To use realtime without streaming (one-shot WebSocket on key release):
+
+```toml
+[hotkey]
+mode = "push_to_talk"       # streaming=false makes PTT safe again
+
+[soniox]
+streaming = false           # buffer locally, single WS round trip on release
+```
+
+### Async (`async_api = true`)
+
+REST-based file upload + poll. Higher accuracy claim, but slower roundtrip.
+
+- **Latency:** for a 15s recording, ~1s upload + 2-5s server processing = 3-6s wait after release.
+- **Model:** `stt-async-v4`.
+- **Activation:** push-to-talk compatible. No live typing, no compositor-state clobbering.
+- **Quality:** marketed as more accurate than realtime. In practice quality varies by language and content — benchmark both before committing.
+
+```toml
+[hotkey]
+mode = "push_to_talk"
+
+[soniox]
+async_api = true
+language_hints = ["en"]
+# model defaults to stt-async-v4 when async_api = true
+```
+
+### Dictation vs Meeting Mode (automatic)
+
+The two Soniox APIs target different use cases and voxtype routes them automatically:
+
+| Mode | API used | Why |
+|---|---|---|
+| Dictation (hotkey) | follows your `async_api` setting (default `false` → realtime WS) | Live partials, sub-second latency |
+| Meeting (`voxtype meeting start`) | **always** async REST, regardless of `async_api` | Fixed-chunk batch is what async is designed for; diarization-friendly; audio-second billing instead of WS-duration; survives network hiccups |
+
+Concretely: if your config has the default `async_api = false`, dictation keeps live-partial WebSocket typing while meetings transparently switch to `stt-async-v4` for each 30-second chunk. No knob to turn off — meetings on the realtime WS would open one fresh socket per chunk, pay connect latency, and bill by session-duration not audio-duration.
+
+If your config has `async_api = true` (explicit), both paths use async — your call.
+
+You can see the meeting-mode switch in the daemon log: `Soniox meeting mode: routing to async API (stt-async-v4); dictation path unchanged`.
+
+## Language Hints
+
+Soniox supports 60+ languages and can auto-detect, but providing `language_hints` improves accuracy and reduces latency for short utterances. For bilingual dictation:
+
+```toml
+[soniox]
+language_hints = ["hu", "en"]   # Hungarian + English, in priority order
+language_hints_strict = true    # default — restrict output to hinted languages
+```
+
+Empty array `[]` means full auto-detect across all supported languages. When `language_hints_strict = true` (the default), the model is strongly biased to produce output only in the listed languages, avoiding mid-stream drift to a third language in partials. Set to `false` to allow the model to occasionally produce other languages it detects with high confidence. The strict flag is ignored when `language_hints` is empty. See https://soniox.com/docs/stt/concepts/language-restrictions.
+
+## Configuration Reference
+
+See [CONFIGURATION.md → [soniox]](CONFIGURATION.md#soniox) for the full field-by-field reference. Key settings:
+
+| Field | Default | Notes |
+|---|---|---|
+| `api_key` | env: `SONIOX_API_KEY` | Required |
+| `model` | `stt-rt-v4` (or `stt-async-v4` if `async_api`) | Advanced override |
+| `language_hints` | `["hu", "en"]` | Empty = auto-detect |
+| `language_hints_strict` | `true` | Restrict output to hinted languages (no-op if hints empty) |
+| `streaming` | `true` | Realtime live; ignored if `async_api` |
+| `type_partials` | `true` | Live cursor feedback; realtime only |
+| `context` | none | Free-form domain prose (`context.text`) |
+| `terms` | none | Inline boost-term array (`context.terms`) |
+| `terms_file` | none | JSON file with boost terms |
+| `async_api` | `false` | Use REST instead of WebSocket |
+| `async_max_wait_secs` | `120` | Async timeout |
+
+## Performance Notes
+
+Streaming output calls the typing driver many times per session (~60 partials for typical dictation). With direct `dotool` invocations each call spawns a fresh dotool process that pays ~700ms of uinput device setup — stacking to 40+ seconds of typing latency per session.
+
+**Strongly recommended:** run `dotoold` so voxtype routes through `dotoolc` (sub-10ms per call). See [Streaming performance: dotoold fast path](CONFIGURATION.md#streaming-performance-dotoold-fast-path) for the systemd user unit template.
+
+If you're on KDE Plasma and see system-tray flicker during streaming, that's the `eitype` driver triggering the RemoteDesktop portal security indicator on each invocation. Prefer `dotool` (via dotoold) in your `[output] driver_order`.
+
+## Troubleshooting
+
+See [TROUBLESHOOTING.md → Soniox Backend Issues](TROUBLESHOOTING.md#soniox-backend-issues) for:
+- Auth errors (401/403)
+- Connect failures and 408 timeouts
+- Tail-revision divergence (typed text doesn't match final)
+- Flicker on KDE
+- Slow typing without dotoold
+- Wrong layout when dotoold is running
+- Stuck async jobs
+
+## Comparing to Local Engines
+
+| | Soniox realtime | Soniox async | Whisper local | Parakeet local |
+|---|---|---|---|---|
+| Quality (HU) | Good | Slightly better | Excellent | N/A |
+| Quality (EN) | Excellent | Excellent | Excellent | Excellent |
+| Latency | ~100ms partials | 3-6s on release | 500ms-3s on release | ~100ms partials |
+| Privacy | Cloud | Cloud | Local | Local |
+| Cost | Paid | Paid | Free | Free |
+| GPU needed | No | No | Optional | Optional |
+| RAM | ~50 MB | ~50 MB | 1-5 GB | ~1.5 GB |
+| Offline | No | No | Yes | Yes |
+| Multilingual | 60+ languages | 60+ languages | 99 languages | English only |
+
+## Limitations
+
+- **No on-prem option.** Soniox is SaaS only.
+- **Internet dependency.** No fallback to a local engine if the network drops mid-session — voxtype surfaces a `Streaming Error` notification and returns to idle.
+- **Stream sessions can't be replayed.** Once tokens arrive, they're processed once. The async API supports re-fetching transcripts, but realtime tokens are not stored.
+- **Tail revisions cause occasional cursor artifacts.** When Soniox revises a non-final token that voxtype already typed (e.g. `,` → `.`), voxtype emits a backspace+retype. In rare cases where the revision is bigger than my LCP-reconciler can handle, you may see transient duplication. Set `type_partials = false` to avoid entirely.
+- **Async API doesn't stream.** Use realtime for live cursor feedback.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,6 +15,7 @@ Solutions to common issues when using Voxtype.
   - [Text output not working on X11](#text-output-not-working-on-x11)
   - [Wrong characters on non-US keyboard layouts](#wrong-characters-on-non-us-keyboard-layouts-yz-swapped-qwertz-azerty)
 - [Performance Issues](#performance-issues)
+- [Soniox Backend Issues](#soniox-backend-issues)
 - [Systemd Service Issues](#systemd-service-issues)
 - [Debug Mode](#debug-mode)
 
@@ -950,6 +951,112 @@ model = "tiny.en"
 1. Ensure voxtype is running with normal priority
 2. Check for other applications using evdev
 3. Try a different hotkey
+
+---
+
+## Soniox Backend Issues
+
+### "Soniox API key required: set [soniox] api_key or SONIOX_API_KEY"
+
+The backend can't find a credential. Either set the env var:
+
+```bash
+export SONIOX_API_KEY="your-key-here"
+```
+
+…or add it to `~/.config/voxtype/config.toml`:
+
+```toml
+[soniox]
+api_key = "your-key-here"   # less safe — lands in dotfiles
+```
+
+The env var is preferred (no key in shell history, no key in config backups).
+
+### "Soniox: WS connect failed: ..." or "connect timeout"
+
+Network or DNS issue reaching `wss://stt-rt.soniox.com`. Check:
+- Internet connectivity (`curl https://api.soniox.com`)
+- Firewall / corporate proxy blocking outbound 443
+- VPN that mangles WebSocket handshakes
+
+Voxtype emits one `Streaming Error` notification and returns to idle. Press the hotkey again to retry once the network is back.
+
+### 401 Unauthorized / 403 Forbidden
+
+API key is invalid, revoked, or out of credit. Check the dashboard at https://console.soniox.com.
+
+### Soniox typed text occasionally diverges from spoken words (realtime mode)
+
+Soniox occasionally revises tail tokens between non-final and final states (`tévedések,` → `tévedések.`, `fejeztem` → `fejezte`). Voxtype emits a `StreamingEvent::Replace { backspace, text }` in this case so the cursor is patched up — but the patch only works if a backspace-capable driver is in the chain (wtype, dotool, eitype, or ydotool).
+
+If you see persistent duplication or wrong tails:
+1. Check `journalctl --user -u voxtype` for `Soniox tail revision: backspace N chars` lines. If you see them, Replace is firing.
+2. If `Soniox final … does not align with typed partial` appears, the divergence was bigger than my LCP-based reconciler could handle gracefully — the full final is typed verbatim and you may see a duplicate. Rare for `stt-rt-v4` with Hungarian/English; common when language hints are wrong.
+3. Disable partial typing entirely: `[soniox] type_partials = false`. Finals are still typed, but no live cursor feedback. Trade-off: feels slower, zero divergence risk.
+
+### Notifications spam during dictation (transient tray icon flicker on KDE)
+
+If your KDE Plasma panel briefly shows an icon and re-layouts every ~150ms during streaming, the cause is usually the `eitype` driver. eitype connects via the XDG RemoteDesktop portal on each call, and KDE's security indicator briefly registers in the system tray.
+
+**Fix:** prefer `dotool` (or `ydotool`, layout-permitting) ahead of `eitype` in `[output] driver_order`. dotool uses kernel uinput directly — no portal, no tray.
+
+```toml
+[output]
+driver_order = ["dotool", "ydotool", "eitype", "clipboard"]
+```
+
+### Streaming is unusably slow (each typed segment takes ~1 second)
+
+You're hitting dotool's uinput init cost (~700ms) on every output call. With 60+ partials per session this stacks into 40+ seconds.
+
+**Fix:** run `dotoold` once at login. voxtype auto-detects its FIFO and routes through `dotoolc`, paying the init cost once for the daemon's lifetime instead of per call. Sub-10ms per typed segment.
+
+See [Streaming performance: dotoold fast path](CONFIGURATION.md#streaming-performance-dotoold-fast-path) in CONFIGURATION.md for the systemd user unit template.
+
+To verify the fast path is active after dictation:
+```bash
+journalctl --user -u voxtype --since "5 min ago" | grep "typed via"
+```
+- `Text typed via dotoolc (N chars)` — fast path
+- `Text typed via dotool (N chars)` — slow path; daemon not running
+
+### Wrong keyboard layout when dotoold is running
+
+dotool's layout setting applies to **the daemon, not the client**. Voxtype's `dotool_xkb_layout` config has no effect on commands routed through `dotoolc` — the layout is whatever dotoold inherits from its own environment.
+
+**Fix:** set `DOTOOL_XKB_LAYOUT` in dotoold's startup environment:
+
+```bash
+# In your systemd user unit:
+Environment=DOTOOL_XKB_LAYOUT=hu
+
+# Then:
+systemctl --user daemon-reload && systemctl --user restart dotoold
+```
+
+### PTT auto-promoted to toggle every time you start the daemon
+
+Expected when `[soniox] streaming = true` (the default for the realtime backend). Live cursor typing while the PTT key is still held breaks libinput's held-key state tracking on Hyprland/Sway/River. Voxtype auto-promotes to toggle for the running session and warns.
+
+To use Soniox with **real** push-to-talk, choose one of:
+- `[soniox] streaming = false` — one-shot WebSocket on key release, no live partials
+- `[soniox] async_api = true` — async REST API, slower but higher accuracy
+- `[hotkey] mode = "toggle"` — accept toggle activation (silences the warning)
+
+### Async API job stuck or "Soniox async: job ... did not complete within Ns"
+
+The async API processing took longer than `async_max_wait_secs` (default 120). For very long recordings or during Soniox capacity spikes, bump the timeout:
+
+```toml
+[soniox]
+async_api = true
+async_max_wait_secs = 300
+```
+
+### Post-stop "Streaming Error: Soniox server error (408): Request timeout"
+
+This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release after v0.7.2 + soniox).
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -988,11 +988,11 @@ API key is invalid, revoked, or out of credit. Check the dashboard at https://co
 
 ### Soniox typed text occasionally diverges from spoken words (realtime mode)
 
-Soniox occasionally revises tail tokens between non-final and final states (`tévedések,` → `tévedések.`, `fejeztem` → `fejezte`). Voxtype emits a `StreamingEvent::Replace { backspace, text }` in this case so the cursor is patched up — but the patch only works if a backspace-capable driver is in the chain (wtype, dotool, eitype, or ydotool).
+Soniox occasionally revises tail tokens between non-final and final states (`tévedések,` → `tévedések.`, `fejeztem` → `fejezte`). Voxtype emits a `StreamingEvent::Replace { backspace, text }` in this case so the cursor is patched up — but the patch only works if a backspace-capable driver is in the chain. The current backspace path tries `wtype`, then `dotool` (via `dotoolc` if the daemon is running), then `ydotool`. `eitype` does not have a backspace implementation.
 
 If you see persistent duplication or wrong tails:
-1. Check `journalctl --user -u voxtype` for `Soniox tail revision: backspace N chars` lines. If you see them, Replace is firing.
-2. If `Soniox final … does not align with typed partial` appears, the divergence was bigger than my LCP-based reconciler could handle gracefully — the full final is typed verbatim and you may see a duplicate. Rare for `stt-rt-v4` with Hungarian/English; common when language hints are wrong.
+1. Check `journalctl --user -u voxtype` for `Soniox tail revision: backspace N chars, type … (lcp=N)` lines. If you see them, Replace is firing.
+2. If you also see `Streaming replace: no backspace-capable backend available; skipping backspace and accepting cursor artifact`, none of wtype/dotool/ydotool was usable — the original tail stayed at the cursor and the corrected text appended. Install at least one of them (`pacman -S wtype` or `pacman -S dotool` on Arch).
 3. Disable partial typing entirely: `[soniox] type_partials = false`. Finals are still typed, but no live cursor feedback. Trade-off: feels slower, zero divergence risk.
 
 ### Notifications spam during dictation (transient tray icon flicker on KDE)

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -436,6 +436,24 @@ on_recording_stop = false
 on_transcription = true
 ```
 
+### Cloud Backend: Soniox
+
+For a cloud streaming alternative to the local engines above, voxtype supports [Soniox](https://soniox.com). Different trade-off space: paid SaaS, no local model, 60+ languages with strong Hungarian/EU coverage, sub-second partials at the cursor.
+
+Build with `--features soniox`, set `SONIOX_API_KEY`, and:
+
+```toml
+engine = "soniox"
+
+[hotkey]
+mode = "toggle"   # required when streaming (default)
+
+[soniox]
+language_hints = ["en"]
+```
+
+See [SONIOX.md](SONIOX.md) for the full reference (realtime vs async modes, performance tips with dotoold, privacy considerations).
+
 ### Creating a Custom Configuration
 
 ```bash

--- a/src/audio/levels.rs
+++ b/src/audio/levels.rs
@@ -55,6 +55,7 @@ use crate::config::Config;
 use std::io;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, Mutex};
@@ -585,6 +586,27 @@ pub fn spawn_emitter_with_streaming_tap(
             }
         }
         tracing::trace!("Audio level emitter task ended");
+    })
+}
+
+/// Publish silent frames at 30 Hz to keep the OSD visible while a
+/// streaming session is draining server-side after the mic has been
+/// stopped. 30 Hz matches typical OSD redraw rates; pumping faster just
+/// burns timer wakeups. Cancelling the returned `JoinHandle` ends the pump.
+pub fn spawn_silence_pump(sink: FrameSink) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut seq: u32 = 0;
+        let mut tick = tokio::time::interval(Duration::from_millis(33));
+        loop {
+            tick.tick().await;
+            sink.publish(AudioFrame {
+                seq,
+                min: 0.0,
+                max: 0.0,
+                peak_dbfs: -120.0,
+            });
+            seq = seq.wrapping_add(1);
+        }
     })
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,7 +71,7 @@ pub struct Cli {
         long,
         value_name = "ENGINE",
         help_heading = "Transcription",
-        long_help = "Override transcription engine: whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere"
+        long_help = "Override transcription engine: whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox"
     )]
     pub engine: Option<String>,
 
@@ -172,6 +172,16 @@ pub struct Cli {
         hide_short_help = true
     )]
     pub remote_api_key: Option<String>,
+
+    // -- Soniox --
+    /// API key for Soniox (or use SONIOX_API_KEY env var)
+    #[arg(
+        long,
+        value_name = "KEY",
+        help_heading = "Soniox",
+        hide_short_help = true
+    )]
+    pub soniox_api_key: Option<String>,
 
     // -- Hotkey --
     /// Override hotkey (e.g., SCROLLLOCK, PAUSE, F13, MEDIA, WEV_234, EVTEST_226)

--- a/src/config.rs
+++ b/src/config.rs
@@ -397,6 +397,11 @@ pub struct Config {
     #[serde(default)]
     pub cohere: Option<CohereConfig>,
 
+    /// Soniox cloud streaming WebSocket STT configuration
+    /// (optional, only used when engine = "soniox")
+    #[serde(default)]
+    pub soniox: Option<SonioxConfig>,
+
     /// Text processing configuration (replacements, spoken punctuation)
     #[serde(default)]
     pub text: TextConfig,
@@ -1198,6 +1203,110 @@ impl Default for CohereConfig {
     }
 }
 
+/// Soniox cloud streaming WebSocket STT configuration
+/// Requires: cargo build --features soniox
+///
+/// Soniox is a paid cloud STT provider. API key required:
+/// either set `api_key` here or via the `SONIOX_API_KEY` env var.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SonioxConfig {
+    /// API key. If unset, falls back to the SONIOX_API_KEY env var.
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Soniox model name. Default: "stt-rt-v4".
+    #[serde(default = "default_soniox_model")]
+    pub model: String,
+
+    /// Language hints (ISO 639-1 codes). Default: ["hu", "en"].
+    /// Empty array means auto-detect.
+    #[serde(default = "default_soniox_language_hints")]
+    pub language_hints: Vec<String>,
+
+    /// Strictly restrict recognition to the languages in `language_hints`.
+    /// When true (default), the model strongly prefers producing output
+    /// only in the hinted languages, avoiding occasional drift to a third
+    /// language in mid-stream partials. Ignored when `language_hints` is
+    /// empty. See https://soniox.com/docs/stt/concepts/language-restrictions.
+    #[serde(default = "default_true")]
+    pub language_hints_strict: bool,
+
+    /// Streaming mode. true = WebSocket session with live partials
+    /// (requires [hotkey] mode = "toggle"; PTT auto-promoted to toggle).
+    /// false = batch mode: buffer audio while held, send one-shot on release
+    /// (PTT-compatible).
+    #[serde(default = "default_true")]
+    pub streaming: bool,
+
+    /// Type partials at cursor as they arrive (streaming mode only).
+    /// false = only finalized segments are typed. Default: true.
+    #[serde(default = "default_true")]
+    pub type_partials: bool,
+
+    /// Free-form context text — mapped to `context.text` in Soniox's init
+    /// frame. Use for short domain prose ("medical consultation",
+    /// "podcast about Rust async runtime"). See
+    /// https://soniox.com/docs/stt/concepts/context.
+    #[serde(default)]
+    pub context: Option<String>,
+
+    /// Vocabulary boost terms (proper names, jargon, product names).
+    /// Mapped to `context.terms` in Soniox's init frame. Can be combined
+    /// with `terms_file`; entries are deduplicated in order.
+    #[serde(default)]
+    pub terms: Option<Vec<String>>,
+
+    /// Path to a JSON file containing a list of vocabulary boost terms
+    /// (`["term1", "term2", ...]`). Loaded once at daemon startup and
+    /// merged into `context.terms`. Useful for sharing a single
+    /// corrections list across multiple voxtype config snapshots.
+    #[serde(default)]
+    pub terms_file: Option<std::path::PathBuf>,
+
+    /// Use the Soniox async transcription API (file upload + poll) instead
+    /// of the realtime WebSocket. Higher accuracy, PTT-compatible, batch
+    /// only (no live partials). When true, overrides `streaming` and
+    /// `type_partials`. Default model becomes `stt-async-v4`.
+    /// Default: false.
+    #[serde(default)]
+    pub async_api: bool,
+
+    /// Maximum total wait time (seconds) for an async API job to complete
+    /// before giving up. Default: 120.
+    #[serde(default = "default_soniox_async_max_wait_secs")]
+    pub async_max_wait_secs: u64,
+}
+
+fn default_soniox_model() -> String {
+    "stt-rt-v4".to_string()
+}
+
+fn default_soniox_language_hints() -> Vec<String> {
+    vec!["hu".to_string(), "en".to_string()]
+}
+
+fn default_soniox_async_max_wait_secs() -> u64 {
+    120
+}
+
+impl Default for SonioxConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            model: default_soniox_model(),
+            language_hints: default_soniox_language_hints(),
+            language_hints_strict: true,
+            streaming: true,
+            type_partials: true,
+            context: None,
+            terms: None,
+            terms_file: None,
+            async_api: false,
+            async_max_wait_secs: default_soniox_async_max_wait_secs(),
+        }
+    }
+}
+
 /// SenseVoice speech-to-text configuration (ONNX-based, CTC encoder-only ASR)
 /// Requires: cargo build --features sensevoice
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1349,6 +1458,9 @@ pub enum TranscriptionEngine {
     /// task tokens). Top of the Open ASR Leaderboard.
     /// Requires: cargo build --features cohere
     Cohere,
+    /// Use Soniox (cloud streaming WebSocket STT).
+    /// Requires: cargo build --features soniox
+    Soniox,
 }
 
 /// VAD backend selection
@@ -2175,6 +2287,7 @@ impl Default for Config {
             dolphin: None,
             omnilingual: None,
             cohere: None,
+            soniox: None,
             text: TextConfig::default(),
             vad: VadConfig::default(),
             status: StatusConfig::default(),
@@ -2187,6 +2300,55 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Returns true if the active engine is configured for streaming output.
+    ///
+    /// Used to decide whether to auto-promote push-to-talk to toggle activation:
+    /// streaming output types characters at the cursor while the user is still
+    /// holding the hotkey, which clobbers libinput's held-key state tracker on
+    /// Hyprland/Sway/River. New streaming backends plug into this gate without
+    /// editing the daemon.
+    pub fn streaming_active(&self) -> bool {
+        match self.engine {
+            TranscriptionEngine::Parakeet => {
+                self.parakeet.as_ref().map(|p| p.streaming).unwrap_or(false)
+            }
+            TranscriptionEngine::Soniox => self
+                .soniox
+                .as_ref()
+                .map(|s| s.streaming && !s.async_api)
+                .unwrap_or(true),
+            _ => false,
+        }
+    }
+
+    /// Clone this config with engine-specific overrides for meeting (long-form)
+    /// transcription. Currently:
+    ///
+    /// - **Soniox:** forces `async_api = true`. Meetings feed fixed-size audio
+    ///   chunks (30s default) to `Transcriber::transcribe()` — the realtime WS
+    ///   would open a fresh socket per chunk, pay connect latency, and bill by
+    ///   WS-duration. The async REST path (`stt-async-v4`) is purpose-built
+    ///   for this: bills audio-seconds, gives higher accuracy, integrates with
+    ///   speaker diarization, and survives network hiccups.
+    ///
+    /// The dictation path still reads the raw config, so a user who set
+    /// `async_api = false` (the default) keeps live-partial WS dictation while
+    /// meetings transparently use the async API.
+    pub fn with_meeting_mode_overrides(&self) -> Self {
+        let mut cfg = self.clone();
+        if matches!(cfg.engine, TranscriptionEngine::Soniox) {
+            if let Some(ref mut sx) = cfg.soniox {
+                if !sx.async_api {
+                    tracing::info!(
+                        "Soniox meeting mode: routing to async API (stt-async-v4); dictation path unchanged"
+                    );
+                    sx.async_api = true;
+                }
+            }
+        }
+        cfg
+    }
+
     /// System-wide config path used as a fallback when no user config exists.
     pub const SYSTEM_PATH: &'static str = "/etc/voxtype/config.toml";
 
@@ -2319,6 +2481,8 @@ impl Config {
                 .as_ref()
                 .map(|c| c.on_demand_loading)
                 .unwrap_or(false),
+            // Soniox is a cloud backend; nothing to load on demand.
+            TranscriptionEngine::Soniox => false,
         }
     }
 
@@ -2361,6 +2525,11 @@ impl Config {
                 .as_ref()
                 .map(|c| c.model.as_str())
                 .unwrap_or("cohere (not configured)"),
+            TranscriptionEngine::Soniox => self
+                .soniox
+                .as_ref()
+                .map(|s| s.model.as_str())
+                .unwrap_or("soniox (not configured)"),
         }
     }
 
@@ -2436,6 +2605,7 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
             "dolphin" => config.engine = TranscriptionEngine::Dolphin,
             "omnilingual" => config.engine = TranscriptionEngine::Omnilingual,
             "cohere" => config.engine = TranscriptionEngine::Cohere,
+            "soniox" => config.engine = TranscriptionEngine::Soniox,
             _ => tracing::warn!("Unknown VOXTYPE_ENGINE value: {}", engine),
         }
     }
@@ -2544,6 +2714,14 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     if let Ok(key) = std::env::var("VOXTYPE_WHISPER_API_KEY") {
         config.whisper.remote_api_key = Some(key);
     }
+
+    // Soniox
+    if let Ok(key) = std::env::var("SONIOX_API_KEY") {
+        config
+            .soniox
+            .get_or_insert_with(SonioxConfig::default)
+            .api_key = Some(key);
+    }
     if let Ok(val) = std::env::var("VOXTYPE_RESTORE_CLIPBOARD") {
         config.output.restore_clipboard = parse_bool_env(&val);
     }
@@ -2583,6 +2761,42 @@ pub fn save_config(config: &Config, path: &Path) -> Result<(), VoxtypeError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn meeting_mode_forces_soniox_async_when_user_had_realtime() {
+        let mut cfg = Config::default();
+        cfg.engine = TranscriptionEngine::Soniox;
+        cfg.soniox = Some(SonioxConfig {
+            api_key: Some("k".into()),
+            async_api: false,
+            ..SonioxConfig::default()
+        });
+        let meeting_cfg = cfg.with_meeting_mode_overrides();
+        assert!(meeting_cfg.soniox.as_ref().unwrap().async_api);
+        // Original config untouched — dictation path keeps realtime.
+        assert!(!cfg.soniox.as_ref().unwrap().async_api);
+    }
+
+    #[test]
+    fn meeting_mode_preserves_explicit_soniox_async() {
+        let mut cfg = Config::default();
+        cfg.engine = TranscriptionEngine::Soniox;
+        cfg.soniox = Some(SonioxConfig {
+            api_key: Some("k".into()),
+            async_api: true,
+            ..SonioxConfig::default()
+        });
+        let meeting_cfg = cfg.with_meeting_mode_overrides();
+        assert!(meeting_cfg.soniox.as_ref().unwrap().async_api);
+    }
+
+    #[test]
+    fn meeting_mode_is_noop_for_non_soniox_engines() {
+        let cfg = Config::default(); // engine = Whisper
+        let meeting_cfg = cfg.with_meeting_mode_overrides();
+        assert_eq!(meeting_cfg.engine, cfg.engine);
+        assert_eq!(meeting_cfg.whisper.model, cfg.whisper.model);
+    }
 
     #[test]
     fn test_default_config() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2312,11 +2312,15 @@ impl Config {
             TranscriptionEngine::Parakeet => {
                 self.parakeet.as_ref().map(|p| p.streaming).unwrap_or(false)
             }
+            // Missing [soniox] section → don't auto-promote PTT. The
+            // transcriber will fail to initialize anyway (no api_key); we
+            // shouldn't change hotkey behaviour for a config that can't
+            // run. Same shape as the Parakeet arm: explicit opt-in only.
             TranscriptionEngine::Soniox => self
                 .soniox
                 .as_ref()
                 .map(|s| s.streaming && !s.async_api)
-                .unwrap_or(true),
+                .unwrap_or(false),
             _ => false,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2764,13 +2764,15 @@ mod tests {
 
     #[test]
     fn meeting_mode_forces_soniox_async_when_user_had_realtime() {
-        let mut cfg = Config::default();
-        cfg.engine = TranscriptionEngine::Soniox;
-        cfg.soniox = Some(SonioxConfig {
-            api_key: Some("k".into()),
-            async_api: false,
-            ..SonioxConfig::default()
-        });
+        let cfg = Config {
+            engine: TranscriptionEngine::Soniox,
+            soniox: Some(SonioxConfig {
+                api_key: Some("k".into()),
+                async_api: false,
+                ..SonioxConfig::default()
+            }),
+            ..Config::default()
+        };
         let meeting_cfg = cfg.with_meeting_mode_overrides();
         assert!(meeting_cfg.soniox.as_ref().unwrap().async_api);
         // Original config untouched — dictation path keeps realtime.
@@ -2779,13 +2781,15 @@ mod tests {
 
     #[test]
     fn meeting_mode_preserves_explicit_soniox_async() {
-        let mut cfg = Config::default();
-        cfg.engine = TranscriptionEngine::Soniox;
-        cfg.soniox = Some(SonioxConfig {
-            api_key: Some("k".into()),
-            async_api: true,
-            ..SonioxConfig::default()
-        });
+        let cfg = Config {
+            engine: TranscriptionEngine::Soniox,
+            soniox: Some(SonioxConfig {
+                api_key: Some("k".into()),
+                async_api: true,
+                ..SonioxConfig::default()
+            }),
+            ..Config::default()
+        };
         let meeting_cfg = cfg.with_meeting_mode_overrides();
         assert!(meeting_cfg.soniox.as_ref().unwrap().async_api);
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -879,7 +879,7 @@ impl Daemon {
     /// `Ended`, or as a teardown after an error). Stops audio capture, awaits
     /// the backend task, and drops the session locals.
     /// Start the OSD "draining" pump that publishes silent frames at
-    /// 100 Hz to keep the visualizer on screen while the streaming
+    /// ~30 Hz to keep the visualizer on screen while the streaming
     /// backend is flushing pending finals after the mic has stopped.
     /// No-op if the pump is already running or the OSD level hub is
     /// disabled.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -563,6 +563,10 @@ pub struct Daemon {
     level_hub: Option<audio::levels::LevelHub>,
     /// Active per-recording level emitter task; aborted when recording stops
     level_emitter_task: Option<tokio::task::JoinHandle<()>>,
+    /// Synthetic zero-level publisher that keeps the OSD visible while a
+    /// streaming session is draining server-side after the mic stopped.
+    /// Aborted in `end_streaming`.
+    streaming_drain_pump: Option<tokio::task::JoinHandle<()>>,
     /// OSD child supervisor task. Holds the JoinHandle so dropping it (on
     /// daemon shutdown) kill_on_drop's the spawned voxtype-osd process.
     osd_supervisor_task: Option<tokio::task::JoinHandle<()>>,
@@ -693,6 +697,7 @@ impl Daemon {
             last_dictation: None,
             level_hub: None,
             level_emitter_task: None,
+            streaming_drain_pump: None,
             osd_supervisor_task: None,
             model_manager: None,
             model_load_task: None,
@@ -873,6 +878,52 @@ impl Daemon {
     /// End a streaming session gracefully (called when the backend emits
     /// `Ended`, or as a teardown after an error). Stops audio capture, awaits
     /// the backend task, and drops the session locals.
+    /// Start the OSD "draining" pump that publishes silent frames at
+    /// 100 Hz to keep the visualizer on screen while the streaming
+    /// backend is flushing pending finals after the mic has stopped.
+    /// No-op if the pump is already running or the OSD level hub is
+    /// disabled.
+    fn start_streaming_drain_pump(&mut self) {
+        if self.streaming_drain_pump.is_some() {
+            return;
+        }
+        if let Some(hub) = &self.level_hub {
+            self.streaming_drain_pump = Some(audio::levels::spawn_silence_pump(hub.frame_sink()));
+        }
+    }
+
+    /// Cut audio flow to the streaming backend immediately. Aborts the
+    /// chunk-rx → streaming_tx pump so any samples still in the audio
+    /// capture's buffer never reach the backend — without this, the
+    /// ~50–100ms of residual samples between the user's stop press and
+    /// the actual mic shutdown leak in as low-level noise and cause
+    /// hallucinated trailing tokens.
+    fn cut_streaming_audio(&mut self) {
+        if let Some(handle) = self.level_emitter_task.take() {
+            handle.abort();
+        }
+    }
+
+    /// Abort the OSD draining pump (if running) so the visualizer can
+    /// fade out on its idle timer once the session is fully closed.
+    fn stop_streaming_drain_pump(&mut self) {
+        if let Some(h) = self.streaming_drain_pump.take() {
+            h.abort();
+        }
+    }
+
+    /// Early-stop the streaming capture: cut audio flow to the backend,
+    /// start the OSD silence pump so the visualizer stays alive during
+    /// drain, and stop the mic. Leaves `streaming_session`/`_chain` for
+    /// the caller to disown (or keep, to receive trailing finals).
+    async fn stop_streaming_capture(&mut self, audio_capture: &mut Option<Box<dyn AudioCapture>>) {
+        self.cut_streaming_audio();
+        self.start_streaming_drain_pump();
+        if let Some(mut c) = audio_capture.take() {
+            let _ = c.stop().await;
+        }
+    }
+
     async fn end_streaming(
         &mut self,
         state: &mut State,
@@ -889,6 +940,7 @@ impl Daemon {
             // completed. We drop events implicitly here.
             let _ = h.task.await;
         }
+        self.stop_streaming_drain_pump();
         *streaming_session = None;
         *streaming_chain = None;
 
@@ -930,6 +982,7 @@ impl Daemon {
                 tracing::warn!("Streaming rewind failed: {}", e);
             }
         }
+        self.stop_streaming_drain_pump();
         *streaming_session = None;
         *streaming_chain = None;
 
@@ -1063,7 +1116,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
-                | crate::config::TranscriptionEngine::Cohere => {
+                | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Soniox => {
                     if let Some(ref t) = transcriber_preloaded {
                         Ok(t.clone())
                     } else {
@@ -2017,16 +2071,11 @@ impl Daemon {
         // the daemon gets stuck in streaming. Force toggle activation when
         // streaming is enabled. The user's config file is left untouched; this
         // override only applies to the running daemon.
-        if self
-            .config
-            .parakeet
-            .as_ref()
-            .map(|p| p.streaming)
-            .unwrap_or(false)
+        if self.config.streaming_active()
             && self.config.hotkey.mode == crate::config::ActivationMode::PushToTalk
         {
             tracing::warn!(
-                "Parakeet streaming requires toggle activation, not push-to-talk. \
+                "Streaming transcription requires toggle activation, not push-to-talk. \
                  Auto-promoting [hotkey] mode from push_to_talk to toggle for this session. \
                  Streaming output types characters at the cursor while you dictate; if your \
                  PTT key is held during typing, libinput-based compositors (Hyprland, Sway, \
@@ -2239,8 +2288,10 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
-                | crate::config::TranscriptionEngine::Cohere => {
-                    // Parakeet/Moonshine uses its own model loading
+                | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Soniox => {
+                    // Non-Whisper engines do their own setup; Soniox just validates
+                    // API key + endpoint at construction (no model to download).
                     transcriber_preloaded = Some(Arc::from(crate::transcribe::create_transcriber(
                         &self.config,
                     )?));
@@ -2357,7 +2408,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
-                | crate::config::TranscriptionEngine::Cohere => {
+                | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Soniox => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -2386,7 +2438,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
-                | crate::config::TranscriptionEngine::Cohere => {
+                | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Soniox => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -2458,9 +2511,7 @@ impl Daemon {
                             tracing::debug!("Received HotkeyEvent::Released (push-to-talk), state.is_recording() = {}", state.is_recording());
                             if state.is_streaming() {
                                 tracing::debug!("Streaming push-to-talk released; closing audio capture and disowning session");
-                                if let Some(mut c) = audio_capture.take() {
-                                    let _ = c.stop().await;
-                                }
+                                self.stop_streaming_capture(&mut audio_capture).await;
                                 // Drop session/chain so the backend's
                                 // post-stop flush emission is dropped at
                                 // the event pump instead of typed.
@@ -2574,7 +2625,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
-                | crate::config::TranscriptionEngine::Cohere => {
+                | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Soniox => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -2603,7 +2655,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
-                | crate::config::TranscriptionEngine::Cohere => {
+                | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Soniox => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -2665,9 +2718,7 @@ impl Daemon {
                                 }
                             } else if state.is_streaming() {
                                 tracing::info!("Toggle stop while streaming; closing capture");
-                                if let Some(mut c) = audio_capture.take() {
-                                    let _ = c.stop().await;
-                                }
+                                self.stop_streaming_capture(&mut audio_capture).await;
                             } else if let State::Recording { model_override: current_model_override, .. } = &state {
                                 let transcriber = match self.get_transcriber_for_recording(
                                     current_model_override.as_deref(),
@@ -2941,71 +2992,85 @@ impl Daemon {
                         }
                     }
 
-                    // Check for recording timeout
-                    if let Some(duration) = state.recording_duration() {
-                        if duration > max_duration {
+                    // Check for recording timeout. Skip when audio_capture is
+                    // already gone so we don't re-fire cleanup on every 100ms
+                    // tick while the streaming session drains server-side
+                    // (state stays Streaming until Ended arrives).
+                    let timeout_fired = audio_capture.is_some()
+                        && state.recording_duration().is_some_and(|d| d > max_duration);
+                    if timeout_fired {
+                        // Streaming has its own clean stop path: skip the
+                        // batch_transcribe branch below to avoid opening a
+                        // second WS session for audio already being processed
+                        // by the active streaming one.
+                        if state.is_streaming() {
                             tracing::warn!(
-                                "Recording timeout ({:.0}s limit), transcribing captured audio",
+                                "Recording timeout ({:.0}s limit) while streaming; closing capture",
                                 max_duration.as_secs_f32()
                             );
+                            self.stop_streaming_capture(&mut audio_capture).await;
+                            continue;
+                        }
 
-                            cleanup_output_mode_override();
-                            cleanup_model_override();
-                            cleanup_profile_override();
-                            cleanup_bool_override("smart_auto_submit");
+                        tracing::warn!(
+                            "Recording timeout ({:.0}s limit), transcribing captured audio",
+                            max_duration.as_secs_f32()
+                        );
 
-                            // Get model override from state before transitioning
-                            let model_override = match &state {
-                                State::Recording { model_override, .. } => model_override.as_deref(),
-                                State::EagerRecording { model_override, .. } => model_override.as_deref(),
-                                _ => None,
-                            };
+                        cleanup_output_mode_override();
+                        cleanup_model_override();
+                        cleanup_profile_override();
+                        cleanup_bool_override("smart_auto_submit");
 
-                            // Get transcriber for this recording
-                            let transcriber = match self.get_transcriber_for_recording(
-                                model_override,
-                                &transcriber_preloaded,
-                            ).await {
-                                Ok(t) => Some(t),
-                                Err(()) => {
-                                    state = State::Idle;
-                                    self.update_state("idle");
-                                    continue;
-                                }
-                            };
+                        let model_override = match &state {
+                            State::Recording { model_override, .. } => model_override.as_deref(),
+                            State::EagerRecording { model_override, .. } => model_override.as_deref(),
+                            _ => None,
+                        };
 
-                            if state.is_eager_recording() {
-                                if let Some(mut capture) = audio_capture.take() {
-                                    if let Ok(final_samples) = capture.stop().await {
-                                        if let State::EagerRecording { accumulated_audio, .. } = &mut state {
-                                            accumulated_audio.extend(final_samples);
-                                        }
-                                    }
-                                }
-
-                                if let Some(transcriber) = transcriber {
-                                    self.update_state("transcribing");
-
-                                    if let Some(text) = self.finish_eager_recording(&mut state, transcriber).await {
-                                        state = State::Transcribing { audio: Vec::new() };
-                                        self.handle_transcription_result(&mut state, Ok(Ok(text))).await;
-                                    } else {
-                                        tracing::debug!("Eager recording timeout produced empty result");
-                                        self.reset_to_idle(&mut state).await;
-                                    }
-                                }
-                                eager_transcriber = None;
-                            } else {
-                                for (_, task) in self.eager_chunk_tasks.drain(..) {
-                                    task.abort();
-                                }
-
-                                self.start_transcription_task(
-                                    &mut state,
-                                    &mut audio_capture,
-                                    transcriber,
-                                ).await;
+                        let transcriber = match self.get_transcriber_for_recording(
+                            model_override,
+                            &transcriber_preloaded,
+                        ).await {
+                            Ok(t) => Some(t),
+                            Err(()) => {
+                                state = State::Idle;
+                                self.update_state("idle");
+                                continue;
                             }
+                        };
+
+                        if state.is_eager_recording() {
+                            if let Some(mut capture) = audio_capture.take() {
+                                if let Ok(final_samples) = capture.stop().await {
+                                    if let State::EagerRecording { accumulated_audio, .. } = &mut state {
+                                        accumulated_audio.extend(final_samples);
+                                    }
+                                }
+                            }
+
+                            if let Some(transcriber) = transcriber {
+                                self.update_state("transcribing");
+
+                                if let Some(text) = self.finish_eager_recording(&mut state, transcriber).await {
+                                    state = State::Transcribing { audio: Vec::new() };
+                                    self.handle_transcription_result(&mut state, Ok(Ok(text))).await;
+                                } else {
+                                    tracing::debug!("Eager recording timeout produced empty result");
+                                    self.reset_to_idle(&mut state).await;
+                                }
+                            }
+                            eager_transcriber = None;
+                        } else {
+                            for (_, task) in self.eager_chunk_tasks.drain(..) {
+                                task.abort();
+                            }
+
+                            self.start_transcription_task(
+                                &mut state,
+                                &mut audio_capture,
+                                transcriber,
+                            ).await;
                         }
                     }
                 }
@@ -3041,7 +3106,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
-                | crate::config::TranscriptionEngine::Cohere => {
+                | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Soniox => {
                                     let config = self.config.clone();
                                     self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                         crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -3069,7 +3135,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Paraformer
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
-                | crate::config::TranscriptionEngine::Cohere => {
+                | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Soniox => {
                                     if let Some(ref t) = transcriber_preloaded {
                                         let transcriber = t.clone();
                                         tokio::task::spawn_blocking(move || {
@@ -3136,18 +3203,13 @@ impl Daemon {
                     tracing::debug!("Received SIGUSR2 (stop recording)");
                     if state.is_streaming() {
                         tracing::info!("SIGUSR2 stop while streaming; closing capture and disowning session");
-                        if let Some(mut c) = audio_capture.take() {
-                            let _ = c.stop().await;
-                        }
-                        // Drop the typing surface synchronously. Any
-                        // Final/Partial event the backend emits while
-                        // draining its internal buffer reaches the
-                        // event-pump arm with `streaming_session = None`
-                        // and is discarded instead of typed. Without
-                        // this, parakeet's flush() emission would type
-                        // into whatever window has focus by the time
-                        // the event arrives — voxtype#TBD streaming
-                        // data-leak.
+                        self.stop_streaming_capture(&mut audio_capture).await;
+                        // Drop the typing surface synchronously so any
+                        // Final/Partial events the backend emits while
+                        // draining its internal buffer reach the event-pump
+                        // arm with `streaming_session = None` and get
+                        // discarded instead of typed into whatever window
+                        // has focus by then.
                         streaming_session = None;
                         streaming_chain = None;
                     } else if let State::Recording { model_override, .. } = &state {
@@ -3269,6 +3331,26 @@ impl Daemon {
                                     tracing::error!("Streaming commit_segment failed: {}", e);
                                 }
                                 // Mirror typed_chars onto the state for cancel-rewind.
+                                if let State::Streaming { typed_chars, finalized_text, .. } = &mut state {
+                                    *typed_chars = s.typed_chars();
+                                    finalized_text.clear();
+                                    finalized_text.push_str(s.finalized_text());
+                                }
+                            }
+                        }
+                        Some(StreamingEvent::Replace { backspace, text, .. }) => {
+                            if let (Some(s), Some(chain)) =
+                                (streaming_session.as_mut(), streaming_chain.as_ref())
+                            {
+                                if let Err(e) = s.replace_and_commit(
+                                    chain,
+                                    backspace,
+                                    &text,
+                                    self.config.output.pre_output_command.as_deref(),
+                                    self.config.output.post_output_command.as_deref(),
+                                ).await {
+                                    tracing::error!("Streaming replace_and_commit failed: {}", e);
+                                }
                                 if let State::Streaming { typed_chars, finalized_text, .. } = &mut state {
                                     *typed_chars = s.typed_chars();
                                     finalized_text.clear();

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,9 +139,10 @@ async fn main() -> anyhow::Result<()> {
             "dolphin" => config.engine = config::TranscriptionEngine::Dolphin,
             "omnilingual" => config.engine = config::TranscriptionEngine::Omnilingual,
             "cohere" => config.engine = config::TranscriptionEngine::Cohere,
+            "soniox" => config.engine = config::TranscriptionEngine::Soniox,
             _ => {
                 eprintln!(
-                    "Error: Invalid engine '{}'. Valid options: whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere",
+                    "Error: Invalid engine '{}'. Valid options: whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox",
                     engine
                 );
                 std::process::exit(1);
@@ -229,6 +230,14 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(key) = cli.remote_api_key {
         config.whisper.remote_api_key = Some(key);
+    }
+
+    // Soniox overrides
+    if let Some(key) = cli.soniox_api_key {
+        config
+            .soniox
+            .get_or_insert_with(config::SonioxConfig::default)
+            .api_key = Some(key);
     }
 
     // Audio overrides
@@ -457,8 +466,9 @@ async fn main() -> anyhow::Result<()> {
                     "dolphin" => config.engine = config::TranscriptionEngine::Dolphin,
                     "omnilingual" => config.engine = config::TranscriptionEngine::Omnilingual,
                     "cohere" => config.engine = config::TranscriptionEngine::Cohere,
+                    "soniox" => config.engine = config::TranscriptionEngine::Soniox,
                     _ => {
-                        eprintln!("Error: Invalid engine '{}'. Valid options: whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere", engine_name);
+                        eprintln!("Error: Invalid engine '{}'. Valid options: whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox", engine_name);
                         std::process::exit(1);
                     }
                 }

--- a/src/meeting/mod.rs
+++ b/src/meeting/mod.rs
@@ -122,9 +122,10 @@ impl MeetingDaemon {
         let storage = MeetingStorage::open(config.storage.clone())
             .map_err(|e| MeetingError::Storage(e.to_string()))?;
 
+        let meeting_app_config = app_config.with_meeting_mode_overrides();
         let transcriber: Arc<dyn Transcriber> =
-            Arc::from(transcribe::create_transcriber(app_config)?);
-        let engine_name = format!("{:?}", app_config.engine).to_lowercase();
+            Arc::from(transcribe::create_transcriber(&meeting_app_config)?);
+        let engine_name = format!("{:?}", meeting_app_config.engine).to_lowercase();
 
         let post_processor = app_config.output.post_process.as_ref().map(|cfg| {
             tracing::info!(

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -185,6 +185,7 @@ fn set_engine(engine: TranscriptionEngine) -> bool {
         TranscriptionEngine::Dolphin => "dolphin",
         TranscriptionEngine::Omnilingual => "omnilingual",
         TranscriptionEngine::Cohere => "cohere",
+        TranscriptionEngine::Soniox => "soniox",
     };
 
     // Check if engine line exists

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -91,7 +91,8 @@ fn send_macos_native(title: &str, body: &str, engine: Option<TranscriptionEngine
         | TranscriptionEngine::Paraformer
         | TranscriptionEngine::Dolphin
         | TranscriptionEngine::Omnilingual
-        | TranscriptionEngine::Cohere => None,
+        | TranscriptionEngine::Cohere
+        | TranscriptionEngine::Soniox => None,
     });
 
     for notifier in notifier_paths {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -178,6 +178,7 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
         crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",  // 🐬
         crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
         crate::config::TranscriptionEngine::Cohere => "\u{1F4DD}",   // 📝
+        crate::config::TranscriptionEngine::Soniox => "\u{2601}\u{FE0F}", // ☁️
     }
 }
 

--- a/src/output/streaming.rs
+++ b/src/output/streaming.rs
@@ -220,15 +220,23 @@ impl StreamingSession {
         if n > 0 {
             let emitted = emit_backspaces(n).await;
             if emitted == 0 {
+                // No backspace-capable backend ran. The cursor still
+                // shows the old partial — DO NOT touch our bookkeeping,
+                // or `typed_chars` will drift from reality and the next
+                // cancel-rewind will leave stray characters behind. Accept
+                // the visual artifact and let the user see + correct.
                 tracing::warn!(
                     "Streaming replace: no backspace-capable backend available; \
                      skipping backspace and accepting cursor artifact"
                 );
+            } else {
+                // Truncate the partial buffer by the count actually emitted
+                // (which equals `n` when emit_backspaces returns non-zero,
+                // per its all-or-nothing contract).
+                let new_partial_len = self.partial.chars().count().saturating_sub(emitted);
+                self.partial = self.partial.chars().take(new_partial_len).collect();
+                self.typed_chars = self.typed_chars.saturating_sub(emitted);
             }
-            // Truncate the partial buffer by the same count (in scalars).
-            let new_partial_len = self.partial.chars().count().saturating_sub(n);
-            self.partial = self.partial.chars().take(new_partial_len).collect();
-            self.typed_chars = self.typed_chars.saturating_sub(n);
         }
 
         if !text.is_empty() {

--- a/src/output/streaming.rs
+++ b/src/output/streaming.rs
@@ -199,6 +199,56 @@ impl StreamingSession {
         Ok(())
     }
 
+    /// Backspace `backspace` chars then commit `text`. Used by streaming
+    /// backends that revise the previously-typed partial tail when
+    /// finalizing (e.g. Soniox punctuation flips).
+    ///
+    /// The partial buffer is truncated by `backspace` scalars, then
+    /// `text` is appended to both cursor and finalized_text. Net effect:
+    /// the cursor ends up with the truncated partial + new text, matching
+    /// what the daemon's commit_segment would do for a plain Final.
+    pub async fn replace_and_commit(
+        &mut self,
+        chain: &[Box<dyn TextOutput>],
+        backspace: usize,
+        text: &str,
+        pre_output_command: Option<&str>,
+        post_output_command: Option<&str>,
+    ) -> Result<(), OutputError> {
+        // Cap backspace at what we've actually typed.
+        let n = backspace.min(self.typed_chars);
+        if n > 0 {
+            let emitted = emit_backspaces(n).await;
+            if emitted == 0 {
+                tracing::warn!(
+                    "Streaming replace: no backspace-capable backend available; \
+                     skipping backspace and accepting cursor artifact"
+                );
+            }
+            // Truncate the partial buffer by the same count (in scalars).
+            let new_partial_len = self.partial.chars().count().saturating_sub(n);
+            self.partial = self.partial.chars().take(new_partial_len).collect();
+            self.typed_chars = self.typed_chars.saturating_sub(n);
+        }
+
+        if !text.is_empty() {
+            let opts = OutputOptions {
+                pre_output_command,
+                post_output_command,
+                wait_for_modifier_release: false,
+                modifier_release_timeout: std::time::Duration::from_millis(0),
+            };
+            output_with_fallback(chain, text, opts).await?;
+            self.typed_chars += text.chars().count();
+            // Treat the (now-truncated) partial + new text as committed,
+            // matching commit_segment's accounting.
+            let finalized_tail = format!("{}{}", self.partial, text);
+            self.finalized_text.push_str(&finalized_tail);
+        }
+        self.clear_partial();
+        Ok(())
+    }
+
     /// Best-effort rewind: emit `typed_chars` BackSpace key events via
     /// wtype, falling back to dotool then ydotool. Returns `Ok(())`
     /// even if no backspace backend is available, since the user has
@@ -213,18 +263,7 @@ impl StreamingSession {
             return Ok(());
         }
 
-        if try_wtype_backspaces(count).await {
-            tracing::debug!("Rewound {} chars via wtype", count);
-            self.typed_chars = 0;
-            return Ok(());
-        }
-        if try_dotool_backspaces(count).await {
-            tracing::debug!("Rewound {} chars via dotool", count);
-            self.typed_chars = 0;
-            return Ok(());
-        }
-        if try_ydotool_backspaces(count).await {
-            tracing::debug!("Rewound {} chars via ydotool", count);
+        if emit_backspaces(count).await > 0 {
             self.typed_chars = 0;
             return Ok(());
         }
@@ -243,6 +282,24 @@ impl Default for StreamingSession {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Backspace `count` chars using the first available method.
+/// Returns the actual number of backspaces emitted.
+async fn emit_backspaces(count: usize) -> usize {
+    if count == 0 {
+        return 0;
+    }
+    if try_wtype_backspaces(count).await {
+        return count;
+    }
+    if try_dotool_backspaces(count).await {
+        return count;
+    }
+    if try_ydotool_backspaces(count).await {
+        return count;
+    }
+    0
 }
 
 async fn try_wtype_backspaces(count: usize) -> bool {

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -16,6 +16,8 @@ pub mod cli;
 #[cfg(feature = "parakeet")]
 pub mod parakeet_streaming;
 pub mod remote;
+#[cfg(feature = "soniox")]
+pub mod soniox;
 pub mod streaming;
 pub mod subprocess;
 pub mod whisper;
@@ -265,6 +267,20 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
         #[cfg(not(feature = "cohere"))]
         TranscriptionEngine::Cohere => Err(TranscribeError::InitFailed(
             "Cohere engine requested but voxtype was not compiled with --features cohere"
+                .to_string(),
+        )),
+        #[cfg(feature = "soniox")]
+        TranscriptionEngine::Soniox => {
+            let cfg = config.soniox.as_ref().ok_or_else(|| {
+                TranscribeError::InitFailed(
+                    "Soniox engine selected but [soniox] config section is missing".to_string(),
+                )
+            })?;
+            Ok(Box::new(soniox::SonioxTranscriber::new(cfg.clone())?))
+        }
+        #[cfg(not(feature = "soniox"))]
+        TranscriptionEngine::Soniox => Err(TranscribeError::InitFailed(
+            "Soniox engine requested but voxtype was not compiled with --features soniox"
                 .to_string(),
         )),
     }

--- a/src/transcribe/soniox.rs
+++ b/src/transcribe/soniox.rs
@@ -6,9 +6,10 @@
 //!
 //! - [`Transcriber::transcribe`] — batch path used when
 //!   `[soniox] streaming = false` (push-to-talk compatible). Buffers the
-//!   audio, opens a one-shot WS session, sends the buffer + empty
-//!   binary end-of-audio marker, drains finals until `finished: true`,
-//!   and returns the concatenated text.
+//!   audio, opens a one-shot WS session, sends the buffer followed by
+//!   the protocol stop sequence — `{"type":"finalize"}` then an empty
+//!   text frame as the end-of-audio marker — drains finals until
+//!   `finished: true`, and returns the concatenated text.
 //!
 //! - [`StreamingTranscriber::start_stream`] — live streaming session.
 //!   Exposed only when `[soniox] streaming = true` (the default). The

--- a/src/transcribe/soniox.rs
+++ b/src/transcribe/soniox.rs
@@ -1,0 +1,1639 @@
+//! Soniox cloud streaming WebSocket STT backend.
+//!
+//! Connects to `wss://stt-rt.soniox.com/transcribe-websocket` and pipes
+//! 16 kHz mono `pcm_s16le` audio frames over WebSocket, receiving JSON
+//! token messages with per-token `is_final` flags. Implements both:
+//!
+//! - [`Transcriber::transcribe`] — batch path used when
+//!   `[soniox] streaming = false` (push-to-talk compatible). Buffers the
+//!   audio, opens a one-shot WS session, sends the buffer + empty
+//!   binary end-of-audio marker, drains finals until `finished: true`,
+//!   and returns the concatenated text.
+//!
+//! - [`StreamingTranscriber::start_stream`] — live streaming session.
+//!   Exposed only when `[soniox] streaming = true` (the default). The
+//!   daemon's `streaming_active()` gate auto-promotes push-to-talk to
+//!   toggle when this is the active engine, matching the constraint
+//!   documented in the v0.7.2 release notes.
+//!
+//! ## Token reconciliation
+//!
+//! Soniox emits cumulative finals (a token marked `is_final: true` is
+//! committed forever) and revisable non-finals (`is_final: false` may
+//! be changed by later messages). Voxtype's `StreamingSession` types
+//! events as deltas at the cursor — there is no rewind primitive for
+//! partial revision. So this backend keeps a small state machine:
+//!
+//! - `typed_partial: String` tracks what's been emitted as `Partial`
+//!   (and thus typed at the cursor as a tentative tail).
+//! - When server finals arrive, the delta against `typed_partial` is
+//!   emitted as `StreamingEvent::Final` so the daemon's
+//!   `commit_segment` reconciliation works out. If the server's finals
+//!   start with `typed_partial`, only the new tail is typed (zero
+//!   churn). If they diverge (rare, would be a non-final revision),
+//!   the full final is typed and the cursor shows a transient artifact
+//!   that the user can fix.
+//! - For partials, only stable extensions of `typed_partial` are
+//!   emitted. Revisions are silently dropped — better to wait for the
+//!   final to resolve than to backspace mid-utterance.
+//!
+//! ## Errors
+//!
+//! Connect timeouts, WS errors, and Soniox server `error_message`
+//! responses surface as `StreamingEvent::Error` followed by `Ended`.
+//! The daemon disowns the session on `Error`/`Ended` so post-stop
+//! emissions are dropped (matches the v0.7.2 disown-on-stop fix).
+
+use super::streaming::{SegmentId, StreamHandle, StreamingEvent, StreamingTranscriber};
+use super::Transcriber;
+use crate::config::SonioxConfig;
+use crate::error::TranscribeError;
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+use tokio_tungstenite::tungstenite::Message;
+
+const SAMPLE_RATE: u32 = 16_000;
+const AUDIO_FORMAT: &str = "pcm_s16le";
+
+/// Production WebSocket endpoint. Soniox doesn't offer regional alternates;
+/// the only realistic override would be a local mock during testing, which
+/// the tests construct directly without touching this constant.
+const SONIOX_WS_ENDPOINT: &str = "wss://stt-rt.soniox.com/transcribe-websocket";
+
+/// Base URL for the Soniox async transcription REST API.
+const SONIOX_ASYNC_BASE: &str = "https://api.soniox.com/v1";
+
+/// WS connect / batch-request timeout. Fixed because the only failure
+/// mode it covers (connect or one-shot request stalls) is a flat network
+/// fault — 30s is comfortable for any working uplink, longer just makes
+/// stalls feel worse.
+const SONIOX_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Async REST job polling cadence. Pure implementation detail of the
+/// poll loop; 500 ms is fast enough that completion feels instant on the
+/// daemon side without burning API call quota.
+const ASYNC_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Manual-finalization control frame per
+/// https://soniox.com/docs/stt/rt/manual-finalization. Server promotes
+/// any in-flight non-final tokens to final and emits a `<fin>` marker.
+const FINALIZE_FRAME: &str = r#"{"type":"finalize"}"#;
+
+#[derive(Debug)]
+pub struct SonioxTranscriber {
+    config: SonioxConfig,
+    api_key: String,
+    /// Merged vocabulary-boost terms from `config.terms` + `config.terms_file`.
+    /// Loaded once at construction so we don't hit disk per session.
+    context_terms: Vec<String>,
+    /// Lazy reqwest client for the async REST path. Built on first use
+    /// via `OnceLock` so we don't pay TLS/DNS-pool init per dictation
+    /// and don't allocate one for users who only use the WS realtime path.
+    async_client: std::sync::OnceLock<reqwest::Client>,
+}
+
+/// Read `config.terms_file` (a JSON array of strings) and merge with
+/// `config.terms`, deduplicating while preserving first-seen order. Empty
+/// strings are skipped. Returns an error if the file path is set but the
+/// file is missing or malformed.
+fn load_context_terms(config: &SonioxConfig) -> Result<Vec<String>, TranscribeError> {
+    let mut out: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let mut push = |t: String| {
+        let trimmed = t.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        if seen.insert(trimmed.to_string()) {
+            out.push(trimmed.to_string());
+        }
+    };
+
+    if let Some(inline) = &config.terms {
+        for t in inline {
+            push(t.clone());
+        }
+    }
+    if let Some(path) = &config.terms_file {
+        let bytes = std::fs::read(path).map_err(|e| {
+            TranscribeError::ConfigError(format!(
+                "Soniox terms_file unreadable ({}): {}",
+                path.display(),
+                e
+            ))
+        })?;
+        let parsed: Vec<String> = serde_json::from_slice(&bytes).map_err(|e| {
+            TranscribeError::ConfigError(format!(
+                "Soniox terms_file must be a JSON array of strings ({}): {}",
+                path.display(),
+                e
+            ))
+        })?;
+        for t in parsed {
+            push(t);
+        }
+    }
+    Ok(out)
+}
+
+impl SonioxTranscriber {
+    pub fn new(mut config: SonioxConfig) -> Result<Self, TranscribeError> {
+        let api_key = config
+            .api_key
+            .clone()
+            .or_else(|| std::env::var("SONIOX_API_KEY").ok())
+            .ok_or_else(|| {
+                TranscribeError::ConfigError(
+                    "Soniox API key required: set [soniox] api_key or SONIOX_API_KEY".into(),
+                )
+            })?;
+
+        // User left the default realtime model with async_api enabled —
+        // swap to the async-default model.
+        if config.async_api && config.model == "stt-rt-v4" {
+            config.model = "stt-async-v4".to_string();
+        }
+
+        let context_terms = load_context_terms(&config)?;
+
+        if config.async_api {
+            tracing::info!(
+                "Soniox backend configured: mode=async, model={}, language_hints={:?} (strict={}), context_terms={}",
+                config.model,
+                config.language_hints,
+                config.language_hints_strict,
+                context_terms.len(),
+            );
+        } else {
+            tracing::info!(
+                "Soniox backend configured: mode=realtime, model={}, streaming={}, language_hints={:?} (strict={}), context_terms={}",
+                config.model,
+                config.streaming,
+                config.language_hints,
+                config.language_hints_strict,
+                context_terms.len(),
+            );
+        }
+        Ok(Self {
+            config,
+            api_key,
+            context_terms,
+            async_client: std::sync::OnceLock::new(),
+        })
+    }
+
+    fn async_client(&self) -> Result<&reqwest::Client, TranscribeError> {
+        if let Some(c) = self.async_client.get() {
+            return Ok(c);
+        }
+        let client = reqwest::Client::builder()
+            .timeout(SONIOX_TIMEOUT)
+            .build()
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("reqwest client build failed: {}", e))
+            })?;
+        // get_or_init can't return Result, so first build then OnceLock::set;
+        // race with another thread is fine — we'd just drop one extra client.
+        let _ = self.async_client.set(client);
+        Ok(self.async_client.get().expect("just initialized"))
+    }
+
+    fn init_frame(&self) -> String {
+        // `enable_endpoint_detection: true` is hardcoded. Turning it off
+        // is strictly worse — mid-stream segment finals don't fire on
+        // natural pauses, so partials churn more. The stop pipeline still
+        // works either way because we drive `{"type":"finalize"}` explicitly.
+        let mut obj = serde_json::json!({
+            "api_key": self.api_key,
+            "model": self.config.model,
+            "audio_format": AUDIO_FORMAT,
+            "sample_rate": SAMPLE_RATE,
+            "num_channels": 1,
+            "language_hints": self.config.language_hints,
+            "enable_endpoint_detection": true,
+        });
+        // Only meaningful when hints are present; Soniox ignores otherwise
+        // but keep the frame clean by gating on non-empty hints.
+        if !self.config.language_hints.is_empty() {
+            obj["language_hints_strict"] =
+                serde_json::Value::Bool(self.config.language_hints_strict);
+        }
+        let mut ctx_obj = serde_json::Map::new();
+        if let Some(text) = self
+            .config
+            .context
+            .as_ref()
+            .filter(|s| !s.trim().is_empty())
+        {
+            ctx_obj.insert("text".to_string(), serde_json::Value::String(text.clone()));
+        }
+        if !self.context_terms.is_empty() {
+            ctx_obj.insert(
+                "terms".to_string(),
+                serde_json::Value::Array(
+                    self.context_terms
+                        .iter()
+                        .map(|t| serde_json::Value::String(t.clone()))
+                        .collect(),
+                ),
+            );
+        }
+        if !ctx_obj.is_empty() {
+            obj["context"] = serde_json::Value::Object(ctx_obj);
+        }
+        obj.to_string()
+    }
+}
+
+// === Soniox WebSocket protocol types ===
+
+#[derive(Deserialize, Debug, Default)]
+struct ServerMessage {
+    #[serde(default)]
+    tokens: Vec<Token>,
+    #[serde(default)]
+    finished: bool,
+    #[serde(default)]
+    error_code: Option<i64>,
+    #[serde(default)]
+    error_message: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Token {
+    text: String,
+    /// Realtime tokens always include `is_final`. Async transcripts
+    /// omit it (everything in the final transcript is implicitly final).
+    /// Default to `true` so the async fetch path works without a separate
+    /// Token type.
+    #[serde(default = "default_is_final")]
+    is_final: bool,
+    // Unused: speaker, language, translation_status, start_ms, end_ms,
+    // confidence, etc.
+}
+
+fn default_is_final() -> bool {
+    true
+}
+
+/// Convert 16 kHz f32 mono samples in [-1.0, 1.0] to little-endian s16 bytes.
+/// The returned Vec is consumed by `Message::Binary` via zero-copy
+/// `Vec → Bytes` ownership transfer, so this is the per-chunk allocation
+/// for the WS streaming path.
+fn f32_to_i16(s: f32) -> i16 {
+    (s.clamp(-1.0, 1.0) * i16::MAX as f32).round() as i16
+}
+
+fn f32_to_s16le_bytes(samples: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(samples.len() * 2);
+    for &s in samples {
+        out.extend_from_slice(&f32_to_i16(s).to_le_bytes());
+    }
+    out
+}
+
+/// Count the number of Unicode scalars shared as a prefix between
+/// `a` and `b`. Used by the reconciler to compute backspace counts
+/// for tail revisions.
+fn common_prefix_char_count(a: &str, b: &str) -> usize {
+    a.chars().zip(b.chars()).take_while(|(x, y)| x == y).count()
+}
+
+/// Replace the `api_key` value in a Soniox init-frame JSON string with
+/// `***` so the wire-trace log doesn't leak credentials. Parses + re-emits
+/// via serde_json so the result handles any formatting variation.
+/// Returns the original frame unchanged if it doesn't parse or has no
+/// api_key field (logging shouldn't crash on edge cases).
+fn redact_api_key(frame: &str) -> String {
+    let mut value: serde_json::Value = match serde_json::from_str(frame) {
+        Ok(v) => v,
+        Err(_) => return frame.to_string(),
+    };
+    if let Some(obj) = value.as_object_mut() {
+        if obj.contains_key("api_key") {
+            obj.insert("api_key".into(), serde_json::Value::String("***".into()));
+        }
+    }
+    value.to_string()
+}
+
+/// Soniox emits special control tokens such as `<end>` (endpoint
+/// detection), `<fin>`, language tags like `<lang:en>`, etc. These are
+/// metadata, not user-visible text — filter them so they don't land at
+/// the cursor.
+fn is_special_token(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.starts_with('<') && trimmed.ends_with('>') && trimmed.len() > 2
+}
+
+/// Split a token list into (concatenated final text, concatenated non-final
+/// text) preserving order. Skips Soniox special tokens (see
+/// [`is_special_token`]).
+fn split_tokens(tokens: &[Token]) -> (String, String) {
+    let mut final_text = String::new();
+    let mut partial_text = String::new();
+    for tok in tokens {
+        if is_special_token(&tok.text) {
+            continue;
+        }
+        if tok.is_final {
+            final_text.push_str(&tok.text);
+        } else {
+            partial_text.push_str(&tok.text);
+        }
+    }
+    (final_text, partial_text)
+}
+
+/// What `Reconciler::process` decided about a server message.
+#[derive(Debug, Default)]
+struct ReconcilerOutput {
+    events: Vec<StreamingEvent>,
+    /// The server signalled `finished: true` or surfaced an error; the
+    /// caller should stop the session after dispatching `events`.
+    terminate: bool,
+}
+
+/// State machine that converts a stream of Soniox `ServerMessage`s into
+/// voxtype `StreamingEvent` deltas.
+///
+/// Soniox emits cumulative finals (committed forever) and revisable
+/// non-finals. Voxtype's `StreamingSession` types events as deltas at the
+/// cursor with no rewind primitive, so the reconciler:
+///
+/// - Tracks `typed_partial` (the non-final tail already typed via Partial
+///   events).
+/// - Strips that prefix from incoming finals so we emit only the new tail.
+/// - For partials, only emits stable extensions of `typed_partial`. If
+///   the server revises the tail (a non-finalstarts-with check fails), we
+///   silently drop the partial and wait for finalization to resolve.
+#[derive(Debug, Default)]
+struct Reconciler {
+    typed_partial: String,
+}
+
+/// Soniox sessions are single-segment from voxtype's perspective: the WS
+/// closes on `finished:true` and any subsequent dictation opens a fresh
+/// session. Other backends use segment_id to demarcate sequential
+/// utterances within one session; we just emit zero.
+const SEGMENT_ID: SegmentId = 0;
+
+impl Reconciler {
+    fn process(&mut self, parsed: &ServerMessage, type_partials: bool) -> ReconcilerOutput {
+        let mut out = ReconcilerOutput::default();
+
+        if let Some(err) = &parsed.error_message {
+            out.events
+                .push(StreamingEvent::Error(TranscribeError::InferenceFailed(
+                    format!(
+                        "Soniox server error{}: {}",
+                        parsed
+                            .error_code
+                            .map(|c| format!(" ({})", c))
+                            .unwrap_or_default(),
+                        err
+                    ),
+                )));
+            out.terminate = true;
+            return out;
+        }
+
+        let (final_text, partial_text) = split_tokens(&parsed.tokens);
+
+        if !final_text.is_empty() {
+            if final_text.starts_with(&self.typed_partial) {
+                // Common case: final extends what we typed as partial.
+                // Type just the tail and consume the partial.
+                let delta = final_text[self.typed_partial.len()..].to_string();
+                if !delta.is_empty() {
+                    out.events.push(StreamingEvent::Final {
+                        text: delta,
+                        segment_id: SEGMENT_ID,
+                    });
+                }
+                self.typed_partial.clear();
+            } else if self.typed_partial.starts_with(&final_text) {
+                // Soniox finalized only the leading portion of what we've
+                // typed as partial; the rest stays in-flight. Nothing new
+                // to type — just shift our local view of the still-pending
+                // partial. The cursor already shows the correct text.
+                self.typed_partial = self.typed_partial[final_text.len()..].to_string();
+            } else {
+                // Tail revision: typed_partial and final_text share a
+                // common prefix but diverge afterward. Backspace the
+                // mismatched tail of typed_partial and type the final's
+                // tail. Counts are in Unicode scalars to match how
+                // typed_chars is tracked.
+                let lcp_chars = common_prefix_char_count(&self.typed_partial, &final_text);
+                let backspace = self.typed_partial.chars().count() - lcp_chars;
+                let final_tail: String = final_text.chars().skip(lcp_chars).collect();
+                tracing::debug!(
+                    "Soniox tail revision: backspace {} chars, type {:?} (lcp={})",
+                    backspace,
+                    final_tail,
+                    lcp_chars,
+                );
+                out.events.push(StreamingEvent::Replace {
+                    backspace,
+                    text: final_tail,
+                    segment_id: SEGMENT_ID,
+                });
+                self.typed_partial.clear();
+            }
+        }
+
+        if type_partials && !partial_text.is_empty() {
+            if partial_text.starts_with(&self.typed_partial) {
+                let delta = partial_text[self.typed_partial.len()..].to_string();
+                if !delta.is_empty() {
+                    out.events.push(StreamingEvent::Partial {
+                        text: delta,
+                        segment_id: SEGMENT_ID,
+                    });
+                    self.typed_partial = partial_text;
+                }
+            }
+            // else: server revised our typed partial. Skip emission; the
+            // next finalization round will resolve the divergence.
+        }
+
+        if parsed.finished {
+            out.terminate = true;
+        }
+
+        out
+    }
+}
+
+impl Transcriber for SonioxTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat("Empty audio buffer".into()));
+        }
+        // Bridge sync trait method to async backend. Two callers:
+        //
+        // - Meeting daemon's chunk processor: already inside a tokio
+        //   runtime (`#[tokio::main]` multi-thread). Building a fresh
+        //   runtime would panic with "Cannot start a runtime from within
+        //   a runtime." Use block_in_place + the existing handle.
+        //
+        // - One-shot CLI (`voxtype transcribe file.wav`): no ambient
+        //   runtime. Spin up a private current-thread one.
+        let run = async {
+            if self.config.async_api {
+                self.async_transcribe(samples).await
+            } else {
+                self.batch_transcribe(samples).await
+            }
+        };
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(run)),
+            Err(_) => {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| {
+                        TranscribeError::InferenceFailed(format!("Failed to create runtime: {}", e))
+                    })?;
+                rt.block_on(run)
+            }
+        }
+    }
+
+    fn as_streaming(&self) -> Option<&dyn StreamingTranscriber> {
+        // Async API is batch-only; streaming=false also keeps PTT compatible.
+        (!self.config.async_api && self.config.streaming).then_some(self as _)
+    }
+}
+
+impl SonioxTranscriber {
+    async fn batch_transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        let (ws_stream, _) = tokio::time::timeout(
+            SONIOX_TIMEOUT,
+            tokio_tungstenite::connect_async(SONIOX_WS_ENDPOINT),
+        )
+        .await
+        .map_err(|_| TranscribeError::InferenceFailed("Soniox: connect timeout".into()))?
+        .map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Soniox: WS connect failed: {}", e))
+        })?;
+
+        let (mut write, mut read) = ws_stream.split();
+
+        let init = self.init_frame();
+        tracing::debug!(target: "voxtype::soniox::wire", "-> init {}", redact_api_key(&init));
+        write.send(Message::Text(init.into())).await.map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Soniox: send init failed: {}", e))
+        })?;
+
+        // Send audio in chunks. 32 KiB = ~1s of pcm_s16le at 16 kHz.
+        // Soniox examples use ~120ms frames but larger frames work fine
+        // for batch.
+        let bytes = f32_to_s16le_bytes(samples);
+        const FRAME_BYTES: usize = 32 * 1024;
+        for chunk in bytes.chunks(FRAME_BYTES) {
+            write
+                .send(Message::Binary(chunk.to_vec().into()))
+                .await
+                .map_err(|e| {
+                    TranscribeError::InferenceFailed(format!("Soniox: send audio failed: {}", e))
+                })?;
+        }
+
+        // Protocol-pure stop: manual finalize forces any pending non-final
+        // tokens to final without waiting for endpoint detection (which
+        // needs 2s of trailing silence by default and won't fire on a
+        // tight batch of pre-recorded audio). Then the empty text frame
+        // ends the stream. Server flushes finals, sends `finished:true`,
+        // closes. Without finalize, short batches stall server-side until
+        // the 408 "Request timeout" fires ~20s later.
+        write
+            .send(Message::Text(FINALIZE_FRAME.into()))
+            .await
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Soniox: send finalize failed: {}", e))
+            })?;
+        write
+            .send(Message::Text(String::new().into()))
+            .await
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Soniox: send EOA failed: {}", e))
+            })?;
+
+        let mut transcript = String::new();
+        let deadline = tokio::time::Instant::now() + SONIOX_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(TranscribeError::InferenceFailed(
+                    "Soniox: batch timeout".into(),
+                ));
+            }
+            let msg = match tokio::time::timeout(remaining, read.next()).await {
+                Ok(Some(Ok(m))) => m,
+                Ok(Some(Err(e))) => {
+                    return Err(TranscribeError::InferenceFailed(format!(
+                        "Soniox: WS error: {}",
+                        e
+                    )))
+                }
+                Ok(None) => break,
+                Err(_) => {
+                    return Err(TranscribeError::InferenceFailed(
+                        "Soniox: batch timeout".into(),
+                    ))
+                }
+            };
+            let text = match msg {
+                Message::Text(t) => t.to_string(),
+                Message::Close(_) => break,
+                _ => continue,
+            };
+            let parsed: ServerMessage = match serde_json::from_str(&text) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::debug!("Soniox: unparseable message ({}): {}", e, text);
+                    continue;
+                }
+            };
+            if let Some(err) = parsed.error_message {
+                return Err(TranscribeError::InferenceFailed(format!(
+                    "Soniox server error{}: {}",
+                    parsed
+                        .error_code
+                        .map(|c| format!(" ({})", c))
+                        .unwrap_or_default(),
+                    err
+                )));
+            }
+            for tok in &parsed.tokens {
+                if tok.is_final && !is_special_token(&tok.text) {
+                    transcript.push_str(&tok.text);
+                }
+            }
+            if parsed.finished {
+                break;
+            }
+        }
+
+        let _ = write.send(Message::Close(None)).await;
+        Ok(transcript.trim().to_string())
+    }
+}
+
+/// Encode 16 kHz f32 mono samples as a WAV byte buffer (PCM 16-bit LE)
+/// for upload to the Soniox async API. Mirrors the helper in
+/// `transcribe/remote.rs` so both cloud backends share one WAV format.
+fn encode_wav_s16le(samples: &[f32]) -> Result<Vec<u8>, TranscribeError> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: SAMPLE_RATE,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut buffer = std::io::Cursor::new(Vec::new());
+    let mut writer = hound::WavWriter::new(&mut buffer, spec)
+        .map_err(|e| TranscribeError::AudioFormat(format!("WAV writer init: {}", e)))?;
+    for &s in samples {
+        writer
+            .write_sample(f32_to_i16(s))
+            .map_err(|e| TranscribeError::AudioFormat(format!("WAV sample write: {}", e)))?;
+    }
+    writer
+        .finalize()
+        .map_err(|e| TranscribeError::AudioFormat(format!("WAV finalize: {}", e)))?;
+    Ok(buffer.into_inner())
+}
+
+#[derive(Deserialize, Debug)]
+struct FileUploadResponse {
+    id: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct TranscriptionCreateResponse {
+    id: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct TranscriptionStatusResponse {
+    status: String,
+    #[serde(default)]
+    error_message: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct TranscriptResponse {
+    tokens: Vec<Token>,
+}
+
+impl SonioxTranscriber {
+    async fn async_transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        let wav = encode_wav_s16le(samples)?;
+        let duration_secs = samples.len() as f32 / SAMPLE_RATE as f32;
+        tracing::info!(
+            "Soniox async: uploading {:.1}s audio ({} KiB) as WAV",
+            duration_secs,
+            wav.len() / 1024
+        );
+
+        let client = self.async_client()?;
+
+        let auth = format!("Bearer {}", self.api_key);
+
+        // 1. Upload file (multipart).
+        let upload_start = std::time::Instant::now();
+        let file_part = reqwest::multipart::Part::bytes(wav)
+            .file_name("voxtype.wav")
+            .mime_str("audio/wav")
+            .map_err(|e| TranscribeError::InferenceFailed(format!("mime build failed: {}", e)))?;
+        let form = reqwest::multipart::Form::new().part("file", file_part);
+        let resp = client
+            .post(format!("{}/files", SONIOX_ASYNC_BASE))
+            .header("Authorization", &auth)
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Soniox async: upload failed: {}", e))
+            })?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(TranscribeError::InferenceFailed(format!(
+                "Soniox async: upload returned {}: {}",
+                status, body
+            )));
+        }
+        let file_resp: FileUploadResponse = resp.json().await.map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Soniox async: parse upload response: {}", e))
+        })?;
+        let file_id = file_resp.id;
+        tracing::debug!(
+            "Soniox async: uploaded in {:.2}s, file_id={}",
+            upload_start.elapsed().as_secs_f32(),
+            file_id
+        );
+
+        // 2. Create transcription job.
+        let mut body = serde_json::json!({
+            "model": self.config.model,
+            "file_id": file_id,
+        });
+        if !self.config.language_hints.is_empty() {
+            body["language_hints"] = serde_json::json!(self.config.language_hints);
+            body["language_hints_strict"] = serde_json::json!(self.config.language_hints_strict);
+        }
+        // Mirror the init_frame context shape: text + terms together.
+        // Critical for meeting mode (which forces async), where users
+        // configuring `terms_file` would otherwise silently lose
+        // vocabulary boosts that work fine for realtime dictation.
+        let mut ctx_obj = serde_json::Map::new();
+        if let Some(text) = self
+            .config
+            .context
+            .as_ref()
+            .filter(|s| !s.trim().is_empty())
+        {
+            ctx_obj.insert("text".to_string(), serde_json::Value::String(text.clone()));
+        }
+        if !self.context_terms.is_empty() {
+            ctx_obj.insert(
+                "terms".to_string(),
+                serde_json::Value::Array(
+                    self.context_terms
+                        .iter()
+                        .map(|t| serde_json::Value::String(t.clone()))
+                        .collect(),
+                ),
+            );
+        }
+        if !ctx_obj.is_empty() {
+            body["context"] = serde_json::Value::Object(ctx_obj);
+        }
+        let resp = client
+            .post(format!("{}/transcriptions", SONIOX_ASYNC_BASE))
+            .header("Authorization", &auth)
+            .header("Content-Type", "application/json")
+            .body(body.to_string())
+            .send()
+            .await
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!(
+                    "Soniox async: create transcription failed: {}",
+                    e
+                ))
+            })?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            // Best effort: delete the orphaned file.
+            self.async_delete_file(&client, &auth, &file_id).await;
+            return Err(TranscribeError::InferenceFailed(format!(
+                "Soniox async: create transcription returned {}: {}",
+                status, text
+            )));
+        }
+        let job: TranscriptionCreateResponse = resp.json().await.map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Soniox async: parse job response: {}", e))
+        })?;
+        let job_id = job.id;
+        tracing::debug!("Soniox async: created job_id={}", job_id);
+
+        // 3. Poll until completed or error.
+        let poll_interval = ASYNC_POLL_INTERVAL;
+        let max_wait = Duration::from_secs(self.config.async_max_wait_secs.max(5));
+        let poll_start = std::time::Instant::now();
+        loop {
+            if poll_start.elapsed() > max_wait {
+                self.async_cleanup(&client, &auth, &job_id).await;
+                return Err(TranscribeError::InferenceFailed(format!(
+                    "Soniox async: job {} did not complete within {}s",
+                    job_id,
+                    max_wait.as_secs()
+                )));
+            }
+            tokio::time::sleep(poll_interval).await;
+            let resp = client
+                .get(format!("{}/transcriptions/{}", SONIOX_ASYNC_BASE, job_id))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .map_err(|e| {
+                    TranscribeError::InferenceFailed(format!("Soniox async: poll failed: {}", e))
+                })?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                self.async_cleanup(&client, &auth, &job_id).await;
+                return Err(TranscribeError::InferenceFailed(format!(
+                    "Soniox async: poll returned {}: {}",
+                    status, text
+                )));
+            }
+            let status_resp: TranscriptionStatusResponse = resp.json().await.map_err(|e| {
+                TranscribeError::InferenceFailed(format!(
+                    "Soniox async: parse status response: {}",
+                    e
+                ))
+            })?;
+            match status_resp.status.as_str() {
+                "completed" => break,
+                "error" => {
+                    let err = status_resp
+                        .error_message
+                        .unwrap_or_else(|| "unspecified error".to_string());
+                    self.async_cleanup(&client, &auth, &job_id).await;
+                    return Err(TranscribeError::InferenceFailed(format!(
+                        "Soniox async: server error: {}",
+                        err
+                    )));
+                }
+                "processing" | "queued" | "running" => {
+                    tracing::trace!("Soniox async: job {} status={}", job_id, status_resp.status);
+                }
+                other => {
+                    tracing::warn!(
+                        "Soniox async: unknown status '{}', continuing to poll",
+                        other
+                    );
+                }
+            }
+        }
+        tracing::info!(
+            "Soniox async: transcription completed in {:.2}s",
+            poll_start.elapsed().as_secs_f32()
+        );
+
+        // 4. Fetch transcript.
+        let resp = client
+            .get(format!(
+                "{}/transcriptions/{}/transcript",
+                SONIOX_ASYNC_BASE, job_id
+            ))
+            .header("Authorization", &auth)
+            .send()
+            .await
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Soniox async: fetch transcript: {}", e))
+            })?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            self.async_cleanup(&client, &auth, &job_id).await;
+            return Err(TranscribeError::InferenceFailed(format!(
+                "Soniox async: fetch transcript returned {}: {}",
+                status, text
+            )));
+        }
+        let body = resp.text().await.map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Soniox async: read transcript body: {}", e))
+        })?;
+        tracing::debug!(target: "voxtype::soniox::wire", "<- transcript: {}", body);
+        let transcript: TranscriptResponse = serde_json::from_str(&body).map_err(|e| {
+            TranscribeError::InferenceFailed(format!(
+                "Soniox async: parse transcript: {} (body: {})",
+                e, body
+            ))
+        })?;
+
+        // 5. Cleanup server-side state (best effort, don't fail user-visible).
+        self.async_cleanup(&client, &auth, &job_id).await;
+
+        // 6. Concatenate tokens (skip special markers).
+        let mut out = String::new();
+        for tok in &transcript.tokens {
+            if is_special_token(&tok.text) {
+                continue;
+            }
+            out.push_str(&tok.text);
+        }
+        Ok(out.trim().to_string())
+    }
+
+    async fn async_delete_file(&self, client: &reqwest::Client, auth: &str, file_id: &str) {
+        let _ = client
+            .delete(format!("{}/files/{}", SONIOX_ASYNC_BASE, file_id))
+            .header("Authorization", auth)
+            .send()
+            .await;
+    }
+
+    async fn async_cleanup(&self, client: &reqwest::Client, auth: &str, job_id: &str) {
+        // DELETE /v1/transcriptions/{id} cascades to its associated file
+        // per Soniox docs, so we don't issue a separate /files/{id} DELETE.
+        let _ = client
+            .delete(format!("{}/transcriptions/{}", SONIOX_ASYNC_BASE, job_id))
+            .header("Authorization", auth)
+            .send()
+            .await;
+    }
+}
+
+impl StreamingTranscriber for SonioxTranscriber {
+    fn start_stream(
+        &self,
+        samples_rx: mpsc::Receiver<Vec<f32>>,
+    ) -> Result<StreamHandle, TranscribeError> {
+        let (events_tx, events_rx) = mpsc::channel::<StreamingEvent>(64);
+        let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
+
+        let init = self.init_frame();
+        let type_partials = self.config.type_partials;
+
+        let task = tokio::spawn(async move {
+            run_streaming_session(init, type_partials, samples_rx, events_tx, cancel_rx).await
+        });
+
+        Ok(StreamHandle {
+            events: events_rx,
+            cancel: cancel_tx,
+            task,
+        })
+    }
+}
+
+/// Emit an `Error` followed by `Ended` so the daemon surfaces a notification
+/// and cleanly resets to idle. The pattern repeats at every fatal site in
+/// `run_streaming_session`.
+async fn send_fatal(events_tx: &mpsc::Sender<StreamingEvent>, msg: String) {
+    let _ = events_tx
+        .send(StreamingEvent::Error(TranscribeError::InferenceFailed(msg)))
+        .await;
+    let _ = events_tx.send(StreamingEvent::Ended).await;
+}
+
+async fn run_streaming_session(
+    init_frame: String,
+    type_partials: bool,
+    mut samples_rx: mpsc::Receiver<Vec<f32>>,
+    events_tx: mpsc::Sender<StreamingEvent>,
+    mut cancel_rx: oneshot::Receiver<()>,
+) -> Result<(), TranscribeError> {
+    // Connect.
+    let ws_result = tokio::time::timeout(
+        SONIOX_TIMEOUT,
+        tokio_tungstenite::connect_async(SONIOX_WS_ENDPOINT),
+    )
+    .await;
+    let ws_stream = match ws_result {
+        Ok(Ok((s, _))) => s,
+        Ok(Err(e)) => {
+            send_fatal(&events_tx, format!("Soniox: WS connect failed: {}", e)).await;
+            return Ok(());
+        }
+        Err(_) => {
+            send_fatal(&events_tx, "Soniox: connect timeout".into()).await;
+            return Ok(());
+        }
+    };
+    let (mut write, mut read) = ws_stream.split();
+
+    // Send init.
+    tracing::debug!(target: "voxtype::soniox::wire", "-> init {}", redact_api_key(&init_frame));
+    if let Err(e) = write.send(Message::Text(init_frame.into())).await {
+        send_fatal(&events_tx, format!("Soniox: send init failed: {}", e)).await;
+        return Ok(());
+    }
+
+    let mut reconciler = Reconciler::default();
+    let mut samples_closed = false;
+    let mut sent_eoa = false;
+    // Safety net for the server failing to close after our protocol-pure
+    // shutdown (see the EOF arm below). The 5 s budget is comfortable for
+    // a clean Soniox close (~200–300 ms in practice).
+    let mut drain_deadline: Option<tokio::time::Instant> = None;
+    const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+    loop {
+        let drain_timer = async {
+            match drain_deadline {
+                Some(d) => tokio::time::sleep_until(d).await,
+                None => std::future::pending::<()>().await,
+            }
+        };
+
+        tokio::select! {
+            biased;
+
+            // Highest priority: cancel signal from daemon.
+            _ = &mut cancel_rx => {
+                tracing::debug!("Soniox streaming session cancelled");
+                break;
+            }
+
+            // Drain timeout fired without server-initiated close.
+            _ = drain_timer, if drain_deadline.is_some() => {
+                tracing::info!("Soniox drain timeout reached after end-of-audio; closing session");
+                break;
+            }
+
+            // Outgoing audio frames.
+            chunk = samples_rx.recv(), if !samples_closed => {
+                match chunk {
+                    Some(c) if !c.is_empty() => {
+                        let bytes = f32_to_s16le_bytes(&c);
+                        if let Err(e) = write.send(Message::Binary(bytes.into())).await {
+                            let _ = events_tx.send(StreamingEvent::Error(
+                                TranscribeError::InferenceFailed(format!(
+                                    "Soniox: send audio failed: {}", e
+                                ))
+                            )).await;
+                            break;
+                        }
+                    }
+                    Some(_) => { /* empty chunk, skip */ }
+                    None => {
+                        // EOF from daemon. Protocol-pure stop sequence per
+                        // https://soniox.com/docs/stt/rt/manual-finalization
+                        // and /docs/api-reference/stt/websocket-api:
+                        //   1. {"type":"finalize"}  — force-finalize any
+                        //      in-flight non-final tokens (the server
+                        //      emits them as is_final:true plus a `<fin>`
+                        //      marker we filter out).
+                        //   2. ""                    — empty text frame,
+                        //      documented end-of-audio signal.
+                        // Server then sends remaining finals followed by
+                        // `finished:true` and closes the socket.
+                        samples_closed = true;
+                        if !sent_eoa {
+                            if let Err(e) = write
+                                .send(Message::Text(FINALIZE_FRAME.into()))
+                                .await
+                            {
+                                tracing::warn!("Soniox: finalize send failed: {}", e);
+                            }
+                            if let Err(e) =
+                                write.send(Message::Text(String::new().into())).await
+                            {
+                                tracing::warn!("Soniox: EOA send failed: {}", e);
+                            }
+                            sent_eoa = true;
+                            drain_deadline =
+                                Some(tokio::time::Instant::now() + DRAIN_TIMEOUT);
+                            tracing::debug!(
+                                "Soniox: sent finalize + empty-text EOA; draining (timeout {}s)",
+                                DRAIN_TIMEOUT.as_secs(),
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Incoming server messages.
+            msg = read.next() => {
+                let msg = match msg {
+                    Some(Ok(m)) => m,
+                    Some(Err(e)) => {
+                        let _ = events_tx.send(StreamingEvent::Error(
+                            TranscribeError::InferenceFailed(format!("Soniox: WS error: {}", e))
+                        )).await;
+                        break;
+                    }
+                    None => break,
+                };
+                let text = match msg {
+                    Message::Text(t) => t.to_string(),
+                    Message::Close(_) => break,
+                    _ => continue,
+                };
+                tracing::debug!(target: "voxtype::soniox::wire", "<- {}", text);
+                let parsed: ServerMessage = match serde_json::from_str(&text) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::warn!("Soniox: unparseable message ({}): {}", e, text);
+                        continue;
+                    }
+                };
+
+                // Suppress 408 (Request timeout) errors that arrive after
+                // we've signalled end-of-audio. These come from the server's
+                // own idle timer after the user pressed stop — surfacing them
+                // as a "Streaming Error" notification is misleading UX.
+                if sent_eoa && parsed.error_code == Some(408) {
+                    tracing::debug!("Soniox: ignoring post-EOA 408 timeout");
+                    break;
+                }
+
+                let out = reconciler.process(&parsed, type_partials);
+                let mut send_failed = false;
+                for ev in out.events {
+                    if events_tx.send(ev).await.is_err() {
+                        send_failed = true;
+                        break;
+                    }
+                }
+                // `finished:true` → reconciler sets terminate. That's the
+                // documented end-of-session signal. The server closes the
+                // socket right after; this break gets us out before the
+                // close fires.
+                if send_failed || out.terminate {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Send a close frame on the way out. On the finished:true happy path the
+    // server already initiated the close (so this may be a no-op against an
+    // already-closing socket), but on cancel/drain-timeout/error paths an
+    // explicit close is cleaner than letting the TCP teardown carry it.
+    let _ = write.send(Message::Close(None)).await;
+
+    let _ = events_tx.send(StreamingEvent::Ended).await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with_key(key: Option<&str>) -> SonioxConfig {
+        SonioxConfig {
+            api_key: key.map(|s| s.to_string()),
+            model: "stt-rt-v4".into(),
+            language_hints: vec!["hu".into(), "en".into()],
+            language_hints_strict: true,
+            streaming: true,
+            type_partials: true,
+            context: None,
+            terms: None,
+            terms_file: None,
+            async_api: false,
+            async_max_wait_secs: 120,
+        }
+    }
+
+    #[test]
+    fn async_api_disables_streaming_surface() {
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.async_api = true;
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        assert!(t.as_streaming().is_none());
+        assert_eq!(t.config.model, "stt-async-v4");
+    }
+
+    #[test]
+    fn async_api_keeps_explicit_model_override() {
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.async_api = true;
+        cfg.model = "stt-async-experimental".into();
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        assert_eq!(t.config.model, "stt-async-experimental");
+    }
+
+    #[test]
+    fn wav_encoding_has_correct_header() {
+        let samples = vec![0.0_f32; 16000]; // 1s of silence
+        let wav = encode_wav_s16le(&samples).unwrap();
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+        assert_eq!(&wav[12..16], b"fmt ");
+        assert_eq!(&wav[36..40], b"data");
+        let data_len = u32::from_le_bytes([wav[40], wav[41], wav[42], wav[43]]);
+        assert_eq!(data_len, 32000);
+        let sr = u32::from_le_bytes([wav[24], wav[25], wav[26], wav[27]]);
+        assert_eq!(sr, 16000);
+        assert_eq!(wav.len(), 44 + 32000);
+    }
+
+    #[test]
+    fn requires_api_key_from_config_or_env() {
+        std::env::remove_var("SONIOX_API_KEY");
+        let err = SonioxTranscriber::new(cfg_with_key(None)).unwrap_err();
+        assert!(matches!(err, TranscribeError::ConfigError(_)));
+    }
+
+    #[test]
+    fn accepts_config_api_key() {
+        let t = SonioxTranscriber::new(cfg_with_key(Some("test-key"))).unwrap();
+        assert_eq!(t.api_key, "test-key");
+    }
+
+    #[test]
+    fn init_frame_contains_required_fields() {
+        let t = SonioxTranscriber::new(cfg_with_key(Some("my-key"))).unwrap();
+        let frame: serde_json::Value = serde_json::from_str(&t.init_frame()).unwrap();
+        assert_eq!(frame["api_key"], "my-key");
+        assert_eq!(frame["model"], "stt-rt-v4");
+        assert_eq!(frame["audio_format"], "pcm_s16le");
+        assert_eq!(frame["sample_rate"], 16000);
+        assert_eq!(frame["num_channels"], 1);
+        assert_eq!(frame["language_hints"][0], "hu");
+        assert_eq!(frame["language_hints"][1], "en");
+        assert_eq!(frame["language_hints_strict"], true);
+        assert_eq!(frame["enable_endpoint_detection"], true);
+    }
+
+    #[test]
+    fn init_frame_honors_language_hints_strict_false() {
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.language_hints_strict = false;
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        let frame: serde_json::Value = serde_json::from_str(&t.init_frame()).unwrap();
+        assert_eq!(frame["language_hints_strict"], false);
+    }
+
+    #[test]
+    fn init_frame_omits_strict_when_hints_empty() {
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.language_hints = vec![];
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        let frame: serde_json::Value = serde_json::from_str(&t.init_frame()).unwrap();
+        assert!(frame["language_hints_strict"].is_null());
+    }
+
+    #[test]
+    fn init_frame_includes_context_text_when_set() {
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.context = Some("medical terminology".into());
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        let frame: serde_json::Value = serde_json::from_str(&t.init_frame()).unwrap();
+        assert_eq!(frame["context"]["text"], "medical terminology");
+        assert!(frame["context"]["terms"].is_null());
+    }
+
+    #[test]
+    fn init_frame_includes_context_terms_when_inline() {
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.terms = Some(vec!["Claude".into(), "voxtype".into()]);
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        let frame: serde_json::Value = serde_json::from_str(&t.init_frame()).unwrap();
+        let terms = frame["context"]["terms"].as_array().expect("terms array");
+        assert_eq!(terms.len(), 2);
+        assert_eq!(terms[0], "Claude");
+        assert_eq!(terms[1], "voxtype");
+    }
+
+    #[test]
+    fn init_frame_omits_context_when_no_text_or_terms() {
+        let cfg = cfg_with_key(Some("k"));
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        let frame: serde_json::Value = serde_json::from_str(&t.init_frame()).unwrap();
+        assert!(
+            frame.get("context").is_none(),
+            "no context field expected when empty"
+        );
+    }
+
+    #[test]
+    fn load_context_terms_dedupes_and_trims() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("terms.json");
+        std::fs::write(
+            &path,
+            r#"["Claude", "  voxtype  ", "Claude", "", "Hyprland"]"#,
+        )
+        .unwrap();
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.terms = Some(vec!["voxtype".into(), "Codecool".into()]);
+        cfg.terms_file = Some(path);
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        assert_eq!(
+            t.context_terms,
+            vec!["voxtype", "Codecool", "Claude", "Hyprland"],
+        );
+    }
+
+    #[test]
+    fn load_context_terms_errors_on_bad_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, r#"{"terms":["x"]}"#).unwrap();
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.terms_file = Some(path);
+        let err = SonioxTranscriber::new(cfg).unwrap_err();
+        assert!(matches!(err, TranscribeError::ConfigError(_)));
+    }
+
+    #[test]
+    fn as_streaming_respects_streaming_flag() {
+        let t = SonioxTranscriber::new(cfg_with_key(Some("k"))).unwrap();
+        assert!(
+            t.as_streaming().is_some(),
+            "streaming=true should expose StreamingTranscriber"
+        );
+
+        let mut cfg = cfg_with_key(Some("k"));
+        cfg.streaming = false;
+        let t = SonioxTranscriber::new(cfg).unwrap();
+        assert!(
+            t.as_streaming().is_none(),
+            "streaming=false should hide StreamingTranscriber"
+        );
+    }
+
+    #[test]
+    fn f32_to_s16le_round_trip_endpoints() {
+        let samples = vec![-1.0_f32, 0.0, 1.0];
+        let bytes = f32_to_s16le_bytes(&samples);
+        assert_eq!(bytes.len(), 6);
+        // -1.0 → -32767 (or -32768; clamp + round depends), 0 → 0, 1.0 → 32767
+        let s0 = i16::from_le_bytes([bytes[0], bytes[1]]);
+        let s1 = i16::from_le_bytes([bytes[2], bytes[3]]);
+        let s2 = i16::from_le_bytes([bytes[4], bytes[5]]);
+        assert!(s0 <= -32700, "-1.0 should map near i16::MIN, got {}", s0);
+        assert_eq!(s1, 0);
+        assert!(s2 >= 32700, "1.0 should map near i16::MAX, got {}", s2);
+    }
+
+    #[test]
+    fn f32_to_s16le_clamps_out_of_range() {
+        let samples = vec![-2.0_f32, 2.0];
+        let bytes = f32_to_s16le_bytes(&samples);
+        let s0 = i16::from_le_bytes([bytes[0], bytes[1]]);
+        let s1 = i16::from_le_bytes([bytes[2], bytes[3]]);
+        // Both clamped: -2.0 → -1.0 → near i16::MIN; 2.0 → 1.0 → near i16::MAX
+        assert!(s0 <= -32700);
+        assert!(s1 >= 32700);
+    }
+
+    #[test]
+    fn split_tokens_preserves_order_and_separates_finality() {
+        let toks = vec![
+            Token {
+                text: "Hello".into(),
+                is_final: true,
+            },
+            Token {
+                text: " ".into(),
+                is_final: true,
+            },
+            Token {
+                text: "world".into(),
+                is_final: false,
+            },
+        ];
+        let (finals, partials) = split_tokens(&toks);
+        assert_eq!(finals, "Hello ");
+        assert_eq!(partials, "world");
+    }
+
+    #[test]
+    fn split_tokens_handles_all_final() {
+        let toks = vec![
+            Token {
+                text: "abc".into(),
+                is_final: true,
+            },
+            Token {
+                text: "def".into(),
+                is_final: true,
+            },
+        ];
+        let (finals, partials) = split_tokens(&toks);
+        assert_eq!(finals, "abcdef");
+        assert_eq!(partials, "");
+    }
+
+    #[test]
+    fn split_tokens_handles_empty() {
+        let (finals, partials) = split_tokens(&[]);
+        assert_eq!(finals, "");
+        assert_eq!(partials, "");
+    }
+
+    // === Reconciler tests ===
+
+    fn msg(tokens: Vec<(&str, bool)>, finished: bool) -> ServerMessage {
+        ServerMessage {
+            tokens: tokens
+                .into_iter()
+                .map(|(t, f)| Token {
+                    text: t.to_string(),
+                    is_final: f,
+                })
+                .collect(),
+            finished,
+            error_code: None,
+            error_message: None,
+        }
+    }
+
+    fn err_msg(code: i64, text: &str) -> ServerMessage {
+        ServerMessage {
+            tokens: vec![],
+            finished: false,
+            error_code: Some(code),
+            error_message: Some(text.to_string()),
+        }
+    }
+
+    fn extract(events: &[StreamingEvent]) -> Vec<(&'static str, String)> {
+        events
+            .iter()
+            .map(|e| match e {
+                StreamingEvent::Partial { text, .. } => ("Partial", text.clone()),
+                StreamingEvent::Final { text, .. } => ("Final", text.clone()),
+                StreamingEvent::Replace {
+                    backspace, text, ..
+                } => ("Replace", format!("-{}+{}", backspace, text)),
+                StreamingEvent::Ended => ("Ended", String::new()),
+                StreamingEvent::Error(e) => ("Error", e.to_string()),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn reconciler_initial_partial_emits_full_delta() {
+        let mut r = Reconciler::default();
+        let out = r.process(&msg(vec![("hel", false)], false), true);
+        assert_eq!(extract(&out.events), vec![("Partial", "hel".to_string())]);
+        assert!(!out.terminate);
+        assert_eq!(r.typed_partial, "hel");
+    }
+
+    #[test]
+    fn reconciler_partial_extension_emits_only_delta() {
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("hel", false)], false), true);
+        let out = r.process(&msg(vec![("hello", false)], false), true);
+        assert_eq!(extract(&out.events), vec![("Partial", "lo".to_string())]);
+        assert_eq!(r.typed_partial, "hello");
+    }
+
+    #[test]
+    fn reconciler_partial_divergence_drops_event() {
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("hello", false)], false), true);
+        // Server revised: "hellp" doesn't start with "hello".
+        let out = r.process(&msg(vec![("hellp", false)], false), true);
+        assert!(
+            out.events.is_empty(),
+            "divergence should be silently dropped"
+        );
+        assert_eq!(
+            r.typed_partial, "hello",
+            "typed_partial unchanged on divergence"
+        );
+    }
+
+    #[test]
+    fn reconciler_final_strips_typed_partial_prefix() {
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("hello", false)], false), true);
+        // Server now finalizes "hello world": prefix "hello" already typed.
+        let out = r.process(&msg(vec![("hello world", true)], false), true);
+        assert_eq!(extract(&out.events), vec![("Final", " world".to_string())]);
+        assert_eq!(r.typed_partial, "");
+    }
+
+    #[test]
+    fn reconciler_final_equals_typed_partial_emits_nothing() {
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("hello", false)], false), true);
+        // Server finalizes exactly what was typed: no delta to type.
+        let out = r.process(&msg(vec![("hello", true)], false), true);
+        assert!(out.events.is_empty());
+        assert_eq!(r.typed_partial, "");
+    }
+
+    #[test]
+    fn reconciler_final_diverges_from_typed_partial_emits_replace() {
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("hello", false)], false), true);
+        // Diverging final: emit Replace with full backspace + new text.
+        let out = r.process(&msg(vec![("goodbye", true)], false), true);
+        // LCP of "hello" and "goodbye" = 0 → backspace 5, type "goodbye"
+        assert_eq!(
+            extract(&out.events),
+            vec![("Replace", "-5+goodbye".to_string())]
+        );
+        assert_eq!(r.typed_partial, "");
+    }
+
+    #[test]
+    fn reconciler_punctuation_revision_emits_minimal_replace() {
+        // Real-world case: Soniox finalized "tévedések." but the partial
+        // had typed "tévedések,". LCP=9, backspace=1 (the comma),
+        // type "."
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("tévedések,", false)], false), true);
+        let out = r.process(&msg(vec![("tévedések.", true)], false), true);
+        assert_eq!(extract(&out.events), vec![("Replace", "-1+.".to_string())]);
+        assert_eq!(r.typed_partial, "");
+    }
+
+    #[test]
+    fn reconciler_tail_revision_handles_unicode_scalars() {
+        // Hungarian: "fejeztem" → "fejezte" (lose 'm', gain nothing) plus
+        // " be a mondat" → " be a mondatot." (gain "ot.")
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("fejeztem be a mondat", false)], false), true);
+        let out = r.process(&msg(vec![("fejezte be a mondatot.", true)], false), true);
+        // LCP = "fejezte" (7 chars). typed has "m be a mondat" (13 chars after lcp).
+        // final has " be a mondatot." (15 chars after lcp).
+        // Backspace 13, type " be a mondatot."
+        assert_eq!(
+            extract(&out.events),
+            vec![("Replace", "-13+ be a mondatot.".to_string())]
+        );
+    }
+
+    #[test]
+    fn common_prefix_counts_unicode_scalars_not_bytes() {
+        // Hungarian "á" is 2 bytes in UTF-8 but 1 scalar.
+        assert_eq!(common_prefix_char_count("áb", "ác"), 1);
+        assert_eq!(common_prefix_char_count("hello", "hellp"), 4);
+        assert_eq!(common_prefix_char_count("abc", "xyz"), 0);
+        assert_eq!(common_prefix_char_count("", "anything"), 0);
+        assert_eq!(common_prefix_char_count("same", "same"), 4);
+    }
+
+    #[test]
+    fn reconciler_finished_terminates() {
+        let mut r = Reconciler::default();
+        let out = r.process(&msg(vec![("done", true)], true), true);
+        assert!(out.terminate);
+        assert_eq!(extract(&out.events), vec![("Final", "done".to_string())]);
+    }
+
+    #[test]
+    fn reconciler_error_terminates_with_error_event() {
+        let mut r = Reconciler::default();
+        let out = r.process(&err_msg(401, "invalid api key"), true);
+        assert!(out.terminate);
+        assert_eq!(out.events.len(), 1);
+        assert!(matches!(out.events[0], StreamingEvent::Error(_)));
+    }
+
+    #[test]
+    fn reconciler_type_partials_false_skips_partial_emission() {
+        let mut r = Reconciler::default();
+        let out = r.process(&msg(vec![("hello", false)], false), false);
+        assert!(
+            out.events.is_empty(),
+            "type_partials=false should emit no Partial"
+        );
+        assert_eq!(
+            r.typed_partial, "",
+            "typed_partial should not advance when not typing"
+        );
+    }
+
+    #[test]
+    fn reconciler_type_partials_false_still_emits_finals() {
+        let mut r = Reconciler::default();
+        let out = r.process(&msg(vec![("hello", true)], false), false);
+        assert_eq!(extract(&out.events), vec![("Final", "hello".to_string())]);
+    }
+
+    #[test]
+    fn reconciler_mixed_final_then_partial_in_one_message() {
+        let mut r = Reconciler::default();
+        let out = r.process(&msg(vec![("Hello ", true), ("world", false)], false), true);
+        assert_eq!(
+            extract(&out.events),
+            vec![
+                ("Final", "Hello ".to_string()),
+                ("Partial", "world".to_string()),
+            ]
+        );
+        assert_eq!(r.typed_partial, "world");
+    }
+
+    #[test]
+    fn reconciler_final_is_prefix_of_typed_partial_emits_nothing() {
+        // Soniox finalizes only the leading portion of what was typed.
+        // The remainder stays as a pending partial. Cursor already shows
+        // the correct text — no new typing needed.
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("Hello world foo", false)], false), true);
+        let out = r.process(&msg(vec![("Hello world", true)], false), true);
+        assert!(out.events.is_empty(), "final-is-prefix should emit nothing");
+        assert_eq!(r.typed_partial, " foo");
+    }
+
+    #[test]
+    fn reconciler_skips_end_token() {
+        let mut r = Reconciler::default();
+        let out = r.process(
+            &msg(
+                vec![("hello", true), ("<end>", true), (" world", false)],
+                false,
+            ),
+            true,
+        );
+        // <end> filtered; only "hello" final + " world" partial.
+        assert_eq!(
+            extract(&out.events),
+            vec![
+                ("Final", "hello".to_string()),
+                ("Partial", " world".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn reconciler_skips_lang_token() {
+        let mut r = Reconciler::default();
+        let out = r.process(&msg(vec![("<lang:en>", true), ("text", true)], false), true);
+        assert_eq!(extract(&out.events), vec![("Final", "text".to_string())]);
+    }
+
+    #[test]
+    fn is_special_token_recognizes_various_brackets() {
+        assert!(is_special_token("<end>"));
+        assert!(is_special_token("<fin>"));
+        assert!(is_special_token("<lang:en>"));
+        assert!(is_special_token("<speaker:1>"));
+        assert!(!is_special_token("hello"));
+        assert!(!is_special_token("<incomplete"));
+        assert!(!is_special_token("incomplete>"));
+        assert!(!is_special_token(""));
+        // Punctuation tokens with brackets like "<3" should not match.
+        assert!(!is_special_token("<3"));
+    }
+
+    #[test]
+    fn reconciler_partial_after_final_extends_cleanly() {
+        let mut r = Reconciler::default();
+        r.process(&msg(vec![("Hello", true)], false), true);
+        let out = r.process(&msg(vec![("world", false)], false), true);
+        assert_eq!(extract(&out.events), vec![("Partial", "world".to_string())]);
+        assert_eq!(r.typed_partial, "world");
+    }
+}

--- a/src/transcribe/soniox.rs
+++ b/src/transcribe/soniox.rs
@@ -445,19 +445,22 @@ impl Reconciler {
             }
         }
 
-        if type_partials && !partial_text.is_empty() {
-            if partial_text.starts_with(&self.typed_partial) {
-                let delta = partial_text[self.typed_partial.len()..].to_string();
-                if !delta.is_empty() {
-                    out.events.push(StreamingEvent::Partial {
-                        text: delta,
-                        segment_id: SEGMENT_ID,
-                    });
-                    self.typed_partial = partial_text;
-                }
+        // When type_partials is off, no partial is empty, AND the server
+        // hasn't revised what we typed, emit only the new tail. The
+        // implicit "else" (server revised our typed partial) is silently
+        // dropped — the next finalization round resolves it.
+        if type_partials
+            && !partial_text.is_empty()
+            && partial_text.starts_with(&self.typed_partial)
+        {
+            let delta = partial_text[self.typed_partial.len()..].to_string();
+            if !delta.is_empty() {
+                out.events.push(StreamingEvent::Partial {
+                    text: delta,
+                    segment_id: SEGMENT_ID,
+                });
+                self.typed_partial = partial_text;
             }
-            // else: server revised our typed partial. Skip emission; the
-            // next finalization round will resolve the divergence.
         }
 
         if parsed.finished {
@@ -525,7 +528,7 @@ impl SonioxTranscriber {
 
         let init = self.init_frame();
         tracing::debug!(target: "voxtype::soniox::wire", "-> init {}", redact_api_key(&init));
-        write.send(Message::Text(init.into())).await.map_err(|e| {
+        write.send(Message::Text(init)).await.map_err(|e| {
             TranscribeError::InferenceFailed(format!("Soniox: send init failed: {}", e))
         })?;
 
@@ -536,7 +539,7 @@ impl SonioxTranscriber {
         const FRAME_BYTES: usize = 32 * 1024;
         for chunk in bytes.chunks(FRAME_BYTES) {
             write
-                .send(Message::Binary(chunk.to_vec().into()))
+                .send(Message::Binary(chunk.to_vec()))
                 .await
                 .map_err(|e| {
                     TranscribeError::InferenceFailed(format!("Soniox: send audio failed: {}", e))
@@ -557,7 +560,7 @@ impl SonioxTranscriber {
                 TranscribeError::InferenceFailed(format!("Soniox: send finalize failed: {}", e))
             })?;
         write
-            .send(Message::Text(String::new().into()))
+            .send(Message::Text(String::new()))
             .await
             .map_err(|e| {
                 TranscribeError::InferenceFailed(format!("Soniox: send EOA failed: {}", e))
@@ -771,7 +774,7 @@ impl SonioxTranscriber {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
             // Best effort: delete the orphaned file.
-            self.async_delete_file(&client, &auth, &file_id).await;
+            self.async_delete_file(client, &auth, &file_id).await;
             return Err(TranscribeError::InferenceFailed(format!(
                 "Soniox async: create transcription returned {}: {}",
                 status, text
@@ -789,7 +792,7 @@ impl SonioxTranscriber {
         let poll_start = std::time::Instant::now();
         loop {
             if poll_start.elapsed() > max_wait {
-                self.async_cleanup(&client, &auth, &job_id).await;
+                self.async_cleanup(client, &auth, &job_id).await;
                 return Err(TranscribeError::InferenceFailed(format!(
                     "Soniox async: job {} did not complete within {}s",
                     job_id,
@@ -808,7 +811,7 @@ impl SonioxTranscriber {
             if !resp.status().is_success() {
                 let status = resp.status();
                 let text = resp.text().await.unwrap_or_default();
-                self.async_cleanup(&client, &auth, &job_id).await;
+                self.async_cleanup(client, &auth, &job_id).await;
                 return Err(TranscribeError::InferenceFailed(format!(
                     "Soniox async: poll returned {}: {}",
                     status, text
@@ -826,7 +829,7 @@ impl SonioxTranscriber {
                     let err = status_resp
                         .error_message
                         .unwrap_or_else(|| "unspecified error".to_string());
-                    self.async_cleanup(&client, &auth, &job_id).await;
+                    self.async_cleanup(client, &auth, &job_id).await;
                     return Err(TranscribeError::InferenceFailed(format!(
                         "Soniox async: server error: {}",
                         err
@@ -863,7 +866,7 @@ impl SonioxTranscriber {
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
-            self.async_cleanup(&client, &auth, &job_id).await;
+            self.async_cleanup(client, &auth, &job_id).await;
             return Err(TranscribeError::InferenceFailed(format!(
                 "Soniox async: fetch transcript returned {}: {}",
                 status, text
@@ -881,7 +884,7 @@ impl SonioxTranscriber {
         })?;
 
         // 5. Cleanup server-side state (best effort, don't fail user-visible).
-        self.async_cleanup(&client, &auth, &job_id).await;
+        self.async_cleanup(client, &auth, &job_id).await;
 
         // 6. Concatenate tokens (skip special markers).
         let mut out = String::new();
@@ -974,7 +977,7 @@ async fn run_streaming_session(
 
     // Send init.
     tracing::debug!(target: "voxtype::soniox::wire", "-> init {}", redact_api_key(&init_frame));
-    if let Err(e) = write.send(Message::Text(init_frame.into())).await {
+    if let Err(e) = write.send(Message::Text(init_frame)).await {
         send_fatal(&events_tx, format!("Soniox: send init failed: {}", e)).await;
         return Ok(());
     }
@@ -1016,7 +1019,7 @@ async fn run_streaming_session(
                 match chunk {
                     Some(c) if !c.is_empty() => {
                         let bytes = f32_to_s16le_bytes(&c);
-                        if let Err(e) = write.send(Message::Binary(bytes.into())).await {
+                        if let Err(e) = write.send(Message::Binary(bytes)).await {
                             let _ = events_tx.send(StreamingEvent::Error(
                                 TranscribeError::InferenceFailed(format!(
                                     "Soniox: send audio failed: {}", e
@@ -1046,9 +1049,7 @@ async fn run_streaming_session(
                             {
                                 tracing::warn!("Soniox: finalize send failed: {}", e);
                             }
-                            if let Err(e) =
-                                write.send(Message::Text(String::new().into())).await
-                            {
+                            if let Err(e) = write.send(Message::Text(String::new())).await {
                                 tracing::warn!("Soniox: EOA send failed: {}", e);
                             }
                             sent_eoa = true;

--- a/src/transcribe/streaming.rs
+++ b/src/transcribe/streaming.rs
@@ -73,6 +73,17 @@ pub enum StreamingEvent {
     /// not produce visible churn.
     Final { text: String, segment_id: SegmentId },
 
+    /// Backspace `backspace` chars then commit `text`. Used by streaming
+    /// backends (notably Soniox) that revise the tail of a previously
+    /// typed non-final tail when finalizing — e.g. punctuation flips
+    /// from `,` to `.` or a token spelling changes between non-final
+    /// and final. Equivalent to `Final` when `backspace == 0`.
+    Replace {
+        backspace: usize,
+        text: String,
+        segment_id: SegmentId,
+    },
+
     /// The backend has finished processing all audio sent so far and is
     /// closing the stream gracefully (e.g., the daemon dropped the
     /// samples sender and the backend has flushed).

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -478,6 +478,8 @@ fn detect_missing_model() -> Option<MissingModel> {
         // Cohere — checked but model layout differs by rc/0.7.0; skip the
         // disk probe rather than emit a false-positive missing warning.
         config::TranscriptionEngine::Cohere => return None,
+        // Soniox is cloud-only, no local model to probe.
+        config::TranscriptionEngine::Soniox => return None,
     };
 
     if model.is_empty() {

--- a/src/tui/hotkey.rs
+++ b/src/tui/hotkey.rs
@@ -488,10 +488,25 @@ fn guidance_enabled<'a>(state: &'a HotkeyState) -> Vec<Line<'a>> {
 
     // Streaming dictation requires toggle activation; if the user has it
     // enabled, suppress PTT-pair suggestions in favor of a toggle binding.
-    let streaming = ConfigEditor::load()
-        .ok()
-        .and_then(|ed| ed.get_bool("parakeet", "streaming"))
-        .unwrap_or(false);
+    // Covers all streaming-capable backends (Parakeet, Soniox, future).
+    let streaming = {
+        let ed = ConfigEditor::load().ok();
+        let engine = ed
+            .as_ref()
+            .and_then(|e| e.get_string("", "engine"))
+            .unwrap_or_else(|| "whisper".to_string());
+        match engine.as_str() {
+            "parakeet" => ed
+                .as_ref()
+                .and_then(|e| e.get_bool("parakeet", "streaming"))
+                .unwrap_or(false),
+            "soniox" => ed
+                .as_ref()
+                .and_then(|e| e.get_bool("soniox", "streaming"))
+                .unwrap_or(true),
+            _ => false,
+        }
+    };
     let suggestions = compositor_bindings::suggest_missing(&bindings, streaming);
     if !suggestions.is_empty() {
         let comp = compositor_bindings::dominant_compositor(&bindings);

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -63,7 +63,8 @@ pub fn create_vad(config: &Config) -> Result<Option<Box<dyn VoiceActivityDetecto
                 | TranscriptionEngine::Paraformer
                 | TranscriptionEngine::Dolphin
                 | TranscriptionEngine::Omnilingual
-                | TranscriptionEngine::Cohere => VadBackend::Energy,
+                | TranscriptionEngine::Cohere
+                | TranscriptionEngine::Soniox => VadBackend::Energy,
             }
         }
         explicit => explicit,


### PR DESCRIPTION
## Background

Picks up the unanswered question from #326 ("Staying local only or expanding
to cloud providers"). This PR is a concrete proposal for one half of the
answer: add a cloud STT provider as a configurable engine choice, not as a
replacement for local models.

Voxtype's local backends do solid work in English. For non-English languages
(Hungarian is my own daily use, which is why I opened #326), Whisper's raw
output isn't quite paste-ready: word boundaries, casing, punctuation, and
proper nouns all need cleanup. The existing workaround is the `post_process`
command hook driving an LLM, typically Gemini Flash or similar.

That path works but has two real costs:

1. **Latency.** On my local hardware (Vulkan), Whisper v3 large turbo takes
   2-3 s for the actual transcription, and Gemini Flash post-processing adds
   another 1.5-2 s. End-to-end that's 4-5 s of perceived wait per utterance
   before paste-ready text reaches the cursor.
2. **Cost.** Every chunk pays the LLM provider's input + output tokens on
   already-transcribed text. For long meetings this adds up fast.

A streaming-quality cloud STT provider that produces paste-ready non-English
output without an LLM post-processing stage solves both: lower end-to-end
latency, lower cost per minute, no separate post-process pipeline to maintain.

[v0.7.2](https://github.com/peteonrails/voxtype/releases/tag/v0.7.2) made
this practical. The streaming dictation release shipped the
`StreamingTranscriber` trait, the `StreamingEvent::{Partial, Final, Ended,
Error}` channel, `StreamingSession` for delta typing + cancel-rewind, and the
PTT-to-toggle auto-promote gate, all aimed at Parakeet streaming (which is
English-only in practice). Once that infrastructure was in place, plugging a
cloud streaming provider in as a second consumer of the same plumbing became
straightforward: implement `StreamingTranscriber`, emit the same events,
inherit all the existing daemon and OSD wiring for free.

Soniox fits the criteria. Realtime WebSocket with sub-second partial latency,
60+ languages with native casing/punctuation, per-token finality flags so the
local reconciler can do live partial typing, and built-in vocabulary boosting
that replaces much of what the post-processing prompt was doing.

## What this PR adds

Two Soniox APIs, two voxtype use cases:

- **Dictation** uses the realtime WebSocket API (`stt-rt-v4`). Live partial
  typing at the cursor, sub-second latency, toggle activation.
- **Meetings** use the async REST API (`stt-async-v4`) automatically. Full
  chunk context gives better diarization-friendly transcripts and
  audio-second billing. Users don't have to flip a flag, it's the natural
  fit.

\`engine = "soniox"\` becomes a first-class voxtype engine. Config surface
(defaults shown):

| Field | Default | Notes |
|---|---|---|
| \`api_key\` | env: \`SONIOX_API_KEY\` | Required |
| \`model\` | \`stt-rt-v4\` (or \`stt-async-v4\` when \`async_api\`) | Override only if pinning a build |
| \`language_hints\` | \`["hu", "en"]\` | Empty = full auto-detect |
| \`language_hints_strict\` | \`true\` | Bias output to hinted languages |
| \`streaming\` | \`true\` | Realtime live partials vs PTT-compatible one-shot |
| \`type_partials\` | \`true\` | Live cursor feedback during streaming |
| \`terms\` / \`terms_file\` | none | Vocabulary boost (proper names, jargon) |
| \`context\` | none | Free-form domain context |
| \`async_api\` | \`false\` | Use REST batch instead of WebSocket |
| \`async_max_wait_secs\` | \`120\` | Async job total timeout |

CLI flag \`--soniox-api-key\`, engine override \`--engine soniox\`.
Push-to-talk auto-promotes to toggle for streaming mode (matches existing
parakeet-streaming behavior); set \`[soniox] streaming = false\` to keep PTT.

### Meeting mode auto-switch

\`Config::with_meeting_mode_overrides()\` returns a clone of the config with
engine-specific tweaks for long-form transcription. For Soniox it forces
\`async_api = true\` regardless of the user's setting. No config flag for
"meeting uses realtime" because opening a fresh WS session per 30 s chunk
has no upside over async.

### Streaming-output extension

The \`StreamingEvent\` enum gains a \`Replace { backspace, text }\` variant.
Soniox occasionally finalizes a non-final tail with revised punctuation or
word choice; \`Replace\` lets the streaming output session emit backspaces
and re-type cleanly without losing cursor state. Parakeet streaming, which
never revises, ignores the new variant.

\`Config::streaming_active()\` is generalized from a hardcoded
\`parakeet.streaming\` check to a per-engine match. Future streaming backends
plug into the PTT auto-promote gate without editing the daemon.

### OSD visibility during async drain

When the user releases the hotkey on a streaming Soniox session, the mic is
cut immediately but the server may still be emitting trailing finals for a
second or two. A small "silence pump" task publishes silent OSD frames during
that drain window so the on-screen display stays visible until the finalized
text actually arrives at the cursor. Without this, the OSD would fade out
as soon as the audio stream stopped and the user wouldn't know to wait.

## Architecture notes

- \`src/transcribe/soniox.rs\` (~1500 lines, new) implements both \`Transcriber\`
  (sync trait) and \`StreamingTranscriber\`. The sync-to-async bridge uses
  \`tokio::runtime::Handle::try_current()\` + \`block_in_place\` to reuse the
  meeting daemon's ambient runtime, falling back to a private current-thread
  runtime for the one-shot CLI path.
- Token reconciliation: Soniox sends finals once (non-cumulative) and
  revisable non-finals. The reconciler tracks only \`typed_partial\` (the
  in-flight non-final tail) and emits \`Partial\` / \`Final\` / \`Replace\`
  based on the LCP between server state and what's already at the cursor.
- Cleanup: \`DELETE /v1/transcriptions/{id}\` cascades to the file, so we
  issue only the transcription delete. No separate \`/files/{id}\` delete
  unless the transcription was never created (orphan upload case).
- Wire-trace log redacts \`api_key\` via a serde_json round-trip.

## Tests

41 unit tests in \`src/transcribe/soniox.rs\` cover the reconciler state
machine, init-frame shape including \`language_hints_strict\` and
\`terms_file\` plumbing, async/realtime mode switching including the meeting
auto-switch, special-token filtering (\`<end>\`, \`<fin>\`, \`<lang:xx>\`,
\`<speaker:N>\`), and WAV / f32-to-s16le encoding.

## Build features

New \`soniox\` cargo feature (default off) pulls \`tokio-tungstenite\` and
\`reqwest\` with rustls. TUI, menubar, and notification engine matches
updated for the new variant so macOS and Linux builds stay exhaustive.

## Docs

- New \`docs/SONIOX.md\` with config recipes, dictation/meeting routing table,
  and a note on dotoold's perf benefit for streaming output.
- \`docs/CONFIGURATION.md\` and \`docs/TROUBLESHOOTING.md\` extended with
  per-field reference and common failure modes (401, 429, etc.).
- \`docs/MODEL_SELECTION_GUIDE.md\` and \`docs/USER_MANUAL.md\` get a Soniox
  row in their engine tables.

## Scope

Standalone on \`dev\`. Does not depend on #410 (dotoolc fast path). When
#410 lands, Soniox streaming benefits from dotoolc routing for free via the
existing \`try_dotool_backspaces\` callsite, no Soniox-side changes required.

## Test plan

- [ ] \`cargo build --features soniox\` clean
- [ ] \`cargo test --features soniox --lib soniox\` passes 41/41
- [ ] \`SONIOX_API_KEY\` set, dictation with \`[soniox] streaming = true, language_hints = ["en"]\`: partial typing visible at cursor, finals stable
- [ ] \`[soniox] streaming = false\`: hotkey-release one-shot still works
- [ ] Bilingual dictation \`language_hints = ["hu", "en"]\`: mid-utterance language switches handled cleanly
- [ ] \`voxtype meeting start\` with \`engine = "soniox"\`: daemon log shows \`Soniox meeting mode: routing to async API (stt-async-v4); dictation path unchanged\`; async chunks complete and land in \`transcript.json\`
- [ ] Cancel mid-stream: typed partials backspaced cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)