### PR TITLE
Add --diarization flag to meeting start for per-meeting backend switch

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -800,6 +800,16 @@ pub enum MeetingAction {
         /// Meeting title (optional)
         #[arg(long, short)]
         title: Option<String>,
+
+        /// Diarization backend override for this meeting only.
+        ///
+        /// `simple` attributes by audio source (You vs Remote) — best for 1:1 calls.
+        /// `ml` uses ONNX speaker embeddings for multi-speaker meetings (requires
+        /// the `ml-diarization` feature and the ECAPA-TDNN model).
+        ///
+        /// When omitted, falls back to `[meeting.diarization].backend` in config.
+        #[arg(long, value_parser = ["simple", "ml"], env = "VOXTYPE_MEETING_DIARIZATION")]
+        diarization: Option<String>,
     },
     /// Stop the current meeting
     Stop,
@@ -2285,6 +2295,85 @@ mod tests {
                 assert_eq!(action.smart_auto_submit_override(), None);
             }
             _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn test_meeting_start_diarization_simple_flag() {
+        let cli = Cli::parse_from(["voxtype", "meeting", "start", "--diarization", "simple"]);
+        match cli.command {
+            Some(Commands::Meeting {
+                action: MeetingAction::Start { diarization, .. },
+            }) => {
+                assert_eq!(diarization.as_deref(), Some("simple"));
+            }
+            _ => panic!("Expected Meeting Start command"),
+        }
+    }
+
+    #[test]
+    fn test_meeting_start_diarization_ml_flag() {
+        let cli = Cli::parse_from([
+            "voxtype",
+            "meeting",
+            "start",
+            "--diarization",
+            "ml",
+            "--title",
+            "standup",
+        ]);
+        match cli.command {
+            Some(Commands::Meeting {
+                action: MeetingAction::Start { diarization, title },
+            }) => {
+                assert_eq!(diarization.as_deref(), Some("ml"));
+                assert_eq!(title.as_deref(), Some("standup"));
+            }
+            _ => panic!("Expected Meeting Start command"),
+        }
+    }
+
+    #[test]
+    fn test_meeting_start_diarization_rejects_invalid() {
+        let result = Cli::try_parse_from(["voxtype", "meeting", "start", "--diarization", "bogus"]);
+        assert!(
+            result.is_err(),
+            "clap should reject diarization values outside [\"simple\", \"ml\"]"
+        );
+    }
+
+    /// Env-var wiring is exercised together with the "no override" case in a
+    /// single test to avoid `VOXTYPE_MEETING_DIARIZATION` leaking between
+    /// tests that run in parallel — env vars are process-global, so two
+    /// independent #[test] functions would race.
+    #[test]
+    fn test_meeting_start_diarization_env_and_default() {
+        // Make sure no stale value is set from the host or a sibling test.
+        std::env::remove_var("VOXTYPE_MEETING_DIARIZATION");
+
+        // No flag, no env var → no override.
+        let cli = Cli::parse_from(["voxtype", "meeting", "start"]);
+        match cli.command {
+            Some(Commands::Meeting {
+                action: MeetingAction::Start { diarization, title },
+            }) => {
+                assert_eq!(diarization, None);
+                assert_eq!(title, None);
+            }
+            _ => panic!("Expected Meeting Start command"),
+        }
+
+        // Env var alone should be picked up by clap's #[arg(env = ...)].
+        std::env::set_var("VOXTYPE_MEETING_DIARIZATION", "ml");
+        let cli = Cli::parse_from(["voxtype", "meeting", "start"]);
+        std::env::remove_var("VOXTYPE_MEETING_DIARIZATION");
+        match cli.command {
+            Some(Commands::Meeting {
+                action: MeetingAction::Start { diarization, .. },
+            }) => {
+                assert_eq!(diarization.as_deref(), Some("ml"));
+            }
+            _ => panic!("Expected Meeting Start command"),
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -357,25 +357,72 @@ fn cleanup_bool_override(name: &str) {
 
 // === Meeting Mode IPC ===
 
-/// Check for meeting start command (via file trigger)
-fn check_meeting_start() -> Option<Option<String>> {
-    let start_file = Config::runtime_dir().join("meeting_start");
-    if start_file.exists() {
-        // Read optional title from file content
-        let title = std::fs::read_to_string(&start_file).ok().and_then(|s| {
-            let trimmed = s.trim();
+/// A pending meeting-start trigger with optional title and diarization override.
+struct MeetingStartTrigger {
+    title: Option<String>,
+    diarization: Option<String>,
+}
+
+/// Read a file and return its trimmed contents, or None if missing or empty.
+///
+/// Logs read failures so transient FS / permission errors aren't silent: a
+/// trigger file existing but being unreadable previously looked identical to
+/// "no file" and would then be consumed by the caller's remove_file.
+fn read_trimmed_nonempty(path: &std::path::Path) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let trimmed = contents.trim();
             if trimmed.is_empty() {
                 None
             } else {
                 Some(trimmed.to_string())
             }
-        });
-        // Remove the file to acknowledge the command
-        let _ = std::fs::remove_file(&start_file);
-        Some(title)
-    } else {
-        None
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            tracing::warn!(path = %path.display(), error = %err, "Failed to read IPC trigger file");
+            None
+        }
     }
+}
+
+/// Allowed diarization backend override values from the CLI handler. Kept in
+/// sync with the `value_parser` list on `MeetingAction::Start::diarization`.
+const ALLOWED_DIARIZATION_OVERRIDES: &[&str] = &["simple", "ml"];
+
+/// Check for meeting start command (via file trigger)
+fn check_meeting_start() -> Option<MeetingStartTrigger> {
+    let runtime_dir = Config::runtime_dir();
+    let start_file = runtime_dir.join("meeting_start");
+    if !start_file.exists() {
+        return None;
+    }
+
+    let title = read_trimmed_nonempty(&start_file);
+
+    // Diarization override is written by the CLI handler before the start
+    // trigger. Clap validates the CLI arg, but the daemon trusts a runtime
+    // file written by an arbitrary process, so re-check against the allowlist
+    // here and drop unknown values with a warning.
+    let diarization_file = runtime_dir.join("meeting_start_diarization");
+    let diarization = read_trimmed_nonempty(&diarization_file).and_then(|value| {
+        if ALLOWED_DIARIZATION_OVERRIDES.contains(&value.as_str()) {
+            Some(value)
+        } else {
+            tracing::warn!(
+                value = %value,
+                "Ignoring unknown diarization override; expected one of {:?}",
+                ALLOWED_DIARIZATION_OVERRIDES
+            );
+            None
+        }
+    });
+    let _ = std::fs::remove_file(&diarization_file);
+
+    // Remove the start trigger last to acknowledge the command.
+    let _ = std::fs::remove_file(&start_file);
+
+    Some(MeetingStartTrigger { title, diarization })
 }
 
 /// Check for meeting stop command (via file trigger)
@@ -416,6 +463,7 @@ fn cleanup_meeting_files() {
     let runtime_dir = Config::runtime_dir();
     for name in &[
         "meeting_start",
+        "meeting_start_diarization",
         "meeting_stop",
         "meeting_pause",
         "meeting_resume",
@@ -1163,22 +1211,32 @@ impl Daemon {
     }
 
     /// Start a new meeting
-    async fn start_meeting(&mut self, title: Option<String>) -> Result<()> {
+    async fn start_meeting(
+        &mut self,
+        title: Option<String>,
+        diarization_override: Option<String>,
+    ) -> Result<()> {
         if self.meeting_daemon.is_some() {
             tracing::warn!("Meeting already in progress");
             return Ok(());
         }
 
+        // CLI override (validated against ["simple", "ml"] by clap) wins over config.
+        let backend = diarization_override
+            .clone()
+            .unwrap_or_else(|| self.config.meeting.diarization.backend.clone());
+
         // Create meeting config from main config
         tracing::debug!(
-            "Diarization config: enabled={}, backend={}",
+            "Diarization config: enabled={}, backend={} (override={:?})",
             self.config.meeting.diarization.enabled,
-            self.config.meeting.diarization.backend
+            backend,
+            diarization_override
         );
         let diarization_config = if self.config.meeting.diarization.enabled {
             Some(meeting::diarization::DiarizationConfig {
                 enabled: true,
-                backend: self.config.meeting.diarization.backend.clone(),
+                backend,
                 max_speakers: self.config.meeting.diarization.max_speakers,
                 min_segment_ms: self.config.meeting.diarization.min_segment_ms,
                 model_path: self.config.meeting.diarization.model_path.clone(),
@@ -3442,10 +3500,10 @@ impl Daemon {
                 // Poll for meeting commands (file-based IPC)
                 _ = tokio::time::sleep(Duration::from_millis(100)) => {
                     // Check for meeting start command
-                    if let Some(title) = check_meeting_start() {
+                    if let Some(trigger) = check_meeting_start() {
                         if self.config.meeting.enabled && self.meeting_daemon.is_none() {
                             tracing::debug!("Meeting start requested via file trigger");
-                            if let Err(e) = self.start_meeting(title).await {
+                            if let Err(e) = self.start_meeting(trigger.title, trigger.diarization).await {
                                 tracing::error!("Failed to start meeting: {}", e);
                             }
                         } else if !self.config.meeting.enabled {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1999,7 +1999,7 @@ async fn run_meeting_command(config: &config::Config, action: MeetingAction) -> 
     };
 
     match action {
-        MeetingAction::Start { title } => {
+        MeetingAction::Start { title, diarization } => {
             // Check if meeting mode is enabled
             if !config.meeting.enabled {
                 eprintln!("Error: Meeting mode is disabled in config.");
@@ -2024,15 +2024,68 @@ async fn run_meeting_command(config: &config::Config, action: MeetingAction) -> 
                 }
             }
 
+            // --diarization ml requires the ml-diarization feature at build
+            // time. Without it the daemon's diarizer factory silently falls
+            // back, leaving the CLI's "(diarization backend: ml)" exit
+            // message a lie. Reject the request up front with a pointer to
+            // the binaries that DO carry ml-diarization.
+            if diarization.as_deref() == Some("ml") && !cfg!(feature = "ml-diarization") {
+                eprintln!("Error: --diarization ml requested but this binary was not built with");
+                eprintln!(
+                    "  the `ml-diarization` feature. ECAPA-TDNN diarization is shipped in the"
+                );
+                eprintln!(
+                    "  ONNX binaries (voxtype-onnx-avx2, voxtype-onnx-avx512, voxtype-onnx-cuda-*,"
+                );
+                eprintln!(
+                    "  voxtype-onnx-migraphx). Install one of those, or omit --diarization to"
+                );
+                eprintln!("  use the source-based `simple` backend.");
+                std::process::exit(1);
+            }
+
             // Ensure GTCRN speech enhancement model is available
             setup::model::ensure_gtcrn_model();
 
+            // A --diarization override only changes the *backend*; it cannot
+            // turn diarization on when config has disabled it. Warn loudly so
+            // users don't think they're getting speaker labels they aren't.
+            let diarization_active = config.meeting.diarization.enabled;
+            if diarization.is_some() && !diarization_active {
+                eprintln!(
+                    "Warning: --diarization is a backend override and only takes effect when"
+                );
+                eprintln!(
+                    "  [meeting.diarization] enabled = true in config; diarization is disabled,"
+                );
+                eprintln!("  so the override will be ignored for this meeting.");
+            }
+
+            // Write the diarization override first so it's visible by the time
+            // the daemon picks up the start trigger.
+            let runtime_dir = config::Config::runtime_dir();
+            let diarization_file = runtime_dir.join("meeting_start_diarization");
+            if let Some(ref backend) = diarization {
+                std::fs::write(&diarization_file, backend)?;
+            } else {
+                // Clear any stale override left from a prior run.
+                let _ = std::fs::remove_file(&diarization_file);
+            }
+
             // Write start trigger file (with optional title)
-            let start_file = config::Config::runtime_dir().join("meeting_start");
+            let start_file = runtime_dir.join("meeting_start");
             let content = title.unwrap_or_default();
             std::fs::write(&start_file, content)?;
 
-            println!("Meeting start requested. Check status with 'voxtype meeting status'.");
+            let suffix = diarization
+                .as_deref()
+                .filter(|_| diarization_active)
+                .map(|b| format!(" (diarization backend: {})", b))
+                .unwrap_or_default();
+            println!(
+                "Meeting start requested{}. Check status with 'voxtype meeting status'.",
+                suffix
+            );
         }
 
         MeetingAction::Stop => {


### PR DESCRIPTION
## Summary

- Add `--diarization` flag (and `VOXTYPE_MEETING_DIARIZATION` env var) to `voxtype meeting start`, accepting `simple` or `ml`
- CLI writes a sibling trigger file `meeting_start_diarization` *before* the existing `meeting_start` trigger; the daemon reads both atomically and overrides `[meeting.diarization].backend` for that meeting only
- Refactor `check_meeting_start` to return a `MeetingStartTrigger { title, diarization }`; extract a small `read_trimmed_nonempty` helper used by both fields

## Why

The diarization backend was only configurable via the config file, which made the choice static. In real use, the right backend depends on the meeting:

- **1:1 calls** — ML diarization is overkill and can over-fragment the transcript across "speakers" that are really just the same person at different acoustic distances from the mic. Source-based attribution (`simple` → You vs Remote) is the safer baseline.
- **Multi-person meetings** — `ml` actually earns its complexity.

Real usage flips between these case by case, so the choice belongs on the CLI, not in a config file.

## Usage

\`\`\`bash
voxtype meeting start --diarization simple        # 1:1, You vs Remote
voxtype meeting start --diarization ml --title "team standup"
VOXTYPE_MEETING_DIARIZATION=ml voxtype meeting start
\`\`\`

Omitting the flag falls back to \`[meeting.diarization].backend\` in config — existing setups are unchanged.

## Implementation notes

- Validation lives in clap (\`value_parser = [\"simple\", \"ml\"]\`); the daemon trusts the file contents on read.
- Write order is load-bearing: diarization sibling file is written first so the daemon never observes \`meeting_start\` without the override having been visible already.
- \`cleanup_meeting_files\` includes the new trigger so a crashed CLI invocation can't leak a stale override into the next meeting.
- \`start_meeting\` signature grew one optional param; the override is applied on top of config when present.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean (default features)
- [x] \`cargo build --features ml-diarization,onnx-load-dynamic\` builds
- [x] \`cargo test --lib meeting::\` passes (175)
- [x] \`cargo test --lib config::\` passes (85)
- [x] \`cargo test --lib --features ml-diarization,onnx-load-dynamic meeting::\` passes (180)
- [x] \`voxtype meeting start --help\` shows the new flag with possible values + env var
- [ ] Manual: start a meeting with \`--diarization simple\` on a 1:1 call, verify transcript shows \"You\" / \"Remote\"
- [ ] Manual: start a meeting with \`--diarization ml\` on a multi-speaker call, verify SPEAKER_NN labels
- [ ] Manual: omit the flag, verify config default still applies
- [ ] Manual: set \`VOXTYPE_MEETING_DIARIZATION=ml\` and confirm it's picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)