### PR TITLE
Honor XDG_CONFIG_HOME on macOS for config and model paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,7 +360,7 @@ Based on open issues and project direction.
 
 ### Non-Goals
 
-- Windows/macOS support (Linux-first, Wayland-native)
+- Windows support (Linux-first, Wayland-native)
 - GUI configuration (GTK/Qt/web). A TUI (`voxtype configure`) is supported and
   surfaced as a desktop-file launcher entry; CLI and config file remain the
   primary interfaces for scripting and headless setups.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,6 +19,12 @@ Voxtype looks for configuration in the following locations (in order):
 3. `/etc/voxtype/config.toml` (system-wide default)
 4. Built-in defaults
 
+`$XDG_CONFIG_HOME` overrides `~/.config` on every platform, macOS included.
+Models follow the same scheme under `$XDG_DATA_HOME` (default `~/.local/share`).
+A macOS install that predates this and stored files under
+`~/Library/Application Support/voxtype` keeps working until you move them into
+`~/.config/voxtype` and `~/.local/share/voxtype`.
+
 ## Configuration Sections
 
 ---

--- a/docs/INSTALL_MACOS.md
+++ b/docs/INSTALL_MACOS.md
@@ -85,7 +85,10 @@ This shows:
 
 ## Configuration
 
-Config file: `~/Library/Application Support/voxtype/config.toml`
+Config file: `~/.config/voxtype/config.toml`, honoring `$XDG_CONFIG_HOME` if set.
+
+Older installs that wrote to `~/Library/Application Support/voxtype/config.toml`
+keep using it until you move the file to `~/.config/voxtype/`.
 
 ```toml
 # Transcription engine

--- a/src/config.rs
+++ b/src/config.rs
@@ -2487,10 +2487,9 @@ impl Config {
     /// System-wide config path used as a fallback when no user config exists.
     pub const SYSTEM_PATH: &'static str = "/etc/voxtype/config.toml";
 
-    /// Get the default user config file path (XDG)
+    /// Default user config file path: `<config_dir>/config.toml`.
     pub fn default_path() -> Option<PathBuf> {
-        directories::ProjectDirs::from("", "", "voxtype")
-            .map(|dirs| dirs.config_dir().join("config.toml"))
+        Self::config_dir().map(|dir| dir.join("config.toml"))
     }
 
     /// Get the system-wide config file path.
@@ -2540,17 +2539,46 @@ impl Config {
             })
     }
 
-    /// Get the config directory path
+    /// Voxtype's user config directory, honoring `$XDG_CONFIG_HOME` (default
+    /// `~/.config`) on every platform including macOS, where the `directories`
+    /// crate would use `~/Library/Application Support` and ignore XDG (#448).
     pub fn config_dir() -> Option<PathBuf> {
-        directories::ProjectDirs::from("", "", "voxtype")
-            .map(|dirs| dirs.config_dir().to_path_buf())
+        Self::xdg_dir(
+            "XDG_CONFIG_HOME",
+            ".config",
+            directories::ProjectDirs::from("", "", "voxtype").map(|d| d.config_dir().to_path_buf()),
+        )
     }
 
-    /// Get the data directory path (for models)
+    /// Voxtype's user data directory (parent of the models dir), honoring
+    /// `$XDG_DATA_HOME` (default `~/.local/share`); same scheme as [`Config::config_dir`].
     pub fn data_dir() -> PathBuf {
-        directories::ProjectDirs::from("", "", "voxtype")
-            .map(|dirs| dirs.data_dir().to_path_buf())
-            .unwrap_or_else(|| PathBuf::from("."))
+        Self::xdg_dir(
+            "XDG_DATA_HOME",
+            ".local/share",
+            directories::ProjectDirs::from("", "", "voxtype").map(|d| d.data_dir().to_path_buf()),
+        )
+        .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    /// Resolve a `voxtype` user dir. An explicit absolute `$xdg_var` wins;
+    /// otherwise `$HOME/<default_rel>/voxtype`. Falls back to an existing
+    /// `legacy` platform-native dir so an upgrade never orphans a prior install.
+    fn xdg_dir(xdg_var: &str, default_rel: &str, legacy: Option<PathBuf>) -> Option<PathBuf> {
+        if let Some(base) = std::env::var_os(xdg_var)
+            .map(PathBuf::from)
+            .filter(|p| p.is_absolute())
+        {
+            return Some(base.join("voxtype"));
+        }
+        let xdg = std::env::var_os("HOME")
+            .filter(|h| !h.is_empty())
+            .map(|h| PathBuf::from(h).join(default_rel).join("voxtype"));
+        match (xdg, legacy) {
+            (Some(x), Some(l)) if x != l && !x.exists() && l.exists() => Some(l),
+            (Some(x), _) => Some(x),
+            (None, l) => l,
+        }
     }
 
     /// Get the models directory path
@@ -4728,5 +4756,42 @@ mod tests {
             output.dotool_xkb_variant,
             Some("explicit-dotool".to_string())
         );
+    }
+
+    #[test]
+    fn xdg_dir_resolution() {
+        // Mutates $HOME / $XDG_CONFIG_HOME, like the other env tests here.
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::remove_var("XDG_CONFIG_HOME");
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        let xdg = tmp.path().join(".config/voxtype");
+        let legacy = tmp.path().join("Library/Application Support/voxtype");
+        let resolve = || Config::xdg_dir("XDG_CONFIG_HOME", ".config", Some(legacy.clone()));
+
+        // Fresh install: XDG path, even before it exists.
+        assert_eq!(resolve(), Some(xdg.clone()));
+        // Only the legacy dir exists (upgrade): keep it, do not orphan config.
+        std::fs::create_dir_all(&legacy).unwrap();
+        assert_eq!(resolve(), Some(legacy.clone()));
+        // Once the XDG dir exists too, it wins.
+        std::fs::create_dir_all(&xdg).unwrap();
+        assert_eq!(resolve(), Some(xdg));
+        // Explicit absolute XDG_CONFIG_HOME overrides everything.
+        std::env::set_var("XDG_CONFIG_HOME", "/tmp/voxtype-xdg-abs");
+        assert_eq!(
+            Config::config_dir(),
+            Some(PathBuf::from("/tmp/voxtype-xdg-abs/voxtype"))
+        );
+
+        match prev_xdg {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
     }
 }

--- a/src/meeting/storage.rs
+++ b/src/meeting/storage.rs
@@ -53,9 +53,7 @@ impl Default for StorageConfig {
 impl StorageConfig {
     /// Get the default storage path
     pub fn default_storage_path() -> PathBuf {
-        directories::ProjectDirs::from("", "", "voxtype")
-            .map(|dirs| dirs.data_dir().join("meetings"))
-            .unwrap_or_else(|| PathBuf::from("~/.local/share/voxtype/meetings"))
+        crate::config::Config::data_dir().join("meetings")
     }
 
     /// Get the database path

--- a/src/transcribe/cohere.rs
+++ b/src/transcribe/cohere.rs
@@ -542,12 +542,7 @@ fn resolve_model_path(name: &str) -> Result<PathBuf, TranscribeError> {
     if let Ok(env) = std::env::var("VOXTYPE_COHERE_MODEL_DIR") {
         return Ok(PathBuf::from(env));
     }
-    let dirs = directories::ProjectDirs::from("io", "voxtype", "voxtype").ok_or_else(|| {
-        TranscribeError::ModelNotFound(
-            "Could not resolve model directory (no ProjectDirs)".to_string(),
-        )
-    })?;
-    Ok(dirs.data_dir().join("models").join(name))
+    Ok(crate::config::Config::models_dir().join(name))
 }
 
 fn build_session(

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -965,10 +965,7 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
 /// resolution path so the TUI's "is this downloaded?" check matches what
 /// the daemon will look for at load time.
 fn model_dir_on_disk(name: &str) -> std::path::PathBuf {
-    if let Some(dirs) = directories::ProjectDirs::from("io", "voxtype", "voxtype") {
-        return dirs.data_dir().join("models").join(name);
-    }
-    std::path::PathBuf::from(name)
+    crate::config::Config::models_dir().join(name)
 }
 
 /// True when the model directory exists with at least one file in it. We


### PR DESCRIPTION
## Problem

`directories::ProjectDirs` returns `~/Library/Application Support/voxtype` on macOS and ignores `XDG_CONFIG_HOME` entirely, so a user who keeps their config in `~/.config` (dotfiles repo) is silently ignored on a Mac (#448). Voxtype is a CLI tool whose `config.toml` is hand-edited, which is exactly the case where the XDG layout is expected. `git`, `gh`, `kubectl`, `neovim`, and the rest of the CLI ecosystem already read `~/.config` on macOS.

## Change

- `Config::config_dir` / `Config::data_dir` now honor `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME` (default `~/.config` and `~/.local/share`) on every platform, macOS included. `default_path` and `models_dir` route through these, so config and models move together.
- An explicit XDG env var always wins. When unset, an existing legacy install under the platform-native location keeps working, so an upgrade never orphans a Mac user's config or already-downloaded models. New installs land in `~/.config`.
- Unified the three call sites that resolved their own `ProjectDirs` (`cohere` model dir, TUI model-on-disk check, meeting storage) through `Config`, so macOS no longer splits models across two directories.
- Updated `docs/CONFIGURATION.md`, `docs/INSTALL_MACOS.md`, and the stale "macOS is a non-goal" line in `CLAUDE.md`.

## Backwards compatibility

On Linux the resolved paths are unchanged: `$XDG_CONFIG_HOME` (or `~/.config`) is what `ProjectDirs` already returned. Only macOS behavior changes, and only for installs that have no legacy directory yet.

## Verification

One regression test added in `src/config.rs`. It fails to compile against `main` (the `xdg_dir` helper and the XDG-first logic do not exist there); it passes on this branch:

```
$ cargo test --lib xdg
running 5 tests
test config::tests::xdg_dir_resolution ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 732 filtered out

$ cargo build
    Finished `dev` profile [optimized + debuginfo] target(s)

$ cargo clippy --lib   # 0 warnings in changed files
```

Full lib suite: 736 passing before, 737 after (1 new).


