### PR TITLE
Fix cuda-13 binary's CUDA-major probe falsely rejecting Blackwell (#386)

### DIFF
--- a/Dockerfile.onnx-cuda-13
+++ b/Dockerfile.onnx-cuda-13
@@ -115,6 +115,15 @@ RUN set -eux; \
 # gates the CUDA EP under `any(load-dynamic, cuda)`, and load-dynamic just
 # changes how libonnxruntime is reached, not whether the EP exists.
 #
+# ORT_CUDA_VERSION isn't consumed by ort-sys here (load-dynamic skips its
+# prebuilt selection), but build.rs reads the same env var to bake
+# VOXTYPE_BUILD_CUDA_MAJOR into the binary. That const drives the CUDA
+# runtime probe in src/transcribe/parakeet.rs, which would otherwise
+# default to "12" and reject CUDA 13.x hosts (#386 — v0.7.3 cuda-13 binary
+# falsely reported "this binary's bundled ONNX Runtime requires CUDA 12.x"
+# and fell back to CPU on Blackwell hosts).
+ENV ORT_CUDA_VERSION=13
+#
 # Disable LTO for faster builds; same as the rest of the matrix.
 RUN cargo build --release \
         --features parakeet-cuda,parakeet-load-dynamic,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,onnx-load-dynamic,ml-diarization \

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -400,25 +400,40 @@ fn probe_cuda_runtime() -> bool {
     // Voxtype ships separate voxtype-onnx-cuda-12 and voxtype-onnx-cuda-13
     // binaries. `voxtype setup gpu --enable` symlinks voxtype-onnx-cuda to
     // whichever variant matches the host's CUDA runtime.
-    const EXPECTED_CUDA_MAJOR: i32 = match env!("VOXTYPE_BUILD_CUDA_MAJOR").as_bytes() {
-        b"13" => 13,
-        _ => 12,
-    };
+    //
+    // Load-dynamic builds skip this check: there is no bundled ORT to
+    // mismatch — the binary dlopens whatever libonnxruntime the system
+    // provides, and ORT does its own kernel-image lookup against the host
+    // CUDA at session-create time. v0.7.3 cuda-13 forgot to set
+    // ORT_CUDA_VERSION=13 in its Dockerfile so VOXTYPE_BUILD_CUDA_MAJOR
+    // baked in the default ("12"), and this probe falsely rejected
+    // Blackwell hosts with "this binary's bundled ONNX Runtime requires
+    // CUDA 12.x" (#386). The Dockerfile fix sets the env var properly,
+    // and gating the check on `not(feature = "onnx-load-dynamic")`
+    // closes the design hole so future load-dynamic builds don't depend
+    // on remembering to set it.
+    #[cfg(not(feature = "onnx-load-dynamic"))]
+    {
+        const EXPECTED_CUDA_MAJOR: i32 = match env!("VOXTYPE_BUILD_CUDA_MAJOR").as_bytes() {
+            b"13" => 13,
+            _ => 12,
+        };
 
-    if major != EXPECTED_CUDA_MAJOR {
-        tracing::error!(
-            "CUDA version mismatch: found CUDA {major}.{minor}, but this binary's \
-             bundled ONNX Runtime requires CUDA {EXPECTED_CUDA_MAJOR}.x. \
-             Continuing would crash the process.\n  \
-             Options:\n  \
-             1. Install the matching voxtype-onnx-cuda-{EXPECTED_CUDA_MAJOR} package\n  \
-             2. Switch to voxtype-onnx-cuda-{} for your CUDA version (`voxtype setup gpu --enable` \
-             auto-detects and points the symlink at the right one)\n  \
-             3. Build from source with --features parakeet-load-dynamic to link \
-             against your system's ONNX Runtime instead",
-            major,
-        );
-        return false;
+        if major != EXPECTED_CUDA_MAJOR {
+            tracing::error!(
+                "CUDA version mismatch: found CUDA {major}.{minor}, but this binary's \
+                 bundled ONNX Runtime requires CUDA {EXPECTED_CUDA_MAJOR}.x. \
+                 Continuing would crash the process.\n  \
+                 Options:\n  \
+                 1. Install the matching voxtype-onnx-cuda-{EXPECTED_CUDA_MAJOR} package\n  \
+                 2. Switch to voxtype-onnx-cuda-{} for your CUDA version (`voxtype setup gpu --enable` \
+                 auto-detects and points the symlink at the right one)\n  \
+                 3. Build from source with --features parakeet-load-dynamic to link \
+                 against your system's ONNX Runtime instead",
+                major,
+            );
+            return false;
+        }
     }
 
     true


### PR DESCRIPTION
v0.7.3 \`voxtype-onnx-cuda-13\` falls back to CPU on RTX 5090 hosts even though that binary is the load-dynamic build that supports Blackwell. Two compounding bugs:

### A. \`Dockerfile.onnx-cuda-13\` doesn't set \`ORT_CUDA_VERSION=13\`

\`build.rs:79-90\` derives \`VOXTYPE_BUILD_CUDA_MAJOR\` from the \`ORT_CUDA_VERSION\` env var, defaulting to \`"12"\` if unset. The Dockerfile doesn't set the env var because \`ort-sys\` doesn't consume it in load-dynamic mode — but \`build.rs\` reads it unconditionally for the runtime-probe constant. So the cuda-13 binary baked in \`EXPECTED_CUDA_MAJOR = 12\` and the runtime probe in \`src/transcribe/parakeet.rs:408\` reported "found CUDA 13.2, but this binary's bundled ONNX Runtime requires CUDA 12.x" on Ty's machine.

Fixed by adding \`ENV ORT_CUDA_VERSION=13\` to the Dockerfile alongside a comment explaining the build.rs / ort-sys decoupling.

### B. The mismatch probe enforces a bundled-ORT expectation even in load-dynamic builds

The probe was designed when both cuda variants had ORT bundled at known ABI. Now cuda-13 uses Microsoft's ORT via \`ort/load-dynamic\` — there is no bundled ORT to mismatch, and ORT does its own kernel-image lookup at session-create. The probe is conceptually wrong for load-dynamic configs.

Fixed by gating the mismatch check on \`cfg!(not(feature = "onnx-load-dynamic"))\`. Future load-dynamic variants (cuda-14, or anyone porting cuda-12 later) won't reintroduce the same class of bug by forgetting to set the env var.

### Verification

- \`cargo fmt --check\` clean
- \`cargo clippy --all-targets --no-deps -- -D warnings\` clean (default features — matches CI)
- \`cargo test --lib\` passes 717/718 (pre-existing parakeet env failure only)
- \`cargo build --features parakeet-cuda,parakeet-load-dynamic,onnx-load-dynamic\` (the cuda-13 build profile) compiles cleanly

### Notes for reviewers

- Need to rebuild + re-release the cuda-13 binary for the in-the-wild fix to land on Ty's machine. The Rust-side change (B) means even a load-dynamic build without ORT_CUDA_VERSION=13 set would now do the right thing — the env var fix (A) is belt-and-suspenders, but it also gets us correct \`VOXTYPE_BUILD_CUDA_MAJOR\` for any consumer that reads the const elsewhere (e.g. version checks in scripts).
- 5 pre-existing clippy warnings surface when building with \`--features parakeet-cuda\` (manual-c-str-literals, needless-return, large-enum-variant, manual-checked-ops). These existed before this PR and aren't in CI's clippy invocation. Not in scope here; could be a small followup.

Closes #386 once the cuda-13 binary is rebuilt and shipped.