### PR TITLE
website: v0.7.5 download URLs + news article

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -318,6 +318,16 @@
             <p class="section-subtitle">Recent releases and what they bring</p>
 
             <div class="news-preview-grid">
+                <a href="news/#v075" class="news-preview-card">
+                    <div class="news-preview-meta">
+                        <time datetime="2026-05-28">May 28, 2026</time>
+                        <span class="news-preview-tag">Release</span>
+                    </div>
+                    <h3>v0.7.5: Quickshell OSD, Soniox streaming, meeting-mode rework</h3>
+                    <p>An opt-in Quickshell OSD frontend with a QML-native waveform, engine picker, and meeting controls. A Soniox cloud streaming backend for low-latency dictation. A meeting-mode rebuild around source diarization, VAD sub-windows, and a per-meeting <code>--diarization</code> flag. Release artifacts are now signed end to end in CI by a dedicated release key that <code>yay</code> auto-fetches on first upgrade.</p>
+                    <span class="news-preview-link">Read more &rarr;</span>
+                </a>
+
                 <a href="news/#v073" class="news-preview-card">
                     <div class="news-preview-meta">
                         <time datetime="2026-05-19">May 19, 2026</time>
@@ -919,11 +929,11 @@ sudo pacman -S wtype wl-clipboard libnotify gtk4-layer-shell</code></pre>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install .deb package</span>
-                            <button class="copy-btn" data-copy="sudo apt install ./voxtype_0.7.3-1_amd64.deb">Copy</button>
+                            <button class="copy-btn" data-copy="sudo apt install ./voxtype_0.7.5-1_amd64.deb">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype_0.7.3-1_amd64.deb
-sudo apt install ./voxtype_0.7.3-1_amd64.deb
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.5/voxtype_0.7.5-1_amd64.deb
+sudo apt install ./voxtype_0.7.5-1_amd64.deb
 
 <span class="comment"># Recommended optional dependencies</span>
 sudo apt install wtype wl-clipboard libnotify-bin pipewire-alsa playerctl</code></pre>
@@ -936,11 +946,11 @@ sudo apt install wtype wl-clipboard libnotify-bin pipewire-alsa playerctl</code>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install RPM package</span>
-                            <button class="copy-btn" data-copy="sudo dnf install ./voxtype-0.7.3-1.x86_64.rpm">Copy</button>
+                            <button class="copy-btn" data-copy="sudo dnf install ./voxtype-0.7.5-1.x86_64.rpm">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype-0.7.3-1.x86_64.rpm
-sudo dnf install ./voxtype-0.7.3-1.x86_64.rpm
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.5/voxtype-0.7.5-1.x86_64.rpm
+sudo dnf install ./voxtype-0.7.5-1.x86_64.rpm
 
 <span class="comment"># Recommended optional dependencies</span>
 sudo dnf install wtype wl-clipboard libnotify pipewire-alsa playerctl</code></pre>
@@ -961,7 +971,7 @@ brew install --cask voxtype
 <span class="comment"># First launch opens a setup wizard that walks you through</span>
 <span class="comment"># Accessibility permissions, model download, and the FN-key hotkey.</span></code></pre>
                     </div>
-                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-0.7.3-macOS-arm64.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
+                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-0.7.5-macOS-arm64.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
                 </div>
 
                 <div id="nixos" class="tab-content">
@@ -969,16 +979,16 @@ brew install --cask voxtype
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install via flake</span>
-                            <button class="copy-btn" data-copy="nix profile install github:peteonrails/voxtype/v0.7.3#vulkan">Copy</button>
+                            <button class="copy-btn" data-copy="nix profile install github:peteonrails/voxtype/v0.7.5#vulkan">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Imperative install</span>
-nix profile install github:peteonrails/voxtype/v0.7.3#vulkan
+nix profile install github:peteonrails/voxtype/v0.7.5#vulkan
 
 <span class="comment"># Available outputs: default, vulkan, cuda, rocm, osdGtk4, osdNative</span>
-nix build github:peteonrails/voxtype/v0.7.3#osdGtk4
+nix build github:peteonrails/voxtype/v0.7.5#osdGtk4
 
 <span class="comment"># Or pin in your flake inputs</span>
-inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.3";</code></pre>
+inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.5";</code></pre>
                     </div>
                     <p class="install-note" style="margin-top: 1rem;"><strong>Next:</strong> <a href="#quick-start">First-run setup</a> below.</p>
                 </div>
@@ -988,15 +998,15 @@ inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.3";</code></pre>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Download and run</span>
-                            <button class="copy-btn" data-copy="chmod +x voxtype-0.7.3-x86_64.AppImage && ./voxtype-0.7.3-x86_64.AppImage">Copy</button>
+                            <button class="copy-btn" data-copy="chmod +x voxtype-0.7.5-x86_64.AppImage && ./voxtype-0.7.5-x86_64.AppImage">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download a variant from the latest release</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype-0.7.3-x86_64.AppImage
-chmod +x voxtype-0.7.3-x86_64.AppImage
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.5/voxtype-0.7.5-x86_64.AppImage
+chmod +x voxtype-0.7.5-x86_64.AppImage
 
 <span class="comment"># Run directly, or move to ~/.local/bin/ for permanent install</span>
-./voxtype-0.7.3-x86_64.AppImage --help
-mv voxtype-0.7.3-x86_64.AppImage ~/.local/bin/voxtype</code></pre>
+./voxtype-0.7.5-x86_64.AppImage --help
+mv voxtype-0.7.5-x86_64.AppImage ~/.local/bin/voxtype</code></pre>
                     </div>
                     <p class="install-note" style="margin-top: 1rem;"><strong>Next:</strong> <a href="#quick-start">First-run setup</a> below.</p>
                 </div>

--- a/website/news/index.html
+++ b/website/news/index.html
@@ -77,6 +77,92 @@
 
             <!-- v0.7.x Era Posts -->
 
+            <article class="news-article" id="v075">
+                <div class="article-meta">
+                    <time datetime="2026-05-28">May 28, 2026</time>
+                    <span class="article-tag">Release</span>
+                </div>
+                <h2>v0.7.5: Quickshell OSD, Soniox streaming, meeting-mode rework</h2>
+                <div class="article-body">
+                    <p>A larger feature release that bundles work queued behind three hotfix cycles. Three themes: an opt-in Quickshell OSD frontend, a Soniox cloud streaming backend, and a rebuild of meeting mode around source diarization. Release artifacts are now signed end-to-end in CI by a dedicated release key, removing the manual signing step from every cut.</p>
+
+                    <h3>Quickshell OSD frontend (opt-in)</h3>
+                    <p>A QML-native on-screen display that replaces the GTK4 surface for users who already run a Quickshell-based desktop. Three composed surfaces ship with the package: a waveform overlay during recording, an engine picker overlay for switching transcription backends without leaving the keyboard, and a meeting controls overlay for starting and stopping meeting captures. A new <code>voxtype-audio-bridge</code> sidecar streams audio levels to the QML side as NDJSON over a UNIX socket.</p>
+
+                    <p><strong>Why use it:</strong> if you already run Quickshell, the OSD blends into your existing shell instead of pulling in a GTK4 surface. The QML stack composes with Hyprland / Niri layer-shell rules cleanly, and the waveform renders at full compositor refresh rate.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>config.toml</span></div>
+                        <pre><code>[osd]
+frontend = "quickshell"</code></pre>
+                    </div>
+
+                    <p>The default frontend stays <code>gtk4</code>. Run <code>voxtype setup quickshell</code> to install the QML files and the sidecar binary into the right Quickshell config paths. Known issue: the Quickshell overlay captures pointer events across the whole screen (<a href="https://github.com/peteonrails/voxtype/issues/440">#440</a>). v0.7.6 will fix.</p>
+
+                    <h3>Soniox cloud streaming backend (<a href="https://github.com/peteonrails/voxtype/issues/411">#411</a>)</h3>
+                    <p>A new engine that streams audio over a WebSocket to Soniox and types each partial transcript at the cursor as it arrives. Lower end-to-end latency than the local Parakeet streaming pipeline, at the cost of network dependence and a third-party API key.</p>
+
+                    <p><strong>Why use it:</strong> the lowest-latency option when you can tolerate cloud transcription. Good for live captioning, long-form interview dictation, or any case where the half-second cost of local Parakeet streaming feels too long.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>config.toml</span></div>
+                        <pre><code>engine = "soniox"
+
+[soniox]
+api_key = "your-soniox-api-key"</code></pre>
+                    </div>
+
+                    <h3>Meeting mode: source diarization and VAD sub-windows</h3>
+                    <p>Three changes converge: a source-diarization path that attributes each speaker by which input device they came from (<a href="https://github.com/peteonrails/voxtype/issues/341">#341</a>, contributed by sjug), VAD sub-windows that let the ECAPA-TDNN ML diarizer run on shorter chunks for better turn-by-turn accuracy (<a href="https://github.com/peteonrails/voxtype/issues/418">#418</a>), and a per-meeting <code>--diarization</code> CLI flag so you can switch backends without editing the config file (<a href="https://github.com/peteonrails/voxtype/issues/420">#420</a>).</p>
+
+                    <p><strong>Why use it:</strong> meetings with a clear host-plus-remote structure (loopback for remote audio, mic for the host) now get correct speaker labels without any ML cost. The per-meeting flag means you can run one meeting with full ML diarization and the next with cheap source diarization without restarting the daemon.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>per-meeting override</span></div>
+                        <pre><code><span class="comment"># Source-based (fast, works when speakers are on different input devices)</span>
+voxtype meeting start --diarization source
+
+<span class="comment"># ML-based (slower, works on a single mixed audio stream)</span>
+voxtype meeting start --diarization ml</code></pre>
+                    </div>
+
+                    <h3>Release signing migrated to a dedicated CI key (<a href="https://github.com/peteonrails/voxtype/issues/437">#437</a>)</h3>
+                    <p>Every release artifact (binaries, companion <code>.so</code> files, <code>SHA256SUMS.txt</code>, <code>.deb</code>, <code>.rpm</code>, and the GitHub source archive) is now signed in CI by a dedicated release primary key (<code>9CCF7915...</code>) that is cross-signed by the offline maintainer key. Both fingerprints are in <code>voxtype-bin</code>'s <code>validpgpkeys</code>, so <code>yay</code> auto-fetches the new key from a keyserver on first upgrade with no manual <code>gpg --recv-keys</code> step.</p>
+
+                    <p><strong>Why this matters:</strong> v0.7.4 used a back-signed signing subkey that <code>yay</code> could not auto-fetch by keyid, which broke <code>yay -Syu voxtype-bin</code> for every user with a stale local keyring. v0.7.5's standalone primary keyserver-resolves correctly on every keyserver implementation. The signing step itself is also now fully in CI, removing the maintainer-laptop step between tag and release.</p>
+
+                    <h3>Variant safety improvements</h3>
+                    <p>Two changes around the <code>/usr/bin/voxtype</code> dispatcher wrapper:</p>
+                    <ul>
+                        <li><strong>Wrapper decision uses basename, not canonicalize</strong> (<a href="https://github.com/peteonrails/voxtype/issues/443">#443</a>). The previous logic followed symlinks and could pick the wrong dispatch shape when <code>/usr/bin/voxtype</code> already pointed at a non-canonical path. Closed-set basename match is more reliable and doesn't depend on filesystem state.</li>
+                        <li><strong>TUI surfaces engine-vs-binary mismatch</strong> (<a href="https://github.com/peteonrails/voxtype/issues/450">#450</a>). A persistent banner appears across every section when the configured engine cannot be served by the running binary. <code>F2</code> jumps to the General section's variant picker. The daemon also fires a desktop notification at startup so users who do not open the TUI still see the warning.</li>
+                    </ul>
+
+                    <h3>Smaller fixes</h3>
+                    <ul>
+                        <li>Streaming Parakeet validator accepts the <code>bobNight</code> naming convention (closes the v0.7.4 known issue).</li>
+                        <li>Per-language XKB variants for <code>eitype</code> (<a href="https://github.com/peteonrails/voxtype/issues/424">#424</a>, contributed by AlexCzar).</li>
+                        <li>Cohere ONNX remote-path prefix fix for the new <code>onnx/</code> subdirectory layout (<a href="https://github.com/peteonrails/voxtype/issues/363">#363</a>, contributed by jpds).</li>
+                        <li>CPU <code>__cpuid</code> wrapped in <code>unsafe</code> block for rustc 1.91+ (<a href="https://github.com/peteonrails/voxtype/issues/419">#419</a>, contributed by materemias).</li>
+                        <li>NixOS CI workflow now builds on every PR (closes <a href="https://github.com/peteonrails/voxtype/issues/369">#369</a>).</li>
+                        <li><code>wl-copy</code> fallback under X11 sessions (<a href="https://github.com/peteonrails/voxtype/issues/346">#346</a>).</li>
+                        <li><code>dotool</code> daemon fast path (<a href="https://github.com/peteonrails/voxtype/issues/410">#410</a>).</li>
+                        <li>Audio socket listener watchdog (<a href="https://github.com/peteonrails/voxtype/issues/391">#391</a>, <a href="https://github.com/peteonrails/voxtype/issues/392">#392</a>).</li>
+                    </ul>
+
+                    <h3>Acknowledgments</h3>
+                    <ul>
+                        <li><strong>sjug</strong> for the source-diarization patch (<a href="https://github.com/peteonrails/voxtype/issues/341">#341</a>).</li>
+                        <li><strong>AlexCzar</strong> for the per-language XKB variants (<a href="https://github.com/peteonrails/voxtype/issues/424">#424</a>).</li>
+                        <li><strong>jpds</strong> for the Cohere ONNX path fix (<a href="https://github.com/peteonrails/voxtype/issues/363">#363</a>).</li>
+                        <li><strong>materemias</strong> for the rustc 1.91 <code>__cpuid</code> fix (<a href="https://github.com/peteonrails/voxtype/issues/419">#419</a>).</li>
+                    </ul>
+
+                    <h3>Downloads</h3>
+                    <p>Full changelog, signed binaries, and SHA256 sums: <a href="https://github.com/peteonrails/voxtype/releases/tag/v0.7.5">v0.7.5 on GitHub</a>.</p>
+                </div>
+            </article>
+
             <article class="news-article" id="v073">
                 <div class="article-meta">
                     <time datetime="2026-05-19">May 19, 2026</time>


### PR DESCRIPTION
## Summary

The public website still advertised v0.7.3 across every download tab and the latest news preview card, even though v0.7.5 has been live for hours. Updates:

- **\`website/index.html\`**: bumps every v0.7.3 download URL (.deb, .rpm, dmg, Nix flake, AppImage) to v0.7.5. Adds a v0.7.5 news preview card above the v0.7.3 one on the home page.
- **\`website/news/index.html\`**: full v0.7.5 article covering Quickshell OSD, Soniox streaming, meeting-mode rework, the release-signing migration to a dedicated CI primary, variant-safety improvements (#443 and #450), smaller fixes, and contributor acknowledgments.

Style matches the existing v0.7.3 article. The v0.7.4 hotfix did not get a preview card or article on the website (consistent with how hotfixes have been handled before).

## Test plan

- [x] HTML structure: 35 opening / 35 closing \`<article>\` tags in news/index.html. v0.7.5 article id=\"v075\" at line 80, v0.7.3 at line 166 (preserved).
- [x] Only one \`0.7.3\` reference left in \`index.html\`: the v0.7.3 news preview card title (correct, historical).
- [ ] Merge to \`main\`. GitHub Pages auto-deploys.
- [ ] Visit voxtype.io and voxtype.io/news/ after deploy to confirm rendering.