### PR TITLE
Detect engine-vs-binary mismatch and surface in TUI + daemon (closes #450)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5755,6 +5755,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smithay-client-toolkit",
+ "strum",
  "tao",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "1"
 anyhow = "1"
 
+# Compile-time enum -> &'static str (replaces hand-written match blocks for
+# TranscriptionEngine::name and similar lookup-by-variant patterns; new enum
+# variants pick up the lowercase name automatically via serialize_all).
+strum = { version = "0.26", default-features = false, features = ["derive"] }
+
 # Text processing
 regex = "1"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1470,6 +1470,35 @@ pub enum TranscriptionEngine {
     Soniox,
 }
 
+impl TranscriptionEngine {
+    /// Canonical lowercase name, matching this enum's serde representation.
+    /// Use this for any user-visible label, config-file value, log key, or
+    /// Cargo feature reference (every non-Whisper engine's feature flag is
+    /// the same string as its name). Centralising the mapping keeps the
+    /// TUI banner, the daemon notification, the menubar engine writer, and
+    /// `variant_check`'s required-feature lookup from drifting out of sync
+    /// when a new engine is added — they all call `.name()`.
+    pub const fn name(&self) -> &'static str {
+        match self {
+            TranscriptionEngine::Whisper => "whisper",
+            TranscriptionEngine::Parakeet => "parakeet",
+            TranscriptionEngine::Moonshine => "moonshine",
+            TranscriptionEngine::SenseVoice => "sensevoice",
+            TranscriptionEngine::Paraformer => "paraformer",
+            TranscriptionEngine::Dolphin => "dolphin",
+            TranscriptionEngine::Omnilingual => "omnilingual",
+            TranscriptionEngine::Cohere => "cohere",
+            TranscriptionEngine::Soniox => "soniox",
+        }
+    }
+}
+
+impl std::fmt::Display for TranscriptionEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
 /// VAD backend selection
 ///
 /// Determines which voice activity detection algorithm to use.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1436,9 +1436,20 @@ impl Default for OmnilingualConfig {
 }
 
 /// Transcription engine selection (which ASR technology to use)
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Deserialize,
+    Serialize,
+    PartialEq,
+    Eq,
+    Default,
+    strum::IntoStaticStr,
+    strum::Display,
+)]
 #[serde(rename_all = "lowercase")]
-#[derive(Default)]
+#[strum(serialize_all = "lowercase")]
 pub enum TranscriptionEngine {
     /// Use Whisper (whisper.cpp via whisper-rs)
     #[default]
@@ -1472,30 +1483,13 @@ pub enum TranscriptionEngine {
 
 impl TranscriptionEngine {
     /// Canonical lowercase name, matching this enum's serde representation.
-    /// Use this for any user-visible label, config-file value, log key, or
-    /// Cargo feature reference (every non-Whisper engine's feature flag is
-    /// the same string as its name). Centralising the mapping keeps the
-    /// TUI banner, the daemon notification, the menubar engine writer, and
-    /// `variant_check`'s required-feature lookup from drifting out of sync
-    /// when a new engine is added — they all call `.name()`.
-    pub const fn name(&self) -> &'static str {
-        match self {
-            TranscriptionEngine::Whisper => "whisper",
-            TranscriptionEngine::Parakeet => "parakeet",
-            TranscriptionEngine::Moonshine => "moonshine",
-            TranscriptionEngine::SenseVoice => "sensevoice",
-            TranscriptionEngine::Paraformer => "paraformer",
-            TranscriptionEngine::Dolphin => "dolphin",
-            TranscriptionEngine::Omnilingual => "omnilingual",
-            TranscriptionEngine::Cohere => "cohere",
-            TranscriptionEngine::Soniox => "soniox",
-        }
-    }
-}
-
-impl std::fmt::Display for TranscriptionEngine {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.name())
+    /// Backed by `strum::IntoStaticStr` so a new variant added to the enum
+    /// picks up its `serialize_all = "lowercase"` name automatically — no
+    /// match block to keep in sync. The hand-written `name()` method
+    /// remains as a stable public API so call sites read `engine.name()`
+    /// rather than the less-obvious `(*engine).into()`.
+    pub fn name(self) -> &'static str {
+        self.into()
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2281,9 +2281,59 @@ impl Daemon {
         }
     }
 
+    /// Fire a desktop notification when the running binary can't service
+    /// the configured engine (e.g. `engine = "parakeet"` but the wrapper
+    /// dispatches to a CPU Whisper variant — the Ryan case from #450).
+    /// Logged at WARN regardless, so journalctl users see it too.
+    fn warn_on_variant_mismatch(&self) {
+        let inventory = crate::setup::binary::inventory();
+        let Some(mismatch) = crate::setup::variant_check::detect_mismatch(&self.config, &inventory)
+        else {
+            return;
+        };
+
+        let active = mismatch
+            .active_variant_name
+            .as_deref()
+            .unwrap_or("the running binary");
+        let title = format!("Voxtype: {} unavailable", mismatch.configured_engine);
+        let body = match &mismatch.remediation {
+            crate::setup::variant_check::Remediation::SwitchToVariant { target } => format!(
+                "{} was built without --features {}. \
+                 Run `sudo voxtype setup onnx --enable` (or open `voxtype configure` and press F2) \
+                 to switch to {}.",
+                active,
+                mismatch.required_feature,
+                target.binary_name(),
+            ),
+            crate::setup::variant_check::Remediation::Rebuild { feature } => format!(
+                "This source build was compiled without --features {}. \
+                 Rebuild voxtype with that feature to enable the {} engine.",
+                feature, mismatch.configured_engine,
+            ),
+        };
+
+        tracing::warn!(
+            engine = mismatch.configured_engine,
+            feature = mismatch.required_feature,
+            active = active,
+            "Variant mismatch at daemon startup: {}",
+            body
+        );
+        crate::notification::send_sync(&title, &body);
+    }
+
     /// Run the daemon main loop
     pub async fn run(&mut self) -> Result<()> {
         tracing::info!("Starting voxtype daemon");
+
+        // Engine-vs-binary mismatch check at startup so users see a desktop
+        // notification before the first transcription attempt would fail.
+        // create_transcriber() below will surface the same error in logs,
+        // but logs go to journald and most users never see them. A
+        // notify-send pops up where the user is actually looking. See
+        // #450 — the silent v0.6.x to v0.7.0 wrapper-flip incident.
+        self.warn_on_variant_mismatch();
 
         // Streaming dictation types characters at the cursor while the user is
         // still holding the PTT key. On Wayland compositors backed by libinput

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -176,17 +176,7 @@ fn set_engine(engine: TranscriptionEngine) -> bool {
 
     let content = std::fs::read_to_string(&config_path).unwrap_or_default();
 
-    let engine_str = match engine {
-        TranscriptionEngine::Parakeet => "parakeet",
-        TranscriptionEngine::Whisper => "whisper",
-        TranscriptionEngine::Moonshine => "moonshine",
-        TranscriptionEngine::SenseVoice => "sensevoice",
-        TranscriptionEngine::Paraformer => "paraformer",
-        TranscriptionEngine::Dolphin => "dolphin",
-        TranscriptionEngine::Omnilingual => "omnilingual",
-        TranscriptionEngine::Cohere => "cohere",
-        TranscriptionEngine::Soniox => "soniox",
-    };
+    let engine_str = engine.name();
 
     // Check if engine line exists
     let new_content = if content.contains("engine =") {

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -25,6 +25,7 @@ pub mod parakeet;
 pub mod quickshell;
 pub mod systemd;
 pub mod vad;
+pub mod variant_check;
 pub mod waybar;
 
 use crate::config::Config;

--- a/src/setup/variant_check.rs
+++ b/src/setup/variant_check.rs
@@ -77,33 +77,12 @@ pub enum Remediation {
 ///
 /// Whisper is unconditional in every variant (the engine itself is the
 /// reason whisper-rs is a non-optional dependency). Every other engine is
-/// behind a feature flag of the same name.
+/// behind a feature flag of the same name — so once Whisper is excluded
+/// the feature name is just the engine's canonical name.
 pub fn required_feature(engine: TranscriptionEngine) -> Option<&'static str> {
     match engine {
         TranscriptionEngine::Whisper => None,
-        TranscriptionEngine::Parakeet => Some("parakeet"),
-        TranscriptionEngine::Moonshine => Some("moonshine"),
-        TranscriptionEngine::SenseVoice => Some("sensevoice"),
-        TranscriptionEngine::Paraformer => Some("paraformer"),
-        TranscriptionEngine::Dolphin => Some("dolphin"),
-        TranscriptionEngine::Omnilingual => Some("omnilingual"),
-        TranscriptionEngine::Cohere => Some("cohere"),
-        TranscriptionEngine::Soniox => Some("soniox"),
-    }
-}
-
-/// Human-facing name for the engine, used in banner text and notifications.
-fn engine_display_name(engine: TranscriptionEngine) -> &'static str {
-    match engine {
-        TranscriptionEngine::Whisper => "whisper",
-        TranscriptionEngine::Parakeet => "parakeet",
-        TranscriptionEngine::Moonshine => "moonshine",
-        TranscriptionEngine::SenseVoice => "sensevoice",
-        TranscriptionEngine::Paraformer => "paraformer",
-        TranscriptionEngine::Dolphin => "dolphin",
-        TranscriptionEngine::Omnilingual => "omnilingual",
-        TranscriptionEngine::Cohere => "cohere",
-        TranscriptionEngine::Soniox => "soniox",
+        other => Some(other.name()),
     }
 }
 
@@ -140,7 +119,7 @@ pub fn detect_mismatch(config: &Config, inventory: &Inventory) -> Option<Variant
     };
 
     Some(VariantMismatch {
-        configured_engine: engine_display_name(engine),
+        configured_engine: engine.name(),
         required_feature: feature,
         active_variant_name,
         remediation,

--- a/src/setup/variant_check.rs
+++ b/src/setup/variant_check.rs
@@ -1,31 +1,13 @@
 //! Engine-vs-running-binary mismatch detection.
 //!
-//! The wrapper at `/usr/bin/voxtype` can dispatch to any of the installed
-//! variants (CPU Whisper, GPU Whisper, or one of the ONNX variants). When
-//! the variant the wrapper points at doesn't ship the engine the user has
-//! configured, the daemon fails with `TranscribeError::InitFailed` at
-//! startup and `voxtype models` lists "rebuild with --features X" for every
-//! engine the binary lacks.
+//! `/usr/bin/voxtype` dispatches to one installed variant (CPU Whisper,
+//! GPU Whisper, or an ONNX variant). When that variant lacks the engine
+//! the user configured, the daemon fails to initialize the transcriber
+//! and `voxtype models` lists "rebuild with --features X" for every
+//! engine the binary doesn't have.
 //!
-//! Two failure modes converge here:
-//!
-//! 1. A user upgraded from 0.6.x to 0.7.0 before the rename map landed in
-//!    voxtype-bin's post-upgrade hook (#446 / Discord/Ryan). Their saved
-//!    backend path `voxtype-parakeet-avx2` no longer existed, the hook
-//!    fell through to `_set_default_backend`, and they've been silently
-//!    running CPU Whisper despite `engine = "parakeet"` in their config.
-//!
-//! 2. A new user followed the AUR install instructions, kept the default
-//!    CPU variant, then edited `engine = "parakeet"` in their config. They
-//!    get the same end state without realizing they also need
-//!    `voxtype setup onnx --enable`.
-//!
-//! Both cases were invisible — `voxtype configure` opened cleanly to
-//! whichever section the user was after, and the engine-section warning
-//! sat behind a navigation away from the section the user opened. This
-//! module exposes the detection as a pure function so it can drive a
-//! global TUI banner, a daemon startup notification, and the Active
-//! Variant TUI switcher screen — all reading the same truth.
+//! Exposed as a pure function so the TUI banner, the daemon startup
+//! notification, and any future surface read the same truth.
 
 use crate::config::{Config, TranscriptionEngine};
 use crate::setup::binary::{Inventory, Variant};

--- a/src/setup/variant_check.rs
+++ b/src/setup/variant_check.rs
@@ -1,0 +1,283 @@
+//! Engine-vs-running-binary mismatch detection.
+//!
+//! The wrapper at `/usr/bin/voxtype` can dispatch to any of the installed
+//! variants (CPU Whisper, GPU Whisper, or one of the ONNX variants). When
+//! the variant the wrapper points at doesn't ship the engine the user has
+//! configured, the daemon fails with `TranscribeError::InitFailed` at
+//! startup and `voxtype models` lists "rebuild with --features X" for every
+//! engine the binary lacks.
+//!
+//! Two failure modes converge here:
+//!
+//! 1. A user upgraded from 0.6.x to 0.7.0 before the rename map landed in
+//!    voxtype-bin's post-upgrade hook (#446 / Discord/Ryan). Their saved
+//!    backend path `voxtype-parakeet-avx2` no longer existed, the hook
+//!    fell through to `_set_default_backend`, and they've been silently
+//!    running CPU Whisper despite `engine = "parakeet"` in their config.
+//!
+//! 2. A new user followed the AUR install instructions, kept the default
+//!    CPU variant, then edited `engine = "parakeet"` in their config. They
+//!    get the same end state without realizing they also need
+//!    `voxtype setup onnx --enable`.
+//!
+//! Both cases were invisible — `voxtype configure` opened cleanly to
+//! whichever section the user was after, and the engine-section warning
+//! sat behind a navigation away from the section the user opened. This
+//! module exposes the detection as a pure function so it can drive a
+//! global TUI banner, a daemon startup notification, and the Active
+//! Variant TUI switcher screen — all reading the same truth.
+
+use crate::config::{Config, TranscriptionEngine};
+use crate::setup::binary::{Inventory, Variant};
+
+/// What's wrong when the running binary can't serve the configured engine.
+///
+/// `None` means everything checks out: either the engine is Whisper (always
+/// available) or the running binary's `compiled_features` includes the
+/// engine's feature flag.
+#[derive(Debug, Clone)]
+pub struct VariantMismatch {
+    /// The engine the user has selected, e.g. `"parakeet"`. Lowercase
+    /// kebab-case so it can drop straight into the banner sentence.
+    pub configured_engine: &'static str,
+    /// The Cargo feature flag that would have to be compiled into a binary
+    /// for this engine to work, e.g. `"parakeet"`. Same string as
+    /// `configured_engine` for every engine today, but kept separate so
+    /// future engines whose feature name diverges from the engine name
+    /// (or that gate on a meta-feature) can be expressed cleanly.
+    pub required_feature: &'static str,
+    /// Basename of the binary the wrapper currently dispatches to, e.g.
+    /// `"voxtype-avx2"`. `None` only on source builds (no wrapper).
+    pub active_variant_name: Option<String>,
+    /// Recommended fix; varies by install kind. See [`Remediation`].
+    pub remediation: Remediation,
+}
+
+/// How to fix the mismatch, tailored to how voxtype was installed.
+///
+/// `Source` and `Package` are very different recovery paths: package users
+/// switch variants with one command, source users have to rebuild the
+/// binary. A TUI banner should phrase both correctly.
+#[derive(Debug, Clone)]
+pub enum Remediation {
+    /// Package install (voxtype-bin / .deb / .rpm / Nix). Swap the
+    /// `/usr/bin/voxtype` dispatch to the listed variant. `target` is the
+    /// recommended ONNX variant for this host's hardware
+    /// (`Inventory::recommendation.onnx`); the variant switcher screen
+    /// uses it as the default selection.
+    SwitchToVariant { target: Variant },
+    /// Source install (cargo build from a git checkout). The user has to
+    /// rebuild — there's no separate ONNX variant to swap to. `feature`
+    /// is the Cargo feature to add to the build, e.g. `"parakeet"`.
+    Rebuild { feature: &'static str },
+}
+
+/// Map a `TranscriptionEngine` to its required Cargo feature, or `None`
+/// for engines that have no compile-time gate.
+///
+/// Whisper is unconditional in every variant (the engine itself is the
+/// reason whisper-rs is a non-optional dependency). Every other engine is
+/// behind a feature flag of the same name.
+pub fn required_feature(engine: TranscriptionEngine) -> Option<&'static str> {
+    match engine {
+        TranscriptionEngine::Whisper => None,
+        TranscriptionEngine::Parakeet => Some("parakeet"),
+        TranscriptionEngine::Moonshine => Some("moonshine"),
+        TranscriptionEngine::SenseVoice => Some("sensevoice"),
+        TranscriptionEngine::Paraformer => Some("paraformer"),
+        TranscriptionEngine::Dolphin => Some("dolphin"),
+        TranscriptionEngine::Omnilingual => Some("omnilingual"),
+        TranscriptionEngine::Cohere => Some("cohere"),
+        TranscriptionEngine::Soniox => Some("soniox"),
+    }
+}
+
+/// Human-facing name for the engine, used in banner text and notifications.
+fn engine_display_name(engine: TranscriptionEngine) -> &'static str {
+    match engine {
+        TranscriptionEngine::Whisper => "whisper",
+        TranscriptionEngine::Parakeet => "parakeet",
+        TranscriptionEngine::Moonshine => "moonshine",
+        TranscriptionEngine::SenseVoice => "sensevoice",
+        TranscriptionEngine::Paraformer => "paraformer",
+        TranscriptionEngine::Dolphin => "dolphin",
+        TranscriptionEngine::Omnilingual => "omnilingual",
+        TranscriptionEngine::Cohere => "cohere",
+        TranscriptionEngine::Soniox => "soniox",
+    }
+}
+
+/// Returns `Some` when the configured engine isn't available in the running
+/// binary's compiled features, `None` when everything matches up.
+///
+/// The check looks only at the *running* binary's `compiled_features` — not
+/// at what's installed under `/usr/lib/voxtype/`. A package install with the
+/// right ONNX variant sitting on disk but the wrapper pointing at the CPU
+/// Whisper variant still trips the mismatch, because the running CLI / TUI
+/// invocation is the CPU binary and the daemon `systemctl --user restart
+/// voxtype` invokes the same wrapper. Surfacing this is the whole point of
+/// the check — the data is already on disk; the user just doesn't know.
+pub fn detect_mismatch(config: &Config, inventory: &Inventory) -> Option<VariantMismatch> {
+    let engine = config.engine;
+    let feature = required_feature(engine)?;
+    if inventory.compiled_features.contains(&feature) {
+        return None;
+    }
+
+    let active_variant_name = inventory
+        .active_variant
+        .map(|v| v.binary_name().to_string());
+
+    let remediation = match inventory.install_kind {
+        crate::setup::binary::InstallKind::Source => Remediation::Rebuild { feature },
+        // Package installs: recommend the hardware-appropriate ONNX variant.
+        // The Inventory's recommendation pass already picked the best one
+        // (CUDA-12/13 vs MIGraphX vs AVX-512 vs AVX2) given the detected
+        // CPU/GPU.
+        _ => Remediation::SwitchToVariant {
+            target: inventory.recommendation.onnx,
+        },
+    };
+
+    Some(VariantMismatch {
+        configured_engine: engine_display_name(engine),
+        required_feature: feature,
+        active_variant_name,
+        remediation,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::setup::binary::{Cpu, EngineFamily, Gpus, InstallKind, Recommendation, Variant};
+
+    fn fake_inventory(
+        install_kind: InstallKind,
+        compiled_features: Vec<&'static str>,
+        active_variant: Variant,
+        recommendation_onnx: Variant,
+    ) -> Inventory {
+        Inventory {
+            install_kind,
+            binary_path: "/usr/bin/voxtype".into(),
+            package_lib_dir: Some("/usr/lib/voxtype".into()),
+            active_variant: Some(active_variant),
+            variants: vec![],
+            cpu: Cpu {
+                avx2: true,
+                avx512: false,
+            },
+            gpus: Gpus {
+                nvidia: false,
+                amd: false,
+            },
+            compiled_features,
+            recommendation: Recommendation {
+                whisper: Variant::WhisperAvx2,
+                whisper_reason: "test",
+                onnx: recommendation_onnx,
+                onnx_reason: "test",
+                primary: Variant::WhisperAvx2,
+            },
+        }
+    }
+
+    fn config_with_engine(engine: TranscriptionEngine) -> Config {
+        Config {
+            engine,
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn whisper_engine_never_mismatches() {
+        let inv = fake_inventory(
+            InstallKind::Package,
+            vec![], // no ONNX features at all
+            Variant::WhisperAvx2,
+            Variant::OnnxAvx2,
+        );
+        let cfg = config_with_engine(TranscriptionEngine::Whisper);
+        assert!(detect_mismatch(&cfg, &inv).is_none());
+    }
+
+    #[test]
+    fn parakeet_on_cpu_whisper_binary_is_mismatch() {
+        // The Ryan case from Discord: engine = parakeet, running binary
+        // is the CPU Whisper variant with no ONNX features compiled in.
+        let inv = fake_inventory(
+            InstallKind::Package,
+            vec![], // only whisper, no parakeet
+            Variant::WhisperAvx2,
+            Variant::OnnxAvx2,
+        );
+        let cfg = config_with_engine(TranscriptionEngine::Parakeet);
+        let m = detect_mismatch(&cfg, &inv).expect("should detect mismatch");
+        assert_eq!(m.configured_engine, "parakeet");
+        assert_eq!(m.required_feature, "parakeet");
+        assert_eq!(m.active_variant_name.as_deref(), Some("voxtype-avx2"));
+        match m.remediation {
+            Remediation::SwitchToVariant { target } => {
+                assert_eq!(target, Variant::OnnxAvx2);
+                assert_eq!(target.family(), EngineFamily::Onnx);
+            }
+            Remediation::Rebuild { .. } => panic!("package install should recommend variant swap"),
+        }
+    }
+
+    #[test]
+    fn parakeet_on_onnx_binary_is_not_mismatch() {
+        let inv = fake_inventory(
+            InstallKind::Package,
+            vec!["parakeet", "moonshine", "sensevoice", "cohere"],
+            Variant::OnnxAvx2,
+            Variant::OnnxAvx2,
+        );
+        let cfg = config_with_engine(TranscriptionEngine::Parakeet);
+        assert!(detect_mismatch(&cfg, &inv).is_none());
+    }
+
+    #[test]
+    fn source_install_recommends_rebuild() {
+        let inv = fake_inventory(
+            InstallKind::Source,
+            vec![], // source build without --features cohere
+            Variant::WhisperNative,
+            Variant::OnnxNative,
+        );
+        let cfg = config_with_engine(TranscriptionEngine::Cohere);
+        let m = detect_mismatch(&cfg, &inv).expect("should detect");
+        match m.remediation {
+            Remediation::Rebuild { feature } => assert_eq!(feature, "cohere"),
+            Remediation::SwitchToVariant { .. } => {
+                panic!("source install should recommend rebuild, not variant swap")
+            }
+        }
+    }
+
+    #[test]
+    fn every_non_whisper_engine_has_a_required_feature() {
+        // Regression guard: if a new engine is added to TranscriptionEngine
+        // without updating required_feature, this catches it before it
+        // ships as a silent always-passes mismatch check.
+        let engines = [
+            TranscriptionEngine::Parakeet,
+            TranscriptionEngine::Moonshine,
+            TranscriptionEngine::SenseVoice,
+            TranscriptionEngine::Paraformer,
+            TranscriptionEngine::Dolphin,
+            TranscriptionEngine::Omnilingual,
+            TranscriptionEngine::Cohere,
+            TranscriptionEngine::Soniox,
+        ];
+        for e in engines {
+            assert!(
+                required_feature(e).is_some(),
+                "engine {:?} must declare a required Cargo feature",
+                e
+            );
+        }
+        assert_eq!(required_feature(TranscriptionEngine::Whisper), None);
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,7 @@
 //! TUI application state.
 
 use crate::setup::binary::{self, Acceleration, EngineFamily, InstallKind, Inventory, Variant};
+use crate::setup::variant_check::{self, VariantMismatch};
 use std::path::Path;
 
 use super::advanced_section::AdvancedState;
@@ -89,6 +90,13 @@ pub struct App {
     /// model name so the General banner can prompt the user to fetch it.
     /// Computed at load time and on `refresh_inventory()`.
     pub missing_model: Option<MissingModel>,
+    /// `Some` when the configured engine isn't available in the running
+    /// binary's compiled features (e.g. config says `engine = "parakeet"`
+    /// but `/usr/bin/voxtype` dispatches to the CPU Whisper variant). When
+    /// present, every section renders a persistent red banner above its
+    /// content pointing the user at the recovery path. Computed at load
+    /// time and on `refresh_inventory()`. See #450.
+    pub variant_mismatch: Option<VariantMismatch>,
     /// Lazily loaded Hotkey section state. None until the user opens Hotkey
     /// for the first time (or load fails).
     pub hotkey: Option<HotkeyState>,
@@ -159,6 +167,7 @@ impl App {
     pub fn new(force_package_mode: bool) -> Self {
         let inventory = build_inventory(force_package_mode);
         let cursor = initial_cursor(&inventory);
+        let variant_mismatch = detect_variant_mismatch(&inventory);
         Self {
             inventory,
             cursor,
@@ -172,6 +181,7 @@ impl App {
             help_open: false,
             quit_pending: false,
             missing_model: detect_missing_model(),
+            variant_mismatch,
             hotkey: None,
             audio: None,
             engine: None,
@@ -272,6 +282,7 @@ impl App {
         self.inventory = build_inventory(self.force_package_mode);
         self.daemon_running = is_daemon_running();
         self.missing_model = detect_missing_model();
+        self.variant_mismatch = detect_variant_mismatch(&self.inventory);
     }
 
     /// True when at least one section state has been loaded — the user has
@@ -414,6 +425,17 @@ fn initial_cursor(inv: &Inventory) -> (usize, usize) {
     } else {
         (0, 0)
     }
+}
+
+/// Compute the engine-vs-running-binary mismatch (see #450). Loads the
+/// config from its default path; returns `None` if config can't be loaded
+/// (we don't want a config parse error to prevent the TUI from opening,
+/// since the user opened it specifically to fix configuration). The
+/// inventory is borrowed from `App` so the call doesn't re-walk
+/// `/usr/lib/voxtype/` on every refresh.
+fn detect_variant_mismatch(inventory: &Inventory) -> Option<VariantMismatch> {
+    let cfg = crate::config::load_config(None).ok()?;
+    variant_check::detect_mismatch(&cfg, inventory)
 }
 
 /// Detect whether the configured engine's active model file is on disk.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -252,6 +252,19 @@ impl App {
         }
     }
 
+    /// Direct-navigate to a specific section, bypassing the sidebar cursor.
+    /// Used by F2 (jump to General to fix a variant mismatch), and a fine
+    /// hook for future "Press X to fix" cross-section affordances. Focuses
+    /// the content pane so the user can act immediately on arrival.
+    pub fn jump_to_section(&mut self, section: Section) {
+        self.current_section = section;
+        if let Some(idx) = Section::ALL.iter().position(|s| *s == section) {
+            self.sidebar_cursor = idx;
+        }
+        self.sidebar_focused = false;
+        self.ensure_section_loaded();
+    }
+
     pub fn focus_sidebar(&mut self) {
         self.sidebar_focused = true;
         // Keep cursor in sync with the active section so the user lands on the

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -366,26 +366,37 @@ fn handle_section_key(app: &mut App, key: KeyEvent) -> Action {
 }
 
 fn draw(f: &mut Frame, app: &App) {
+    // Reserve a row for the variant-mismatch banner when it's active. Slotting
+    // it between the title and the sidebar/content split means it stays
+    // visible no matter which section the user is on, which is the whole
+    // point — the General section's existing model-missing banner sits
+    // *inside* its section pane and disappears when the user navigates
+    // away. See #450.
+    let banner_height = if app.variant_mismatch.is_some() { 2 } else { 0 };
     let outer = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // title bar
-            Constraint::Min(0),    // body (sidebar + content)
-            Constraint::Length(1), // footer / help
+            Constraint::Length(1),             // title bar
+            Constraint::Length(banner_height), // variant-mismatch banner (0 when absent)
+            Constraint::Min(0),                // body (sidebar + content)
+            Constraint::Length(1),             // footer / help
         ])
         .split(f.area());
 
     render_title(f, outer[0]);
+    if app.variant_mismatch.is_some() {
+        render_variant_mismatch_banner(f, outer[1], app);
+    }
 
     let body = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Length(sidebar::WIDTH), Constraint::Min(0)])
-        .split(outer[1]);
+        .split(outer[2]);
 
     sidebar::render(f, body[0], app);
     render_section(f, body[1], app);
 
-    render_footer(f, outer[2], app);
+    render_footer(f, outer[3], app);
 
     if app.help_open {
         render_help_overlay(f);
@@ -513,6 +524,55 @@ fn render_title(f: &mut Frame, area: Rect) {
         ),
     ]);
     f.render_widget(Paragraph::new(line), area);
+}
+
+/// Persistent two-line banner shown at the top of every section when the
+/// running binary can't service the configured engine (see #450). The
+/// emoji-free, monochrome-bright style matches the existing TUI feedback
+/// banners (yellow accent, plain ASCII glyphs) so it renders the same in
+/// any palette.
+fn render_variant_mismatch_banner(f: &mut Frame, area: Rect, app: &App) {
+    use crate::setup::variant_check::Remediation;
+    let Some(m) = app.variant_mismatch.as_ref() else {
+        return;
+    };
+    let warn = Style::default().fg(Color::Yellow);
+    let dim = Style::default().fg(Color::DarkGray);
+    let bold = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(ratatui::style::Modifier::BOLD);
+
+    let active = m
+        .active_variant_name
+        .as_deref()
+        .unwrap_or("the running binary");
+
+    let line1 = Line::from(vec![
+        Span::styled(" ! ", bold),
+        Span::styled("engine = ", warn),
+        Span::styled(m.configured_engine, bold),
+        Span::styled(" but ", warn),
+        Span::styled(active, bold),
+        Span::styled(" was built without ", warn),
+        Span::styled(format!("--features {}", m.required_feature), bold),
+    ]);
+
+    let line2 = match &m.remediation {
+        Remediation::SwitchToVariant { target } => Line::from(vec![
+            Span::styled("   Fix: ", dim),
+            Span::styled("sudo voxtype setup onnx --enable", warn),
+            Span::styled(
+                format!("  (recommended variant: {})", target.binary_name()),
+                dim,
+            ),
+        ]),
+        Remediation::Rebuild { feature } => Line::from(vec![
+            Span::styled("   Fix: rebuild voxtype with ", dim),
+            Span::styled(format!("--features {}", feature), warn),
+        ]),
+    };
+
+    f.render_widget(Paragraph::new(vec![line1, line2]), area);
 }
 
 fn render_footer(f: &mut Frame, area: Rect, app: &App) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -278,6 +278,14 @@ fn handle_global_key(app: &mut App, key: KeyEvent) -> Option<Action> {
     match (key.code, key.modifiers) {
         (KeyCode::Char('q'), KeyModifiers::NONE) => Some(Action::Quit),
         (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => Some(Action::Quit),
+        // F2 jumps to the General section, where the variant-matrix picker
+        // lives. Mentioned in the variant-mismatch banner so a user landing
+        // on (say) Audio can fix the engine/binary mismatch without
+        // navigating the sidebar by hand. See #450.
+        (KeyCode::F(2), _) => {
+            app.jump_to_section(Section::General);
+            Some(Action::None)
+        }
         (KeyCode::Tab, _) => {
             if app.sidebar_focused {
                 app.focus_content();
@@ -479,6 +487,7 @@ fn render_help_overlay(f: &mut Frame) {
         Line::from("  Esc          Sidebar focus / quit from sidebar"),
         Line::from("  q, Ctrl-C    Quit"),
         Line::from("  ?            Toggle this help"),
+        Line::from("  F2           Jump to General (variant picker)"),
         Line::from(""),
         Line::from(Span::styled("Sidebar", bold)),
         Line::from("  ↑↓ / jk      Navigate sections"),
@@ -559,12 +568,11 @@ fn render_variant_mismatch_banner(f: &mut Frame, area: Rect, app: &App) {
 
     let line2 = match &m.remediation {
         Remediation::SwitchToVariant { target } => Line::from(vec![
-            Span::styled("   Fix: ", dim),
+            Span::styled("   Fix: press ", dim),
+            Span::styled("F2", warn),
+            Span::styled(" to open the variant picker, or run ", dim),
             Span::styled("sudo voxtype setup onnx --enable", warn),
-            Span::styled(
-                format!("  (recommended variant: {})", target.binary_name()),
-                dim,
-            ),
+            Span::styled(format!("  (recommended: {})", target.binary_name()), dim),
         ]),
         Remediation::Rebuild { feature } => Line::from(vec![
             Span::styled("   Fix: rebuild voxtype with ", dim),


### PR DESCRIPTION
## Summary

Three-surface fix for the silent variant-flip incident from Discord (Ryan: `engine = "parakeet"` in config, `/usr/bin/voxtype` dispatching to a CPU Whisper variant since his v0.6.x → v0.7.0 upgrade, no visible error). All three surfaces read from the same `detect_mismatch()` pure function so they can't drift apart.

**Commit 1** — `src/setup/variant_check.rs` (new module): pure detection function. Maps `config.engine` to its required Cargo feature, compares against the running binary's `compiled_features`, returns `VariantMismatch` with a per-install-kind remediation (variant swap for package installs, rebuild for source). Includes a regression test that breaks loudly if a new `TranscriptionEngine` variant is added without updating the feature map.

**Commit 2** — Persistent TUI banner. Two-row strip between the title bar and section content, shown on every section (not just General) whenever the running binary lacks the engine's feature. Phrases the fix as both the CLI command and the in-TUI hotkey:

```
 ! engine = parakeet but voxtype-avx2 was built without --features parakeet
    Fix: press F2 to open the variant picker, or run sudo voxtype setup onnx --enable  (recommended: voxtype-onnx-avx2)
```

For source builds the second line becomes `Fix: rebuild voxtype with --features parakeet`.

**Commit 3** — `F2` global shortcut jumps to the General section (variant matrix picker). Lands the user with the content pane focused so they can act immediately. Listed in the `?` help overlay so it's discoverable independent of the mismatch banner.

**Commit 4** — Daemon startup desktop notification. `Daemon::warn_on_variant_mismatch` runs as the first step of `Daemon::run`. Catches users who never open the TUI — they get a `notify-send` popup with the same remediation phrasing as the banner. Logged at `tracing::warn!` for journald.

## Why

`voxtype models` from the affected user lists `Parakeet (not available - rebuild with --features parakeet)`. That string is only printed by binaries compiled without the parakeet feature, so the wrapper's been dispatching to the CPU Whisper variant the whole time. The user's `config.toml` was correct; the binary couldn't service it. The voxtype-bin `_preserve_or_set_backend` hook fell through to `_set_default_backend` on the v0.6.x → v0.7.0 binary rename, and every subsequent upgrade preserved that wrong choice. #443 hardened the Rust `install_active_binary` path in v0.7.5 but did nothing for users *already* flipped — they just never knew.

## Test plan

- [x] `cargo test --lib` (744 pass, plus the pre-existing parakeet test #454 is fixing separately).
- [x] `cargo clippy --lib -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] Manual: open `voxtype configure` with `engine = "parakeet"` on a CPU Whisper variant → banner visible on every section; F2 navigates to General.
- [ ] Manual: `systemctl --user restart voxtype` with the same mismatch → desktop notification fires; daemon still starts (Whisper unaffected).
- [ ] Manual: source build with `engine = "cohere"` but no `--features cohere` → banner reads "rebuild voxtype with --features cohere", daemon notification reads same.

Closes #450.