### PR TITLE
fix: support per-language XKB variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ type_delay_ms = 0   # Increase if characters are dropped
 # auto_submit = true  # Send Enter after transcription (for chat apps, terminals)
 # Note: "paste" mode copies to clipboard then simulates Ctrl+V
 #       Useful for non-US keyboard layouts where ydotool typing fails
+# For multilingual layouts with variants through direct dotool fallback:
+# [output.language_to_variant]
+# ru = "phonetic"
+# dotoolc does not work with variants and cannot receive these hints. When
+# using dotool, switch your desktop layout to Russian phonetic before dictating.
 
 [output.notification]
 on_recording_start = false  # Notify when PTT activates
@@ -602,6 +607,13 @@ which wtype dotool ydotool
 # In ~/.config/voxtype/config.toml:
 # [output]
 # dotool_xkb_layout = "de"  # Your layout (de, fr, es, etc.)
+# dotool_xkb_variant = "nodeadkeys"  # Optional fixed variant; uses direct dotool
+#
+# For multilingual dictation, prefer per-language variants through direct dotool:
+# [output.language_to_variant]
+# ru = "phonetic"
+# dotoolc does not work with variants and cannot receive these hints. Also
+# switch your desktop layout to the target layout before dictating.
 
 # If using ydotool fallback (X11/TTY), start the daemon:
 systemctl --user start ydotool
@@ -668,7 +680,7 @@ flowchart LR
 
 **Fallback: evdev hotkey.** For X11 or compositors without key-release support, voxtype includes a built-in hotkey using evdev (the Linux input subsystem). This requires the user to be in the `input` group.
 
-**Why wtype + dotool + ydotool?** On Wayland, wtype uses the virtual-keyboard protocol for text input, with excellent Unicode/CJK support and no daemon required. When wtype fails (KDE/GNOME), dotool provides keyboard layout support via XKB for non-US layouts. As a final fallback, ydotool uses uinput for text injection on X11/TTY. This combination ensures Voxtype works on any Linux desktop with proper keyboard layout support.
+**Why wtype + dotool + ydotool?** On Wayland, wtype uses the virtual-keyboard protocol for text input, with excellent Unicode/CJK support and no daemon required. When wtype fails (KDE/GNOME), direct dotool fallback provides keyboard layout support via XKB for non-US layouts. As a final fallback, ydotool uses uinput for text injection on X11/TTY. This combination ensures Voxtype works on any Linux desktop with proper keyboard layout support.
 
 **Post-processing.** Transcriptions can optionally be piped through an external command before output. Use this to integrate local LLMs (Ollama, llama.cpp) for grammar correction, text expansion, or domain-specific vocabulary. Any command that reads stdin and writes stdout works.
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -139,6 +139,16 @@ mode = "type"
 # Fall back to clipboard if typing fails
 fallback_to_clipboard = true
 
+# Per-language XKB layout variants for multilingual dictation.
+# Use this with language arrays such as `language = ["en", "ru"]` when a
+# language needs a variant that should not apply to other languages.
+# Built-in layout defaults already include `ru = "ru"` in language_to_layout.
+# dotoolc does not work with variants and cannot receive these hints; voxtype
+# uses direct dotool for them. Switch your desktop layout to the target
+# layout/variant before dictating; dotool does not change the active layout.
+# [output.language_to_variant]
+# ru = "phonetic"
+
 # Delay between typed characters in milliseconds
 # 0 = fastest possible, increase if characters are dropped
 type_delay_ms = 0

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1622,7 +1622,13 @@ file_mode = "append"
 wtype does not work on KDE Plasma or GNOME Wayland because these compositors don't support the virtual keyboard protocol. On these desktops, voxtype automatically falls back to dotool (if installed) or ydotool. For ydotool, the daemon must be running (`systemctl --user enable --now ydotool`). See [Troubleshooting](TROUBLESHOOTING.md#wtype-not-working-on-kde-plasma-or-gnome-wayland) for details.
 
 **Note about non-US keyboard layouts:**
-For non-US keyboard layouts (German QWERTZ, French AZERTY, etc.), dotool is recommended over ydotool. Set `dotool_xkb_layout` to your layout code (e.g., `"de"` for German). ydotool does not support keyboard layouts and will produce incorrect characters (e.g., 'y' and 'z' swapped on German layouts).
+For non-US keyboard layouts (German QWERTZ, French AZERTY, etc.), dotool is recommended over ydotool. Set `dotool_xkb_layout` to your layout code (e.g., `"de"` for German) when using direct dotool fallback. ydotool does not support keyboard layouts and will produce incorrect characters (e.g., 'y' and 'z' swapped on German layouts).
+
+For multilingual dictation, prefer `language_to_layout` and
+`language_to_variant` so voxtype can use the right keymap for each
+transcription through direct dotool fallback. `dotoolc` does not work with
+voxtype's variants. When using dotool, you must also switch the active desktop
+keyboard layout to the language/variant you want to type in.
 
 **Note about paste mode:**
 The `paste` mode is an alternative for non-US keyboard layouts. Instead of typing characters directly, it copies text to the clipboard and simulates a paste keystroke. This works regardless of keyboard layout but overwrites your clipboard. Requires wl-copy for clipboard access.
@@ -1723,7 +1729,7 @@ Custom order of output drivers to try when `mode = "type"`. Each driver is tried
 **Available drivers:**
 - `wtype` - Wayland virtual keyboard protocol (best CJK/Unicode support, wlroots compositors only)
 - `eitype` - Wayland via libei/EI protocol (works on GNOME, KDE, and compositors with libei support). On KDE Plasma 6, each invocation briefly registers via the XDG RemoteDesktop portal, which can cause a system-tray icon to flicker during streaming dictation (many fast typing calls). Prefer `dotool` for streaming if you're on KDE.
-- `dotool` - uinput-based typing (supports keyboard layouts, works on X11/Wayland/TTY). For streaming backends (Parakeet, Soniox), run `dotoold` to make this **much** faster — see [Streaming performance: dotoold fast path](#streaming-performance-dotoold-fast-path) below.
+- `dotool` - uinput-based typing (supports keyboard layouts, works on X11/Wayland/TTY). For streaming backends (Parakeet, Soniox), run `dotoold` to make this **much** faster when no per-call layout or variant hint is needed — see [Streaming performance: dotoold fast path](#streaming-performance-dotoold-fast-path) below.
 - `ydotool` - uinput-based typing (requires `ydotoold` daemon, X11/Wayland/TTY). Fast spawn, but **does not support keyboard layouts** — sends raw US keycodes. Wrong output on non-US layouts (e.g. Hungarian Z/Y swap).
 - `clipboard` - Wayland clipboard via wl-copy
 - `xclip` - X11 clipboard via xclip
@@ -1761,7 +1767,7 @@ voxtype --driver=ydotool,clipboard daemon
 
 Streaming backends (Parakeet, Soniox) call the output driver many times per session — once for every partial token batch. With direct `dotool` invocations each call spawns a fresh dotool process that pays the kernel uinput device setup cost (**~700-800ms** on most systems). For 60+ partials per session this stacks into 40+ seconds of typing latency — unusable.
 
-dotool ships a daemon/client pair (`dotoold` + `dotoolc`) specifically for this case. When `dotoold` is running, voxtype auto-detects its FIFO at `/tmp/dotool-pipe` and routes every typing call through `dotoolc`, which simply relays commands to the long-lived daemon. The uinput device is registered **once** at daemon startup, not on every typed segment. Sub-10ms per call.
+dotool ships a daemon/client pair (`dotoold` + `dotoolc`) specifically for this case. When `dotoold` is running and voxtype has no per-call XKB layout or variant hint, voxtype auto-detects its FIFO at `/tmp/dotool-pipe` and routes typing through `dotoolc`, which simply relays commands to the long-lived daemon. The uinput device is registered **once** at daemon startup, not on every typed segment. Sub-10ms per call.
 
 **Strongly recommended** if you use `dotool` as your primary typing driver with any streaming backend.
 
@@ -1777,9 +1783,10 @@ After=default.target
 
 [Service]
 ExecStart=/usr/bin/dotoold
-# Set DOTOOL_XKB_LAYOUT here (NOT in voxtype) — layout applies to the
-# daemon, not the per-call client. voxtype's dotool_xkb_layout config
-# is ignored when routing through dotoolc.
+# Set DOTOOL_XKB_LAYOUT here when you want the dotoold fast path with one
+# fixed dotool keymap. dotoolc does not work with variants and cannot receive
+# voxtype's per-call XKB hints, so voxtype uses direct dotool instead whenever
+# it needs a layout or variant hint.
 Environment=DOTOOL_XKB_LAYOUT=hu
 Restart=on-failure
 
@@ -1805,9 +1812,24 @@ After dictating a session, check the daemon log:
 journalctl --user -u voxtype --since "5 min ago" | grep "typed via"
 ```
 - `Text typed via dotoolc (N chars)` — fast path active
-- `Text typed via dotool (N chars)` — daemon not running, slow per-call spawn
+- `Text typed via dotool (N chars)` — direct path; either the daemon is not running or voxtype had a per-call XKB hint
 
-**Important caveat:** Keyboard layout (`DOTOOL_XKB_LAYOUT` / `DOTOOL_XKB_VARIANT`) applies to **the daemon, not the client**. When dotoold is running, voxtype's `dotool_xkb_layout` config setting has no effect — set the env var in dotoold's unit file or shell instead.
+The layout setting for the fast path applies to **the daemon, not the client**.
+If you need the `dotoold` fast path with one fixed layout, set
+`DOTOOL_XKB_LAYOUT` in dotoold's unit file or shell and leave voxtype's dotool
+XKB fields unset.
+
+`dotoolc` does not work with variants and cannot receive voxtype's per-call XKB
+hints. When voxtype has a per-call XKB layout or variant hint, it bypasses
+`dotoolc` and invokes direct `dotool` so the hint is used for text-to-key
+lookup.
+
+**Important direct-dotool caveat:** direct dotool's keyboard layout
+(`DOTOOL_XKB_LAYOUT` / `DOTOOL_XKB_VARIANT`) only controls how dotool converts
+text to key events. It does **not** switch the active desktop/compositor layout.
+If the focused app is still using an English layout, Russian phonetic key events
+will be interpreted as English letters. Switch your desktop layout to the target
+layout/variant before dictating.
 
 ### dotool_xkb_layout
 
@@ -1815,9 +1837,18 @@ journalctl --user -u voxtype --since "5 min ago" | grep "typed via"
 **Default:** None
 **Required:** No
 
-Keyboard layout for dotool output driver. Required for non-US keyboard layouts (German, French, etc.) when using dotool as the typing backend.
+Keyboard layout for direct dotool fallback. Required for non-US keyboard
+layouts (German, French, etc.) when using dotool as the typing backend.
 
-dotool is automatically used as a fallback when wtype fails (e.g., on GNOME/KDE Wayland). Unlike ydotool, dotool supports keyboard layouts via XKB environment variables.
+dotool is automatically used as a fallback when wtype fails (e.g., on GNOME/KDE Wayland). Unlike ydotool, direct dotool fallback supports keyboard layouts via XKB environment variables.
+
+This setting tells direct `dotool` which XKB keymap to use when converting
+Unicode text to physical key events. Setting it in voxtype makes voxtype use
+direct `dotool` instead of the `dotoolc` fast path, because `dotoolc` does not
+work with variants and cannot receive voxtype's per-call XKB hints.
+
+It does not change the active desktop layout. Before dictating with dotool,
+switch your desktop/compositor to the same layout.
 
 **Common values:**
 - `"de"` - German (QWERTZ)
@@ -1839,7 +1870,13 @@ dotool_xkb_layout = "de"  # German keyboard layout
 **Default:** None
 **Required:** No
 
-Keyboard layout variant for dotool. Use this for layout variations like `nodeadkeys`.
+Keyboard layout variant for direct dotool fallback. Use this for layout
+variations like `nodeadkeys`.
+
+`dotoolc` does not work with variants. Setting this in voxtype makes
+voxtype use direct `dotool` so the variant can be passed to that invocation.
+As with `dotool_xkb_layout`, this configures dotool's key lookup only. The
+active desktop layout must already be using the same variant.
 
 **Example:**
 ```toml
@@ -1893,12 +1930,19 @@ Maps detected language codes (ISO 639-1, e.g. `en`, `ru`, `de`) to XKB
 keyboard layout codes (e.g. `us`, `ru`, `de`). When a transcriber reports the
 language used for a transcription and neither `eitype_xkb_layout` nor
 `dotool_xkb_layout` is set, voxtype looks the language up in this map and
-passes the resulting layout to eitype/dotool for that transcription only.
+passes the resulting layout hint to eitype/dotool for that transcription.
 
 This is what makes the multi-language case from issue #180 work
 end-to-end: with `language = ["en", "ru"]` and `driver_order = ["eitype"]`,
 voxtype detects the spoken language, looks it up here, and tells eitype
 to type with the right keyboard layout.
+
+For dotool, this map chooses the keymap used by direct dotool fallback to
+convert text into key events. `dotoolc` does not work with variants and cannot
+receive voxtype's per-call XKB hints, so voxtype bypasses `dotoolc` for those
+calls. This does not switch the active desktop layout. If you use dotool for
+Russian phonetic typing, switch your desktop layout to Russian phonetic before
+dictating Russian.
 
 **Built-in defaults include:**
 - `en = "us"` (English)
@@ -1936,6 +1980,41 @@ inference entirely; eitype/dotool will use whatever explicit
 [output.language_to_layout]
 # (empty)
 ```
+
+### language_to_variant
+
+**Type:** Table (map of two-letter language code to XKB layout variant)
+**Default:** Empty
+
+Maps detected language codes to XKB layout variants for that language. Use this
+when a language needs a variant, but that variant must not apply to every
+language you dictate.
+
+This is useful for Russian phonetic typing:
+
+```toml
+[whisper]
+language = ["en", "ru"]
+
+[output.language_to_layout]
+en = "us"
+ru = "ru"
+
+[output.language_to_variant]
+ru = "phonetic"
+```
+
+When Russian is detected, voxtype passes `ru` plus `phonetic` to eitype or
+direct dotool fallback. When English is detected, it passes `us` with no
+variant. `dotoolc` does not work with variants and cannot receive voxtype's
+per-call XKB hints, so voxtype bypasses it for these calls. With dotool, also
+switch the active desktop layout before dictating; otherwise the focused app
+will interpret the key events using whatever layout is currently active.
+
+Explicit driver settings still win. For example, `dotool_xkb_variant =
+"nodeadkeys"` prevents `language_to_variant` from changing dotool's key lookup
+variant, but eitype can still use the per-language variant if
+`eitype_xkb_variant` is unset.
 
 ### file_path
 

--- a/docs/SONIOX.md
+++ b/docs/SONIOX.md
@@ -160,7 +160,16 @@ See [CONFIGURATION.md → [soniox]](CONFIGURATION.md#soniox) for the full field-
 
 Streaming output calls the typing driver many times per session (~60 partials for typical dictation). With direct `dotool` invocations each call spawns a fresh dotool process that pays ~700ms of uinput device setup — stacking to 40+ seconds of typing latency per session.
 
-**Strongly recommended:** run `dotoold` so voxtype routes through `dotoolc` (sub-10ms per call). See [Streaming performance: dotoold fast path](CONFIGURATION.md#streaming-performance-dotoold-fast-path) for the systemd user unit template.
+**Strongly recommended:** run `dotoold` so voxtype can route calls without
+per-call XKB hints through `dotoolc` (sub-10ms per call). `dotoolc` does not
+work with variants and cannot receive voxtype's per-call XKB hints, so hinted
+layout/variant calls use direct `dotool` instead. See
+[Streaming performance: dotoold fast path](CONFIGURATION.md#streaming-performance-dotoold-fast-path)
+for the systemd user unit template.
+
+If you rely on direct dotool layout or variant hints for non-English text,
+switch the active desktop layout to the matching layout before dictating.
+dotool sends key events; it does not change the focused app's active layout.
 
 If you're on KDE Plasma and see system-tray flicker during streaming, that's the `eitype` driver triggering the RemoteDesktop portal security indicator on each invocation. Prefer `dotool` (via dotoold) in your `[output] driver_order`.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -496,7 +496,7 @@ Look for log messages about speech detection to understand what VAD is doing wit
 
 **What happens:** Voxtype detects this failure and automatically falls back to dotool, then ydotool. If neither is set up, it falls back to clipboard mode.
 
-**Solution 1 (Recommended):** Install dotool. Unlike ydotool, dotool does not require a daemon and supports keyboard layouts for non-US keyboards:
+**Solution 1 (Recommended):** Install dotool. Unlike ydotool, direct dotool fallback does not require a daemon and supports keyboard layouts for non-US keyboards:
 
 ```bash
 # 1. Install dotool (check your distribution's package manager)
@@ -571,7 +571,7 @@ ERROR Output failed: All output methods failed.
 
 **Option 1 (Recommended): Install dotool**
 
-dotool works on X11, supports keyboard layouts, and doesn't need a daemon:
+direct dotool works on X11, supports keyboard layouts, and doesn't need a daemon:
 
 ```bash
 # Ubuntu/Debian (from source):
@@ -630,7 +630,8 @@ This shows which output tools are installed and available.
 
 **Cause:** ydotool sends raw US keycodes and doesn't support keyboard layouts. When voxtype falls back to ydotool (e.g., on X11, Cinnamon, or when wtype fails), characters are typed as if you had a US keyboard layout.
 
-**Solution:** Install dotool and configure your keyboard layout. Unlike ydotool, dotool supports keyboard layouts via XKB:
+**Solution:** Install dotool and configure your keyboard layout. Unlike
+ydotool, direct dotool fallback supports keyboard layouts via XKB:
 
 ```bash
 # 1. Install dotool
@@ -655,6 +656,10 @@ Add to `~/.config/voxtype/config.toml`:
 dotool_xkb_layout = "de"  # German QWERTZ
 ```
 
+Then switch your desktop/compositor keyboard layout to the same layout before
+dictating. dotool sends key events; it does not switch the active layout for
+the focused app.
+
 Common layout codes:
 - `de` - German (QWERTZ)
 - `fr` - French (AZERTY)
@@ -673,6 +678,28 @@ dotool_xkb_layout = "de"
 dotool_xkb_variant = "nodeadkeys"
 ```
 
+The active desktop layout must use the same variant.
+
+For multilingual dictation, use per-language mappings so the variant only
+applies to the language that needs it. For example, Russian phonetic typing:
+
+```toml
+[whisper]
+language = ["en", "ru"]
+
+[output.language_to_layout]
+en = "us"
+ru = "ru"
+
+[output.language_to_variant]
+ru = "phonetic"
+```
+
+Before dictating Russian through direct dotool fallback, switch the active
+desktop layout to Russian phonetic. If the active layout is still English,
+dotool will send the right key positions for Russian phonetic, but the focused
+app will receive English letters such as `Probuem goworitx po-russki`.
+
 **Alternative:** Use paste mode, which copies text to the clipboard and simulates Ctrl+V. This works regardless of keyboard layout:
 
 ```toml
@@ -684,21 +711,28 @@ mode = "paste"
 
 ---
 
-### eitype: "Character not found in keymap" or wrong characters when transcribing a second language
+### Wrong characters when transcribing a second language
 
-**Symptom:** With `language = ["en", "ru"]` and `driver_order = ["eitype"]`,
-transcribing Russian on a US system layout fails with eitype reporting
-`Character not found in keymap`, or prints garbled text. English
-transcriptions work fine.
+**Symptom:** With `language = ["en", "ru"]`, transcribing Russian on a US
+system layout fails with eitype reporting `Character not found in keymap`, or
+dotool/eitype prints garbled text. English transcriptions work fine.
 
 **Cause:** Before voxtype v0.7.3, the daemon did not pass a layout hint to
 the `eitype` binary. eitype fell back to the system's active XKB layout,
 which lacked the keycodes for Cyrillic (or any non-system language) and so
 either errored or typed the wrong characters. This is issue #180.
 
-**Solution:** Upgrade to voxtype v0.7.3 or later. The daemon now reads the
-language Whisper picked for each transcription and passes it to eitype as
-`-l <layout>`, switching the layout for that call only.
+**Solution:** Upgrade to a version with per-language XKB hints. The daemon
+reads the language Whisper picked for each transcription and passes a matching
+layout/variant hint to eitype or direct dotool fallback for that call.
+
+`dotoolc` does not work with variants and cannot receive voxtype's per-call XKB
+hints, so voxtype uses direct `dotool` for these hinted calls. This hint only
+controls dotool's text-to-key lookup. You must switch the active desktop layout
+to the target language/variant before dictating. If you dictate Russian while
+the active layout is English, the result can look transliterated
+(`Probuem goworitx po-russki`) even though dotool sent the intended key
+positions.
 
 Verify:
 
@@ -706,6 +740,7 @@ Verify:
 voxtype daemon -vv  # debug logs
 # After a Russian transcription you should see:
 # DEBUG Auto layout for eitype: language='ru' -> layout='ru'
+# DEBUG Auto variant for eitype: language='ru' -> variant='phonetic'
 ```
 
 **Forcing a specific layout.** To pin eitype to a fixed layout regardless of
@@ -718,15 +753,19 @@ eitype_xkb_layout = "us"          # or "de", "ru", etc.
 # eitype_xkb_variant = "dvorak"   # optional
 ```
 
-**Customizing the language-to-layout map.** Voxtype ships built-in defaults
-(`en→us`, `ru→ru`, `de→de`, etc.). Layouts that don't match the language code
-(e.g. Brazilian Portuguese uses `br`, not `pt`) need an override in config:
+**Customizing the language-to-layout and variant maps.** Voxtype ships built-in
+layout defaults (`en->us`, `ru->ru`, `de->de`, etc.). Layouts that don't match
+the language code (e.g. Brazilian Portuguese uses `br`, not `pt`) need an
+override in config. Variants are empty by default because they are user-specific:
 
 ```toml
 [output.language_to_layout]
 en = "us"
 pt = "br"
 ru = "ru"
+
+[output.language_to_variant]
+ru = "phonetic"
 ```
 
 See `docs/CONFIGURATION.md` for the full list of built-in defaults and merge
@@ -1010,7 +1049,10 @@ driver_order = ["dotool", "ydotool", "eitype", "clipboard"]
 
 You're hitting dotool's uinput init cost (~700ms) on every output call. With 60+ partials per session this stacks into 40+ seconds.
 
-**Fix:** run `dotoold` once at login. voxtype auto-detects its FIFO and routes through `dotoolc`, paying the init cost once for the daemon's lifetime instead of per call. Sub-10ms per typed segment.
+**Fix:** run `dotoold` once at login. When there is no per-call XKB hint,
+voxtype auto-detects its FIFO and routes through `dotoolc`, paying the init
+cost once for the daemon's lifetime instead of per call. Sub-10ms per typed
+segment.
 
 See [Streaming performance: dotoold fast path](CONFIGURATION.md#streaming-performance-dotoold-fast-path) in CONFIGURATION.md for the systemd user unit template.
 
@@ -1019,13 +1061,16 @@ To verify the fast path is active after dictation:
 journalctl --user -u voxtype --since "5 min ago" | grep "typed via"
 ```
 - `Text typed via dotoolc (N chars)` — fast path
-- `Text typed via dotool (N chars)` — slow path; daemon not running
+- `Text typed via dotool (N chars)` — direct path; daemon not running or voxtype had a per-call XKB hint
 
 ### Wrong keyboard layout when dotoold is running
 
-dotool's layout setting applies to **the daemon, not the client**. Voxtype's `dotool_xkb_layout` config has no effect on commands routed through `dotoolc` — the layout is whatever dotoold inherits from its own environment.
+dotool's layout setting applies to **the daemon, not the client**. When voxtype
+has no per-call XKB hint, commands routed through `dotoolc` use whatever
+layout dotoold inherited from its own environment.
 
-**Fix:** set `DOTOOL_XKB_LAYOUT` in dotoold's startup environment:
+**Fix for one fixed layout:** set `DOTOOL_XKB_LAYOUT` in dotoold's startup
+environment and leave voxtype's dotool XKB fields unset:
 
 ```bash
 # In your systemd user unit:
@@ -1034,6 +1079,12 @@ Environment=DOTOOL_XKB_LAYOUT=hu
 # Then:
 systemctl --user daemon-reload && systemctl --user restart dotoold
 ```
+
+For per-language layouts or variants, configure `language_to_layout` /
+`language_to_variant` in voxtype. `dotoolc` does not work with variants and
+cannot receive voxtype's per-call XKB hints, so voxtype will use direct
+`dotool` instead of `dotoolc` for those calls. You still need to switch the
+active desktop layout to the same language/variant before dictating.
 
 ### PTT auto-promoted to toggle every time you start the daemon
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,6 +183,13 @@ fallback_to_clipboard = true
 #   driver_order = ["ydotool"]
 # driver_order = ["wtype", "dotool", "ydotool", "clipboard"]
 
+# Per-language XKB layout variants for multilingual dictation.
+# Use this with language arrays such as `language = ["en", "ru"]` when a
+# language needs a variant that should not apply to other languages.
+# Built-in layout defaults already include `ru = "ru"` in language_to_layout.
+# [output.language_to_variant]
+# ru = "phonetic"
+
 # Delay between typed characters in milliseconds
 # 0 = fastest possible, increase if characters are dropped
 type_delay_ms = 0
@@ -2032,6 +2039,16 @@ pub struct OutputConfig {
     #[serde(default = "default_language_to_layout")]
     pub language_to_layout: std::collections::HashMap<String, String>,
 
+    /// Mapping from detected language code (two-letter ISO 639-1) to XKB
+    /// keyboard layout variant. Applied per transcription, after
+    /// `language_to_layout`, when no explicit `eitype_xkb_variant` /
+    /// `dotool_xkb_variant` is set.
+    ///
+    /// This is intentionally empty by default. Variants are user-specific
+    /// layout choices (for example, Russian phonetic vs standard).
+    #[serde(default)]
+    pub language_to_variant: std::collections::HashMap<String, String>,
+
     /// File path for file output mode (required when mode = "file")
     /// Also used as default path for --output-file CLI flag
     #[serde(default)]
@@ -2074,6 +2091,29 @@ fn default_modifier_release_timeout_ms() -> u64 {
     750
 }
 
+/// Result of applying a per-language XKB layout/variant hint to output config.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AppliedLanguageXkbHint {
+    /// Layout found in `language_to_layout`, if any.
+    pub layout: Option<String>,
+    /// Variant found in `language_to_variant`, if any.
+    pub variant: Option<String>,
+    /// Whether the layout was applied to eitype for this transcription.
+    pub eitype_layout_applied: bool,
+    /// Whether the layout was applied to dotool for this transcription.
+    pub dotool_layout_applied: bool,
+    /// Whether the variant was applied to eitype for this transcription.
+    pub eitype_variant_applied: bool,
+    /// Whether the variant was applied to dotool for this transcription.
+    pub dotool_variant_applied: bool,
+}
+
+impl AppliedLanguageXkbHint {
+    pub fn is_empty(&self) -> bool {
+        self.layout.is_none() && self.variant.is_none()
+    }
+}
+
 /// Built-in mapping from two-letter ISO 639-1 language codes to XKB layout
 /// codes. Used when the transcriber reports a detected language and the user
 /// has not set an explicit `eitype_xkb_layout` / `dotool_xkb_layout`.
@@ -2103,6 +2143,45 @@ pub fn default_language_to_layout() -> std::collections::HashMap<String, String>
 }
 
 impl OutputConfig {
+    /// Apply per-language XKB layout/variant hints to eitype and dotool.
+    ///
+    /// Explicit driver-specific settings win independently per field:
+    /// `dotool_xkb_layout` prevents only the automatic dotool layout, while
+    /// `dotool_xkb_variant` prevents only the automatic dotool variant.
+    pub fn apply_language_xkb_hint(&mut self, lang: &str) -> AppliedLanguageXkbHint {
+        let layout = self.language_to_layout.get(lang).cloned();
+        let variant = self.language_to_variant.get(lang).cloned();
+        let mut applied = AppliedLanguageXkbHint {
+            layout,
+            variant,
+            ..AppliedLanguageXkbHint::default()
+        };
+
+        if let Some(ref layout) = applied.layout {
+            if self.eitype_xkb_layout.is_none() {
+                self.eitype_xkb_layout = Some(layout.clone());
+                applied.eitype_layout_applied = true;
+            }
+            if self.dotool_xkb_layout.is_none() {
+                self.dotool_xkb_layout = Some(layout.clone());
+                applied.dotool_layout_applied = true;
+            }
+        }
+
+        if let Some(ref variant) = applied.variant {
+            if self.eitype_xkb_variant.is_none() {
+                self.eitype_xkb_variant = Some(variant.clone());
+                applied.eitype_variant_applied = true;
+            }
+            if self.dotool_xkb_variant.is_none() {
+                self.dotool_xkb_variant = Some(variant.clone());
+                applied.dotool_variant_applied = true;
+            }
+        }
+
+        applied
+    }
+
     /// Get the effective pre-type delay, handling deprecated wtype_delay_ms
     pub fn effective_pre_type_delay_ms(&self) -> u32 {
         if self.wtype_delay_ms > 0 {
@@ -2272,6 +2351,7 @@ impl Default for Config {
                 eitype_xkb_layout: None,
                 eitype_xkb_variant: None,
                 language_to_layout: default_language_to_layout(),
+                language_to_variant: HashMap::new(),
                 file_path: None,
                 file_mode: FileMode::default(),
                 restore_clipboard: false,
@@ -4428,6 +4508,7 @@ mod tests {
             cfg.output.language_to_layout.get("en"),
             Some(&"us".to_string())
         );
+        assert!(cfg.output.language_to_variant.is_empty());
         // New eitype layout fields are unset by default; the layout is
         // inferred from the detected language only when both fields are
         // empty (see daemon::handle_transcription_result).
@@ -4497,6 +4578,101 @@ mod tests {
         assert_eq!(
             config.output.language_to_layout.get("en"),
             Some(&"dvorak".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_language_to_variant() {
+        let toml_str = r#"
+            [hotkey]
+            key = "PAUSE"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = ["en", "ru"]
+
+            [output]
+            mode = "type"
+
+            [output.language_to_layout]
+            en = "us"
+            ru = "ru"
+
+            [output.language_to_variant]
+            ru = "phonetic"
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.output.language_to_variant.get("ru"),
+            Some(&"phonetic".to_string())
+        );
+        assert!(!config.output.language_to_variant.contains_key("en"));
+    }
+
+    #[test]
+    fn test_apply_language_xkb_hint_applies_layout_and_variant() {
+        let mut output = Config::default().output;
+        output
+            .language_to_variant
+            .insert("ru".to_string(), "phonetic".to_string());
+
+        let applied = output.apply_language_xkb_hint("ru");
+
+        assert_eq!(applied.layout, Some("ru".to_string()));
+        assert_eq!(applied.variant, Some("phonetic".to_string()));
+        assert!(applied.eitype_layout_applied);
+        assert!(applied.dotool_layout_applied);
+        assert!(applied.eitype_variant_applied);
+        assert!(applied.dotool_variant_applied);
+        assert_eq!(output.eitype_xkb_layout, Some("ru".to_string()));
+        assert_eq!(output.dotool_xkb_layout, Some("ru".to_string()));
+        assert_eq!(output.eitype_xkb_variant, Some("phonetic".to_string()));
+        assert_eq!(output.dotool_xkb_variant, Some("phonetic".to_string()));
+    }
+
+    #[test]
+    fn test_apply_language_xkb_hint_does_not_leak_variant_between_languages() {
+        let mut output = Config::default().output;
+        output
+            .language_to_variant
+            .insert("ru".to_string(), "phonetic".to_string());
+
+        let applied = output.apply_language_xkb_hint("en");
+
+        assert_eq!(applied.layout, Some("us".to_string()));
+        assert_eq!(applied.variant, None);
+        assert_eq!(output.eitype_xkb_layout, Some("us".to_string()));
+        assert_eq!(output.dotool_xkb_layout, Some("us".to_string()));
+        assert_eq!(output.eitype_xkb_variant, None);
+        assert_eq!(output.dotool_xkb_variant, None);
+    }
+
+    #[test]
+    fn test_apply_language_xkb_hint_preserves_explicit_variant() {
+        let mut output = Config::default().output;
+        output.eitype_xkb_variant = Some("explicit-eitype".to_string());
+        output.dotool_xkb_variant = Some("explicit-dotool".to_string());
+        output
+            .language_to_variant
+            .insert("ru".to_string(), "phonetic".to_string());
+
+        let applied = output.apply_language_xkb_hint("ru");
+
+        assert_eq!(applied.variant, Some("phonetic".to_string()));
+        assert!(!applied.eitype_variant_applied);
+        assert!(!applied.dotool_variant_applied);
+        assert_eq!(
+            output.eitype_xkb_variant,
+            Some("explicit-eitype".to_string())
+        );
+        assert_eq!(
+            output.dotool_xkb_variant,
+            Some("explicit-dotool".to_string())
         );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1964,41 +1964,57 @@ impl Daemon {
                         output_config.auto_submit = true;
                     }
 
-                    // Inject a keyboard-layout hint derived from the
+                    // Inject keyboard layout/variant hints derived from the
                     // transcriber's detected language (issue #180). Skipped
-                    // when the user has already set an explicit
-                    // `eitype_xkb_layout` / `dotool_xkb_layout`, so static
-                    // configuration wins over auto-detection. Only the
-                    // `language_to_layout` map is consulted; if the language
-                    // isn't mapped, no hint is applied (eitype/dotool fall
-                    // back to the system layout).
+                    // per field when the user has already set explicit
+                    // `eitype_xkb_*` / `dotool_xkb_*` values, so static
+                    // configuration wins over auto-detection.
                     if let Some(ref transcriber) = active_transcriber {
                         if let Some(lang) = transcriber.last_detected_language() {
-                            if let Some(layout) =
-                                self.config.output.language_to_layout.get(&lang).cloned()
-                            {
-                                if output_config.eitype_xkb_layout.is_none() {
-                                    tracing::debug!(
-                                        "Auto layout for eitype: language='{}' -> layout='{}'",
-                                        lang,
-                                        layout
-                                    );
-                                    output_config.eitype_xkb_layout = Some(layout.clone());
-                                }
-                                if output_config.dotool_xkb_layout.is_none() {
-                                    tracing::debug!(
-                                        "Auto layout for dotool: language='{}' -> layout='{}'",
-                                        lang,
-                                        layout
-                                    );
-                                    output_config.dotool_xkb_layout = Some(layout);
-                                }
-                            } else {
+                            let applied = output_config.apply_language_xkb_hint(&lang);
+                            if applied.is_empty() {
                                 tracing::debug!(
-                                    "No layout mapping for detected language '{}'; \
-                                     not setting a layout hint",
+                                    "No XKB mapping for detected language '{}'; \
+                                     not setting a layout or variant hint",
                                     lang
                                 );
+                            } else {
+                                if applied.eitype_layout_applied {
+                                    if let Some(ref layout) = applied.layout {
+                                        tracing::debug!(
+                                            "Auto layout for eitype: language='{}' -> layout='{}'",
+                                            lang,
+                                            layout
+                                        );
+                                    }
+                                }
+                                if applied.dotool_layout_applied {
+                                    if let Some(ref layout) = applied.layout {
+                                        tracing::debug!(
+                                            "Auto layout for dotool: language='{}' -> layout='{}'",
+                                            lang,
+                                            layout
+                                        );
+                                    }
+                                }
+                                if applied.eitype_variant_applied {
+                                    if let Some(ref variant) = applied.variant {
+                                        tracing::debug!(
+                                            "Auto variant for eitype: language='{}' -> variant='{}'",
+                                            lang,
+                                            variant
+                                        );
+                                    }
+                                }
+                                if applied.dotool_variant_applied {
+                                    if let Some(ref variant) = applied.variant {
+                                        tracing::debug!(
+                                            "Auto variant for dotool: language='{}' -> variant='{}'",
+                                            lang,
+                                            variant
+                                        );
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -1,15 +1,18 @@
 //! dotool-based text output
 //!
-//! Uses dotool to simulate keyboard input with proper keyboard layout support.
-//! Unlike ydotool, dotool respects keyboard layouts via DOTOOL_XKB_LAYOUT.
+//! Uses dotool to simulate keyboard input with keyboard-layout-aware key lookup.
+//! Unlike ydotool, direct `dotool` invocations can respect keyboard layouts
+//! and variants via XKB environment variables when converting text to key
+//! events.
 //!
 //! ## Fast path: dotoold + dotoolc
 //!
 //! dotool ships a daemon/client pair specifically for low-latency repeated
-//! typing. When `dotoold` is running, voxtype detects its FIFO and routes
-//! every output() call through `dotoolc` — which simply relays commands
-//! to the long-lived daemon. The ~700ms uinput device setup is paid once
-//! at daemon startup, not on every typed segment. Sub-10ms per call.
+//! typing. When `dotoold` is running and the current output does not need a
+//! per-call XKB hint, voxtype detects its FIFO and routes output() through
+//! `dotoolc` — which simply relays commands to the long-lived daemon. The
+//! ~700ms uinput device setup is paid once at daemon startup, not on every
+//! typed segment. Sub-10ms per call.
 //!
 //! Strongly recommended for streaming backends (Parakeet, Soniox), where
 //! 60+ output() calls land per session — without the daemon, the first
@@ -17,8 +20,15 @@
 //! installs `dotoold` as a dependency; setup is out of scope here.
 //!
 //! Keyboard layout (`DOTOOL_XKB_LAYOUT`) applies to **the daemon, not the
-//! client**. Set the env var on dotoold's startup; voxtype's
-//! `dotool_xkb_layout` config setting cannot override a running daemon.
+//! client**. For a fixed layout on the fast path, set the env var on dotoold's
+//! startup and leave voxtype's dotool XKB fields unset. `dotoolc` does not
+//! work with variants and cannot receive voxtype's per-call XKB hints, so when
+//! voxtype has an XKB layout or variant hint it bypasses `dotoolc` and invokes
+//! direct `dotool` so dotool uses the requested keymap for text-to-key lookup.
+//!
+//! Important: dotool still sends key events. It does not switch the active
+//! desktop/compositor layout. The user must switch to the layout/variant they
+//! want to type in before dictation.
 //!
 //! ## Fallback path: direct dotool
 //!
@@ -26,13 +36,16 @@
 //! call. This is correct but pays the full uinput init cost (~700ms) on
 //! every typed segment — fine for one-shot batch transcription, painful
 //! for streaming.
+//! This is also the path used when voxtype needs an XKB layout or variant
+//! hint, because direct `dotool` can receive those hints per invocation.
 //!
 //! ## Requirements
 //!
 //! - dotool installed (https://sr.ht/~geb/dotool/)
 //! - User in 'input' group for uinput access
-//! - DOTOOL_XKB_LAYOUT set (on dotoold or in voxtype config) for non-US
-//!   keyboard layouts
+//! - DOTOOL_XKB_LAYOUT set (on dotoold for the fixed-layout fast path, or in
+//!   voxtype config for direct dotool fallback) for non-US keyboard layouts,
+//!   with the matching desktop layout active
 
 use super::TextOutput;
 use crate::error::OutputError;
@@ -41,6 +54,14 @@ use std::process::Stdio;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DotoolInvocation {
+    binary: &'static str,
+    pipe: Option<PathBuf>,
+    set_layout_env: bool,
+    skipped_daemon_for_layout: bool,
+}
 
 /// Truncate a string for log emission, replacing newlines with literal `\n`
 /// so multi-line dotool command streams stay on one log line. Keeps the
@@ -147,6 +168,36 @@ impl DotoolOutput {
 
         commands
     }
+
+    fn has_xkb_override(&self) -> bool {
+        self.xkb_layout.is_some() || self.xkb_variant.is_some()
+    }
+
+    fn choose_invocation(&self, daemon_pipe: Option<PathBuf>) -> DotoolInvocation {
+        if self.has_xkb_override() {
+            return DotoolInvocation {
+                binary: "dotool",
+                pipe: None,
+                set_layout_env: true,
+                skipped_daemon_for_layout: daemon_pipe.is_some(),
+            };
+        }
+
+        match daemon_pipe {
+            Some(pipe) => DotoolInvocation {
+                binary: "dotoolc",
+                pipe: Some(pipe),
+                set_layout_env: false,
+                skipped_daemon_for_layout: false,
+            },
+            None => DotoolInvocation {
+                binary: "dotool",
+                pipe: None,
+                set_layout_env: true,
+                skipped_daemon_for_layout: false,
+            },
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -166,9 +217,12 @@ impl TextOutput for DotoolOutput {
         }
 
         let commands = self.build_commands(text);
-        let pipe = Self::daemon_pipe_path();
-        let binary = if pipe.is_some() { "dotoolc" } else { "dotool" };
-        let set_layout_env = pipe.is_none();
+        let invocation = self.choose_invocation(Self::daemon_pipe_path());
+        if invocation.skipped_daemon_for_layout {
+            tracing::debug!(
+                "dotool: using direct dotool instead of dotoolc so the XKB layout/variant hint is honored"
+            );
+        }
         // Wire trace only at the TRACE level so the user's typed text
         // isn't dumped to logs on the default -vv (DEBUG) verbosity.
         // The dotool command stream contains every typed character.
@@ -180,19 +234,21 @@ impl TextOutput for DotoolOutput {
             );
         }
 
-        let mut cmd = Command::new(binary);
+        let mut cmd = Command::new(invocation.binary);
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::piped());
-        if let Some(ref pipe) = pipe {
+        if let Some(ref pipe) = invocation.pipe {
             cmd.env("DOTOOL_PIPE", pipe);
         }
-        if set_layout_env {
+        if invocation.set_layout_env {
             if let Some(ref layout) = self.xkb_layout {
                 cmd.env("DOTOOL_XKB_LAYOUT", layout);
+                cmd.env("XKB_DEFAULT_LAYOUT", layout);
             }
             if let Some(ref variant) = self.xkb_variant {
                 cmd.env("DOTOOL_XKB_VARIANT", variant);
+                cmd.env("XKB_DEFAULT_VARIANT", variant);
             }
         }
 
@@ -200,14 +256,20 @@ impl TextOutput for DotoolOutput {
             if e.kind() == std::io::ErrorKind::NotFound {
                 OutputError::DotoolNotFound
             } else {
-                OutputError::InjectionFailed(format!("Failed to spawn {}: {}", binary, e))
+                OutputError::InjectionFailed(format!(
+                    "Failed to spawn {}: {}",
+                    invocation.binary, e
+                ))
             }
         })?;
 
         // Write commands to stdin
         if let Some(mut stdin) = child.stdin.take() {
             stdin.write_all(commands.as_bytes()).await.map_err(|e| {
-                OutputError::InjectionFailed(format!("Failed to write to {} stdin: {}", binary, e))
+                OutputError::InjectionFailed(format!(
+                    "Failed to write to {} stdin: {}",
+                    invocation.binary, e
+                ))
             })?;
             // Close stdin to signal end of input
             drop(stdin);
@@ -215,7 +277,7 @@ impl TextOutput for DotoolOutput {
 
         // Wait for dotool to complete
         let output = child.wait_with_output().await.map_err(|e| {
-            OutputError::InjectionFailed(format!("Failed to wait for {}: {}", binary, e))
+            OutputError::InjectionFailed(format!("Failed to wait for {}: {}", invocation.binary, e))
         })?;
 
         if !output.status.success() {
@@ -225,16 +287,20 @@ impl TextOutput for DotoolOutput {
             if stderr.contains("uinput") || stderr.contains("permission") {
                 return Err(OutputError::InjectionFailed(format!(
                     "{}: uinput permission denied. Is user in 'input' group?",
-                    binary
+                    invocation.binary
                 )));
             }
             return Err(OutputError::InjectionFailed(format!(
                 "{} exited with error: {}",
-                binary, stderr
+                invocation.binary, stderr
             )));
         }
 
-        tracing::info!("Text typed via {} ({} chars)", binary, text.chars().count());
+        tracing::info!(
+            "Text typed via {} ({} chars)",
+            invocation.binary,
+            text.chars().count()
+        );
         Ok(())
     }
 
@@ -298,6 +364,39 @@ mod tests {
         let dot_pos = cmds.find("type .\n").unwrap();
         let enter_pos = cmds.find("key enter\n").unwrap();
         assert!(dot_pos < enter_pos);
+    }
+
+    #[test]
+    fn choose_invocation_uses_dotoolc_when_daemon_available_without_xkb_override() {
+        let output = DotoolOutput::new(0, 0, false, None, None, None);
+        let invocation = output.choose_invocation(Some(PathBuf::from("/tmp/dotool-pipe")));
+
+        assert_eq!(invocation.binary, "dotoolc");
+        assert_eq!(invocation.pipe, Some(PathBuf::from("/tmp/dotool-pipe")));
+        assert!(!invocation.set_layout_env);
+        assert!(!invocation.skipped_daemon_for_layout);
+    }
+
+    #[test]
+    fn choose_invocation_bypasses_daemon_when_layout_override_is_set() {
+        let output = DotoolOutput::new(0, 0, false, None, Some("ru".to_string()), None);
+        let invocation = output.choose_invocation(Some(PathBuf::from("/tmp/dotool-pipe")));
+
+        assert_eq!(invocation.binary, "dotool");
+        assert_eq!(invocation.pipe, None);
+        assert!(invocation.set_layout_env);
+        assert!(invocation.skipped_daemon_for_layout);
+    }
+
+    #[test]
+    fn choose_invocation_bypasses_daemon_when_variant_override_is_set() {
+        let output = DotoolOutput::new(0, 0, false, None, None, Some("phonetic".to_string()));
+        let invocation = output.choose_invocation(Some(PathBuf::from("/tmp/dotool-pipe")));
+
+        assert_eq!(invocation.binary, "dotool");
+        assert_eq!(invocation.pipe, None);
+        assert!(invocation.set_layout_env);
+        assert!(invocation.skipped_daemon_for_layout);
     }
 
     /// Serialize tests that mutate `DOTOOL_PIPE` — Rust's default


### PR DESCRIPTION
## Summary
- add per-language XKB variant mapping alongside the existing language-to-layout mapping
- apply detected layout and variant hints to eitype and direct dotool fallback when explicit driver settings are unset
- bypass dotoolc for per-call XKB hints and document that direct dotool still requires the active desktop layout to match

## Testing
- cargo fmt
- cargo clippy --all-targets --no-deps -- -D warnings
- cargo test

Closes #422.