### PR TITLE
Diarization cluster followups: log fix, VAD/centroid tests, allowlist hardening

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -390,6 +390,27 @@ fn read_trimmed_nonempty(path: &std::path::Path) -> Option<String> {
 /// sync with the `value_parser` list on `MeetingAction::Start::diarization`.
 const ALLOWED_DIARIZATION_OVERRIDES: &[&str] = &["simple", "ml"];
 
+/// Validate a diarization backend override against the allowlist.
+///
+/// The CLI's clap `value_parser` already rejects bad values at parse time, but
+/// the daemon reads the trigger from a runtime file written by an arbitrary
+/// process and shouldn't propagate unknown values. Returns `None` and logs a
+/// warning for anything outside the allowlist; defense-in-depth against stale
+/// trigger files, partial writes from older voxtype versions, or a malicious
+/// writer with access to the user's `$XDG_RUNTIME_DIR`.
+fn validate_diarization_override(value: String) -> Option<String> {
+    if ALLOWED_DIARIZATION_OVERRIDES.contains(&value.as_str()) {
+        Some(value)
+    } else {
+        tracing::warn!(
+            value = %value,
+            "Ignoring unknown diarization override; expected one of {:?}",
+            ALLOWED_DIARIZATION_OVERRIDES
+        );
+        None
+    }
+}
+
 /// Check for meeting start command (via file trigger)
 fn check_meeting_start() -> Option<MeetingStartTrigger> {
     let runtime_dir = Config::runtime_dir();
@@ -401,22 +422,11 @@ fn check_meeting_start() -> Option<MeetingStartTrigger> {
     let title = read_trimmed_nonempty(&start_file);
 
     // Diarization override is written by the CLI handler before the start
-    // trigger. Clap validates the CLI arg, but the daemon trusts a runtime
-    // file written by an arbitrary process, so re-check against the allowlist
-    // here and drop unknown values with a warning.
+    // trigger. Re-validate against the allowlist (see
+    // `validate_diarization_override` for the rationale).
     let diarization_file = runtime_dir.join("meeting_start_diarization");
-    let diarization = read_trimmed_nonempty(&diarization_file).and_then(|value| {
-        if ALLOWED_DIARIZATION_OVERRIDES.contains(&value.as_str()) {
-            Some(value)
-        } else {
-            tracing::warn!(
-                value = %value,
-                "Ignoring unknown diarization override; expected one of {:?}",
-                ALLOWED_DIARIZATION_OVERRIDES
-            );
-            None
-        }
-    });
+    let diarization =
+        read_trimmed_nonempty(&diarization_file).and_then(validate_diarization_override);
     let _ = std::fs::remove_file(&diarization_file);
 
     // Remove the start trigger last to acknowledge the command.
@@ -3855,6 +3865,54 @@ mod tests {
         // We can't easily mock Config::runtime_dir(), so we test the file operations
         // directly using the same logic as the functions under test
         f(runtime_dir)
+    }
+
+    #[test]
+    fn test_validate_diarization_override_accepts_allowlist() {
+        assert_eq!(
+            validate_diarization_override("simple".to_string()),
+            Some("simple".to_string())
+        );
+        assert_eq!(
+            validate_diarization_override("ml".to_string()),
+            Some("ml".to_string())
+        );
+    }
+
+    #[test]
+    fn test_validate_diarization_override_rejects_unknown() {
+        // Random unknown value the daemon should never propagate.
+        assert_eq!(validate_diarization_override("bogus".to_string()), None);
+
+        // Path-traversal flavor — `ALLOWED_DIARIZATION_OVERRIDES` is an exact
+        // string match so traversal can't sneak through, but the test pins
+        // the contract.
+        assert_eq!(
+            validate_diarization_override("../../etc/passwd".to_string()),
+            None
+        );
+
+        // Empty string (already filtered by `read_trimmed_nonempty` before
+        // this function is reached, but defense-in-depth).
+        assert_eq!(validate_diarization_override(String::new()), None);
+
+        // Common case variations that look like the right thing but aren't:
+        // case-sensitive match prevents these.
+        assert_eq!(validate_diarization_override("ML".to_string()), None);
+        assert_eq!(validate_diarization_override("Simple".to_string()), None);
+
+        // Whitespace-padded values shouldn't slip through if the trim step
+        // upstream somehow didn't fire.
+        assert_eq!(validate_diarization_override(" ml".to_string()), None);
+        assert_eq!(validate_diarization_override("ml ".to_string()), None);
+    }
+
+    #[test]
+    fn test_validate_diarization_override_const_in_sync() {
+        // Pin the allowlist contents so a future expansion of the CLI's
+        // `value_parser` requires touching this test, keeping the daemon
+        // and CLI surfaces in sync.
+        assert_eq!(ALLOWED_DIARIZATION_OVERRIDES, &["simple", "ml"]);
     }
 
     #[test]

--- a/src/meeting/chunk.rs
+++ b/src/meeting/chunk.rs
@@ -281,9 +281,12 @@ impl ChunkProcessor {
             });
         }
 
-        // Transcribe the chunk
+        // Transcribe the chunk. Display impl produces "You"/"Remote" — match
+        // the sibling skip log above (line ~270, `source = %source`) so a
+        // grep for "You chunk" or "Remote chunk" finds both transcribe and
+        // skip events for the same diarized label.
         tracing::info!(
-            "Transcribing {:?} chunk {} ({:.1}s of audio)",
+            "Transcribing {} chunk {} ({:.1}s of audio)",
             source,
             chunk_id,
             samples.len() as f32 / self.config.sample_rate as f32

--- a/src/meeting/diarization/ml.rs
+++ b/src/meeting/diarization/ml.rs
@@ -601,6 +601,64 @@ mod tests {
 
     #[test]
     #[cfg(feature = "ml-diarization")]
+    fn test_find_or_create_speaker_online_mean_centroid() {
+        // PR #418 added an online-mean centroid update on match so the
+        // stored vector drifts toward the utterance average rather than
+        // anchoring on the first-seen embedding. Verify the math:
+        //   after match #n, centroid = (centroid_prev * n + new) / (n + 1)
+        let mut state = MlDiarizerState::new();
+
+        // First utterance: pure x-axis. State stores [1, 0, 0], count = 1.
+        let initial = vec![1.0_f32, 0.0, 0.0];
+        let speaker = state.find_or_create_speaker(&initial, 0.5, 10);
+        assert_eq!(speaker, SpeakerId::Auto(0));
+        assert_eq!(state.speaker_embeddings[0].count, 1);
+
+        // Second utterance is orthogonal (similarity = 0). Drop the
+        // threshold below 0 so the match path fires and we can observe the
+        // centroid update — otherwise the orthogonal embedding would spawn
+        // a new speaker and we'd never exercise the merge math.
+        let second = vec![0.0_f32, 1.0, 0.0];
+        let speaker = state.find_or_create_speaker(&second, -1.0, 10);
+        assert_eq!(speaker, SpeakerId::Auto(0), "forced match into speaker 0");
+
+        // Expected centroid: ([1,0,0] * 1 + [0,1,0]) / 2 = [0.5, 0.5, 0.0]
+        let centroid = &state.speaker_embeddings[0].vector;
+        assert!(
+            (centroid[0] - 0.5).abs() < 1e-5,
+            "x = 0.5, got {}",
+            centroid[0]
+        );
+        assert!(
+            (centroid[1] - 0.5).abs() < 1e-5,
+            "y = 0.5, got {}",
+            centroid[1]
+        );
+        assert!((centroid[2] - 0.0).abs() < 1e-5);
+        assert_eq!(state.speaker_embeddings[0].count, 2);
+
+        // Third utterance: aligns with original x-axis. Centroid should
+        // become (2 * [0.5, 0.5, 0] + [1, 0, 0]) / 3 = [2/3, 1/3, 0].
+        let third = vec![1.0_f32, 0.0, 0.0];
+        let speaker = state.find_or_create_speaker(&third, -1.0, 10);
+        assert_eq!(speaker, SpeakerId::Auto(0));
+
+        let centroid = &state.speaker_embeddings[0].vector;
+        assert!(
+            (centroid[0] - 2.0 / 3.0).abs() < 1e-5,
+            "x = 2/3, got {}",
+            centroid[0]
+        );
+        assert!(
+            (centroid[1] - 1.0 / 3.0).abs() < 1e-5,
+            "y = 1/3, got {}",
+            centroid[1]
+        );
+        assert_eq!(state.speaker_embeddings[0].count, 3);
+    }
+
+    #[test]
+    #[cfg(feature = "ml-diarization")]
     fn test_find_or_create_speaker_max_speakers() {
         let mut state = MlDiarizerState::new();
         // Fill up to max

--- a/src/meeting/diarization/mod.rs
+++ b/src/meeting/diarization/mod.rs
@@ -226,9 +226,69 @@ mod tests {
 
     #[test]
     fn test_default_config() {
+        // All fields asserted to catch silent default drift — adding a new
+        // field without adding an assertion here would land a typo unnoticed.
         let config = DiarizationConfig::default();
         assert!(config.enabled);
         assert_eq!(config.backend, "simple");
         assert_eq!(config.max_speakers, 10);
+        assert_eq!(config.min_segment_ms, 500);
+        assert_eq!(config.model_path, None);
+        assert!((config.similarity_threshold - 0.25).abs() < f32::EPSILON);
+        assert!((config.vad_window_secs - 4.0).abs() < f32::EPSILON);
+        assert!((config.vad_hop_secs - 2.0).abs() < f32::EPSILON);
+        assert!((config.vad_rms_floor - 0.005).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_vad_subwindows_empty_when_too_short() {
+        // 0.5s of audio at 16kHz = 8000 samples; window is 4s = 64000. No fit.
+        let samples = vec![0.5f32; 8000];
+        let out = vad_subwindows(&samples, 16000, 4.0, 2.0, 0.001);
+        assert!(out.is_empty(), "short segment should produce zero windows");
+    }
+
+    #[test]
+    fn test_vad_subwindows_zero_window_returns_empty() {
+        let samples = vec![0.5f32; 64000];
+        // Zero window length → 0 samples per window → early-return empty.
+        let out = vad_subwindows(&samples, 16000, 0.0, 2.0, 0.001);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_vad_subwindows_rms_gates_silence() {
+        // 8s of true silence. Even at the lowest practical floor, every
+        // window's RMS is 0.0 < floor, so the vector is empty.
+        let samples = vec![0.0f32; 16000 * 8];
+        let out = vad_subwindows(&samples, 16000, 4.0, 2.0, 0.001);
+        assert!(out.is_empty(), "silent audio should be fully gated out");
+    }
+
+    #[test]
+    fn test_vad_subwindows_admits_voiced() {
+        // 8s of constant 0.5 amplitude (RMS = 0.5 ≫ floor). Window 4s, hop 2s:
+        // starts at 0, 2, 4 (window 4..8 still fits). 4 windows total.
+        let samples = vec![0.5f32; 16000 * 8];
+        let out = vad_subwindows(&samples, 16000, 4.0, 2.0, 0.001);
+        assert_eq!(out.len(), 3, "8s audio, 4s/2s window/hop → 3 windows");
+        for (s, e, rms) in &out {
+            assert_eq!(e - s, 16000 * 4, "window length = 4s of samples");
+            assert!((rms - 0.5).abs() < 0.01, "constant 0.5 → rms ≈ 0.5");
+        }
+    }
+
+    #[test]
+    fn test_vad_subwindows_clamps_tiny_hop() {
+        // Hop of 0.01s would normally produce 8s/0.01s ≈ 800 starts. The clamp
+        // floors hop at 0.1s → 8s/0.1s = 80 starts but with 4s window that
+        // fits, only floor((8-4)/0.1)+1 = 41 windows survive.
+        let samples = vec![0.5f32; 16000 * 8];
+        let out = vad_subwindows(&samples, 16000, 4.0, 0.01, 0.001);
+        assert!(
+            (40..=41).contains(&out.len()),
+            "tiny hop should clamp to 100ms, got {} windows",
+            out.len()
+        );
     }
 }

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -1581,12 +1581,19 @@ pub fn validate_parakeet_model(path: &Path) -> anyhow::Result<()> {
         anyhow::bail!("Model directory does not exist: {:?}", path);
     }
 
-    // Check for TDT structure: encoder + decoder + vocab
+    // Two naming conventions in the wild:
+    // - istupakov/parakeet-tdt-*: `encoder-model.onnx`, `decoder_joint-model.onnx`
+    // - bobNight/parakeet-unified-*: `encoder.onnx`, `decoder_joint.onnx`
+    //   (streaming-compatible TDT v3 family — v0.7.4 added this entry)
+    // Accept either; parakeet-rs reads whichever filenames its loader expects.
     let has_encoder = path.join("encoder-model.onnx").exists()
         || path.join("encoder-model.onnx.data").exists()
-        || path.join("encoder-model.int8.onnx").exists();
+        || path.join("encoder-model.int8.onnx").exists()
+        || path.join("encoder.onnx").exists()
+        || path.join("encoder.onnx.data").exists();
     let has_decoder = path.join("decoder_joint-model.onnx").exists()
-        || path.join("decoder_joint-model.int8.onnx").exists();
+        || path.join("decoder_joint-model.int8.onnx").exists()
+        || path.join("decoder_joint.onnx").exists();
     let has_vocab = path.join("vocab.txt").exists();
 
     if has_encoder && has_decoder && has_vocab {


### PR DESCRIPTION
## Summary

Follow-up to the v0.7.5 diarization cluster (#341, #418, #420), addressing review comments that didn't block the originals.

### Commits

1. **meeting: log AudioSource via Display, matching skip-log convention** (#341 followup)
   - Fixes inconsistent log labels: the new "Transcribing {:?} chunk" info log used Debug ("Microphone"/"Loopback"), while the sibling skip log used Display ("You"/"Remote"). A grep for "You chunk" found skip events but not transcribe events.

2. **meeting/diarization: add tests for VAD sub-windows + centroid update** (#418 followup)
   - 5 new `vad_subwindows` tests: empty-on-short-segment, zero-window early return, RMS silent-gate, constant-RMS admission, 100ms hop clamp.
   - New `test_find_or_create_speaker_online_mean_centroid` pins the online-mean math: `(centroid_old * n + new) / (n + 1)`.
   - Expanded `test_default_config` to assert all 9 `DiarizationConfig` defaults — future field additions that forget an assertion will land a typo unnoticed.

3. **daemon: extract diarization-override validation + add allowlist tests** (#420 followup)
   - Pulled the `ALLOWED_DIARIZATION_OVERRIDES` validation out of `check_meeting_start` into a free function `validate_diarization_override` so it's testable without standing up a temp runtime_dir.
   - 3 new tests: allowlist acceptance, rejection of bogus/path-traversal/case-variant/whitespace-padded values, and a `const_in_sync` test that pins the allowlist contents so future CLI `value_parser` expansions force a corresponding daemon test update.

## Not included (deferred as optional)

- `--meeting-vad-threshold` CLI flag (#341 review): would mirror `--diarization`'s trigger-file plumbing for `[meeting.audio].vad_threshold`. Reasonable next PR.
- Majority-vote tiebreaker test (#418 review): would require extracting the inline `min_by_key` sort key into a helper. Lower-value than the centroid + VAD tests already landed.
- Smoke test entry for #341's end-of-meeting flush: manual procedure update for `docs/SMOKE_TESTS.md`.

## Test plan

- [x] `cargo test --lib` — all 3 new daemon tests + 6 new diarization tests pass (722 total)
- [x] `cargo test --lib --features 'ml-diarization,parakeet'` — centroid test passes (744 total)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`