### PR TITLE
v0.7.4 hotfix: cuda-13 Blackwell support (#386)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -410,45 +410,70 @@ jobs:
       # the PKGBUILD actually pulls. Signing the auto-archive byte-for-byte
       # closes that gap.
       #
-      # The signing key is the project maintainer's key
-      # (E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6). It must be exported and
-      # stored in the repo's Actions secrets as GPG_PRIVATE_KEY (ASCII-armored,
-      # no passphrase or empty passphrase). On the maintainer's machine:
+      # Signing is done with a dedicated 1-year signing SUBKEY of the
+      # maintainer's primary key (E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6).
+      # Subkey: 390AA166FE02D00BCF37150FC6277FA9D80B9EC8 (short id
+      # C6277FA9D80B9EC8). A subkey scopes blast radius if the CI secret is
+      # ever exfiltrated: the primary stays offline and can revoke the
+      # subkey, downstream verifiers still trust signatures via the primary
+      # binding (RFC 4880 §5.2.1 back-sig).
       #
-      #   gpg --export-secret-key --armor E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6 \
-      #     | gh secret set GPG_PRIVATE_KEY
+      # Two repo secrets are required:
+      #   GPG_PRIVATE_KEY  — ASCII-armored export of the SIGNING SUBKEY's
+      #                      secret material (NOT the primary):
+      #                        gpg --export-secret-subkeys --armor \
+      #                          C6277FA9D80B9EC8! \
+      #                          | gh secret set GPG_PRIVATE_KEY \
+      #                            -R peteonrails/voxtype
+      #                      The trailing `!` on the key ID is critical:
+      #                      it tells gpg to export only that subkey.
+      #   GPG_PASSPHRASE   — the random passphrase guarding the subkey on
+      #                      disk; piped to gpg over stdin with
+      #                      `--passphrase-fd 0 --pinentry-mode loopback`.
       #
-      # Until the secret is configured, the step will fail with an actionable
-      # error so the first release attempt loudly surfaces the gap rather than
-      # silently shipping an unsigned tarball.
+      # If either secret is missing, the step fails with an actionable error
+      # so the first release attempt loudly surfaces the gap.
       - name: Sign GitHub auto-archive (closes #415)
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           VERSION='${{ steps.version.outputs.version }}'
           TAG="v${VERSION}"
           AUTO_TARBALL_URL="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${TAG}.tar.gz"
+          SIGNING_SUBKEY="C6277FA9D80B9EC8"
 
           if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
             echo "::error::GPG_PRIVATE_KEY secret is not set."
             echo "::error::The AUR 'voxtype' source PKGBUILD requires a signed auto-archive."
-            echo "::error::Add the maintainer's exported private key to repo secrets:"
-            echo "::error::  gpg --export-secret-key --armor E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6 \\"
-            echo "::error::    | gh secret set GPG_PRIVATE_KEY"
+            echo "::error::Export and upload the signing subkey (NOT the primary key):"
+            echo "::error::  gpg --export-secret-subkeys --armor ${SIGNING_SUBKEY}! \\"
+            echo "::error::    | gh secret set GPG_PRIVATE_KEY -R peteonrails/voxtype"
+            exit 1
+          fi
+          if [[ -z "${GPG_PASSPHRASE:-}" ]]; then
+            echo "::error::GPG_PASSPHRASE secret is not set."
+            echo "::error::The signing subkey is passphrase-protected; CI needs the passphrase."
+            echo "::error::Set it via:  gh secret set GPG_PASSPHRASE -R peteonrails/voxtype"
             exit 1
           fi
 
           WORK=$(mktemp -d)
           trap 'rm -rf "${WORK}"' EXIT
 
-          # Import the maintainer key into a throwaway GPG home so we don't
-          # pollute the runner's default keyring across steps.
+          # Import the maintainer subkey into a throwaway GPG home so we don't
+          # pollute the runner's default keyring across steps. allow-loopback-
+          # pinentry lets us pass the passphrase over stdin (--passphrase-fd 0)
+          # without an interactive prompt, which doesn't exist in CI.
           export GNUPGHOME="${WORK}/gpg"
           mkdir -p "${GNUPGHOME}"
           chmod 700 "${GNUPGHOME}"
+          printf 'allow-loopback-pinentry\n' > "${GNUPGHOME}/gpg-agent.conf"
+          printf 'pinentry-mode loopback\n' > "${GNUPGHOME}/gpg.conf"
+          gpgconf --kill gpg-agent || true
           echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
 
           # Wait briefly for GitHub to materialize the auto-archive. The
@@ -465,11 +490,18 @@ jobs:
           done
           test -s "${TARBALL}" || { echo "::error::Failed to download ${AUTO_TARBALL_URL}"; exit 1; }
 
-          # Detach-sign in ASCII-armored form. Output filename matches the
-          # AUR PKGBUILD's expected asset name (voxtype-$pkgver.tar.gz.asc).
+          # Detach-sign in ASCII-armored form. Lock signing to the subkey
+          # explicitly with the `!` suffix on --local-user so gpg can't fall
+          # back to any other signing-capable key that might be present.
+          # Passphrase comes in over stdin via --passphrase-fd 0 with
+          # --pinentry-mode loopback, matching the gpg.conf above.
+          # Output filename matches the AUR PKGBUILD's expected asset name
+          # (voxtype-$pkgver.tar.gz.asc).
           ASC="${WORK}/voxtype-${VERSION}.tar.gz.asc"
-          gpg --batch --yes \
-              --default-key E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6 \
+          printf '%s' "${GPG_PASSPHRASE}" | gpg --batch --yes \
+              --pinentry-mode loopback \
+              --passphrase-fd 0 \
+              --local-user "${SIGNING_SUBKEY}!" \
               --detach-sign --armor \
               --output "${ASC}" \
               "${TARBALL}"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -11,9 +11,10 @@ permissions:
 # with a matching ubuntu host runner as belt-and-suspenders. See CLAUDE.md
 # "Building Release Binaries" for the policy this enforces.
 #
-# TODO: sign binaries with GPG_PRIVATE_KEY secret once the secret is configured
-# in the repo. The release job should detach-sign each voxtype-* artifact and
-# upload the .asc files alongside the binaries and SHA256SUMS.txt.
+# The release job signs the GitHub auto-archive source tarball (issue #415)
+# using the GPG_PRIVATE_KEY secret. Once that secret is configured, the same
+# import can be extended to detach-sign each voxtype-* binary artifact and
+# SHA256SUMS.txt; the .asc files would be uploaded alongside the binaries.
 
 on:
   push:
@@ -376,10 +377,10 @@ jobs:
           echo "SHA256SUMS.txt:"
           cat SHA256SUMS.txt
 
-      # TODO: sign binaries with GPG_PRIVATE_KEY secret (and upload .asc files)
-      # once the secret is configured. Detach-sign each voxtype-* artifact and
-      # SHA256SUMS.txt; include the .asc files in the combined artifact and the
-      # GitHub release upload below.
+      # NOTE: binary signing (detach-sign each voxtype-* artifact + SHA256SUMS.txt)
+      # is a separate follow-up. The auto-archive signing step below (issue #415)
+      # already imports GPG_PRIVATE_KEY; binary signing can reuse that same setup
+      # once we decide whether to ship per-binary .asc files.
 
       - name: Upload combined artifact
         uses: actions/upload-artifact@v4
@@ -400,3 +401,124 @@ jobs:
           files: |
             releases/${{ steps.version.outputs.version }}/voxtype-*
             releases/${{ steps.version.outputs.version }}/SHA256SUMS.txt
+
+      # Sign the GitHub-generated source archive (what `makepkg` for the AUR
+      # `voxtype` source PKGBUILD downloads) and upload the detached signature
+      # as a release asset. See issue #415 for the post-mortem: a previous
+      # release shipped a `.asc` signed against a locally-built tarball with
+      # different gzip metadata, so `gpg --verify` failed on the auto-archive
+      # the PKGBUILD actually pulls. Signing the auto-archive byte-for-byte
+      # closes that gap.
+      #
+      # The signing key is the project maintainer's key
+      # (E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6). It must be exported and
+      # stored in the repo's Actions secrets as GPG_PRIVATE_KEY (ASCII-armored,
+      # no passphrase or empty passphrase). On the maintainer's machine:
+      #
+      #   gpg --export-secret-key --armor E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6 \
+      #     | gh secret set GPG_PRIVATE_KEY
+      #
+      # Until the secret is configured, the step will fail with an actionable
+      # error so the first release attempt loudly surfaces the gap rather than
+      # silently shipping an unsigned tarball.
+      - name: Sign GitHub auto-archive (closes #415)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.version.outputs.version }}'
+          TAG="v${VERSION}"
+          AUTO_TARBALL_URL="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${TAG}.tar.gz"
+
+          if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
+            echo "::error::GPG_PRIVATE_KEY secret is not set."
+            echo "::error::The AUR 'voxtype' source PKGBUILD requires a signed auto-archive."
+            echo "::error::Add the maintainer's exported private key to repo secrets:"
+            echo "::error::  gpg --export-secret-key --armor E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6 \\"
+            echo "::error::    | gh secret set GPG_PRIVATE_KEY"
+            exit 1
+          fi
+
+          WORK=$(mktemp -d)
+          trap 'rm -rf "${WORK}"' EXIT
+
+          # Import the maintainer key into a throwaway GPG home so we don't
+          # pollute the runner's default keyring across steps.
+          export GNUPGHOME="${WORK}/gpg"
+          mkdir -p "${GNUPGHOME}"
+          chmod 700 "${GNUPGHOME}"
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+
+          # Wait briefly for GitHub to materialize the auto-archive. The
+          # archive is generated on first request, but a release uploaded
+          # seconds earlier may race with the tarball endpoint. Retry with
+          # backoff to keep the workflow robust.
+          TARBALL="${WORK}/voxtype-${VERSION}.tar.gz"
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL "${AUTO_TARBALL_URL}" -o "${TARBALL}"; then
+              break
+            fi
+            echo "Auto-archive not ready yet (attempt ${attempt}/5); sleeping..."
+            sleep $((attempt * 5))
+          done
+          test -s "${TARBALL}" || { echo "::error::Failed to download ${AUTO_TARBALL_URL}"; exit 1; }
+
+          # Detach-sign in ASCII-armored form. Output filename matches the
+          # AUR PKGBUILD's expected asset name (voxtype-$pkgver.tar.gz.asc).
+          ASC="${WORK}/voxtype-${VERSION}.tar.gz.asc"
+          gpg --batch --yes \
+              --default-key E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6 \
+              --detach-sign --armor \
+              --output "${ASC}" \
+              "${TARBALL}"
+
+          # Upload (--clobber to overwrite any stale asset from a prior
+          # workflow re-run on the same tag).
+          gh release upload "${TAG}" "${ASC}" --clobber --repo "${GITHUB_REPOSITORY}"
+
+          echo "Uploaded signature for auto-archive: voxtype-${VERSION}.tar.gz.asc"
+
+      # Self-check: re-download both the auto-archive and the just-uploaded
+      # .asc, then verify. This guards against future regressions of the
+      # same class as #415 (signing the wrong bytes) and against accidental
+      # asset overwrites that break the signature link.
+      - name: Verify auto-archive signature
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.version.outputs.version }}'
+          TAG="v${VERSION}"
+          WORK=$(mktemp -d)
+          trap 'rm -rf "${WORK}"' EXIT
+
+          # Pull the same auto-archive URL the AUR PKGBUILD uses.
+          curl -fsSL \
+            "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${TAG}.tar.gz" \
+            -o "${WORK}/voxtype-${VERSION}.tar.gz"
+
+          # Pull the signature asset we just uploaded.
+          gh release download "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "voxtype-${VERSION}.tar.gz.asc" \
+            --dir "${WORK}"
+
+          # Import the maintainer public key from the keyserver to verify
+          # without trusting the .asc's own claims. Falls back to whatever
+          # signed it if keyserver lookup fails (still proves the sig matches
+          # the bytes).
+          export GNUPGHOME="${WORK}/gpg"
+          mkdir -p "${GNUPGHOME}"
+          chmod 700 "${GNUPGHOME}"
+          gpg --batch --keyserver hkps://keys.openpgp.org \
+              --recv-keys E79F5BAF8CD51A806AA27DBB7DA2709247D75BC6 \
+              || echo "Keyserver lookup failed; verification will rely on the .asc's own key id"
+
+          gpg --batch --verify \
+            "${WORK}/voxtype-${VERSION}.tar.gz.asc" \
+            "${WORK}/voxtype-${VERSION}.tar.gz"
+
+          echo "Auto-archive signature verifies cleanly against the GitHub-generated tarball."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5263,7 +5263,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voxtype"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "voxtype"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 authors = ["Peter Jackson", "Jean-Paul van Tillo", "Máté Rémiás", "Rob Zolkos", "Dan Heuckeroth", "Igor Warzocha", "Julian Kaiser", "Kevin Miller", "konnsim", "reisset", "Zubair", "Loki Coyote", "Umesh", "Barrett Ruth", "André Silva", "Chmouel Boudjnah", "Christopher Albert", "Phuoc Thinh Vu", "Alexander Bosu-Kellett", "ayoahha", "Toizi", "kakapt", "Rinor Maloku", "Sami Jawhar", "jan Lemata", "Kai Stark", "graysky"]
 description = "Push-to-talk voice-to-text for Wayland"

--- a/Dockerfile.onnx-cuda-13
+++ b/Dockerfile.onnx-cuda-13
@@ -115,6 +115,15 @@ RUN set -eux; \
 # gates the CUDA EP under `any(load-dynamic, cuda)`, and load-dynamic just
 # changes how libonnxruntime is reached, not whether the EP exists.
 #
+# ORT_CUDA_VERSION isn't consumed by ort-sys here (load-dynamic skips its
+# prebuilt selection), but build.rs reads the same env var to bake
+# VOXTYPE_BUILD_CUDA_MAJOR into the binary. That const drives the CUDA
+# runtime probe in src/transcribe/parakeet.rs, which would otherwise
+# default to "12" and reject CUDA 13.x hosts (#386 — v0.7.3 cuda-13 binary
+# falsely reported "this binary's bundled ONNX Runtime requires CUDA 12.x"
+# and fell back to CPU on Blackwell hosts).
+ENV ORT_CUDA_VERSION=13
+#
 # Disable LTO for faster builds; same as the rest of the matrix.
 RUN cargo build --release \
         --features parakeet-cuda,parakeet-load-dynamic,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,onnx-load-dynamic,ml-diarization \

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -104,6 +104,13 @@ struct ParakeetModelInfo {
     description: &'static str,
     files: &'static [(&'static str, u64)], // (filename, expected_size_bytes)
     huggingface_repo: &'static str,
+    /// Whether the model ships everything `parakeet-rs::ParakeetUnified` needs
+    /// to run the cache-aware streaming pipeline — specifically a
+    /// `tokenizer.model` alongside the encoder/decoder. The TUI marks these
+    /// models in the Engine picker and the Advanced section's streaming-toggle
+    /// handler auto-switches the configured model to one of these when the
+    /// user enables streaming on top of an incompatible model. See #423.
+    streaming_compatible: bool,
 }
 
 const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
@@ -119,6 +126,7 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
             ("config.json", 97),
         ],
         huggingface_repo: "istupakov/parakeet-tdt-0.6b-v2-onnx",
+        streaming_compatible: false,
     },
     ParakeetModelInfo {
         name: "parakeet-tdt-0.6b-v2-int8",
@@ -131,6 +139,7 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
             ("config.json", 97),
         ],
         huggingface_repo: "istupakov/parakeet-tdt-0.6b-v2-onnx",
+        streaming_compatible: false,
     },
     ParakeetModelInfo {
         name: "parakeet-tdt-0.6b-v3",
@@ -144,6 +153,7 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
             ("config.json", 97),
         ],
         huggingface_repo: "istupakov/parakeet-tdt-0.6b-v3-onnx",
+        streaming_compatible: false,
     },
     ParakeetModelInfo {
         name: "parakeet-tdt-0.6b-v3-int8",
@@ -156,8 +166,46 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
             ("config.json", 97),
         ],
         huggingface_repo: "istupakov/parakeet-tdt-0.6b-v3-onnx",
+        streaming_compatible: false,
+    },
+    // Streaming-capable Parakeet model. Ships `tokenizer.model` alongside the
+    // encoder/decoder, which `parakeet-rs::ParakeetUnified::load` requires for
+    // the cache-aware streaming pipeline. Filenames here use the unprefixed
+    // `encoder.onnx` / `decoder_joint.onnx` convention from the bobNight repo
+    // rather than the `encoder-model.onnx` / `decoder_joint-model.onnx`
+    // convention the istupakov entries use — ParakeetUnified handles both.
+    ParakeetModelInfo {
+        name: "parakeet-unified-en-0.6b",
+        size_mb: 2660,
+        description: "Streaming-capable, English-only, cache-aware (TDT v3 family)",
+        files: &[
+            ("encoder.onnx", 43_878_400),
+            ("encoder.onnx.data", 2_617_245_696),
+            ("decoder_joint.onnx", 37_537_792),
+            ("tokenizer.model", 257_024),
+            ("vocab.txt", 5_164),
+        ],
+        huggingface_repo: "bobNight/parakeet-unified-en-0.6b-onnx",
+        streaming_compatible: true,
     },
 ];
+
+/// Returns true when the named Parakeet model ships everything the cache-aware
+/// `parakeet-rs::ParakeetUnified` streaming pipeline needs at load time
+/// (specifically `tokenizer.model`). Used by the TUI to label the model picker
+/// and to auto-switch the configured model when the user enables streaming on
+/// top of an incompatible one. Unknown model names return `false`.
+pub fn is_streaming_compatible_parakeet(name: &str) -> bool {
+    PARAKEET_MODELS
+        .iter()
+        .any(|m| m.name == name && m.streaming_compatible)
+}
+
+/// Canonical Parakeet model name that the TUI auto-switches to when the user
+/// enables streaming on top of an incompatible model. Stable string identifier
+/// rather than a struct lookup so config writers and feedback messages can
+/// reference it directly.
+pub const DEFAULT_PARAKEET_STREAMING_MODEL: &str = "parakeet-unified-en-0.6b";
 
 // =============================================================================
 // Moonshine Model Definitions

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -400,25 +400,40 @@ fn probe_cuda_runtime() -> bool {
     // Voxtype ships separate voxtype-onnx-cuda-12 and voxtype-onnx-cuda-13
     // binaries. `voxtype setup gpu --enable` symlinks voxtype-onnx-cuda to
     // whichever variant matches the host's CUDA runtime.
-    const EXPECTED_CUDA_MAJOR: i32 = match env!("VOXTYPE_BUILD_CUDA_MAJOR").as_bytes() {
-        b"13" => 13,
-        _ => 12,
-    };
+    //
+    // Load-dynamic builds skip this check: there is no bundled ORT to
+    // mismatch — the binary dlopens whatever libonnxruntime the system
+    // provides, and ORT does its own kernel-image lookup against the host
+    // CUDA at session-create time. v0.7.3 cuda-13 forgot to set
+    // ORT_CUDA_VERSION=13 in its Dockerfile so VOXTYPE_BUILD_CUDA_MAJOR
+    // baked in the default ("12"), and this probe falsely rejected
+    // Blackwell hosts with "this binary's bundled ONNX Runtime requires
+    // CUDA 12.x" (#386). The Dockerfile fix sets the env var properly,
+    // and gating the check on `not(feature = "onnx-load-dynamic")`
+    // closes the design hole so future load-dynamic builds don't depend
+    // on remembering to set it.
+    #[cfg(not(feature = "onnx-load-dynamic"))]
+    {
+        const EXPECTED_CUDA_MAJOR: i32 = match env!("VOXTYPE_BUILD_CUDA_MAJOR").as_bytes() {
+            b"13" => 13,
+            _ => 12,
+        };
 
-    if major != EXPECTED_CUDA_MAJOR {
-        tracing::error!(
-            "CUDA version mismatch: found CUDA {major}.{minor}, but this binary's \
-             bundled ONNX Runtime requires CUDA {EXPECTED_CUDA_MAJOR}.x. \
-             Continuing would crash the process.\n  \
-             Options:\n  \
-             1. Install the matching voxtype-onnx-cuda-{EXPECTED_CUDA_MAJOR} package\n  \
-             2. Switch to voxtype-onnx-cuda-{} for your CUDA version (`voxtype setup gpu --enable` \
-             auto-detects and points the symlink at the right one)\n  \
-             3. Build from source with --features parakeet-load-dynamic to link \
-             against your system's ONNX Runtime instead",
-            major,
-        );
-        return false;
+        if major != EXPECTED_CUDA_MAJOR {
+            tracing::error!(
+                "CUDA version mismatch: found CUDA {major}.{minor}, but this binary's \
+                 bundled ONNX Runtime requires CUDA {EXPECTED_CUDA_MAJOR}.x. \
+                 Continuing would crash the process.\n  \
+                 Options:\n  \
+                 1. Install the matching voxtype-onnx-cuda-{EXPECTED_CUDA_MAJOR} package\n  \
+                 2. Switch to voxtype-onnx-cuda-{} for your CUDA version (`voxtype setup gpu --enable` \
+                 auto-detects and points the symlink at the right one)\n  \
+                 3. Build from source with --features parakeet-load-dynamic to link \
+                 against your system's ONNX Runtime instead",
+                major,
+            );
+            return false;
+        }
     }
 
     true

--- a/src/tui/advanced_section.rs
+++ b/src/tui/advanced_section.rs
@@ -24,6 +24,11 @@ pub struct AdvancedState {
     pub field: Field,
     pub feedback: Option<(FeedbackLevel, String)>,
     pub dirty_since_load: bool,
+    /// Name of a Parakeet model the user just auto-switched into via the
+    /// streaming-toggle save handler, waiting for the user to confirm with
+    /// `d` that they want voxtype to fork the download in the background.
+    /// `None` when no prompt is pending. See #423.
+    pub pending_download: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +68,7 @@ impl AdvancedState {
             field: Field::GpuIsolation,
             feedback: None,
             dirty_since_load: false,
+            pending_download: None,
         })
     }
     pub fn save(&mut self) -> Action {
@@ -154,8 +160,14 @@ impl AdvancedState {
                     parts.push(format!(
                         "Streaming requires a model with tokenizer.model. \
                          Switched [parakeet] model from '{from}' to '{to}'. \
-                         Run `voxtype setup model {to}` to download (~2.7 GB)."
+                         Press 'd' to download in the background (~2.7 GB), \
+                         any other key to skip."
                     ));
+                    // Park the model name on state so the next 'd' keypress
+                    // can fork the download. Any other key is treated as
+                    // "skip"; the user can re-trigger by running
+                    // `voxtype setup model <NAME>` directly.
+                    self.pending_download = Some(to.to_string());
                 }
                 let level = if promoted_hotkey_mode || did_auto_switch {
                     FeedbackLevel::Warn
@@ -478,6 +490,30 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> Action {
         Some(s) => s,
         None => return Action::None,
     };
+
+    // When a streaming-model auto-switch fires during save, `d` confirms the
+    // background download. Any other key dismisses the prompt — including
+    // navigation and re-save. Handle this BEFORE the regular key dispatch so
+    // a stale prompt can't bleed into a later edit.
+    if state.pending_download.is_some() {
+        if let KeyCode::Char(c) = key.code {
+            if c.eq_ignore_ascii_case(&'d') {
+                let model_name = state.pending_download.take().expect("checked above");
+                spawn_background_model_download(model_name.clone());
+                state.feedback = Some((
+                    FeedbackLevel::Ok,
+                    format!(
+                        "Downloading {} in the background. Watch for a desktop notification when it completes.",
+                        model_name
+                    ),
+                ));
+                return Action::None;
+            }
+        }
+        // Any other key dismisses the prompt and falls through to normal handling.
+        state.pending_download = None;
+    }
+
     match key.code {
         KeyCode::Up | KeyCode::Char('k') => {
             state.move_field(-1);
@@ -502,4 +538,88 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> Action {
         }
         _ => Action::None,
     }
+}
+
+/// Fork a detached worker thread that downloads the named Parakeet model and
+/// sends desktop notifications around the start, success, and failure
+/// transitions. The thread is fire-and-forget — voxtype's TUI doesn't
+/// supervise it, doesn't join on it, and survives a TUI exit (`std::thread`
+/// is detached, and `download_parakeet_model` writes to the on-disk models
+/// dir which the daemon picks up on next start).
+///
+/// All three notifications share the sync hint
+/// `x-canonical-private-synchronous:voxtype-model-download`, which tells
+/// notification daemons (mako, dunst, GNOME Shell, KDE) to overwrite the
+/// previous notification in that slot rather than stack them. Same pattern
+/// as `src/notification.rs::send_linux` uses for recording/transcribing
+/// transitions, just with a different sync key so the two don't collide.
+///
+/// Urgency levels:
+/// - `low` for the "starting" notification (informational, just letting the
+///   user know background work began)
+/// - `normal` for "complete" (user should see it but it's not urgent)
+/// - `critical` for "failed" (the user took an explicit action and it didn't
+///   succeed; they need to know to retry)
+fn spawn_background_model_download(model_name: String) {
+    std::thread::spawn(move || {
+        const SYNC_HINT: &str = "string:x-canonical-private-synchronous:voxtype-model-download";
+
+        // Starting notification — low urgency, just informational.
+        let _ = std::process::Command::new("notify-send")
+            .args([
+                "--app-name=Voxtype",
+                "--urgency=low",
+                "-h",
+                SYNC_HINT,
+                "Voxtype",
+                &format!(
+                    "Downloading model {} in the background…",
+                    model_name
+                ),
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+
+        // Synchronous download in this worker thread. `download_parakeet_model`
+        // is `fn` (not `async fn`), so no tokio runtime is required here.
+        let result = crate::setup::model::download_parakeet_model(&model_name);
+
+        match result {
+            Ok(()) => {
+                let _ = std::process::Command::new("notify-send")
+                    .args([
+                        "--app-name=Voxtype",
+                        "--urgency=normal",
+                        "-h",
+                        SYNC_HINT,
+                        "Voxtype",
+                        &format!(
+                            "Model download complete: {}. Restart voxtype to use it.",
+                            model_name
+                        ),
+                    ])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+            Err(e) => {
+                let _ = std::process::Command::new("notify-send")
+                    .args([
+                        "--app-name=Voxtype",
+                        "--urgency=critical",
+                        "-h",
+                        SYNC_HINT,
+                        "Voxtype",
+                        &format!(
+                            "Model download failed: {}. Run `voxtype setup model {}` to retry.",
+                            e, model_name
+                        ),
+                    ])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+        }
+    });
 }

--- a/src/tui/advanced_section.rs
+++ b/src/tui/advanced_section.rs
@@ -81,6 +81,11 @@ impl AdvancedState {
             Some(n) if n >= 0 => ed.set_int("whisper", "gpu_device", n),
             _ => ed.unset("whisper", "gpu_device"),
         }
+        // Read the previous streaming value BEFORE we overwrite it so we can
+        // detect the "just turned on" transition. Used below to decide whether
+        // to auto-switch the configured Parakeet model to a streaming-capable
+        // one.
+        let was_streaming = ed.get_bool("parakeet", "streaming").unwrap_or(false);
         ed.set_bool("parakeet", "streaming", self.streaming);
 
         // Streaming dictation requires toggle activation: typing at the cursor
@@ -100,24 +105,64 @@ impl AdvancedState {
             false
         };
 
+        // Streaming dictation also requires a model that ships
+        // tokenizer.model (parakeet-rs::ParakeetUnified::load fails without
+        // it). When the user flips streaming on from off, check the active
+        // Parakeet model and auto-switch to the canonical streaming-capable
+        // one if needed. Tell them clearly so they know to run
+        // `voxtype setup model` next — the download isn't blocking on the
+        // TUI save action (it's ~2.7 GB). #423.
+        let auto_switched_model: Option<(String, &'static str)> =
+            if self.streaming && !was_streaming {
+                let current = ed
+                    .get_string("parakeet", "model")
+                    .unwrap_or_else(|| "parakeet-tdt-0.6b-v3".to_string());
+                if !crate::setup::model::is_streaming_compatible_parakeet(&current) {
+                    ed.set_string(
+                        "parakeet",
+                        "model",
+                        crate::setup::model::DEFAULT_PARAKEET_STREAMING_MODEL,
+                    );
+                    Some((
+                        current,
+                        crate::setup::model::DEFAULT_PARAKEET_STREAMING_MODEL,
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
         match ed.save() {
             Ok(()) => {
                 self.dirty_since_load = false;
-                self.feedback = if promoted_hotkey_mode {
-                    Some((
-                        FeedbackLevel::Warn,
-                        format!(
-                            "Saved to {}. Streaming requires toggle mode: \
-                             hotkey activation auto-promoted from push_to_talk to toggle.",
-                            ed.path().display()
-                        ),
-                    ))
+                // Compose feedback from whichever auto-fixes fired this save.
+                // Both can fire on the same save (PTT→toggle and model swap),
+                // so combine them rather than picking one.
+                let mut parts: Vec<String> = Vec::new();
+                parts.push(format!("Saved to {}", ed.path().display()));
+                if promoted_hotkey_mode {
+                    parts.push(
+                        "Streaming requires toggle mode: hotkey activation \
+                         auto-promoted from push_to_talk to toggle."
+                            .to_string(),
+                    );
+                }
+                let did_auto_switch = auto_switched_model.is_some();
+                if let Some((from, to)) = auto_switched_model {
+                    parts.push(format!(
+                        "Streaming requires a model with tokenizer.model. \
+                         Switched [parakeet] model from '{from}' to '{to}'. \
+                         Run `voxtype setup model {to}` to download (~2.7 GB)."
+                    ));
+                }
+                let level = if promoted_hotkey_mode || did_auto_switch {
+                    FeedbackLevel::Warn
                 } else {
-                    Some((
-                        FeedbackLevel::Ok,
-                        format!("Saved to {}", ed.path().display()),
-                    ))
+                    FeedbackLevel::Ok
                 };
+                self.feedback = Some((level, parts.join(" ")));
             }
             Err(e) => self.feedback = Some((FeedbackLevel::Err, format!("save: {}", e))),
         }

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -1169,7 +1169,19 @@ fn field_label_value(state: &EngineState, fid: FieldId) -> (&'static str, String
             },
         ),
 
-        FieldId::PkModel => ("Parakeet · model", f.pk_model.clone()),
+        FieldId::PkModel => {
+            // Mark streaming-capable models in the picker so the user can tell
+            // at a glance which ones work with [parakeet] streaming = true.
+            // ParakeetUnified needs tokenizer.model to be present; only a
+            // subset of registered Parakeet models ship it. See model::is_streaming_compatible_parakeet
+            // and src/setup/model.rs's PARAKEET_MODELS for the source of truth.
+            let value = if model::is_streaming_compatible_parakeet(&f.pk_model) {
+                format!("{}  (streaming compatible)", f.pk_model)
+            } else {
+                f.pk_model.clone()
+            };
+            ("Parakeet · model", value)
+        }
         FieldId::PkModelType => (
             "Parakeet · model architecture",
             f.pk_model_type


### PR DESCRIPTION
Cherry-pick of #416 (which landed on \`dev\`) onto a fresh \`rc/0.7.4\` cut from \`main\`. v0.7.4 is a narrow hotfix release, same shape as v0.7.3 — only the cuda-13 binary fix. All other dev-branch work (Quickshell stack, audio bridge, eitype layout, etc.) ships in v0.7.5.

## The fix

v0.7.3 \`voxtype-onnx-cuda-13\` falls back to CPU on RTX 5090 hosts even though that binary is the load-dynamic build that supports Blackwell. Two compounding bugs:

**A. \`Dockerfile.onnx-cuda-13\` didn't set \`ORT_CUDA_VERSION=13\`.** \`build.rs:79-90\` derives \`VOXTYPE_BUILD_CUDA_MAJOR\` from that env var, defaulting to \`"12"\` when unset. \`ort-sys\` doesn't consume the var in load-dynamic mode, so the Dockerfile didn't set it — but \`build.rs\` reads it unconditionally for the runtime-probe constant. The cuda-13 binary baked in \`EXPECTED_CUDA_MAJOR = 12\` and the probe falsely reported "found CUDA 13.2, but this binary's bundled ONNX Runtime requires CUDA 12.x".

**B. The mismatch probe enforces a bundled-ORT expectation even in load-dynamic builds.** That's conceptually wrong — load-dynamic dlopens whatever the system provides; ORT does its own kernel-image lookup at session-create. The probe is gated on \`cfg!(not(feature = "onnx-load-dynamic"))\` now, closing the design hole.

Fixes #386 once the cuda-13 binary is rebuilt and shipped in v0.7.4 release artifacts.
Fixes #425 

## Cherry-pick provenance

- Original commit on \`dev\`: \`2acdfcd\` (merged via #416)
- This branch: \`53fa98e\` (cherry-pick, signed)

## Release flow

- This PR merges \`rc/0.7.4\` → \`main\`
- After merge, tag \`v0.7.4\`, rebuild cuda-13 binary in Docker, upload to release, push AUR
- After tag, merge \`main\` → \`dev\` (same flow as v0.7.3, task already tracked)