### PR TITLE
Migrate ONNX model downloads to R2 CDN + consolidate download functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4629,6 +4629,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5754,6 +5765,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "smithay-client-toolkit",
  "strum",
  "tao",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ which = "7"
 # Temp files (for CLI backend audio)
 tempfile = "3"
 
+# SHA-256 integrity check for R2 model downloads
+sha2 = "0.10"
+
 # Audio playback (for feedback sounds)
 rodio = { version = "0.19", default-features = false, features = ["wav"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,6 +305,13 @@ path = "src/bin/voxtype_audio_bridge.rs"
 name = "voxtype-osd-quickshell"
 path = "src/bin/voxtype_osd_quickshell.rs"
 
+# Internal helper that dumps the ONNX model registry as JSON for the
+# `scripts/mirror-models-to-r2.sh` script. Not shipped in releases; it's
+# a build-tree-only utility for populating R2 from upstream HF.
+[[bin]]
+name = "voxtype-mirror-registry"
+path = "src/bin/voxtype_mirror_registry.rs"
+
 [[example]]
 name = "inspect_cohere_onnx"
 required-features = ["cohere"]

--- a/scripts/mirror-models-to-r2.sh
+++ b/scripts/mirror-models-to-r2.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# mirror-models-to-r2.sh — populate the voxtype-models R2 bucket from
+# upstream HuggingFace repos, generating manifest.json with sha256s along
+# the way.
+#
+# Layout written to R2:
+#   r2:voxtype-models/{engine_prefix}/{model_name}/manifest.json
+#   r2:voxtype-models/{engine_prefix}/{model_name}/{relative_file_path}
+#
+# The local file path on R2 matches what `download_artifact` writes to disk
+# under `{models_dir}/{model_name}/`, so the runtime sees a byte-identical
+# tree.
+#
+# Prerequisites:
+#   - rclone configured with a remote literally named `r2` pointing at the
+#     Cloudflare R2 bucket holding the `voxtype-models` namespace. The
+#     remote's bucket name must be `voxtype-models`.
+#       rclone config show r2          # to verify
+#   - curl available on PATH.
+#   - sha256sum (coreutils).
+#   - cargo + a checkout of this repo (the script runs
+#     `cargo run --bin voxtype-mirror-registry` to discover models).
+#
+# Usage:
+#   ./scripts/mirror-models-to-r2.sh <model-name>      # one model
+#   ./scripts/mirror-models-to-r2.sh --all             # every model
+#   ./scripts/mirror-models-to-r2.sh --all --dry-run   # skip rclone upload
+#
+# For the very first population (no models on R2 yet) Pete should run:
+#   ./scripts/mirror-models-to-r2.sh --all
+#
+# This is idempotent: re-running re-downloads from HF, recomputes sha256s,
+# and (unless --dry-run) overwrites R2 with the fresh bytes. Identical
+# uploads are a no-op for rclone's size/mtime checks but the manifest will
+# always be re-uploaded.
+
+set -euo pipefail
+
+DRY_RUN=0
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --all)
+            TARGET="--all"
+            shift
+            ;;
+        --help|-h)
+            sed -n 's/^# \{0,1\}//p' "$0" | sed -n '1,40p'
+            exit 0
+            ;;
+        --*)
+            echo "error: unknown flag: $1" >&2
+            exit 2
+            ;;
+        *)
+            if [[ -n "$TARGET" && "$TARGET" != "--all" ]]; then
+                echo "error: multiple positional args; pass one model name or --all" >&2
+                exit 2
+            fi
+            TARGET="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$TARGET" ]]; then
+    echo "error: pass a model name or --all (try --help)" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+R2_REMOTE="${VOXTYPE_R2_REMOTE:-r2:voxtype-models}"
+
+# Sanity-check tooling up front rather than failing mid-mirror.
+for cmd in curl sha256sum cargo jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "error: required command not found on PATH: $cmd" >&2
+        exit 1
+    fi
+done
+
+if [[ "$DRY_RUN" -eq 0 ]] && ! command -v rclone >/dev/null 2>&1; then
+    echo "error: rclone not found on PATH (or pass --dry-run)" >&2
+    exit 1
+fi
+
+cd "$REPO_DIR"
+
+echo "[mirror] building voxtype-mirror-registry..." >&2
+cargo build --quiet --bin voxtype-mirror-registry
+
+REGISTRY_JSON="$(./target/debug/voxtype-mirror-registry)"
+
+mirror_one() {
+    local engine="$1"
+    local name="$2"
+    local upstream="$3"
+    local files_json="$4"
+
+    local workdir
+    workdir="$(mktemp -d -t voxtype-mirror-XXXXXX)"
+    trap 'rm -rf "$workdir"' RETURN
+
+    echo "" >&2
+    echo "[mirror] $engine/$name <- huggingface.co/$upstream" >&2
+
+    # Build manifest while downloading.
+    local manifest_files="[]"
+    local total_size=0
+    local file_count
+    file_count="$(echo "$files_json" | jq 'length')"
+
+    for i in $(seq 0 $((file_count - 1))); do
+        local upstream_path local_path url dest size sha
+        upstream_path="$(echo "$files_json" | jq -r ".[$i].upstream_path")"
+        local_path="$(echo "$files_json" | jq -r ".[$i].local_path")"
+        url="https://huggingface.co/$upstream/resolve/main/$upstream_path"
+        dest="$workdir/$local_path"
+
+        mkdir -p "$(dirname "$dest")"
+        echo "  fetching $upstream_path -> $local_path" >&2
+        # `--fail` so a 404 doesn't quietly produce an HTML error page.
+        curl -fsSL --retry 3 -o "$dest" "$url"
+
+        size="$(stat -c %s "$dest")"
+        sha="$(sha256sum "$dest" | awk '{print $1}')"
+        total_size=$((total_size + size))
+
+        manifest_files="$(jq --arg p "$local_path" --argjson s "$size" --arg h "$sha" \
+            '. + [{"path": $p, "size": $s, "sha256": $h}]' <<< "$manifest_files")"
+    done
+
+    local manifest_json
+    manifest_json="$(jq -n \
+        --argjson v 1 \
+        --arg m "$name" \
+        --arg e "$engine" \
+        --argjson f "$manifest_files" \
+        '{version: $v, model: $m, engine: $e, files: $f}')"
+    echo "$manifest_json" > "$workdir/manifest.json"
+
+    local manifest_sha
+    manifest_sha="$(sha256sum "$workdir/manifest.json" | awk '{print $1}')"
+    local dest_path="$R2_REMOTE/$engine/$name/"
+
+    echo "[mirror] $name: $file_count files, $total_size bytes, manifest sha256 $manifest_sha" >&2
+    echo "[mirror] destination: $dest_path" >&2
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "[mirror] --dry-run set, skipping rclone copy" >&2
+    else
+        rclone copy --progress "$workdir/" "$dest_path"
+    fi
+}
+
+if [[ "$TARGET" == "--all" ]]; then
+    echo "$REGISTRY_JSON" | jq -c '.[]' | while read -r entry; do
+        engine="$(echo "$entry" | jq -r '.engine_prefix')"
+        name="$(echo "$entry" | jq -r '.name')"
+        upstream="$(echo "$entry" | jq -r '.upstream_repo')"
+        files_json="$(echo "$entry" | jq -c '.files')"
+        mirror_one "$engine" "$name" "$upstream" "$files_json"
+    done
+else
+    entry="$(echo "$REGISTRY_JSON" | jq -c --arg n "$TARGET" '.[] | select(.name == $n)')"
+    if [[ -z "$entry" ]]; then
+        echo "error: no model named '$TARGET' in the registry" >&2
+        echo "       try --all to mirror everything, or pick one of:" >&2
+        echo "$REGISTRY_JSON" | jq -r '.[].name' | sed 's/^/         - /' >&2
+        exit 1
+    fi
+    engine="$(echo "$entry" | jq -r '.engine_prefix')"
+    name="$(echo "$entry" | jq -r '.name')"
+    upstream="$(echo "$entry" | jq -r '.upstream_repo')"
+    files_json="$(echo "$entry" | jq -c '.files')"
+    mirror_one "$engine" "$name" "$upstream" "$files_json"
+fi
+
+echo "" >&2
+echo "[mirror] done." >&2

--- a/scripts/mirror-models-to-r2.sh
+++ b/scripts/mirror-models-to-r2.sh
@@ -39,6 +39,12 @@ set -euo pipefail
 DRY_RUN=0
 TARGET=""
 
+# Models that hit a per-file 404 (or transient fetch failure) during mirroring
+# and got skipped. Reported as a non-fatal summary at the end so the operator
+# knows which registry entries need follow-up cleanup. See the warn branch in
+# `mirror_one` and the registry-cleanup TODO.
+SKIPPED_MODELS=()
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)
@@ -126,7 +132,18 @@ mirror_one() {
         mkdir -p "$(dirname "$dest")"
         echo "  fetching $upstream_path -> $local_path" >&2
         # `--fail` so a 404 doesn't quietly produce an HTML error page.
-        curl -fsSL --retry 3 -o "$dest" "$url"
+        # Use `if !` to opt out of `set -e` for this one call — a single
+        # missing file should skip the model and continue with the next,
+        # not abort the whole run. The registry has stale entries (e.g.
+        # Moonshine language variants that expect decoder_model_merged.onnx
+        # while the upstream HF repo only ships decoder_model.onnx); their
+        # fix is a separate registry-cleanup PR, not blocking the mirror.
+        if ! curl -fsSL --retry 3 -o "$dest" "$url"; then
+            echo "  WARN: HF 404 (or transient failure) on $upstream_path" >&2
+            echo "  WARN: skipping model $engine/$name; will not be mirrored" >&2
+            SKIPPED_MODELS+=("$engine/$name (missing: $upstream_path)")
+            return 0
+        fi
 
         size="$(stat -c %s "$dest")"
         sha="$(sha256sum "$dest" | awk '{print $1}')"
@@ -160,13 +177,16 @@ mirror_one() {
 }
 
 if [[ "$TARGET" == "--all" ]]; then
-    echo "$REGISTRY_JSON" | jq -c '.[]' | while read -r entry; do
+    # Process-substitution rather than `... | while` so SKIPPED_MODELS+=
+    # inside mirror_one persists past the loop body (a pipe would put the
+    # whole while-loop in a subshell and lose the array on exit).
+    while read -r entry; do
         engine="$(echo "$entry" | jq -r '.engine_prefix')"
         name="$(echo "$entry" | jq -r '.name')"
         upstream="$(echo "$entry" | jq -r '.upstream_repo')"
         files_json="$(echo "$entry" | jq -c '.files')"
         mirror_one "$engine" "$name" "$upstream" "$files_json"
-    done
+    done < <(echo "$REGISTRY_JSON" | jq -c '.[]')
 else
     entry="$(echo "$REGISTRY_JSON" | jq -c --arg n "$TARGET" '.[] | select(.name == $n)')"
     if [[ -z "$entry" ]]; then
@@ -184,3 +204,15 @@ fi
 
 echo "" >&2
 echo "[mirror] done." >&2
+
+if [[ ${#SKIPPED_MODELS[@]} -gt 0 ]]; then
+    echo "" >&2
+    echo "[mirror] WARNING: ${#SKIPPED_MODELS[@]} model(s) skipped due to upstream 404 or fetch failure:" >&2
+    for entry in "${SKIPPED_MODELS[@]}"; do
+        echo "  - $entry" >&2
+    done
+    echo "" >&2
+    echo "[mirror] These registry entries point at upstream HuggingFace files that do not exist (or" >&2
+    echo "         changed). Audit them in src/setup/model.rs and either fix the file list or" >&2
+    echo "         remove the entry. The remaining models were mirrored successfully." >&2
+fi

--- a/src/bin/voxtype_mirror_registry.rs
+++ b/src/bin/voxtype_mirror_registry.rs
@@ -1,0 +1,15 @@
+//! Helper binary that dumps voxtype's ONNX-engine model registry to stdout
+//! as JSON. Consumed by `scripts/mirror-models-to-r2.sh` so the script
+//! doesn't have to parse Rust source to know which models to mirror.
+//!
+//! Each registry entry includes the engine sub-namespace, the model name
+//! (which doubles as the R2 directory under the engine), the upstream
+//! HuggingFace repo, and the upstream→local file-path mapping. The mirror
+//! script downloads upstream paths and uploads them to R2 under local paths
+//! so the runtime sees exactly what `download_artifact` expects.
+
+fn main() {
+    let registry = voxtype::setup::model::registry_snapshot();
+    let json = serde_json::to_string_pretty(&registry).expect("registry serializes to JSON");
+    println!("{}", json);
+}

--- a/src/setup/manifest.rs
+++ b/src/setup/manifest.rs
@@ -1,0 +1,320 @@
+//! R2 model manifest schema and `ModelArtifact` trait.
+//!
+//! Every ONNX-engine model voxtype downloads is mirrored to Cloudflare R2 at
+//! `https://models.voxtype.io/{engine_prefix}/{model_name}/`. Alongside the
+//! model files sits a `manifest.json` describing the file list and per-file
+//! sha256 hashes. The runtime downloader fetches the manifest first, then
+//! validates each file as it lands on disk.
+//!
+//! The manifest is the source of truth for integrity. The struct-level
+//! `expected_files()` list in `ModelArtifact` is a sanity check used by both
+//! the mirror script (so it knows what to publish) and the runtime (so a
+//! download that succeeds but doesn't match the publisher's expectation is
+//! surfaced before transcription tries to load a broken model directory).
+//!
+//! See `roadmap` in `CLAUDE.md` ("voxtype-models CDN") and the matching
+//! mirror script at `scripts/mirror-models-to-r2.sh`.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Base URL for the Cloudflare R2 model mirror. Every model artifact lives at
+/// `{MODELS_BASE_URL}/{engine_prefix}/{name}/{file}` and ships a sibling
+/// `manifest.json` describing the files and their sha256 hashes.
+pub const MODELS_BASE_URL: &str = "https://models.voxtype.io";
+
+/// Schema version currently produced by the mirror script and consumed by the
+/// runtime downloader. Bump this only with a coordinated runtime + mirror
+/// rollout.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// One file's entry in `manifest.json`. `path` is relative to the model
+/// directory on R2 (and to the local target directory on disk). `sha256` is
+/// lowercase hex, matching the output of `sha256sum`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ManifestFile {
+    pub path: String,
+    pub size: u64,
+    pub sha256: String,
+}
+
+/// `manifest.json` content shipped alongside every model on R2.
+///
+/// `model` and `engine` are checked against the requesting `ModelArtifact` so
+/// a misrouted upload (e.g. parakeet manifest under moonshine prefix) fails
+/// fast instead of silently corrupting a model directory.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Manifest {
+    pub version: u32,
+    pub model: String,
+    pub engine: String,
+    pub files: Vec<ManifestFile>,
+}
+
+/// A file the local installer expects to see in the model directory once
+/// download finishes. The runtime compares the manifest's `files` against the
+/// artifact's `expected_files()` so a publisher who forgets to list a file
+/// (and therefore wouldn't sha256-verify it) doesn't silently leave a hole.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedFile {
+    pub path: String,
+    pub size: u64,
+}
+
+/// Common interface across every ONNX engine's model definition struct.
+/// Implemented by `ParakeetModelInfo`, `MoonshineModelInfo`, etc. in
+/// `super::model`. The unified `download_artifact()` consumes this trait so
+/// the per-engine `download_*_model_by_info` duplicates can be deleted.
+///
+/// `engine_prefix` is the R2 sub-namespace and matches the manifest's
+/// `engine` field. `upstream_repo` is only consumed by the mirror script
+/// (`scripts/mirror-models-to-r2.sh`); the runtime never touches it.
+pub trait ModelArtifact {
+    /// Stable model identifier. Used as the URL segment under `engine_prefix`
+    /// and as the on-disk directory name under `models_dir`.
+    fn name(&self) -> &str;
+
+    /// Engine sub-namespace under `MODELS_BASE_URL`. Static because every
+    /// implementor knows its engine at compile time.
+    fn engine_prefix(&self) -> &'static str;
+
+    /// HuggingFace `owner/repo` of the upstream the model was mirrored from.
+    /// The mirror script reads this; the runtime does not.
+    fn upstream_repo(&self) -> &str;
+
+    /// Files the publisher expects this model to ship, with their expected
+    /// sizes. The manifest is authoritative for sha256s; this list catches
+    /// "publisher forgot to enumerate a file in the manifest" cases.
+    fn expected_files(&self) -> Vec<ExpectedFile>;
+}
+
+/// Validate that a manifest matches the artifact requesting it. Returns an
+/// error if the version/model/engine don't line up, or if any file the
+/// artifact expects is missing from the manifest.
+///
+/// Pulled out into a free function so unit tests can exercise it without
+/// going near the network.
+pub fn validate_manifest<T: ModelArtifact + ?Sized>(
+    manifest: &Manifest,
+    artifact: &T,
+) -> anyhow::Result<()> {
+    if manifest.version != MANIFEST_SCHEMA_VERSION {
+        anyhow::bail!(
+            "unsupported manifest version {} (expected {}) for model '{}'",
+            manifest.version,
+            MANIFEST_SCHEMA_VERSION,
+            artifact.name()
+        );
+    }
+    if manifest.model != artifact.name() {
+        anyhow::bail!(
+            "manifest model name mismatch: manifest says '{}', artifact says '{}'",
+            manifest.model,
+            artifact.name()
+        );
+    }
+    if manifest.engine != artifact.engine_prefix() {
+        anyhow::bail!(
+            "manifest engine mismatch for '{}': manifest says '{}', artifact says '{}'",
+            artifact.name(),
+            manifest.engine,
+            artifact.engine_prefix()
+        );
+    }
+    let manifest_paths: std::collections::HashSet<&str> =
+        manifest.files.iter().map(|f| f.path.as_str()).collect();
+    let mut missing = Vec::new();
+    for expected in artifact.expected_files() {
+        if !manifest_paths.contains(expected.path.as_str()) {
+            missing.push(expected.path);
+        }
+    }
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "manifest for '{}' is missing expected files: {}",
+            artifact.name(),
+            missing.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// Compute the R2 URL for a model's manifest.
+pub fn manifest_url<T: ModelArtifact + ?Sized>(artifact: &T) -> String {
+    format!(
+        "{}/{}/{}/manifest.json",
+        MODELS_BASE_URL,
+        artifact.engine_prefix(),
+        artifact.name()
+    )
+}
+
+/// Compute the R2 URL for one file within a model.
+pub fn file_url<T: ModelArtifact + ?Sized>(artifact: &T, relative_path: &str) -> String {
+    format!(
+        "{}/{}/{}/{}",
+        MODELS_BASE_URL,
+        artifact.engine_prefix(),
+        artifact.name(),
+        relative_path
+    )
+}
+
+/// Local on-disk path for one file within a model directory under
+/// `models_dir`. Centralised so the downloader and the mirror script agree
+/// on layout.
+pub fn local_file_path(models_dir: &std::path::Path, name: &str, relative_path: &str) -> PathBuf {
+    models_dir.join(name).join(relative_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeArtifact {
+        name: &'static str,
+        engine: &'static str,
+        files: Vec<ExpectedFile>,
+    }
+
+    impl ModelArtifact for FakeArtifact {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn engine_prefix(&self) -> &'static str {
+            self.engine
+        }
+        fn upstream_repo(&self) -> &str {
+            "fake/repo"
+        }
+        fn expected_files(&self) -> Vec<ExpectedFile> {
+            self.files.clone()
+        }
+    }
+
+    fn good_manifest() -> Manifest {
+        Manifest {
+            version: 1,
+            model: "fake".to_string(),
+            engine: "parakeet".to_string(),
+            files: vec![
+                ManifestFile {
+                    path: "encoder.onnx".to_string(),
+                    size: 100,
+                    sha256: "aa".to_string(),
+                },
+                ManifestFile {
+                    path: "vocab.txt".to_string(),
+                    size: 10,
+                    sha256: "bb".to_string(),
+                },
+            ],
+        }
+    }
+
+    fn good_artifact() -> FakeArtifact {
+        FakeArtifact {
+            name: "fake",
+            engine: "parakeet",
+            files: vec![ExpectedFile {
+                path: "encoder.onnx".to_string(),
+                size: 100,
+            }],
+        }
+    }
+
+    #[test]
+    fn manifest_round_trip_json() {
+        let m = good_manifest();
+        let s = serde_json::to_string(&m).unwrap();
+        let back: Manifest = serde_json::from_str(&s).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn deserializes_sample_json() {
+        let json = r#"{
+            "version": 1,
+            "model": "parakeet-unified-en-0.6b",
+            "engine": "parakeet",
+            "files": [
+                {"path": "encoder.onnx", "size": 43878400, "sha256": "abcd"},
+                {"path": "tokenizer.model", "size": 257024, "sha256": "ef01"}
+            ]
+        }"#;
+        let m: Manifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.version, 1);
+        assert_eq!(m.model, "parakeet-unified-en-0.6b");
+        assert_eq!(m.engine, "parakeet");
+        assert_eq!(m.files.len(), 2);
+        assert_eq!(m.files[0].path, "encoder.onnx");
+        assert_eq!(m.files[0].size, 43_878_400);
+    }
+
+    #[test]
+    fn validate_manifest_happy_path() {
+        validate_manifest(&good_manifest(), &good_artifact()).unwrap();
+    }
+
+    #[test]
+    fn validate_manifest_rejects_wrong_version() {
+        let mut m = good_manifest();
+        m.version = 2;
+        let err = validate_manifest(&m, &good_artifact()).unwrap_err();
+        assert!(err.to_string().contains("unsupported manifest version"));
+    }
+
+    #[test]
+    fn validate_manifest_rejects_model_mismatch() {
+        let mut m = good_manifest();
+        m.model = "different".to_string();
+        let err = validate_manifest(&m, &good_artifact()).unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("manifest model name mismatch"), "got: {}", s);
+        assert!(s.contains("different"));
+        assert!(s.contains("fake"));
+    }
+
+    #[test]
+    fn validate_manifest_rejects_engine_mismatch() {
+        let mut m = good_manifest();
+        m.engine = "moonshine".to_string();
+        let err = validate_manifest(&m, &good_artifact()).unwrap_err();
+        assert!(err.to_string().contains("manifest engine mismatch"));
+    }
+
+    #[test]
+    fn validate_manifest_flags_missing_expected_file() {
+        let artifact = FakeArtifact {
+            name: "fake",
+            engine: "parakeet",
+            files: vec![
+                ExpectedFile {
+                    path: "encoder.onnx".to_string(),
+                    size: 100,
+                },
+                ExpectedFile {
+                    path: "missing.bin".to_string(),
+                    size: 50,
+                },
+            ],
+        };
+        let err = validate_manifest(&good_manifest(), &artifact).unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("missing expected files"), "got: {}", s);
+        assert!(s.contains("missing.bin"), "got: {}", s);
+    }
+
+    #[test]
+    fn url_helpers_match_spec() {
+        let a = good_artifact();
+        assert_eq!(
+            manifest_url(&a),
+            "https://models.voxtype.io/parakeet/fake/manifest.json"
+        );
+        assert_eq!(
+            file_url(&a, "encoder.onnx"),
+            "https://models.voxtype.io/parakeet/fake/encoder.onnx"
+        );
+    }
+}

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -20,6 +20,7 @@ pub mod hammerspoon;
 pub mod launchd;
 #[cfg(target_os = "macos")]
 pub mod macos;
+pub mod manifest;
 pub mod model;
 pub mod parakeet;
 pub mod quickshell;

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -856,6 +856,147 @@ impl ModelArtifact for CohereModelInfo {
 }
 
 // =============================================================================
+// Registry export (for the mirror script)
+// =============================================================================
+
+/// One entry in the registry consumed by the `voxtype-mirror-registry`
+/// helper binary. The mirror script reads JSON-serialised
+/// `RegistryEntry`s and iterates them to populate R2 from upstream HF.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RegistryEntry {
+    pub engine_prefix: &'static str,
+    pub name: String,
+    pub upstream_repo: String,
+    /// Mapping from upstream HF repo path to the local file path we
+    /// publish on R2. Identical to what `download_artifact` writes to
+    /// disk. The mirror script keeps the local form authoritative so
+    /// the manifest's sha256s match what the runtime will see.
+    pub files: Vec<RegistryFile>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RegistryFile {
+    pub upstream_path: String,
+    pub local_path: String,
+}
+
+/// Snapshot the full ONNX-engine model registry (Parakeet, Moonshine,
+/// SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) into a single
+/// flat list. Used by `voxtype-mirror-registry` to drive
+/// `scripts/mirror-models-to-r2.sh`.
+pub fn registry_snapshot() -> Vec<RegistryEntry> {
+    let mut out = Vec::new();
+    for m in PARAKEET_MODELS {
+        out.push(RegistryEntry {
+            engine_prefix: "parakeet",
+            name: m.name.to_string(),
+            upstream_repo: m.huggingface_repo.to_string(),
+            // Parakeet's `files` is `(filename, size)`; the same name is
+            // used upstream and locally.
+            files: m
+                .files
+                .iter()
+                .map(|(f, _)| RegistryFile {
+                    upstream_path: (*f).to_string(),
+                    local_path: (*f).to_string(),
+                })
+                .collect(),
+        });
+    }
+    for m in MOONSHINE_MODELS {
+        out.push(RegistryEntry {
+            engine_prefix: "moonshine",
+            name: m.dir_name.to_string(),
+            upstream_repo: m.huggingface_repo.to_string(),
+            files: m
+                .files
+                .iter()
+                .map(|(remote, local)| RegistryFile {
+                    upstream_path: (*remote).to_string(),
+                    local_path: (*local).to_string(),
+                })
+                .collect(),
+        });
+    }
+    for m in SENSEVOICE_MODELS {
+        out.push(RegistryEntry {
+            engine_prefix: "sensevoice",
+            name: m.dir_name.to_string(),
+            upstream_repo: m.huggingface_repo.to_string(),
+            files: m
+                .files
+                .iter()
+                .map(|(remote, local)| RegistryFile {
+                    upstream_path: (*remote).to_string(),
+                    local_path: (*local).to_string(),
+                })
+                .collect(),
+        });
+    }
+    for m in PARAFORMER_MODELS {
+        out.push(RegistryEntry {
+            engine_prefix: "paraformer",
+            name: m.dir_name.to_string(),
+            upstream_repo: m.huggingface_repo.to_string(),
+            files: m
+                .files
+                .iter()
+                .map(|(remote, local)| RegistryFile {
+                    upstream_path: (*remote).to_string(),
+                    local_path: (*local).to_string(),
+                })
+                .collect(),
+        });
+    }
+    for m in DOLPHIN_MODELS {
+        out.push(RegistryEntry {
+            engine_prefix: "dolphin",
+            name: m.dir_name.to_string(),
+            upstream_repo: m.huggingface_repo.to_string(),
+            files: m
+                .files
+                .iter()
+                .map(|(remote, local)| RegistryFile {
+                    upstream_path: (*remote).to_string(),
+                    local_path: (*local).to_string(),
+                })
+                .collect(),
+        });
+    }
+    for m in OMNILINGUAL_MODELS {
+        out.push(RegistryEntry {
+            engine_prefix: "omnilingual",
+            name: m.dir_name.to_string(),
+            upstream_repo: m.huggingface_repo.to_string(),
+            files: m
+                .files
+                .iter()
+                .map(|(remote, local)| RegistryFile {
+                    upstream_path: (*remote).to_string(),
+                    local_path: (*local).to_string(),
+                })
+                .collect(),
+        });
+    }
+    for m in COHERE_MODELS {
+        out.push(RegistryEntry {
+            engine_prefix: "cohere",
+            name: m.dir_name.to_string(),
+            upstream_repo: m.huggingface_repo.to_string(),
+            files: m
+                .files
+                .iter()
+                .map(|(remote, local)| RegistryFile {
+                    upstream_path: (*remote).to_string(),
+                    local_path: (*local).to_string(),
+                })
+                .collect(),
+        });
+    }
+    out
+}
+
+// =============================================================================
 // Unified R2 downloader
 // =============================================================================
 

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -702,6 +702,10 @@ impl ModelArtifact for ParakeetModelInfo {
 }
 
 impl ModelArtifact for MoonshineModelInfo {
+    // Intentional: the trait method is `name()` but the struct field that
+    // serves as the canonical identifier is `dir_name`. Clippy's
+    // misnamed_getters lint fires on the mismatch; it's not a bug.
+    #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         self.dir_name
     }
@@ -727,6 +731,10 @@ impl ModelArtifact for MoonshineModelInfo {
 }
 
 impl ModelArtifact for SenseVoiceModelInfo {
+    // Intentional: the trait method is `name()` but the struct field that
+    // serves as the canonical identifier is `dir_name`. Clippy's
+    // misnamed_getters lint fires on the mismatch; it's not a bug.
+    #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         self.dir_name
     }
@@ -748,6 +756,10 @@ impl ModelArtifact for SenseVoiceModelInfo {
 }
 
 impl ModelArtifact for ParaformerModelInfo {
+    // Intentional: the trait method is `name()` but the struct field that
+    // serves as the canonical identifier is `dir_name`. Clippy's
+    // misnamed_getters lint fires on the mismatch; it's not a bug.
+    #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         self.dir_name
     }
@@ -769,6 +781,10 @@ impl ModelArtifact for ParaformerModelInfo {
 }
 
 impl ModelArtifact for DolphinModelInfo {
+    // Intentional: the trait method is `name()` but the struct field that
+    // serves as the canonical identifier is `dir_name`. Clippy's
+    // misnamed_getters lint fires on the mismatch; it's not a bug.
+    #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         self.dir_name
     }
@@ -790,6 +806,10 @@ impl ModelArtifact for DolphinModelInfo {
 }
 
 impl ModelArtifact for OmnilingualModelInfo {
+    // Intentional: the trait method is `name()` but the struct field that
+    // serves as the canonical identifier is `dir_name`. Clippy's
+    // misnamed_getters lint fires on the mismatch; it's not a bug.
+    #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         self.dir_name
     }
@@ -811,6 +831,10 @@ impl ModelArtifact for OmnilingualModelInfo {
 }
 
 impl ModelArtifact for CohereModelInfo {
+    // Intentional: the trait method is `name()` but the struct field that
+    // serves as the canonical identifier is `dir_name`. Clippy's
+    // misnamed_getters lint fires on the mismatch; it's not a bug.
+    #[allow(clippy::misnamed_getters)]
     fn name(&self) -> &str {
         self.dir_name
     }
@@ -829,6 +853,180 @@ impl ModelArtifact for CohereModelInfo {
             })
             .collect()
     }
+}
+
+// =============================================================================
+// Unified R2 downloader
+// =============================================================================
+
+/// Download a model artifact from the voxtype-models R2 mirror.
+///
+/// Fetches `{MODELS_BASE_URL}/{engine_prefix}/{name}/manifest.json`, validates
+/// it against the artifact's identity and expected file list, then downloads
+/// every file the manifest enumerates into `{models_dir}/{name}/`. Each file
+/// is sha256-verified against the manifest as soon as the download finishes;
+/// a mismatched file is deleted and the call fails.
+///
+/// No HuggingFace fallback. Voxtype controls R2 directly so we can serve
+/// integrity guarantees that community HF accounts can't promise; falling
+/// back to HF would defeat the purpose of the migration. If R2 is genuinely
+/// unreachable, the error message points users at the Cloudflare status
+/// page.
+pub fn download_artifact<T: ModelArtifact + ?Sized>(
+    artifact: &T,
+    models_dir: &Path,
+) -> anyhow::Result<()> {
+    use super::manifest::{file_url, manifest_url, validate_manifest, Manifest};
+
+    let model_dir = models_dir.join(artifact.name());
+    std::fs::create_dir_all(&model_dir)?;
+
+    let manifest_url_str = manifest_url(artifact);
+    let manifest_json = curl_fetch_text(&manifest_url_str).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to fetch manifest from {}: {}.\n  \
+             If this persists, check models.voxtype.io status: \
+             https://www.cloudflarestatus.com/",
+            manifest_url_str,
+            e
+        )
+    })?;
+
+    let manifest: Manifest = serde_json::from_str(&manifest_json).map_err(|e| {
+        anyhow::anyhow!("Manifest at {} is not valid JSON: {}", manifest_url_str, e)
+    })?;
+    validate_manifest(&manifest, artifact)?;
+
+    println!(
+        "\nDownloading {} ({} files via {})...\n",
+        artifact.name(),
+        manifest.files.len(),
+        manifest_url_str,
+    );
+
+    for file in &manifest.files {
+        let dest = model_dir.join(&file.path);
+
+        if dest.exists() {
+            // Re-verify existing file's sha256 so a partial/corrupt cached
+            // file doesn't silently survive an upgrade. If it matches, skip;
+            // otherwise treat as missing and re-download.
+            match sha256_file(&dest) {
+                Ok(hash) if hash == file.sha256.to_lowercase() => {
+                    println!("  {} already verified, skipping", file.path);
+                    continue;
+                }
+                _ => {
+                    println!("  {} present but unverified, re-downloading", file.path);
+                    let _ = std::fs::remove_file(&dest);
+                }
+            }
+        }
+
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let url = file_url(artifact, &file.path);
+        println!("Downloading {}...", file.path);
+        curl_download(&url, &dest)?;
+
+        let observed = sha256_file(&dest).map_err(|e| {
+            let _ = std::fs::remove_file(&dest);
+            anyhow::anyhow!("Failed to hash {}: {}", file.path, e)
+        })?;
+        let expected = file.sha256.to_lowercase();
+        if observed != expected {
+            let _ = std::fs::remove_file(&dest);
+            anyhow::bail!(
+                "sha256 mismatch for {} (downloaded from {}): expected {}, got {}",
+                file.path,
+                url,
+                expected,
+                observed,
+            );
+        }
+    }
+
+    print_success(&format!(
+        "Model '{}' downloaded to {:?}",
+        artifact.name(),
+        model_dir
+    ));
+    Ok(())
+}
+
+/// Fetch a small text body via curl. Used for `manifest.json`.
+fn curl_fetch_text(url: &str) -> anyhow::Result<String> {
+    let output = Command::new("curl")
+        .args(["-fsSL", "--retry", "2", "--max-time", "30", url])
+        .output()
+        .map_err(|e| anyhow::anyhow!("failed to run curl: {}", e))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "curl failed with exit code {} (stderr: {})",
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+/// Download a single URL to `dest` via curl with a progress bar. Cleans up
+/// the partial file on failure.
+fn curl_download(url: &str, dest: &Path) -> anyhow::Result<()> {
+    let status = Command::new("curl")
+        .args([
+            "-L",
+            "--fail",
+            "--progress-bar",
+            "-o",
+            dest.to_str().unwrap_or("file"),
+            url,
+        ])
+        .status();
+
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        Ok(s) => {
+            let _ = std::fs::remove_file(dest);
+            print_failure(&format!(
+                "Download failed: curl exited with code {}",
+                s.code().unwrap_or(-1)
+            ));
+            anyhow::bail!(
+                "Download failed for {} from {}.\n  \
+                 If this persists, check models.voxtype.io status: \
+                 https://www.cloudflarestatus.com/",
+                dest.display(),
+                url
+            )
+        }
+        Err(e) => {
+            print_failure(&format!("Failed to run curl: {}", e));
+            print_info("Please ensure curl is installed (e.g., 'sudo pacman -S curl')");
+            anyhow::bail!("curl not available: {}", e)
+        }
+    }
+}
+
+/// Streaming sha256 of a file on disk. Used both for post-download
+/// verification and for re-validating a previously cached file.
+fn sha256_file(path: &Path) -> anyhow::Result<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 // =============================================================================
@@ -1226,40 +1424,19 @@ pub async fn interactive_select() -> anyhow::Result<()> {
         handle_sensevoice_selection(sensevoice_index).await
     } else if paraformer_available && selection <= paraformer_offset + paraformer_count {
         let idx = selection - paraformer_offset;
-        handle_onnx_engine_selection(
-            "paraformer",
-            PARAFORMER_MODELS
-                .iter()
-                .map(|m| (m.name, m.dir_name, m.size_mb, m.files, m.huggingface_repo))
-                .collect(),
-            idx,
-            validate_onnx_ctc_model,
-        )
-        .await
+        let entries: Vec<(&str, &ParaformerModelInfo)> =
+            PARAFORMER_MODELS.iter().map(|m| (m.name, m)).collect();
+        handle_onnx_engine_selection("paraformer", &entries, idx, validate_onnx_ctc_model).await
     } else if dolphin_available && selection <= dolphin_offset + dolphin_count {
         let idx = selection - dolphin_offset;
-        handle_onnx_engine_selection(
-            "dolphin",
-            DOLPHIN_MODELS
-                .iter()
-                .map(|m| (m.name, m.dir_name, m.size_mb, m.files, m.huggingface_repo))
-                .collect(),
-            idx,
-            validate_onnx_ctc_model,
-        )
-        .await
+        let entries: Vec<(&str, &DolphinModelInfo)> =
+            DOLPHIN_MODELS.iter().map(|m| (m.name, m)).collect();
+        handle_onnx_engine_selection("dolphin", &entries, idx, validate_onnx_ctc_model).await
     } else if omnilingual_available && selection <= omnilingual_offset + omnilingual_count {
         let idx = selection - omnilingual_offset;
-        handle_onnx_engine_selection(
-            "omnilingual",
-            OMNILINGUAL_MODELS
-                .iter()
-                .map(|m| (m.name, m.dir_name, m.size_mb, m.files, m.huggingface_repo))
-                .collect(),
-            idx,
-            validate_onnx_ctc_model,
-        )
-        .await
+        let entries: Vec<(&str, &OmnilingualModelInfo)> =
+            OMNILINGUAL_MODELS.iter().map(|m| (m.name, m)).collect();
+        handle_onnx_engine_selection("omnilingual", &entries, idx, validate_onnx_ctc_model).await
     } else if cohere_available && selection <= cohere_offset + cohere_count {
         let idx = selection - cohere_offset;
         handle_cohere_selection(idx).await
@@ -1367,7 +1544,8 @@ async fn handle_parakeet_selection(selection: usize) -> anyhow::Result<()> {
     }
 
     // Download the model
-    download_parakeet_model_by_info(model)?;
+    download_artifact(model, &Config::models_dir())?;
+    validate_parakeet_model(&Config::models_dir().join(model.name))?;
 
     // Update config and restart daemon
     update_config_parakeet(model.name)?;
@@ -1438,7 +1616,8 @@ async fn handle_moonshine_selection(selection: usize) -> anyhow::Result<()> {
     }
 
     // Download the model
-    download_moonshine_model_by_info(model)?;
+    download_artifact(model, &Config::models_dir())?;
+    validate_moonshine_model(&Config::models_dir().join(model.dir_name))?;
 
     // Update config and restart daemon
     update_config_moonshine(model.name)?;
@@ -1833,79 +2012,21 @@ pub fn validate_parakeet_model(path: &Path) -> anyhow::Result<()> {
     }
 }
 
-/// Download a Parakeet model by name (public API for run_setup)
+/// Download a Parakeet model by name (public API for run_setup).
+///
+/// Routes through the unified R2 downloader (`download_artifact`). The
+/// per-engine validator runs after the download to guard against publisher
+/// errors that the sha256 check can't catch (e.g. a missing file the
+/// manifest didn't enumerate).
 pub fn download_parakeet_model(model_name: &str) -> anyhow::Result<()> {
     let model = PARAKEET_MODELS
         .iter()
         .find(|m| m.name == model_name)
         .ok_or_else(|| anyhow::anyhow!("Unknown Parakeet model: {}", model_name))?;
 
-    download_parakeet_model_by_info(model)
-}
-
-/// Download a Parakeet model using its info struct
-fn download_parakeet_model_by_info(model: &ParakeetModelInfo) -> anyhow::Result<()> {
     let models_dir = Config::models_dir();
-    let model_path = models_dir.join(model.name);
-
-    // Create model directory
-    std::fs::create_dir_all(&model_path)?;
-
-    println!("\nDownloading {} ({} MB)...\n", model.name, model.size_mb);
-
-    for (filename, _expected_size) in model.files {
-        let file_path = model_path.join(filename);
-
-        if file_path.exists() {
-            println!("  {} already exists, skipping", filename);
-            continue;
-        }
-
-        let url = format!(
-            "https://huggingface.co/{}/resolve/main/{}",
-            model.huggingface_repo, filename
-        );
-
-        println!("Downloading {}...", filename);
-
-        let status = Command::new("curl")
-            .args([
-                "-L",
-                "--progress-bar",
-                "-o",
-                file_path.to_str().unwrap_or("file"),
-                &url,
-            ])
-            .status();
-
-        match status {
-            Ok(exit_status) if exit_status.success() => {
-                // Success, continue
-            }
-            Ok(exit_status) => {
-                print_failure(&format!(
-                    "Download failed: curl exited with code {}",
-                    exit_status.code().unwrap_or(-1)
-                ));
-                // Clean up partial download
-                let _ = std::fs::remove_file(&file_path);
-                anyhow::bail!("Download failed for {}", filename)
-            }
-            Err(e) => {
-                print_failure(&format!("Failed to run curl: {}", e));
-                print_info("Please ensure curl is installed (e.g., 'sudo pacman -S curl')");
-                anyhow::bail!("curl not available: {}", e)
-            }
-        }
-    }
-
-    // Validate all files are present
-    validate_parakeet_model(&model_path)?;
-    print_success(&format!(
-        "Model '{}' downloaded to {:?}",
-        model.name, model_path
-    ));
-
+    download_artifact(model, &models_dir)?;
+    validate_parakeet_model(&models_dir.join(model.name))?;
     Ok(())
 }
 
@@ -2105,82 +2226,20 @@ pub fn validate_moonshine_model(path: &Path) -> anyhow::Result<()> {
     }
 }
 
-/// Download a Moonshine model by name (public API for run_setup)
+/// Download a Moonshine model by name (public API for run_setup).
+///
+/// Routes through the unified R2 downloader; per-engine validator runs
+/// after to guard against publisher errors that the sha256 check can't
+/// catch.
 pub fn download_moonshine_model(model_name: &str) -> anyhow::Result<()> {
     let model = MOONSHINE_MODELS
         .iter()
         .find(|m| m.name == model_name)
         .ok_or_else(|| anyhow::anyhow!("Unknown Moonshine model: {}", model_name))?;
 
-    download_moonshine_model_by_info(model)
-}
-
-/// Download a Moonshine model using its info struct
-fn download_moonshine_model_by_info(model: &MoonshineModelInfo) -> anyhow::Result<()> {
     let models_dir = Config::models_dir();
-    let model_path = models_dir.join(model.dir_name);
-
-    // Create model directory
-    std::fs::create_dir_all(&model_path)?;
-
-    println!(
-        "\nDownloading {} ({} MB)...\n",
-        model.dir_name, model.size_mb
-    );
-
-    for (repo_path, local_filename) in model.files {
-        let file_path = model_path.join(local_filename);
-
-        if file_path.exists() {
-            println!("  {} already exists, skipping", local_filename);
-            continue;
-        }
-
-        let url = format!(
-            "https://huggingface.co/{}/resolve/main/{}",
-            model.huggingface_repo, repo_path
-        );
-
-        println!("Downloading {}...", local_filename);
-
-        let status = Command::new("curl")
-            .args([
-                "-L",
-                "--progress-bar",
-                "-o",
-                file_path.to_str().unwrap_or("file"),
-                &url,
-            ])
-            .status();
-
-        match status {
-            Ok(exit_status) if exit_status.success() => {
-                // Success, continue
-            }
-            Ok(exit_status) => {
-                print_failure(&format!(
-                    "Download failed: curl exited with code {}",
-                    exit_status.code().unwrap_or(-1)
-                ));
-                // Clean up partial download
-                let _ = std::fs::remove_file(&file_path);
-                anyhow::bail!("Download failed for {}", local_filename)
-            }
-            Err(e) => {
-                print_failure(&format!("Failed to run curl: {}", e));
-                print_info("Please ensure curl is installed (e.g., 'sudo pacman -S curl')");
-                anyhow::bail!("curl not available: {}", e)
-            }
-        }
-    }
-
-    // Validate all files are present
-    validate_moonshine_model(&model_path)?;
-    print_success(&format!(
-        "Model '{}' downloaded to {:?}",
-        model.dir_name, model_path
-    ));
-
+    download_artifact(model, &models_dir)?;
+    validate_moonshine_model(&models_dir.join(model.dir_name))?;
     Ok(())
 }
 
@@ -2227,23 +2286,18 @@ pub fn validate_cohere_model(path: &Path) -> anyhow::Result<()> {
 }
 
 /// Download a Cohere model by name (public API for run_setup).
+///
+/// Cohere is the largest artifact voxtype ships (up to ~4 GB across a
+/// handful of files). We print a size + disk headroom estimate before
+/// the unified downloader takes over so users don't wonder why their
+/// disk is filling.
 pub fn download_cohere_model(model_name: &str) -> anyhow::Result<()> {
     let model = COHERE_MODELS
         .iter()
         .find(|m| m.name == model_name)
         .ok_or_else(|| anyhow::anyhow!("Unknown Cohere model: {}", model_name))?;
-    download_cohere_model_by_info(model)
-}
-
-/// Download a Cohere model using its info struct.
-fn download_cohere_model_by_info(model: &CohereModelInfo) -> anyhow::Result<()> {
     let models_dir = Config::models_dir();
     let model_path = models_dir.join(model.dir_name);
-    std::fs::create_dir_all(&model_path)?;
-
-    // Cohere is a multi-GB download. Even with a fast connection it's a
-    // visible commitment, and on slow links it can mean 30+ minutes. Print
-    // the size up front so users don't wonder why their disk is filling.
     println!(
         "\nDownloading {} ({} MB across {} files)...",
         model.dir_name,
@@ -2257,56 +2311,8 @@ fn download_cohere_model_by_info(model: &CohereModelInfo) -> anyhow::Result<()> 
         model.size_mb + (model.size_mb / 10),
         model_path.display(),
     );
-
-    for (repo_path, local_filename) in model.files {
-        let file_path = model_path.join(local_filename);
-
-        if file_path.exists() {
-            println!("  {} already exists, skipping", local_filename);
-            continue;
-        }
-
-        let url = format!(
-            "https://huggingface.co/{}/resolve/main/{}",
-            model.huggingface_repo, repo_path
-        );
-
-        println!("Downloading {}...", local_filename);
-
-        let status = Command::new("curl")
-            .args([
-                "-L",
-                "--progress-bar",
-                "-o",
-                file_path.to_str().unwrap_or("file"),
-                &url,
-            ])
-            .status();
-
-        match status {
-            Ok(exit_status) if exit_status.success() => {}
-            Ok(exit_status) => {
-                print_failure(&format!(
-                    "Download failed: curl exited with code {}",
-                    exit_status.code().unwrap_or(-1)
-                ));
-                let _ = std::fs::remove_file(&file_path);
-                anyhow::bail!("Download failed for {}", local_filename)
-            }
-            Err(e) => {
-                print_failure(&format!("Failed to run curl: {}", e));
-                print_info("Please ensure curl is installed (e.g., 'sudo pacman -S curl')");
-                anyhow::bail!("curl not available: {}", e)
-            }
-        }
-    }
-
+    download_artifact(model, &models_dir)?;
     validate_cohere_model(&model_path)?;
-    print_success(&format!(
-        "Model '{}' downloaded to {:?}",
-        model.dir_name, model_path
-    ));
-
     Ok(())
 }
 
@@ -2368,7 +2374,8 @@ async fn handle_cohere_selection(selection: usize) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    download_cohere_model_by_info(model)?;
+    download_artifact(model, &Config::models_dir())?;
+    validate_cohere_model(&Config::models_dir().join(model.dir_name))?;
     update_config_cohere(model.dir_name)?;
     restart_daemon_if_running().await;
     Ok(())
@@ -2608,7 +2615,8 @@ async fn handle_sensevoice_selection(selection: usize) -> anyhow::Result<()> {
     }
 
     // Download the model
-    download_sensevoice_model_by_info(model)?;
+    download_artifact(model, &Config::models_dir())?;
+    validate_sensevoice_model(&Config::models_dir().join(model.dir_name))?;
 
     // Update config and restart daemon
     update_config_sensevoice(model.name)?;
@@ -2713,81 +2721,19 @@ pub fn validate_sensevoice_model(path: &Path) -> anyhow::Result<()> {
     }
 }
 
-/// Download a SenseVoice model by name (public API for run_setup)
+/// Download a SenseVoice model by name (public API for run_setup).
+///
+/// Routes through the unified R2 downloader; per-engine validator runs
+/// after to guard against publisher errors the sha256 check can't catch.
 pub fn download_sensevoice_model(model_name: &str) -> anyhow::Result<()> {
     let model = SENSEVOICE_MODELS
         .iter()
         .find(|m| m.name == model_name)
         .ok_or_else(|| anyhow::anyhow!("Unknown SenseVoice model: {}", model_name))?;
 
-    download_sensevoice_model_by_info(model)
-}
-
-/// Download a SenseVoice model using its info struct
-fn download_sensevoice_model_by_info(model: &SenseVoiceModelInfo) -> anyhow::Result<()> {
     let models_dir = Config::models_dir();
-    let model_path = models_dir.join(model.dir_name);
-
-    // Create model directory
-    std::fs::create_dir_all(&model_path)?;
-
-    println!(
-        "\nDownloading {} ({} MB)...\n",
-        model.dir_name, model.size_mb
-    );
-
-    for (repo_path, local_filename) in model.files {
-        let file_path = model_path.join(local_filename);
-
-        if file_path.exists() {
-            println!("  {} already exists, skipping", local_filename);
-            continue;
-        }
-
-        let url = format!(
-            "https://huggingface.co/{}/resolve/main/{}",
-            model.huggingface_repo, repo_path
-        );
-
-        println!("Downloading {}...", local_filename);
-
-        let status = Command::new("curl")
-            .args([
-                "-L",
-                "--progress-bar",
-                "-o",
-                file_path.to_str().unwrap_or("file"),
-                &url,
-            ])
-            .status();
-
-        match status {
-            Ok(exit_status) if exit_status.success() => {
-                // Success, continue
-            }
-            Ok(exit_status) => {
-                print_failure(&format!(
-                    "Download failed: curl exited with code {}",
-                    exit_status.code().unwrap_or(-1)
-                ));
-                let _ = std::fs::remove_file(&file_path);
-                anyhow::bail!("Download failed for {}", local_filename)
-            }
-            Err(e) => {
-                print_failure(&format!("Failed to run curl: {}", e));
-                print_info("Please ensure curl is installed (e.g., 'sudo pacman -S curl')");
-                anyhow::bail!("curl not available: {}", e)
-            }
-        }
-    }
-
-    // Validate all files are present
-    validate_sensevoice_model(&model_path)?;
-    print_success(&format!(
-        "Model '{}' downloaded to {:?}",
-        model.dir_name, model_path
-    ));
-
+    download_artifact(model, &models_dir)?;
+    validate_sensevoice_model(&models_dir.join(model.dir_name))?;
     Ok(())
 }
 
@@ -2957,11 +2903,16 @@ fn validate_onnx_ctc_model(path: &Path) -> anyhow::Result<()> {
     }
 }
 
-/// Generic handler for ONNX engine model selection (download/config/restart)
-#[allow(clippy::type_complexity)]
-async fn handle_onnx_engine_selection(
+/// Generic handler for ONNX engine model selection (download/config/restart).
+///
+/// `models` is a slice of any type implementing `ModelArtifact` plus the
+/// engine's `name` (config key, which can differ from the artifact's
+/// `name()` / on-disk directory for the legacy paraformer/dolphin/omni
+/// engines where the config short-name doesn't match the directory). The
+/// caller pairs each artifact with its short name.
+async fn handle_onnx_engine_selection<T: ModelArtifact>(
     engine_name: &str,
-    models: Vec<(&str, &str, u32, &[(&str, &str)], &str)>,
+    models: &[(&str, &T)],
     selection: usize,
     validate_fn: fn(&Path) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
@@ -2972,12 +2923,12 @@ async fn handle_onnx_engine_selection(
         return Ok(());
     }
 
-    let (name, dir_name, size_mb, files, repo) = &models[selection - 1];
-    let model_path = models_dir.join(dir_name);
+    let (short_name, artifact) = models[selection - 1];
+    let model_path = models_dir.join(artifact.name());
 
     // Check if already installed
     if model_path.exists() && validate_fn(&model_path).is_ok() {
-        println!("\nModel '{}' is already installed.\n", dir_name);
+        println!("\nModel '{}' is already installed.\n", artifact.name());
         println!("  [1] Set as default model (update config)");
         println!("  [2] Re-download");
         println!("  [0] Cancel\n");
@@ -2991,7 +2942,7 @@ async fn handle_onnx_engine_selection(
 
         match choice {
             "" | "1" => {
-                update_config_engine(engine_name, name)?;
+                update_config_engine(engine_name, short_name)?;
                 restart_daemon_if_running().await;
                 return Ok(());
             }
@@ -3005,76 +2956,16 @@ async fn handle_onnx_engine_selection(
         }
     }
 
-    // Download the model
-    download_onnx_model(dir_name, *size_mb, files, repo)?;
+    // Download via the unified R2 downloader.
+    download_artifact(artifact, &models_dir)?;
 
-    // Validate
+    // Per-engine on-disk validation (catches publisher-side omissions the
+    // manifest's sha256 verification can't surface).
     validate_fn(&model_path)?;
-    print_success(&format!(
-        "Model '{}' downloaded to {:?}",
-        dir_name, model_path
-    ));
 
     // Update config and restart daemon
-    update_config_engine(engine_name, name)?;
+    update_config_engine(engine_name, short_name)?;
     restart_daemon_if_running().await;
-
-    Ok(())
-}
-
-/// Download an ONNX model from HuggingFace
-fn download_onnx_model(
-    dir_name: &str,
-    size_mb: u32,
-    files: &[(&str, &str)],
-    repo: &str,
-) -> anyhow::Result<()> {
-    let models_dir = Config::models_dir();
-    let model_path = models_dir.join(dir_name);
-
-    std::fs::create_dir_all(&model_path)?;
-
-    println!("\nDownloading {} ({} MB)...\n", dir_name, size_mb);
-
-    for (repo_path, local_filename) in files {
-        let file_path = model_path.join(local_filename);
-
-        if file_path.exists() {
-            println!("  {} already exists, skipping", local_filename);
-            continue;
-        }
-
-        let url = format!("https://huggingface.co/{}/resolve/main/{}", repo, repo_path);
-
-        println!("Downloading {}...", local_filename);
-
-        let status = Command::new("curl")
-            .args([
-                "-L",
-                "--progress-bar",
-                "-o",
-                file_path.to_str().unwrap_or("file"),
-                &url,
-            ])
-            .status();
-
-        match status {
-            Ok(exit_status) if exit_status.success() => {}
-            Ok(exit_status) => {
-                print_failure(&format!(
-                    "Download failed: curl exited with code {}",
-                    exit_status.code().unwrap_or(-1)
-                ));
-                let _ = std::fs::remove_file(&file_path);
-                anyhow::bail!("Download failed for {}", local_filename)
-            }
-            Err(e) => {
-                print_failure(&format!("Failed to run curl: {}", e));
-                print_info("Please ensure curl is installed (e.g., 'sudo pacman -S curl')");
-                anyhow::bail!("curl not available: {}", e)
-            }
-        }
-    }
 
     Ok(())
 }
@@ -3851,5 +3742,18 @@ mode = "type"
             assert_eq!(m.engine_prefix(), "cohere");
             assert_eq!(m.name(), m.dir_name);
         }
+    }
+
+    #[test]
+    fn sha256_file_matches_known_vector() {
+        // sha256 of "hello world" (no trailing newline)
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload");
+        std::fs::write(&path, b"hello world").unwrap();
+        let got = sha256_file(&path).unwrap();
+        assert_eq!(
+            got,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
     }
 }

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -1,5 +1,6 @@
 //! Interactive model selection and download
 
+use super::manifest::{ExpectedFile, ModelArtifact};
 use super::{print_failure, print_info, print_success, print_warning};
 use crate::config::{Config, TranscriptionEngine};
 use crate::transcribe::whisper::{get_model_filename, get_model_url};
@@ -666,6 +667,169 @@ const COHERE_MODELS: &[CohereModelInfo] = &[
         huggingface_repo: "onnx-community/cohere-transcribe-03-2026-ONNX",
     },
 ];
+
+// =============================================================================
+// ModelArtifact implementations
+// =============================================================================
+//
+// Each ONNX engine's model-info struct implements `ModelArtifact` so the
+// unified `download_artifact` consumes them uniformly. The trait's
+// `name()` is the URL segment + on-disk directory name; for engines that
+// historically used a `dir_name` distinct from `name` (Moonshine,
+// SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere), we return
+// `dir_name` so the R2 layout matches what's on disk. For Parakeet the
+// model `name` was always the directory name; nothing to translate.
+
+impl ModelArtifact for ParakeetModelInfo {
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn engine_prefix(&self) -> &'static str {
+        "parakeet"
+    }
+    fn upstream_repo(&self) -> &str {
+        self.huggingface_repo
+    }
+    fn expected_files(&self) -> Vec<ExpectedFile> {
+        self.files
+            .iter()
+            .map(|(path, size)| ExpectedFile {
+                path: (*path).to_string(),
+                size: *size,
+            })
+            .collect()
+    }
+}
+
+impl ModelArtifact for MoonshineModelInfo {
+    fn name(&self) -> &str {
+        self.dir_name
+    }
+    fn engine_prefix(&self) -> &'static str {
+        "moonshine"
+    }
+    fn upstream_repo(&self) -> &str {
+        self.huggingface_repo
+    }
+    fn expected_files(&self) -> Vec<ExpectedFile> {
+        // Moonshine's upstream files live under `onnx/...` paths but we
+        // rewrite them to canonical local names. The mirror script flattens
+        // the directory layout in R2 to the local-canonical names, so we
+        // report the local name as the expected path.
+        self.files
+            .iter()
+            .map(|(_repo, local)| ExpectedFile {
+                path: (*local).to_string(),
+                size: 0,
+            })
+            .collect()
+    }
+}
+
+impl ModelArtifact for SenseVoiceModelInfo {
+    fn name(&self) -> &str {
+        self.dir_name
+    }
+    fn engine_prefix(&self) -> &'static str {
+        "sensevoice"
+    }
+    fn upstream_repo(&self) -> &str {
+        self.huggingface_repo
+    }
+    fn expected_files(&self) -> Vec<ExpectedFile> {
+        self.files
+            .iter()
+            .map(|(_repo, local)| ExpectedFile {
+                path: (*local).to_string(),
+                size: 0,
+            })
+            .collect()
+    }
+}
+
+impl ModelArtifact for ParaformerModelInfo {
+    fn name(&self) -> &str {
+        self.dir_name
+    }
+    fn engine_prefix(&self) -> &'static str {
+        "paraformer"
+    }
+    fn upstream_repo(&self) -> &str {
+        self.huggingface_repo
+    }
+    fn expected_files(&self) -> Vec<ExpectedFile> {
+        self.files
+            .iter()
+            .map(|(_repo, local)| ExpectedFile {
+                path: (*local).to_string(),
+                size: 0,
+            })
+            .collect()
+    }
+}
+
+impl ModelArtifact for DolphinModelInfo {
+    fn name(&self) -> &str {
+        self.dir_name
+    }
+    fn engine_prefix(&self) -> &'static str {
+        "dolphin"
+    }
+    fn upstream_repo(&self) -> &str {
+        self.huggingface_repo
+    }
+    fn expected_files(&self) -> Vec<ExpectedFile> {
+        self.files
+            .iter()
+            .map(|(_repo, local)| ExpectedFile {
+                path: (*local).to_string(),
+                size: 0,
+            })
+            .collect()
+    }
+}
+
+impl ModelArtifact for OmnilingualModelInfo {
+    fn name(&self) -> &str {
+        self.dir_name
+    }
+    fn engine_prefix(&self) -> &'static str {
+        "omnilingual"
+    }
+    fn upstream_repo(&self) -> &str {
+        self.huggingface_repo
+    }
+    fn expected_files(&self) -> Vec<ExpectedFile> {
+        self.files
+            .iter()
+            .map(|(_repo, local)| ExpectedFile {
+                path: (*local).to_string(),
+                size: 0,
+            })
+            .collect()
+    }
+}
+
+impl ModelArtifact for CohereModelInfo {
+    fn name(&self) -> &str {
+        self.dir_name
+    }
+    fn engine_prefix(&self) -> &'static str {
+        "cohere"
+    }
+    fn upstream_repo(&self) -> &str {
+        self.huggingface_repo
+    }
+    fn expected_files(&self) -> Vec<ExpectedFile> {
+        self.files
+            .iter()
+            .map(|(_repo, local)| ExpectedFile {
+                path: (*local).to_string(),
+                size: 0,
+            })
+            .collect()
+    }
+}
 
 // =============================================================================
 // Whisper Model Functions
@@ -3620,5 +3784,72 @@ mode = "type"
         let msg = err.to_string();
         assert!(msg.contains("encoder_model.onnx"), "got: {}", msg);
         assert!(msg.contains("tokenizer.json"), "got: {}", msg);
+    }
+
+    // =========================================================================
+    // ModelArtifact trait impl coverage
+    // =========================================================================
+    //
+    // The runtime downloader and the mirror script both route off
+    // `engine_prefix()`. A typo in one impl would silently send downloads to
+    // the wrong R2 namespace, so we lock the value of each impl in.
+
+    #[test]
+    fn parakeet_engine_prefix() {
+        for m in PARAKEET_MODELS {
+            assert_eq!(m.engine_prefix(), "parakeet");
+            assert_eq!(m.name(), m.name); // sanity
+            assert_eq!(m.upstream_repo(), m.huggingface_repo);
+            assert_eq!(m.expected_files().len(), m.files.len());
+        }
+    }
+
+    #[test]
+    fn moonshine_engine_prefix() {
+        for m in MOONSHINE_MODELS {
+            assert_eq!(m.engine_prefix(), "moonshine");
+            assert_eq!(m.name(), m.dir_name);
+            assert_eq!(m.expected_files().len(), m.files.len());
+        }
+    }
+
+    #[test]
+    fn sensevoice_engine_prefix() {
+        for m in SENSEVOICE_MODELS {
+            assert_eq!(m.engine_prefix(), "sensevoice");
+            assert_eq!(m.name(), m.dir_name);
+        }
+    }
+
+    #[test]
+    fn paraformer_engine_prefix() {
+        for m in PARAFORMER_MODELS {
+            assert_eq!(m.engine_prefix(), "paraformer");
+            assert_eq!(m.name(), m.dir_name);
+        }
+    }
+
+    #[test]
+    fn dolphin_engine_prefix() {
+        for m in DOLPHIN_MODELS {
+            assert_eq!(m.engine_prefix(), "dolphin");
+            assert_eq!(m.name(), m.dir_name);
+        }
+    }
+
+    #[test]
+    fn omnilingual_engine_prefix() {
+        for m in OMNILINGUAL_MODELS {
+            assert_eq!(m.engine_prefix(), "omnilingual");
+            assert_eq!(m.name(), m.dir_name);
+        }
+    }
+
+    #[test]
+    fn cohere_engine_prefix() {
+        for m in COHERE_MODELS {
+            assert_eq!(m.engine_prefix(), "cohere");
+            assert_eq!(m.name(), m.dir_name);
+        }
     }
 }


### PR DESCRIPTION
## Why

Voxtype currently fetches every ONNX engine's models directly from community HuggingFace accounts (`csukuangfj/*`, `istupakov/*`, `onnx-community/*`). That's been mostly fine, but it leaves three loose ends:

- **Availability is out of our hands.** If any of those accounts gets archived, renamed, or moved, every user's `voxtype setup` breaks until we ship a release.
- **No integrity guarantees.** A community upload could change shape without a version bump and we'd download whatever showed up.
- **No bandwidth control.** Heavy users (Cohere is ~4 GB) hammer HF; we have no caching layer to absorb traffic.

This PR plumbs a single Cloudflare R2 mirror at `https://models.voxtype.io` and adds per-model `manifest.json` files with sha256s, validated at download time. HuggingFace stays as the upstream of record for the mirror script; the runtime stops talking to HF entirely for ONNX engines.

Whisper, VAD (Silero, GTCRN), and ECAPA-TDNN diarization are intentionally out of scope — they're separate codepaths and not affected by community-account risk in the same way.

## What changed

- **New module `src/setup/manifest.rs`** holds the `MODELS_BASE_URL` constant, the `Manifest`/`ManifestFile`/`ExpectedFile` structs (serde), and the `ModelArtifact` trait. Manifest validation lives here as a free function with full unit-test coverage so we can exercise the logic without network IO.
- **`ModelArtifact` impl for all 7 ONNX engines** (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere). Each impl returns its R2 sub-namespace as a `&'static str` locked in by a per-engine unit test (so a typo can't silently misroute downloads).
- **Single `download_artifact<T: ModelArtifact>` function** replaces 5 near-identical download helpers (`download_parakeet_model_by_info`, `download_moonshine_model_by_info`, `download_cohere_model_by_info`, `download_sensevoice_model_by_info`, `download_onnx_model`). Net diff is roughly 350 lines deleted from `src/setup/model.rs` and 280 added back, plus 330 lines of new module + tooling.
- **sha256 verification** on every downloaded file, plus on cached files at re-download time so a partial/corrupt cached file doesn't survive an upgrade.
- **No HF fallback.** R2 unreachable means a clear error pointing at the Cloudflare status page. The whole point of the migration is to decouple from HF; falling back would defeat it.
- **`voxtype-mirror-registry` helper binary** dumps the model registry as JSON. Not shipped in releases; build-tree only.
- **`scripts/mirror-models-to-r2.sh`** consumes that JSON, downloads upstream HF files, computes sha256s, generates `manifest.json`, and `rclone copy`s the lot to `r2:voxtype-models/{engine_prefix}/{model_name}/`. Supports one model by name or `--all`, with `--dry-run` to inspect manifests before pushing.
- **Deps:** `sha2 = "0.10"` added (not previously transitive). `serde_json` was already a direct dep.

## Phasing reminder

This PR ships the code only. The R2 bucket needs to be populated and the `models.voxtype.io` CNAME needs to land before this can merge to `dev` — the runtime is R2-only with no HuggingFace fallback, so merging before R2 is live would break every fresh install. Suggested sequence:

1. Set up rclone with an `r2` remote pointing at the Cloudflare R2 bucket.
2. Run `./scripts/mirror-models-to-r2.sh --all --dry-run` to inspect the manifests.
3. Run `./scripts/mirror-models-to-r2.sh --all` to populate R2.
4. Point `models.voxtype.io` DNS at the R2 bucket.
5. Then merge this PR.

## Test plan

- [x] `cargo test --lib` — 763 passed.
- [x] `cargo clippy --lib --bins -- -D warnings` — clean on default features.
- [x] `cargo check --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere` — clean.
- [x] `cargo run --bin voxtype-mirror-registry` produces the expected JSON snapshot (verified manually).
- [x] `bash -n scripts/mirror-models-to-r2.sh` — script parses.
- [ ] End-to-end mirror dry-run once `models.voxtype.io` is reachable.
- [ ] Smoke download of one model (Parakeet base recommended) once R2 is populated.