### PR TITLE
setup: error suggestion echoes the subcommand the user invoked (closes #449)

### DIFF
--- a/src/setup/binary.rs
+++ b/src/setup/binary.rs
@@ -60,7 +60,17 @@ fn variant_subdir(basename: &str) -> Option<&'static str> {
     }
 }
 
-pub fn install_active_binary(active_bin: &str, binary_path: &Path) -> anyhow::Result<()> {
+/// `retry_hint` is the subcommand fragment to suggest in error messages when
+/// the write fails (typically because the user forgot `sudo`). Callers pass
+/// the command they were invoked under so the user can retry exactly what
+/// they ran — e.g. `setup gpu --enable` for a Vulkan switch, or `setup onnx
+/// --enable` for a Parakeet switch. The function emits the full retry as
+/// `Try: sudo voxtype <retry_hint>`.
+pub fn install_active_binary(
+    active_bin: &str,
+    binary_path: &Path,
+    retry_hint: &str,
+) -> anyhow::Result<()> {
     // Decide whether this variant needs a wrapper script (vs a plain symlink)
     // from the BASENAME, not from the canonicalized parent dir. The previous
     // implementation looked at `fs::canonicalize(binary_path).parent()`,
@@ -94,9 +104,10 @@ pub fn install_active_binary(active_bin: &str, binary_path: &Path) -> anyhow::Re
         fs::remove_file(active_bin).map_err(|e| {
             anyhow::anyhow!(
                 "Failed to remove existing {} (need sudo?): {}\n\
-                 Try: sudo voxtype setup onnx --enable",
+                 Try: sudo voxtype {}",
                 active_bin,
-                e
+                e,
+                retry_hint
             )
         })?;
     }
@@ -130,9 +141,10 @@ pub fn install_active_binary(active_bin: &str, binary_path: &Path) -> anyhow::Re
         let mut f = fs::File::create(active_bin).map_err(|e| {
             anyhow::anyhow!(
                 "Failed to create {} (need sudo?): {}\n\
-                 Try: sudo voxtype setup onnx --enable",
+                 Try: sudo voxtype {}",
                 active_bin,
-                e
+                e,
+                retry_hint
             )
         })?;
         f.write_all(wrapper.as_bytes())?;
@@ -144,8 +156,9 @@ pub fn install_active_binary(active_bin: &str, binary_path: &Path) -> anyhow::Re
         symlink(binary_path, active_bin).map_err(|e| {
             anyhow::anyhow!(
                 "Failed to create symlink (need sudo?): {}\n\
-                 Try: sudo voxtype setup onnx --enable",
-                e
+                 Try: sudo voxtype {}",
+                e,
+                retry_hint
             )
         })?;
     }
@@ -791,7 +804,16 @@ pub fn switch_to(variant: Variant) -> anyhow::Result<()> {
         );
     }
 
-    install_active_binary(SYSTEM_BIN, &binary_path)?;
+    // Whisper variants live behind `setup gpu`; ONNX variants behind
+    // `setup onnx`. Pick the retry hint matching the user's destination
+    // so a permission failure points them at the same subcommand they'd
+    // normally use to install this variant directly.
+    let retry_hint = match variant.family() {
+        EngineFamily::Whisper => "setup gpu --enable",
+        EngineFamily::Onnx => "setup onnx --enable",
+    };
+
+    install_active_binary(SYSTEM_BIN, &binary_path, retry_hint)?;
 
     Ok(())
 }

--- a/src/setup/gpu.rs
+++ b/src/setup/gpu.rs
@@ -352,7 +352,7 @@ fn switch_backend_tiered(backend: Backend) -> anyhow::Result<()> {
         );
     }
 
-    install_active_binary(active_bin, &binary_path)
+    install_active_binary(active_bin, &binary_path, "setup gpu --enable")
 }
 
 /// Enable GPU in simple mode (switch symlink from native to vulkan)
@@ -990,5 +990,5 @@ fn switch_backend_tiered_parakeet(binary_name: &str) -> anyhow::Result<()> {
         );
     }
 
-    install_active_binary(active_bin, &binary_path)
+    install_active_binary(active_bin, &binary_path, "setup onnx --enable")
 }


### PR DESCRIPTION
## Summary

\`install_active_binary\`'s three permission-denied error messages hardcoded \`Try: sudo voxtype setup onnx --enable\`. A user running \`voxtype setup gpu --enable\` saw the wrong suggestion, sending them at the engine-class switcher instead of letting them retry the GPU command with sudo.

Add a \`retry_hint: &str\` parameter; callers pass their own subcommand fragment. The function emits \`Try: sudo voxtype <hint>\`. Three callers updated:

- \`switch_backend_tiered\` → \`"setup gpu --enable"\`
- \`switch_backend_tiered_parakeet\` → \`"setup onnx --enable"\`
- \`switch_to(variant)\` → derived from \`variant.family()\` (Whisper variants → gpu, ONNX variants → onnx)

The wrapper script's internal \`Managed by\` comment stays as \`setup onnx --enable\` because the wrapper is only generated for ONNX GPU variants (cuda-12, cuda-13, migraphx).

Closes #449.

## Test plan

- [x] \`cargo check\` + \`clippy -D warnings\` clean.
- [x] \`cargo test --lib\` — all 742 pass.
- [ ] Manual: \`voxtype setup gpu --enable\` (no sudo) shows \`Try: sudo voxtype setup gpu --enable\`.
- [ ] Manual: \`voxtype setup onnx --enable\` (no sudo) shows \`Try: sudo voxtype setup onnx --enable\`.