### PR TITLE
docs: refactoring policy (CONTRIBUTING + REFACTORING.md)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,36 @@ Fixes #123
 
 Types: `fix`, `feat`, `docs`, `style`, `refactor`, `test`, `chore`
 
+## Refactoring while contributing
+
+If you're already inside a file to fix a bug or add a feature, it's fine to
+clean up what you're touching. The rules are short.
+
+Stay inside the files your change already touches. If you notice something
+ugly in a neighbouring module, open an issue and link it from your PR; don't
+expand the diff. Adjacent cleanup is how PRs grow until they don't ship.
+
+Wait for the third call site before extracting a helper. Two might be a
+coincidence. The same shape happening to recur in places that answer
+different questions is also a coincidence; don't merge those. Genuine
+duplication of a fact across files (the same name spelled out repeatedly, the
+same parse logic copy-pasted) is the case worth fixing.
+
+Put the cleanup in its own commit, separate from the behaviour change. It
+makes the PR easier to review and easier to revert in pieces if needed. If
+you're refactoring something with no test coverage, write a small test that
+pins current behaviour before you change anything.
+
+If your cleanup is going to add more than half a day of work, stop and split.
+Ship the feature; do the refactor as a follow-up PR. Don't invent abstractions
+for a single implementation, and don't split a file just because it's long.
+File splits and other structural decisions are
+[the maintainer's call](docs/REFACTORING.md).
+
+If you're not sure whether a cleanup belongs in your PR, ask in the
+description before doing it. Skipping a refactor is always cheaper than
+reverting one.
+
 ## Code of Conduct
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing. We are committed to providing a welcoming and positive experience for everyone.

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -1,0 +1,97 @@
+# Refactoring policy
+
+This is for me when I'm planning releases. Contributor-side cleanup is
+covered in [`CONTRIBUTING.md`](../CONTRIBUTING.md); the difference is
+that contributors clean as they go, and I sometimes ship a whole release
+whose point is structural work.
+
+I treat a tidy codebase as a feature. The cost of letting structure
+decay shows up later as slower feature PRs, recurring bug classes, and
+maintainer reluctance to re-enter modules I haven't touched in months.
+So refactoring competes with features by being scheduled like them, not
+by being squeezed in around them.
+
+## When a release is refactor-themed
+
+Most releases ship features. Some ship structural work instead. I pick
+a refactor theme when one of these is true:
+
+A bug class has recurred. The fix patched a symptom and the mechanism
+that produced it is still there. The liveness check duplication is the
+canonical example: fixed once on the CLI side, still latent in the TUI.
+
+The next feature on the roadmap would force enough structural change
+that doing the structural work first is cheaper than smuggling it into a
+feature PR.
+
+A specific file or function has grown to the point where I burn ten or
+fifteen minutes rebuilding context every time I open it. `daemon.rs::run()`
+at 1580 lines is in this category.
+
+I won't ship a refactor theme just because a release is short on
+features. There has to be a real problem to remove.
+
+## What gets into the release
+
+I admit refactor items by one of five tests. An item earns its spot if
+at least one holds:
+
+1. It's a correctness risk. Duplicate sources of truth, untested critical
+   paths, a class of bug that has surfaced once and could come back.
+2. It's blocking something on the upcoming roadmap. Feature pressure
+   pulls the structural work in.
+3. The same change keeps coming up in PRs. Every new flag adds another
+   override-block copy; every new engine adds another download function.
+4. A file's name no longer predicts its contents. The split is along
+   meaning (subcommands, event types, data vs logic), not line counts.
+5. The same fact is written in two places that can drift. Code that
+   merely looks similar but answers different questions is not the same
+   fact; leave it alone.
+
+The sixteen sentinel files under `runtime_dir/` (`model_override`,
+`cancel`, `meeting_state`...) look alike but are unrelated; merging them
+would invent write-race surface that doesn't exist today. The
+daemon-liveness check, by contrast, asks one question in three places,
+and the three places disagree on macOS.
+
+If none of the five tests holds, the refactor doesn't make the release.
+
+## How items have to be specified
+
+Every item in scope needs a done test that's a yes or no. "Consolidated
+the liveness check" is a vibe; "no file outside `daemon.rs` references
+the legacy `pid` filename, asserted by a test" is a done test.
+
+Before changing code that doesn't already have tests, write one that
+pins the current behaviour. The refactor has to keep every test that
+passed before. If a refactor changes behaviour, it isn't a refactor; it
+just looks like one.
+
+Lock the result in with something the compiler or CI enforces. A
+deletion that makes the wrong path impossible (the strum-derived
+`TranscriptionEngine::name()`) is better than a comment saying "use the
+new helper". A guard test that fails when an old pattern reappears is
+better than relying on discipline.
+
+If a refactor item grows past its planned size, stop and split it.
+
+## Things to avoid
+
+I won't ship a refactor whose justification is that the file is large
+or that the code is ugly. Large and stable is fine. Ugly and unused is
+fine.
+
+I won't bundle behaviour changes inside a refactor PR. If a "while I'm
+here" tweak slips in, the PR isn't behaviour-preserving and review
+costs go up sharply. They go in separate PRs.
+
+I won't extract abstractions from a single call site. The first version
+of an abstraction is almost always wrong about which axis varies; wait
+for two or three concrete uses before pulling out a trait or a generic.
+
+## What to track
+
+Three rough numbers to glance at periodically: how many places encode
+the same fact, how many files I have to touch to add a new model or
+engine, and how much of the config surface is exposed by default versus
+buried under `[advanced]`. Lower is better on all three.


### PR DESCRIPTION
## Summary

Two complementary documents codifying how voxtype balances feature work against keeping the codebase tractable.

- **\`CONTRIBUTING.md\`** gains a \"Refactoring while contributing\" section. Bounded clean-as-you-go discipline for contributors and the maintainer when in a feature PR: separate commit from the behavior change, characterize before changing, half-day scope cap, file-an-issue for adjacent debt. Includes an in-scope / out-of-scope table.

- **\`docs/REFACTORING.md\`** is new. Maintainer-side policy: refactoring as a first-class release theme, the three release-theme types (feature / refactor / bug-fix), five admission criteria for refactor items, per-item discipline (binary done-tests, characterization tests, guard tests, scope ceilings), and a worked v0.8.0 example.

The fact-vs-shape distinction under criterion 5 (SSoT) is called out explicitly because it's where most misapplied DRY work runs aground. Examples from past releases illustrate the cut.

## Why

We've been doing both kinds of refactoring (clean-as-you-go in feature PRs, structural passes between feature waves) for a while, but the discipline wasn't written down. That means it lives only in the maintainer's head and contributors don't know what's expected. Writing it down does three things:

1. Sets expectations for contributors (what they can clean up vs what they should file as an issue).
2. Gives the maintainer a stable framework for picking release themes without re-litigating the question every cycle.
3. Provides a clear answer when external critique surfaces (\"this codebase is sprawling\") - the answer is in REFACTORING.md, not invented on the spot.

## Test plan

- [x] No code changes; pure documentation.
- [x] Em-dashes scrubbed per the project style guide.
- [ ] Self-review for tone match against existing CONTRIBUTING.md voice.
- [ ] Worked example in REFACTORING.md (v0.8.0) is illustrative - replace with the actual decision when v0.8.0 planning kicks off.