### PR TITLE
tui: serialize feedback volume + VAD threshold as TOML floats (closes #451)

### DIFF
--- a/src/tui/audio.rs
+++ b/src/tui/audio.rs
@@ -95,15 +95,7 @@ impl AudioState {
             feedback_theme: ed
                 .get_string("audio.feedback", "theme")
                 .unwrap_or_else(|| "default".to_string()),
-            feedback_volume: ed
-                .get_float("audio.feedback", "volume")
-                .map(|f| f as f32)
-                .or_else(|| ed.get_int("audio.feedback", "volume").map(|n| n as f32))
-                .or_else(|| {
-                    ed.get_string("audio.feedback", "volume")
-                        .and_then(|s| s.parse().ok())
-                })
-                .unwrap_or(0.7),
+            feedback_volume: ed.get_f32_or("audio.feedback", "volume", 0.7),
             field: Field::Device,
             feedback: None,
             dirty_since_load: false,
@@ -156,7 +148,7 @@ impl AudioState {
         ed.set_bool("audio", "pause_media", self.pause_media);
         ed.set_bool("audio.feedback", "enabled", self.feedback_enabled);
         ed.set_string("audio.feedback", "theme", &self.feedback_theme);
-        ed.set_float("audio.feedback", "volume", self.feedback_volume as f64);
+        ed.set_f32("audio.feedback", "volume", self.feedback_volume);
 
         match ed.save() {
             Ok(()) => {

--- a/src/tui/audio.rs
+++ b/src/tui/audio.rs
@@ -96,9 +96,13 @@ impl AudioState {
                 .get_string("audio.feedback", "theme")
                 .unwrap_or_else(|| "default".to_string()),
             feedback_volume: ed
-                .get_string("audio.feedback", "volume")
-                .and_then(|s| s.parse().ok())
+                .get_float("audio.feedback", "volume")
+                .map(|f| f as f32)
                 .or_else(|| ed.get_int("audio.feedback", "volume").map(|n| n as f32))
+                .or_else(|| {
+                    ed.get_string("audio.feedback", "volume")
+                        .and_then(|s| s.parse().ok())
+                })
                 .unwrap_or(0.7),
             field: Field::Device,
             feedback: None,
@@ -152,11 +156,7 @@ impl AudioState {
         ed.set_bool("audio", "pause_media", self.pause_media);
         ed.set_bool("audio.feedback", "enabled", self.feedback_enabled);
         ed.set_string("audio.feedback", "theme", &self.feedback_theme);
-        ed.set_string(
-            "audio.feedback",
-            "volume",
-            &format!("{:.2}", self.feedback_volume),
-        );
+        ed.set_float("audio.feedback", "volume", self.feedback_volume as f64);
 
         match ed.save() {
             Ok(()) => {

--- a/src/tui/config_editor.rs
+++ b/src/tui/config_editor.rs
@@ -365,4 +365,53 @@ mod tests {
         ed.set_string("hotkey", "key", "PAUSE");
         assert!(ed.is_dirty());
     }
+
+    #[test]
+    fn set_float_writes_toml_number_not_string() {
+        // Regression for #451: the TUI audio + vad sections used `set_string`
+        // with `format!("{:.2}", f32)` to write floats, producing
+        // `volume = "0.70"`. The daemon's serde config expects `f32` and
+        // rejects the string with "invalid type: string \"0.70\", expected f32".
+        // `set_float` must emit a TOML number so deserialization works on next
+        // load, and `get_float` must round-trip it back.
+        let (_dir, path) = temp_config("");
+        let mut ed = ConfigEditor::load_from(path.clone()).unwrap();
+        ed.set_float("audio.feedback", "volume", 0.70);
+        ed.set_float("vad", "threshold", 0.5);
+        let serialized = ed.document.to_string();
+
+        assert!(
+            serialized.contains("volume = 0.7"),
+            "expected bare TOML float, got: {}",
+            serialized
+        );
+        assert!(
+            !serialized.contains("volume = \"0.7"),
+            "volume must not be quoted as a string: {}",
+            serialized
+        );
+        assert!(
+            serialized.contains("threshold = 0.5"),
+            "expected bare TOML float, got: {}",
+            serialized
+        );
+
+        // Write the serialized form to disk directly and reload — bypasses
+        // ConfigEditor::save() which validates the full schema (the partial
+        // doc here has no [audio] device etc., which validation would reject).
+        // We just want to prove that set_float -> file -> get_float preserves
+        // the value as a float.
+        fs::write(&path, &serialized).unwrap();
+        let reloaded = ConfigEditor::load_from(path).unwrap();
+        assert_eq!(
+            reloaded.get_float("audio.feedback", "volume"),
+            Some(0.70),
+            "volume must round-trip as a float"
+        );
+        assert_eq!(
+            reloaded.get_float("vad", "threshold"),
+            Some(0.5),
+            "threshold must round-trip as a float"
+        );
+    }
 }

--- a/src/tui/config_editor.rs
+++ b/src/tui/config_editor.rs
@@ -148,6 +148,31 @@ impl ConfigEditor {
         self.dirty = true;
     }
 
+    /// Write an `f32` as a TOML float. Convenience wrapper over `set_float`
+    /// so callers working with `f32`-typed config fields don't need to
+    /// repeat the widening cast at every call site (the missing `as f64`
+    /// is exactly how the audio.feedback.volume and vad.threshold fields
+    /// ended up serialized as quoted strings — see #451).
+    pub fn set_f32(&mut self, table: &str, key: &str, value: f32) {
+        self.set_float(table, key, value as f64);
+    }
+
+    /// Read an `f32`, tolerating older TOML representations where the TUI
+    /// wrote the value as a quoted string (`volume = "0.70"`) or as an
+    /// int. Returns `default` if the key is absent or none of the fallback
+    /// parses succeed. The string fallback exists for a transitional
+    /// window after the v0.7.6 fix to #451 — every reload through this
+    /// helper migrates the user's config to a proper TOML float on next
+    /// save. Can be retired once we're confident no fielded config still
+    /// carries the legacy form.
+    pub fn get_f32_or(&self, table: &str, key: &str, default: f32) -> f32 {
+        self.get_float(table, key)
+            .map(|f| f as f32)
+            .or_else(|| self.get_int(table, key).map(|n| n as f32))
+            .or_else(|| self.get_string(table, key).and_then(|s| s.parse().ok()))
+            .unwrap_or(default)
+    }
+
     /// Remove a key from a table (no-op if absent).
     pub fn unset(&mut self, table: &str, key: &str) {
         if let Some(t) = self.table_mut(table) {
@@ -367,51 +392,64 @@ mod tests {
     }
 
     #[test]
-    fn set_float_writes_toml_number_not_string() {
+    fn set_f32_writes_toml_number_not_string() {
         // Regression for #451: the TUI audio + vad sections used `set_string`
         // with `format!("{:.2}", f32)` to write floats, producing
         // `volume = "0.70"`. The daemon's serde config expects `f32` and
         // rejects the string with "invalid type: string \"0.70\", expected f32".
-        // `set_float` must emit a TOML number so deserialization works on next
-        // load, and `get_float` must round-trip it back.
+        // `set_f32` must emit a TOML number so deserialization works on next
+        // load, and `get_f32_or` must round-trip it back.
         let (_dir, path) = temp_config("");
         let mut ed = ConfigEditor::load_from(path.clone()).unwrap();
-        ed.set_float("audio.feedback", "volume", 0.70);
-        ed.set_float("vad", "threshold", 0.5);
+        // 0.5 and 0.25 are exact in IEEE-754 so the f32 -> f64 widening
+        // doesn't decorate the serialized form with a long mantissa.
+        ed.set_f32("audio.feedback", "volume", 0.5);
+        ed.set_f32("vad", "threshold", 0.25);
         let serialized = ed.document.to_string();
 
+        // The critical invariant from #451: no quoted string form.
         assert!(
-            serialized.contains("volume = 0.7"),
+            !serialized.contains("\"0."),
+            "no value should be quoted as a string, got: {}",
+            serialized
+        );
+        // Loose sanity check on the bare-number form.
+        assert!(
+            serialized.contains("volume = 0.5"),
             "expected bare TOML float, got: {}",
             serialized
         );
         assert!(
-            !serialized.contains("volume = \"0.7"),
-            "volume must not be quoted as a string: {}",
-            serialized
-        );
-        assert!(
-            serialized.contains("threshold = 0.5"),
+            serialized.contains("threshold = 0.25"),
             "expected bare TOML float, got: {}",
             serialized
         );
 
-        // Write the serialized form to disk directly and reload — bypasses
-        // ConfigEditor::save() which validates the full schema (the partial
-        // doc here has no [audio] device etc., which validation would reject).
-        // We just want to prove that set_float -> file -> get_float preserves
-        // the value as a float.
+        // Write to disk and reload — bypasses ConfigEditor::save()'s schema
+        // validation (the partial doc here lacks required [audio].device etc.).
+        // We just want to prove set_f32 -> file -> get_f32_or preserves the
+        // value as a float.
         fs::write(&path, &serialized).unwrap();
         let reloaded = ConfigEditor::load_from(path).unwrap();
-        assert_eq!(
-            reloaded.get_float("audio.feedback", "volume"),
-            Some(0.70),
-            "volume must round-trip as a float"
-        );
-        assert_eq!(
-            reloaded.get_float("vad", "threshold"),
-            Some(0.5),
-            "threshold must round-trip as a float"
-        );
+        assert_eq!(reloaded.get_f32_or("audio.feedback", "volume", -1.0), 0.5);
+        assert_eq!(reloaded.get_f32_or("vad", "threshold", -1.0), 0.25);
+    }
+
+    #[test]
+    fn get_f32_or_recovers_legacy_string_and_int_forms() {
+        // Users running fielded v0.7.5 had their audio.feedback.volume and
+        // vad.threshold written as quoted strings by the buggy TUI. After
+        // the fix, the loader must still read those legacy values so the
+        // user isn't reset to the default — and the next save will migrate
+        // them to a proper TOML float.
+        let (_dir, path) = temp_config(concat!(
+            "[audio.feedback]\nvolume = \"0.70\"\n",
+            "[vad]\nthreshold = 1\n", // legacy int form
+            "[other]\n",              // missing key uses default
+        ));
+        let ed = ConfigEditor::load_from(path).unwrap();
+        assert_eq!(ed.get_f32_or("audio.feedback", "volume", -1.0), 0.70);
+        assert_eq!(ed.get_f32_or("vad", "threshold", -1.0), 1.0);
+        assert_eq!(ed.get_f32_or("other", "missing", 0.42), 0.42);
     }
 }

--- a/src/tui/vad_section.rs
+++ b/src/tui/vad_section.rs
@@ -43,9 +43,13 @@ impl VadState {
                 .get_string("vad", "backend")
                 .unwrap_or_else(|| "auto".to_string()),
             threshold: ed
-                .get_string("vad", "threshold")
-                .and_then(|s| s.parse().ok())
+                .get_float("vad", "threshold")
+                .map(|f| f as f32)
                 .or_else(|| ed.get_int("vad", "threshold").map(|n| n as f32))
+                .or_else(|| {
+                    ed.get_string("vad", "threshold")
+                        .and_then(|s| s.parse().ok())
+                })
                 .unwrap_or(0.5),
             field: Field::Enabled,
             feedback: None,
@@ -63,7 +67,7 @@ impl VadState {
         };
         ed.set_bool("vad", "enabled", self.enabled);
         ed.set_string("vad", "backend", &self.backend);
-        ed.set_string("vad", "threshold", &format!("{:.2}", self.threshold));
+        ed.set_float("vad", "threshold", self.threshold as f64);
         match ed.save() {
             Ok(()) => {
                 self.dirty_since_load = false;

--- a/src/tui/vad_section.rs
+++ b/src/tui/vad_section.rs
@@ -42,15 +42,7 @@ impl VadState {
             backend: ed
                 .get_string("vad", "backend")
                 .unwrap_or_else(|| "auto".to_string()),
-            threshold: ed
-                .get_float("vad", "threshold")
-                .map(|f| f as f32)
-                .or_else(|| ed.get_int("vad", "threshold").map(|n| n as f32))
-                .or_else(|| {
-                    ed.get_string("vad", "threshold")
-                        .and_then(|s| s.parse().ok())
-                })
-                .unwrap_or(0.5),
+            threshold: ed.get_f32_or("vad", "threshold", 0.5),
             field: Field::Enabled,
             feedback: None,
             dirty_since_load: false,
@@ -67,7 +59,7 @@ impl VadState {
         };
         ed.set_bool("vad", "enabled", self.enabled);
         ed.set_string("vad", "backend", &self.backend);
-        ed.set_float("vad", "threshold", self.threshold as f64);
+        ed.set_f32("vad", "threshold", self.threshold);
         match ed.save() {
             Ok(()) => {
                 self.dirty_since_load = false;


### PR DESCRIPTION
## Summary

The Audio and VAD TUI sections wrote their float-typed config fields via `ed.set_string(..., &format!("{:.2}", value))`, producing `volume = "0.70"` and `threshold = "0.50"` — quoted strings. The daemon's serde config rejects them with `invalid type: string "0.70", expected f32`.

Switch both writes to `ed.set_float(...)`, and prefer `get_float` on the loader side. Keep the existing `get_int` and `get_string` fallbacks so config files that already have the wrong form from a prior TUI save still parse cleanly on next open.

Adds a regression test in `config_editor` that pins serialization to a bare TOML number and round-trips through file -> load -> `get_float`.

Closes #451.

## Test plan

- [x] `cargo test --lib tui::` — all 38 pass, including the new `set_float_writes_toml_number_not_string`.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --lib -- -D warnings` clean.
- [ ] Manual: open TUI Audio section, change volume, save, confirm daemon restarts without error.
- [ ] Manual: open TUI VAD section, change threshold, save, confirm daemon restarts without error.
- [ ] Manual: existing config with `volume = "0.70"` (string) opens cleanly via fallback path.