### PR TITLE
transcribe: fail-fast when streaming pairs with non-streaming model (closes #442)

### DIFF
--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -201,6 +201,14 @@ pub fn is_streaming_compatible_parakeet(name: &str) -> bool {
         .any(|m| m.name == name && m.streaming_compatible)
 }
 
+/// Returns true when the named model is one this build's registry knows about.
+/// Lets callers distinguish "known model that doesn't support streaming"
+/// (error case) from "unknown custom model" (warn-but-proceed case) when
+/// gating the streaming pipeline at load time.
+pub fn is_known_parakeet_model(name: &str) -> bool {
+    PARAKEET_MODELS.iter().any(|m| m.name == name)
+}
+
 /// Canonical Parakeet model name that the TUI auto-switches to when the user
 /// enables streaming on top of an incompatible model. Stable string identifier
 /// rather than a struct lookup so config writers and feedback messages can

--- a/src/transcribe/parakeet_streaming.rs
+++ b/src/transcribe/parakeet_streaming.rs
@@ -56,6 +56,41 @@ pub struct ParakeetStreamingTranscriber {
 
 impl ParakeetStreamingTranscriber {
     pub fn new(config: &ParakeetConfig) -> Result<Self, TranscribeError> {
+        // Streaming-capability gate. The cache-aware streaming pipeline
+        // needs both `tokenizer.model` at load time and a decoder graph
+        // sized for the streaming inference loop. Models in the registry
+        // that don't meet both (e.g. istupakov's TDT-v3) hit either a
+        // tokenizer-not-found at load or an ONNX Gather shape error at
+        // first chunk — neither is a useful diagnostic. Fail fast here
+        // with a message that names the model and the known-good
+        // alternative. Unknown model names (custom user directories)
+        // fall through with a warning since we can't validate them.
+        if crate::setup::model::is_known_parakeet_model(&config.model)
+            && !crate::setup::model::is_streaming_compatible_parakeet(&config.model)
+        {
+            return Err(TranscribeError::InitFailed(format!(
+                "Parakeet streaming is enabled but model `{}` does not support \
+                 cache-aware streaming.\n\n\
+                 Fix one of:\n\n  \
+                 - Disable streaming in config.toml under [parakeet]:\n\n      \
+                 streaming = false\n\n  \
+                 - Or switch to the streaming-compatible model:\n\n      \
+                 voxtype setup model {streaming_model}\n\n    \
+                 and set [parakeet] model = \"{streaming_model}\" in config.toml.",
+                config.model,
+                streaming_model = crate::setup::model::DEFAULT_PARAKEET_STREAMING_MODEL,
+            )));
+        }
+        if !crate::setup::model::is_known_parakeet_model(&config.model) {
+            tracing::warn!(
+                model = %config.model,
+                "Parakeet streaming requested with a model not in the registry; \
+                 cannot validate streaming compatibility ahead of time. If load \
+                 fails below, switch [parakeet] model to {} or set streaming = false.",
+                crate::setup::model::DEFAULT_PARAKEET_STREAMING_MODEL
+            );
+        }
+
         let model_path = resolve_model_path(&config.model)?;
 
         tracing::info!(
@@ -282,5 +317,38 @@ mod tests {
     fn streaming_config_validation_accepts_defaults() {
         let cfg = UnifiedStreamingConfig::default();
         assert!(cfg.validate().is_ok());
+    }
+
+    /// Regression for #442: enabling streaming on a known non-streaming model
+    /// (e.g. `parakeet-tdt-0.6b-v3`) must fail early in `new()` with a
+    /// message that names the model and points the user at the
+    /// streaming-compatible alternative, instead of falling through to an
+    /// opaque ONNX Gather shape error at the first audio chunk.
+    #[test]
+    fn new_rejects_streaming_on_known_incompatible_model() {
+        let cfg = ParakeetConfig {
+            model: "parakeet-tdt-0.6b-v3".to_string(),
+            streaming: true,
+            ..ParakeetConfig::default()
+        };
+        // Can't use `.expect_err`: ParakeetStreamingTranscriber wraps
+        // parakeet-rs types that don't derive Debug.
+        let err = match ParakeetStreamingTranscriber::new(&cfg) {
+            Ok(_) => panic!("streaming on a non-streaming model should error before model load"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parakeet-tdt-0.6b-v3"),
+            "error must name the configured model: {msg}"
+        );
+        assert!(
+            msg.contains(crate::setup::model::DEFAULT_PARAKEET_STREAMING_MODEL),
+            "error must name the streaming-compatible alternative: {msg}"
+        );
+        assert!(
+            msg.contains("streaming = false") || msg.contains("voxtype setup model"),
+            "error must offer at least one concrete fix: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Add a streaming-capability gate at the top of `ParakeetStreamingTranscriber::new`. When the configured Parakeet model is in the registry and marked `streaming_compatible: false` (e.g. `parakeet-tdt-0.6b-v3`), return a clear `TranscribeError::InitFailed` before reaching ONNX Runtime. Unknown models fall through with a warning.

Error message names the configured model, both fix options, and the exact \`voxtype setup model\` command to run.

Closes #442 (the v0.7.6 follow-up from Pete's last comment on the issue).

## Behavior change

Before:
```
$ systemctl --user restart voxtype
ERROR ... Failed to open tokenizer.model: No such file or directory (os error 2)
```
or
```
ERROR ... ONNX Runtime: Got invalid dimensions for input: ... index out of bounds
```

After:
```
Error: Parakeet streaming is enabled but model \`parakeet-tdt-0.6b-v3\` does not
support cache-aware streaming.

Fix one of:

  - Disable streaming in config.toml under [parakeet]:

      streaming = false

  - Or switch to the streaming-compatible model:

      voxtype setup model parakeet-unified-en-0.6b

    and set [parakeet] model = "parakeet-unified-en-0.6b" in config.toml.
```

## Test plan

- [x] `cargo test --lib --features parakeet transcribe::parakeet_streaming::` — 3 tests pass, including the new `new_rejects_streaming_on_known_incompatible_model`.
- [ ] Manual: edit `config.toml` to `[parakeet] model = "parakeet-tdt-0.6b-v3"` + `streaming = true`, restart daemon, confirm clear error before model load.