### PR TITLE
Make Soniox unconditional (ship in every v0.7.5 binary)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ hound = "3"  # WAV file reading/writing
 # HTTP client for remote transcription
 ureq = { version = "2", features = ["json"] }
 
-# WebSocket client for Soniox streaming backend (optional)
-tokio-tungstenite = { version = "0.24", optional = true, features = ["rustls-tls-webpki-roots"] }
-futures-util = { version = "0.3", optional = true }
+# WebSocket client for Soniox streaming backend
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
 # Async HTTP client for Soniox async transcription API (multipart upload + poll)
-reqwest = { version = "0.12", optional = true, default-features = false, features = ["json", "multipart", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 
 # JSON parsing (for CLI backend)
 serde_json = "1"
@@ -238,8 +238,10 @@ omnilingual-tensorrt = ["omnilingual", "onnx-tensorrt-enabled"]
 cohere = ["onnx-common", "dep:half", "dep:tokenizers"]
 cohere-cuda = ["cohere", "onnx-cuda-enabled"]
 cohere-tensorrt = ["cohere", "onnx-tensorrt-enabled"]
-# Soniox cloud streaming WebSocket STT backend (no local model, just a network client)
-soniox = ["dep:tokio-tungstenite", "dep:futures-util", "dep:reqwest"]
+# Soniox is unconditional. Its deps (tokio-tungstenite, futures-util, reqwest)
+# add ~1-2 MB after LTO+strip and ride alongside ureq, which every binary
+# already ships for model downloads. Treating it like remote.rs (also always
+# compiled) keeps the engine surface uniform across release flavors.
 # No cohere-migraphx feature: MIGraphX 7.2 still fails on the
 # onnx-community q4 export. Original blocker was MatMulNBits bits=8
 # (cstr int8); q4 has bits=4 which is supported, but its zero_points

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -70,7 +70,7 @@ config changes; restart it with `systemctl --user restart voxtype` for the
 new engine to take effect.
 
 **Notes:**
-- All engines except Whisper require an ONNX-enabled binary (`voxtype-*-onnx-*`)
+- Whisper, Remote Whisper, and Soniox run in every binary. The other engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) require an ONNX-enabled binary (`voxtype-*-onnx-*`)
 - Each ONNX engine reads its own `[<engine>]` section (e.g. `[parakeet]`, `[cohere]`)
 - See [PARAKEET.md](PARAKEET.md) for detailed Parakeet setup instructions
 - See [MOONSHINE.md](MOONSHINE.md) for detailed Moonshine setup instructions

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1576,13 +1576,13 @@ language_hints = ["hu", "en"]
 
 ### Building from Source
 
-Source builds need the `soniox` Cargo feature:
+Soniox is built unconditionally; no Cargo feature flag is required:
 
 ```bash
-cargo build --release --features soniox
+cargo build --release
 ```
 
-The `soniox` feature is independent of the other engine features and adds a small WebSocket client (tokio-tungstenite + rustls) plus an async HTTP client (reqwest) for the async API. It can be combined with any local engine feature, e.g. `--features "soniox parakeet"` for a binary that runs Parakeet locally and Soniox in the cloud depending on the `engine` setting.
+The Soniox backend pulls in a small WebSocket client (tokio-tungstenite + rustls) and an async HTTP client (reqwest) for the async API. They ship in every release binary so the engine surface stays uniform across flavors.
 
 ---
 

--- a/docs/MODEL_SELECTION_GUIDE.md
+++ b/docs/MODEL_SELECTION_GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide helps you choose the right transcription engine and model for voxtype v0.6.0. The choice depends on your language, hardware, and how you use dictation.
 
-Voxtype has seven transcription engines. Two are bundled with the standard binary (Whisper and Remote Whisper). The other five require the ONNX binary variant.
+Voxtype has eight transcription engines. Three ship in every binary — Whisper (local), Remote Whisper (HTTP API), and Soniox (cloud streaming). The other five require the ONNX binary variant.
 
 ---
 

--- a/docs/MODEL_SELECTION_GUIDE.md
+++ b/docs/MODEL_SELECTION_GUIDE.md
@@ -17,9 +17,9 @@ Voxtype has seven transcription engines. Two are bundled with the standard binar
 | **Paraformer** | zh, en | Encoder-predictor-decoder | 220 - 487 MB | Fast | No | ONNX |
 | **Dolphin** | 40+ langs, 22 Chinese dialects | CTC E-Branchformer | 198 MB | Fast | No | ONNX |
 | **Omnilingual** | 1600+ | CTC wav2vec2 | 3.9 GB | Moderate | No | ONNX |
-| **Soniox** (cloud) | 60+ | Cloud (WebSocket / REST) | n/a (no local model) | Cloud-bound | Yes | Soniox feature |
+| **Soniox** (cloud) | 60+ | Cloud (WebSocket / REST) | n/a (no local model) | Cloud-bound | Yes | Built-in |
 
-**Soniox** is different from the others — it's a paid cloud service over WebSocket / REST. No local model, no GPU. Sub-second partial latency. Strong for non-English languages where local Whisper-based engines struggle on lower-end hardware. Requires `cargo build --features soniox` and a `SONIOX_API_KEY`. See [SONIOX.md](SONIOX.md) for the full story.
+**Soniox** is different from the others — it's a paid cloud service over WebSocket / REST. No local model, no GPU. Sub-second partial latency. Strong for non-English languages where local Whisper-based engines struggle on lower-end hardware. Ships in every release binary; you only need a `SONIOX_API_KEY`. See [SONIOX.md](SONIOX.md) for the full story.
 
 ---
 

--- a/docs/SONIOX.md
+++ b/docs/SONIOX.md
@@ -23,10 +23,7 @@ Soniox is paid SaaS. Sign up at [console.soniox.com](https://console.soniox.com)
 
 ## Requirements
 
-- voxtype built with the `soniox` Cargo feature:
-  ```bash
-  cargo build --release --features soniox
-  ```
+- voxtype (Soniox ships in every release binary; no feature flag needed)
 - A Soniox API key (free tier credits available)
 - Outbound HTTPS / WebSocket (wss://) access
 

--- a/docs/SONIOX.md
+++ b/docs/SONIOX.md
@@ -23,9 +23,10 @@ Soniox is paid SaaS. Sign up at [console.soniox.com](https://console.soniox.com)
 
 ## Requirements
 
-- voxtype (Soniox ships in every release binary; no feature flag needed)
 - A Soniox API key (free tier credits available)
 - Outbound HTTPS / WebSocket (wss://) access
+
+Soniox ships in every release binary; no build flag needed.
 
 No local model files. No GPU.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1107,7 +1107,7 @@ async_max_wait_secs = 300
 
 ### Post-stop "Streaming Error: Soniox server error (408): Request timeout"
 
-This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release after v0.7.2 + soniox).
+This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release v0.7.3 or later includes it).
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1107,7 +1107,7 @@ async_max_wait_secs = 300
 
 ### Post-stop "Streaming Error: Soniox server error (408): Request timeout"
 
-This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release v0.7.3 or later includes it).
+This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release v0.7.5 or later includes it).
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -440,7 +440,7 @@ on_transcription = true
 
 For a cloud streaming alternative to the local engines above, voxtype supports [Soniox](https://soniox.com). Different trade-off space: paid SaaS, no local model, 60+ languages with strong Hungarian/EU coverage, sub-second partials at the cursor.
 
-Build with `--features soniox`, set `SONIOX_API_KEY`, and:
+Soniox ships in every release binary. Set `SONIOX_API_KEY` and:
 
 ```toml
 engine = "soniox"

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -64,7 +64,6 @@ pub enum TranscriptionEngine {
     /// Requires: cargo build --features cohere
     Cohere,
     /// Use Soniox (cloud streaming WebSocket STT).
-    /// Requires: cargo build --features soniox
     Soniox,
 }
 

--- a/src/config/engines/soniox.rs
+++ b/src/config/engines/soniox.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use super::super::default_true;
 
 /// Soniox cloud streaming WebSocket STT configuration
-/// Requires: cargo build --features soniox
 ///
 /// Soniox is a paid cloud STT provider. API key required:
 /// either set `api_key` here or via the `SONIOX_API_KEY` env var.

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -16,7 +16,6 @@ pub mod cli;
 #[cfg(feature = "parakeet")]
 pub mod parakeet_streaming;
 pub mod remote;
-#[cfg(feature = "soniox")]
 pub mod soniox;
 pub mod streaming;
 pub mod subprocess;
@@ -269,7 +268,6 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
             "Cohere engine requested but voxtype was not compiled with --features cohere"
                 .to_string(),
         )),
-        #[cfg(feature = "soniox")]
         TranscriptionEngine::Soniox => {
             let cfg = config.soniox.as_ref().ok_or_else(|| {
                 TranscribeError::InitFailed(
@@ -278,11 +276,6 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
             })?;
             Ok(Box::new(soniox::SonioxTranscriber::new(cfg.clone())?))
         }
-        #[cfg(not(feature = "soniox"))]
-        TranscriptionEngine::Soniox => Err(TranscribeError::InitFailed(
-            "Soniox engine requested but voxtype was not compiled with --features soniox"
-                .to_string(),
-        )),
     }
 }
 


### PR DESCRIPTION
## Summary

- Promotes `soniox` from a Cargo feature gate to an always-on backend, so every release binary in the v0.7.5 matrix (whisper avx2/avx512/vulkan + onnx-avx2/avx512/cuda-12/cuda-13/migraphx) can talk to Soniox out of the box.
- Aligns Soniox with the existing OpenAI-compatible `RemoteTranscriber`, which has always shipped unconditionally — same shape (pure WebSocket + HTTP client, no model, no GPU), so the asymmetric gating was the odd one out.
- Drops the corresponding `#[cfg(feature = "soniox")]` gates and the "Requires: cargo build --features soniox" doc lines.

## Why now

This is queued behind #432 (v0.7.5). The Quickshell engine picker added in that PR lists Soniox alongside the local engines; if some release flavors lack the backend, the picker either lies per binary or has to grow capability detection. Shipping Soniox in every binary keeps the engine surface uniform across the release matrix.

## Lightweight by design — should just work

Soniox is the lightest backend voxtype has: no local model, no GPU, no CPU-instruction concerns, no per-distro shared library. It's a thin WebSocket + HTTP client. There is no hardware or platform reason for it to need a special build — the only thing standing between a user and Soniox is the API key. Putting that behind `--features soniox` makes the lightest backend the *hardest* one to enable from a fresh install (you have to find the docs, learn cargo features, rebuild). Flipping it to always-on means: install any voxtype binary, drop an API key in the config, done. That matches the "dead simple user experience" principle in `CLAUDE.md`.

## Cost

`tokio-tungstenite` (rustls) + `futures-util` + `reqwest` (rustls) become required deps. After LTO + strip this adds roughly 1-2 MB on top of the `ureq` client every binary already carries for model downloads. Whisper-only binaries pay it too, but they already ship `ureq` for setup downloads — the "fully offline" ship has already sailed.

## Files

- `Cargo.toml` — drop `soniox` feature, demote `optional = true` on the three deps.
- `src/transcribe/mod.rs` — remove module-decl gate and the two factory-arm gates (the `#[cfg(not(feature = "soniox"))]` "engine requested but not compiled in" arm goes away with them).
- `src/config.rs` — drop two stale "Requires: cargo build --features soniox" doc lines on `SonioxConfig` and `TranscriptionEngine::Soniox`.
- `docs/CONFIGURATION.md`, `docs/USER_MANUAL.md`, `docs/SONIOX.md`, `docs/MODEL_SELECTION_GUIDE.md` — update build instructions and the feature-matrix entry.

## Target release

**v0.7.5** — should land before #432 ships so the engine surface is uniform from the first v0.7.5 binary onward.

## Test plan

- [x] `cargo build --release` (no `--features soniox`) succeeds on dev branch + this change
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `cargo test --release --lib soniox` — 41 passed
- [x] `cargo test --release --lib` — only pre-existing `setup::parakeet::tests::detect_available_backends_returns_vec` failure (environment-dependent, reproduces on dev without this change)
- [ ] Confirm Soniox actually transcribes end-to-end with a release binary built without `--features soniox`
- [ ] Verify Quickshell engine picker shows soniox on a whisper-only binary (no ONNX engines)

## Out of scope

- Updating the `Dockerfile.onnx*` `--features` lists. They no longer need `soniox` appended (the feature is gone), and they're currently feature-clean of it already, so no Dockerfile edits are required for this PR. The MIGraphX / CUDA Dockerfiles are unaffected.
- The Nix flake — same reasoning. If the flake passes `--no-default-features`, soniox keeps working because its deps are no longer behind a feature flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
