### PR TITLE
cpu: wrap __cpuid call in unsafe block for rustc 1.91+

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -86,7 +86,7 @@ pub fn is_running_in_vm() -> bool {
     // CPUID leaf 1, ECX bit 31 is the hypervisor present bit
     #[cfg(target_arch = "x86_64")]
     {
-        let result = std::arch::x86_64::__cpuid(1);
+        let result = unsafe { std::arch::x86_64::__cpuid(1) };
         (result.ecx & (1 << 31)) != 0
     }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -86,6 +86,7 @@ pub fn is_running_in_vm() -> bool {
     // CPUID leaf 1, ECX bit 31 is the hypervisor present bit
     #[cfg(target_arch = "x86_64")]
     {
+        #[allow(unused_unsafe)]
         let result = unsafe { std::arch::x86_64::__cpuid(1) };
         (result.ecx & (1 << 31)) != 0
     }


### PR DESCRIPTION
## Summary

- Wraps `std::arch::x86_64::__cpuid(1)` inside `is_running_in_vm` in an `unsafe` block.
- Rustc 1.91 turned the implicit-unsafe diagnostic on intrinsic calls into a hard error, so the previous form fails to build on current stable. Older toolchains still accept the explicit `unsafe` block, so this is forward- and backward-compatible.

## Test plan

- [x] `cargo check` succeeds locally on rustc 1.91+.
- [ ] CI build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)