### PR TITLE
meeting/diarization: VAD sub-windows + tunable ECAPA threshold

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1697,6 +1697,24 @@ pub struct MeetingDiarizationConfig {
     /// Minimum segment duration in milliseconds for ML embedding extraction
     #[serde(default = "default_min_segment_ms")]
     pub min_segment_ms: u64,
+
+    // The four fields below apply only to backend = "ml"; the "simple" and
+    // "remote" backends ignore them.
+    /// Cosine similarity threshold for the ML backend (0.20-0.30 typical for ECAPA on 4s windows)
+    #[serde(default = "default_similarity_threshold")]
+    pub similarity_threshold: f32,
+
+    /// VAD sub-window length in seconds for ECAPA feeding
+    #[serde(default = "default_vad_window_secs")]
+    pub vad_window_secs: f32,
+
+    /// VAD sub-window hop in seconds
+    #[serde(default = "default_vad_hop_secs")]
+    pub vad_hop_secs: f32,
+
+    /// RMS floor for treating a sub-window as silence
+    #[serde(default = "default_vad_rms_floor")]
+    pub vad_rms_floor: f32,
 }
 
 fn default_diarization_backend() -> String {
@@ -1709,6 +1727,25 @@ fn default_max_speakers() -> u32 {
 
 fn default_min_segment_ms() -> u64 {
     500
+}
+
+// Empirically tuned against multi-speaker test clips (4-person roundtable,
+// 3-person panel, 1h talk). The previous 0.75 anchor was far too strict for
+// 4s ECAPA windows and produced overwhelmingly Unknown labels in practice.
+fn default_similarity_threshold() -> f32 {
+    0.25
+}
+
+fn default_vad_window_secs() -> f32 {
+    4.0
+}
+
+fn default_vad_hop_secs() -> f32 {
+    2.0
+}
+
+fn default_vad_rms_floor() -> f32 {
+    0.005
 }
 
 fn default_chunk_duration() -> u32 {
@@ -1731,6 +1768,10 @@ impl Default for MeetingDiarizationConfig {
             max_speakers: default_max_speakers(),
             model_path: None,
             min_segment_ms: default_min_segment_ms(),
+            similarity_threshold: default_similarity_threshold(),
+            vad_window_secs: default_vad_window_secs(),
+            vad_hop_secs: default_vad_hop_secs(),
+            vad_rms_floor: default_vad_rms_floor(),
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1182,6 +1182,10 @@ impl Daemon {
                 max_speakers: self.config.meeting.diarization.max_speakers,
                 min_segment_ms: self.config.meeting.diarization.min_segment_ms,
                 model_path: self.config.meeting.diarization.model_path.clone(),
+                similarity_threshold: self.config.meeting.diarization.similarity_threshold,
+                vad_window_secs: self.config.meeting.diarization.vad_window_secs,
+                vad_hop_secs: self.config.meeting.diarization.vad_hop_secs,
+                vad_rms_floor: self.config.meeting.diarization.vad_rms_floor,
             })
         } else {
             None

--- a/src/meeting/diarization/ml.rs
+++ b/src/meeting/diarization/ml.rs
@@ -20,10 +20,13 @@ use ort::value::Tensor;
 /// Speaker embedding (voice fingerprint)
 #[derive(Debug, Clone)]
 pub struct SpeakerEmbedding {
-    /// Embedding vector (typically 192 or 256 dimensions)
+    /// Embedding vector (typically 192 or 256 dimensions). Treated as a running
+    /// centroid that is updated via online mean when new utterances cluster here.
     pub vector: Vec<f32>,
     /// Speaker ID this embedding belongs to
     pub speaker_id: SpeakerId,
+    /// Number of embeddings merged into this centroid (for the online mean update)
+    pub count: u32,
 }
 
 impl SpeakerEmbedding {
@@ -75,7 +78,12 @@ impl MlDiarizerState {
         }
     }
 
-    /// Find or create speaker ID for an embedding
+    /// Find or create speaker ID for an embedding.
+    ///
+    /// On match, the existing centroid is updated with an online mean of the
+    /// new embedding (each centroid tracks `count` merged samples). This
+    /// improves robustness to within-speaker variation across long recordings
+    /// versus anchoring on a single first-utterance embedding.
     #[cfg(feature = "ml-diarization")]
     fn find_or_create_speaker(
         &mut self,
@@ -86,6 +94,7 @@ impl MlDiarizerState {
         let new_embedding = SpeakerEmbedding {
             vector: embedding.to_vec(),
             speaker_id: SpeakerId::Auto(self.next_speaker_id),
+            count: 1,
         };
 
         // Find best matching existing speaker
@@ -104,13 +113,22 @@ impl MlDiarizerState {
         }
 
         if let Some((idx, sim)) = best_match {
-            // Return existing speaker
+            // Update the matched speaker's centroid with the online mean of the
+            // new embedding. Cosine similarity is scale-invariant so we don't
+            // need to renormalize the stored vector.
+            let existing = &mut self.speaker_embeddings[idx];
+            let n = existing.count as f32;
+            for (c, e) in existing.vector.iter_mut().zip(embedding.iter()) {
+                *c = (*c * n + *e) / (n + 1.0);
+            }
+            existing.count += 1;
             tracing::debug!(
-                "Speaker match: {} (similarity: {:.3})",
-                self.speaker_embeddings[idx].speaker_id,
-                sim
+                "Speaker match: {} (similarity: {:.3}, n={})",
+                existing.speaker_id,
+                sim,
+                existing.count
             );
-            self.speaker_embeddings[idx].speaker_id.clone()
+            existing.speaker_id.clone()
         } else if self.next_speaker_id < max_speakers {
             // Log best similarity for debugging
             let best_sim = self
@@ -130,6 +148,7 @@ impl MlDiarizerState {
             self.speaker_embeddings.push(SpeakerEmbedding {
                 vector: embedding.to_vec(),
                 speaker_id: speaker_id.clone(),
+                count: 1,
             });
             self.next_speaker_id += 1;
             speaker_id
@@ -158,6 +177,15 @@ pub struct MlDiarizer {
     /// Minimum segment duration for embedding (ms)
     #[cfg(feature = "ml-diarization")]
     min_segment_ms: u64,
+    /// VAD sub-window length in seconds for ECAPA feeding
+    #[cfg(feature = "ml-diarization")]
+    vad_window_secs: f32,
+    /// VAD sub-window hop in seconds
+    #[cfg(feature = "ml-diarization")]
+    vad_hop_secs: f32,
+    /// RMS floor below which a sub-window is treated as silence
+    #[cfg(feature = "ml-diarization")]
+    vad_rms_floor: f32,
     /// Sample rate for audio
     #[cfg(feature = "ml-diarization")]
     sample_rate: u32,
@@ -172,11 +200,17 @@ impl MlDiarizer {
             session: None,
             state: Mutex::new(MlDiarizerState::new()),
             #[cfg(feature = "ml-diarization")]
-            similarity_threshold: 0.75,
+            similarity_threshold: config.similarity_threshold,
             #[cfg(feature = "ml-diarization")]
             max_speakers: config.max_speakers,
             #[cfg(feature = "ml-diarization")]
             min_segment_ms: config.min_segment_ms,
+            #[cfg(feature = "ml-diarization")]
+            vad_window_secs: config.vad_window_secs,
+            #[cfg(feature = "ml-diarization")]
+            vad_hop_secs: config.vad_hop_secs,
+            #[cfg(feature = "ml-diarization")]
+            vad_rms_floor: config.vad_rms_floor,
             #[cfg(feature = "ml-diarization")]
             sample_rate: 16000,
         }
@@ -362,39 +396,76 @@ impl Diarizer for MlDiarizer {
 
                 let segment_samples = &samples[start_sample..end_sample.min(samples.len())];
 
-                // Extract embedding and match to speaker
-                match self.extract_embedding(segment_samples) {
-                    Ok(embedding) => {
-                        let speaker = match self.state.lock() {
-                            Ok(mut state) => state.find_or_create_speaker(
-                                &embedding,
-                                self.similarity_threshold,
-                                self.max_speakers,
-                            ),
-                            Err(e) => {
-                                tracing::warn!("Speaker state lock poisoned: {}", e);
-                                SpeakerId::Unknown
+                // ECAPA-TDNN is trained on ~2-5s utterances. Feeding whole
+                // Soniox-style 30s mega-segments produces noisy averaged
+                // embeddings that fail to cluster. Split into VAD-gated sub-windows
+                // (length/hop/floor configurable) and pick the dominant per-segment label.
+                let subwindows = super::vad_subwindows(
+                    segment_samples,
+                    self.sample_rate,
+                    self.vad_window_secs,
+                    self.vad_hop_secs,
+                    self.vad_rms_floor,
+                );
+
+                // Count sub-window labels directly; one HashMap, one lock guard
+                // hoisted across the loop so we don't re-acquire per window.
+                let mut counts: HashMap<SpeakerId, u32> = HashMap::new();
+                if let Ok(mut state) = self.state.lock() {
+                    let windows = if subwindows.is_empty() {
+                        // Fall back to whole-segment embedding when no voiced
+                        // sub-window is found (very short or quiet segment).
+                        vec![(0usize, segment_samples.len(), 0.0f32)]
+                    } else {
+                        subwindows
+                    };
+                    for (ws, we, _rms) in windows {
+                        match self.extract_embedding(&segment_samples[ws..we]) {
+                            Ok(embedding) => {
+                                let label = state.find_or_create_speaker(
+                                    &embedding,
+                                    self.similarity_threshold,
+                                    self.max_speakers,
+                                );
+                                *counts.entry(label).or_insert(0) += 1;
                             }
-                        };
-                        results.push(DiarizedSegment {
-                            speaker,
-                            start_ms: seg.start_ms,
-                            end_ms: seg.end_ms,
-                            text: seg.text.clone(),
-                            confidence: 0.8,
-                        });
+                            Err(e) => tracing::warn!("Failed to extract embedding: {}", e),
+                        }
                     }
-                    Err(e) => {
-                        tracing::warn!("Failed to extract embedding: {}", e);
-                        results.push(DiarizedSegment {
-                            speaker: SpeakerId::Unknown,
-                            start_ms: seg.start_ms,
-                            end_ms: seg.end_ms,
-                            text: seg.text.clone(),
-                            confidence: 0.0,
-                        });
-                    }
+                } else {
+                    tracing::warn!("Speaker state lock poisoned");
                 }
+
+                // Dominant speaker = mode of sub-window labels.
+                // Sort key: (named beats Unknown, higher count wins, then
+                // lowest Auto(n) wins on ties — first-seen speaker keeps the
+                // segment when two speakers vote-tie within a chunk).
+                // Without the third component, HashMap iteration order would
+                // make tied results nondeterministic across runs.
+                let speaker = counts
+                    .into_iter()
+                    .min_by_key(|(sp, c)| {
+                        let auto_id = match sp {
+                            SpeakerId::Auto(n) => *n as i64,
+                            _ => i64::MAX,
+                        };
+                        (matches!(sp, SpeakerId::Unknown), -(*c as i64), auto_id)
+                    })
+                    .map(|(sp, _)| sp)
+                    .unwrap_or(SpeakerId::Unknown);
+
+                let confidence = if matches!(speaker, SpeakerId::Unknown) {
+                    0.0
+                } else {
+                    0.8
+                };
+                results.push(DiarizedSegment {
+                    speaker,
+                    start_ms: seg.start_ms,
+                    end_ms: seg.end_ms,
+                    text: seg.text.clone(),
+                    confidence,
+                });
             }
 
             results
@@ -415,10 +486,12 @@ mod tests {
         let a = SpeakerEmbedding {
             vector: vec![1.0, 0.0, 0.0],
             speaker_id: SpeakerId::Auto(0),
+            count: 1,
         };
         let b = SpeakerEmbedding {
             vector: vec![1.0, 0.0, 0.0],
             speaker_id: SpeakerId::Auto(1),
+            count: 1,
         };
         assert!((a.cosine_similarity(&b) - 1.0).abs() < 0.001);
     }
@@ -428,10 +501,12 @@ mod tests {
         let a = SpeakerEmbedding {
             vector: vec![1.0, 0.0, 0.0],
             speaker_id: SpeakerId::Auto(0),
+            count: 1,
         };
         let b = SpeakerEmbedding {
             vector: vec![0.0, 1.0, 0.0],
             speaker_id: SpeakerId::Auto(1),
+            count: 1,
         };
         assert!(a.cosine_similarity(&b).abs() < 0.001);
     }
@@ -441,10 +516,12 @@ mod tests {
         let a = SpeakerEmbedding {
             vector: vec![1.0, 0.0, 0.0],
             speaker_id: SpeakerId::Auto(0),
+            count: 1,
         };
         let b = SpeakerEmbedding {
             vector: vec![-1.0, 0.0, 0.0],
             speaker_id: SpeakerId::Auto(1),
+            count: 1,
         };
         assert!((a.cosine_similarity(&b) + 1.0).abs() < 0.001);
     }

--- a/src/meeting/diarization/ml.rs
+++ b/src/meeting/diarization/ml.rs
@@ -408,32 +408,40 @@ impl Diarizer for MlDiarizer {
                     self.vad_rms_floor,
                 );
 
-                // Count sub-window labels directly; one HashMap, one lock guard
-                // hoisted across the loop so we don't re-acquire per window.
+                // Extract all sub-window embeddings without holding the state
+                // lock — ECAPA inference is the slow step and shouldn't block
+                // any concurrent reader of speaker_embeddings. Fall back to a
+                // single whole-segment window when no voiced sub-window is
+                // found (very short or quiet segment).
+                let windows = if subwindows.is_empty() {
+                    vec![(0usize, segment_samples.len(), 0.0f32)]
+                } else {
+                    subwindows
+                };
+                let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(windows.len());
+                for (ws, we, _rms) in windows {
+                    match self.extract_embedding(&segment_samples[ws..we]) {
+                        Ok(embedding) => embeddings.push(embedding),
+                        Err(e) => tracing::warn!("Failed to extract embedding: {}", e),
+                    }
+                }
+
+                // Now take the lock once and process the cluster updates
+                // sequentially (order matters: online centroid updates feed
+                // back into subsequent matches within the same segment).
                 let mut counts: HashMap<SpeakerId, u32> = HashMap::new();
-                if let Ok(mut state) = self.state.lock() {
-                    let windows = if subwindows.is_empty() {
-                        // Fall back to whole-segment embedding when no voiced
-                        // sub-window is found (very short or quiet segment).
-                        vec![(0usize, segment_samples.len(), 0.0f32)]
-                    } else {
-                        subwindows
-                    };
-                    for (ws, we, _rms) in windows {
-                        match self.extract_embedding(&segment_samples[ws..we]) {
-                            Ok(embedding) => {
-                                let label = state.find_or_create_speaker(
-                                    &embedding,
-                                    self.similarity_threshold,
-                                    self.max_speakers,
-                                );
-                                *counts.entry(label).or_insert(0) += 1;
-                            }
-                            Err(e) => tracing::warn!("Failed to extract embedding: {}", e),
+                match self.state.lock() {
+                    Ok(mut state) => {
+                        for embedding in &embeddings {
+                            let label = state.find_or_create_speaker(
+                                embedding,
+                                self.similarity_threshold,
+                                self.max_speakers,
+                            );
+                            *counts.entry(label).or_insert(0) += 1;
                         }
                     }
-                } else {
-                    tracing::warn!("Speaker state lock poisoned");
+                    Err(e) => tracing::warn!("Speaker state lock poisoned: {}", e),
                 }
 
                 // Dominant speaker = mode of sub-window labels.

--- a/src/meeting/diarization/mod.rs
+++ b/src/meeting/diarization/mod.rs
@@ -67,6 +67,42 @@ pub struct DiarizedSegment {
 /// Speaker labels mapping auto IDs to names
 pub type SpeakerLabels = HashMap<SpeakerId, String>;
 
+/// Split audio into overlapping voiced sub-windows by RMS gating.
+///
+/// Returns `(start_sample, end_sample, rms)` tuples for windows whose
+/// RMS energy meets or exceeds `rms_floor`. ECAPA-TDNN performs best on
+/// 2-5s segments, so callers should use `window_secs ≈ 4.0`, `hop_secs ≈ 2.0`.
+pub fn vad_subwindows(
+    samples: &[f32],
+    sample_rate: u32,
+    window_secs: f32,
+    hop_secs: f32,
+    rms_floor: f32,
+) -> Vec<(usize, usize, f32)> {
+    // Clamp at the seconds level: a hop of 0 or a very small fraction would
+    // otherwise produce hundreds of thousands of overlapping windows per
+    // segment and overwhelm ECAPA inference. 100 ms is the lowest hop that
+    // still makes sense for speaker fingerprinting.
+    let hop_secs = hop_secs.max(0.1);
+    let win = (window_secs * sample_rate as f32) as usize;
+    let hop = (hop_secs * sample_rate as f32) as usize;
+    if win == 0 || hop == 0 || samples.len() < win {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    while start + win <= samples.len() {
+        let segment = &samples[start..start + win];
+        let sum_sq: f32 = segment.iter().map(|s| s * s).sum();
+        let rms = (sum_sq / segment.len() as f32).sqrt();
+        if rms >= rms_floor {
+            out.push((start, start + win, rms));
+        }
+        start += hop;
+    }
+    out
+}
+
 /// Trait for diarization backends
 pub trait Diarizer: Send + Sync {
     /// Process audio samples and return diarized segments
@@ -94,6 +130,17 @@ pub struct DiarizationConfig {
     pub min_segment_ms: u64,
     /// Path to ONNX model for ML backend
     pub model_path: Option<String>,
+    /// Cosine similarity threshold for matching new embeddings to existing
+    /// speakers. Lower = more merging (fewer speakers detected); higher =
+    /// more fragmentation. Empirically 0.20-0.30 is the useful range for
+    /// ECAPA-TDNN on 4s windows.
+    pub similarity_threshold: f32,
+    /// VAD sub-window length in seconds for ECAPA feeding
+    pub vad_window_secs: f32,
+    /// VAD sub-window hop in seconds
+    pub vad_hop_secs: f32,
+    /// RMS floor below which a sub-window is treated as silence
+    pub vad_rms_floor: f32,
 }
 
 impl Default for DiarizationConfig {
@@ -104,6 +151,10 @@ impl Default for DiarizationConfig {
             max_speakers: 10,
             min_segment_ms: 500,
             model_path: None,
+            similarity_threshold: 0.25,
+            vad_window_secs: 4.0,
+            vad_hop_secs: 2.0,
+            vad_rms_floor: 0.005,
         }
     }
 }


### PR DESCRIPTION
## Summary

The ML speaker diarizer (`backend = "ml"`) was effectively unusable in real meetings: a 2 h 20 m capture earlier this month finished with 96% of segments labeled `Unknown` and four stray `SPEAKER_NN` labels that clustered by audio source rather than by voice. This PR fixes both root causes and exposes the relevant tuning knobs as config.

## Problem

Two compounding issues in `src/meeting/diarization/ml.rs`:

1. **30 s mega-segment feeding.** Each transcript segment from Soniox is roughly a full 30 s chunk's worth of audio. ECAPA-TDNN was trained on 2–5 s utterances. Averaging a 30 s mixed-speech blob into one embedding produces a noisy centroid that doesn't cluster against anything reliably.
2. **Hardcoded `similarity_threshold = 0.75`.** Combined with the noisy embeddings above, the cosine similarity between two same-speaker segments rarely cleared 0.75. `next_speaker_id` raced ahead until `max_speakers` was hit, then every subsequent embedding fell to `Unknown`.

The transcript looked plausible (Soniox kept transcribing fine) but diarization was effectively off.

## Changes

- New `super::vad_subwindows(samples, sample_rate, window_secs, hop_secs, rms_floor)` helper. RMS-gated overlapping windows. `hop_secs` is clamped to a minimum of 0.1 s so a misconfigured 0 cannot generate hundreds of thousands of windows per segment.
- `SpeakerEmbedding` gains a `count: u32` field and an online-mean centroid update on match. The previous code anchored each speaker on a single first-utterance embedding, which drifted on long recordings.
- `MlDiarizer::diarize` now splits each transcript segment into 4 s sub-windows (2 s hop by default), embeds each, votes by majority for the segment's speaker, hoists the state mutex once per segment, and breaks tied votes deterministically by lowest `SpeakerId::Auto(n)` (first-seen wins).
- `DiarizationConfig` and `[meeting.diarization]` gain four backward-compatible serde-defaulted knobs:

  | Field | Default | Purpose |
  |---|---|---|
  | `similarity_threshold` | `0.25` | cosine sim for matching new embeddings to existing speakers |
  | `vad_window_secs` | `4.0` | ECAPA sub-window length |
  | `vad_hop_secs` | `2.0` | sub-window hop |
  | `vad_rms_floor` | `0.005` | silence gate |

  All four are no-ops when `backend != "ml"`.

## Validation

Empirical sweep against five YouTube clips covering different speaker counts and conditions:

| Source | Duration | Expected | Detected @ default 0.25 |
|---|---|---|---|
| EN 4-person roundtable | 2:00 | 4 | **4** |
| HU 3-person | 2:00 | 3 | **3** (1 single-window blip) |
| 1 h talk | 58:05 | unknown | **5** (4 stable + 1 noise) |
| EN 4-person podcast | 22:41 | 4 | 3 at 0.25; **4** at 0.30 |
| 10-person Google Meet | 1:17:21 | 10 | **10** with plausible time distribution |

For studio recordings with similar voices, raising `similarity_threshold` to 0.30–0.35 hits the right count. The defaults are conservative enough for noisier real-meeting audio.

The 17 unit tests in `meeting::diarization` pass. `cargo build`, `cargo test`, `cargo fmt`, and `cargo clippy` all clean (no new warnings introduced by this PR; three pre-existing warnings remain).

## Known limitations (not addressed here)

- `MlDiarizer` ignores the `_source` argument, so mic and loopback share the same speaker state. If you and a remote sound alike, they can merge at threshold 0.25. Raising the threshold or using `backend = "simple"` are the workarounds.
- First-chunk-wins ordering means `SPEAKER_00` is whoever spoke first; identities aren't stable across meetings.
- Codec asymmetry (Opus-encoded loopback vs raw mic) can shift embeddings slightly even for the same voice.

Follow-up ideas: hybrid backend (source-keyed `You`/`Remote` plus ECAPA only on loopback for multi-remote), pre-enrolled speaker bank, post-meeting agglomerative re-clustering, Silero VAD instead of energy gating, larger embedding model.

## Build note

This PR is independent of PR #341, but the current `dev` tip fails to build on rustc 1.91+ because `src/cpu.rs` calls `std::arch::x86_64::__cpuid` without an `unsafe` block. That's a separate one-line fix not included here. CI on older toolchains should be unaffected.

## Test plan

- [ ] `cargo build --release --features ml-diarization,onnx-load-dynamic` on a host with `onnxruntime-cpu` installed
- [ ] `cargo test --features ml-diarization,onnx-load-dynamic --lib meeting::diarization`
- [ ] Run a 1-on-1 meeting with `backend = "ml"` and verify two clean clusters (You + Remote)
- [ ] Run a multi-person meeting and verify the right number of distinct labels appear
- [ ] Verify users on `backend = "simple"` or `"remote"` see no behavior change (the new knobs are silently ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)