### PR TITLE
soniox: document runtime requirement, warn on drain timeout

### DIFF
--- a/src/transcribe/soniox.rs
+++ b/src/transcribe/soniox.rs
@@ -473,6 +473,17 @@ impl Reconciler {
 }
 
 impl Transcriber for SonioxTranscriber {
+    /// Run a one-shot transcription.
+    ///
+    /// **Runtime requirement:** when called from inside an existing tokio
+    /// runtime, that runtime must be **multi-threaded** (the default for
+    /// `#[tokio::main]`). The sync→async bridge below uses
+    /// `tokio::task::block_in_place`, which panics on a current-thread
+    /// runtime. Voxtype's binary entry point is multi-thread so this is
+    /// always satisfied in production; the caveat matters only for tests
+    /// — prefer `#[tokio::test(flavor = "multi_thread")]` when exercising
+    /// this method, or call the async helpers (`batch_transcribe` /
+    /// `async_transcribe`) directly.
     fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
         if samples.is_empty() {
             return Err(TranscribeError::AudioFormat("Empty audio buffer".into()));
@@ -1010,8 +1021,18 @@ async fn run_streaming_session(
             }
 
             // Drain timeout fired without server-initiated close.
+            //
+            // Logged at warn level because hitting the deadline means
+            // trailing finals from the server were dropped on the floor —
+            // the user may notice missing words at the end of an utterance.
+            // Typical clean closes complete in ~200-300 ms, so a 5 s hit
+            // usually indicates a degraded uplink or a server-side hang.
             _ = drain_timer, if drain_deadline.is_some() => {
-                tracing::info!("Soniox drain timeout reached after end-of-audio; closing session");
+                tracing::warn!(
+                    "Soniox drain timeout ({}s) reached after end-of-audio; \
+                     trailing finals may be lost",
+                    DRAIN_TIMEOUT.as_secs(),
+                );
                 break;
             }
 


### PR DESCRIPTION
## Summary

Two small follow-ups from the PR #411 review.

### 1. Document multi-thread runtime requirement on `Transcriber::transcribe`

The sync→async bridge in `SonioxTranscriber::transcribe` uses
`tokio::task::block_in_place`, which panics on a current-thread runtime.
Voxtype's binary entry point is `#[tokio::main]` (multi-thread by default),
so production is fine — but `#[tokio::test]` defaults to current-thread,
which would surprise anyone wiring the trait method into an integration test.

Added a doc comment on the trait impl spelling out the requirement and
pointing test authors at `flavor = "multi_thread"` or the async helpers
(`batch_transcribe` / `async_transcribe`) directly.

### 2. Promote drain-timeout log from `info!` to `warn!`

When `DRAIN_TIMEOUT` (5s) fires, the server's end-of-audio finals were
dropped — the user may notice missing words at the end of an utterance.
A typical clean close is 200–300ms, so hitting the deadline usually means
a degraded uplink or a server-side hang. Worth surfacing at `warn!` and
including the user-visible consequence in the message.

## Notes

Other items from the review were intentionally **not** addressed:

- **Hungarian default for `language_hints`** — kept as a tribute to
  @materemias, per Pete's request.
- **reqwest TLS features** — already correct (`default-features = false`
  + `rustls-tls`), no change needed.
- **TUI engine picker integration** — Soniox is missing from
  `src/tui/engine.rs` (the `voxtype configure` engine selector and field
  editor). That's a real gap but bigger than this follow-up — needs its
  own PR with an engine catalog entry plus a Soniox config section
  (api_key, language_hints, terms_file, etc.).
- **Configurable `DRAIN_TIMEOUT`** — left for a follow-up if user reports
  trailing-finals loss in the wild.

## Test plan

- [x] `cargo build --features soniox` clean
- [x] `cargo test --features soniox --lib soniox` — 41/41 pass
- [ ] Manual: dictation with a slow / lossy uplink to confirm the new
      warn message is informative when the drain deadline fires

Co-authored-by: Máté Rémiás <mate@remias.dev>