### PR TITLE
test: drop stale upper-bound on detect_available_backends

### DIFF
--- a/src/setup/parakeet.rs
+++ b/src/setup/parakeet.rs
@@ -420,9 +420,16 @@ mod tests {
     }
 
     #[test]
-    fn detect_available_backends_returns_vec() {
-        let backends = detect_available_backends();
-        assert!(backends.len() <= 5);
+    fn detect_available_backends_does_not_panic() {
+        // Smoke test only — the function walks /usr/lib/voxtype/ on
+        // package installs and inspects /proc/self/exe on source builds,
+        // and the count of returned backends is bounded by whatever the
+        // host actually has installed (0 on a minimal CI runner, up to
+        // every ParakeetBackend variant on a fully-provisioned dev box).
+        // An earlier `len() <= 5` upper bound dated from before the v0.7.0
+        // CUDA 12/13 split and MIGraphX rename and started failing on
+        // dev boxes with the full variant set installed.
+        let _ = detect_available_backends();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`cargo test --lib` fails on `origin/dev` with:

```
thread 'setup::parakeet::tests::detect_available_backends_returns_vec'
panicked at src/setup/parakeet.rs:425:9:
assertion failed: backends.len() <= 5
```

The `len() <= 5` upper bound dates from the pre-v0.7.0 `ParakeetBackend` layout (`Avx2`, `Avx512`, `Cuda`, `Migraphx`, `Custom`). v0.7.0 split CUDA into `Cuda12` + `Cuda13`, added an unversioned `Cuda` legacy variant for source builds, and renamed ROCm → MIGraphX, bringing the enum to 7 variants. Dev boxes with most binaries installed under `/usr/lib/voxtype/` return more than 5 entries and trip the assertion.

The upper bound was never load-bearing — the count is bounded by what's on disk, not by anything the test should pin. Replace with a no-op call that still catches a panic or filesystem-walk crash, matching the shape of the adjacent `is_parakeet_active_does_not_panic`.

## Test plan

- [x] `cargo test --lib setup::parakeet::tests::` — all 8 pass locally.
- [ ] Confirm CI on dev goes green after merge.