### PR TITLE
Merge main into dev (post v0.7.5 release, website, refactoring docs)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -11,10 +11,11 @@ permissions:
 # with a matching ubuntu host runner as belt-and-suspenders. See CLAUDE.md
 # "Building Release Binaries" for the policy this enforces.
 #
-# The release job signs the GitHub auto-archive source tarball (issue #415)
-# using the GPG_PRIVATE_KEY secret. Once that secret is configured, the same
-# import can be extended to detach-sign each voxtype-* binary artifact and
-# SHA256SUMS.txt; the .asc files would be uploaded alongside the binaries.
+# The release job signs every binary, companion .so, SHA256SUMS.txt, .deb,
+# .rpm, and the GitHub auto-archive source tarball (issue #415) using the
+# dedicated CI signing primary 9CCF7915... via the GPG_PRIVATE_KEY secret.
+# All .asc files are uploaded alongside their artifacts on tag push so AUR /
+# Deb / RPM consumers can verify without manual maintainer signing.
 
 on:
   push:
@@ -380,10 +381,68 @@ jobs:
           echo "SHA256SUMS.txt:"
           cat SHA256SUMS.txt
 
-      # NOTE: binary signing (detach-sign each voxtype-* artifact + SHA256SUMS.txt)
-      # is a separate follow-up. The auto-archive signing step below (issue #415)
-      # already imports GPG_PRIVATE_KEY; binary signing can reuse that same setup
-      # once we decide whether to ship per-binary .asc files.
+      # Sign every binary + companion .so + SHA256SUMS.txt with the dedicated
+      # CI signing primary 9CCF7915..., cross-signed by the offline maintainer
+      # key. Prior to v0.7.5 these `.asc` files were produced manually on Pete's
+      # laptop after each release; v0.7.4 was distributed without any per-binary
+      # `.asc` files in the initial cut for that reason. Moving signing to CI
+      # closes that gap so every release has hands-off per-artifact signatures
+      # without requiring a maintainer at the keyboard.
+      #
+      # Runs after SHA256SUMS.txt is written but before the .deb/.rpm packages
+      # are built, so the for-loop only walks binaries + companion .so files
+      # (the .deb/.rpm artifacts are signed in their own step below to keep
+      # the loop's glob simple). Both signing steps use the same GPG import
+      # plumbing — they share `WORK`/`GNUPGHOME` semantics by re-creating the
+      # ephemeral keyring per step, which is cheap and keeps the two signing
+      # surfaces independent.
+      - name: Sign binary artifacts
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GPG_PRIVATE_KEY:-}" || -z "${GPG_PASSPHRASE:-}" ]]; then
+            echo "::warning::GPG secrets not set; skipping binary signing."
+            exit 0
+          fi
+          VERSION='${{ steps.version.outputs.version }}'
+          SIGNING_KEY="9CCF7915B750CAE8B095ED1AA3FC9F33FD209279"
+          WORK=$(mktemp -d)
+          trap 'rm -rf "${WORK}"' EXIT
+          export GNUPGHOME="${WORK}/gpg"
+          mkdir -p "${GNUPGHOME}"
+          chmod 700 "${GNUPGHOME}"
+          printf 'allow-loopback-pinentry\n' > "${GNUPGHOME}/gpg-agent.conf"
+          printf 'pinentry-mode loopback\n' > "${GNUPGHOME}/gpg.conf"
+          gpgconf --kill gpg-agent || true
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+          cd "releases/${VERSION}"
+          shopt -s nullglob
+          # Every binary + companion .so + the checksum manifest. `.asc` is
+          # excluded so a re-run doesn't sign sigs of sigs; .deb/.rpm don't
+          # exist yet at this point but are filtered defensively.
+          targets=()
+          for f in voxtype-* SHA256SUMS.txt; do
+            case "$f" in
+              *.asc|*.deb|*.rpm) continue ;;
+            esac
+            [[ -f "$f" ]] && targets+=("$f")
+          done
+          if [[ ${#targets[@]} -eq 0 ]]; then
+            echo "::warning::No artifacts to sign."
+            exit 0
+          fi
+          for f in "${targets[@]}"; do
+            printf '%s' "${GPG_PASSPHRASE}" | gpg --batch --yes \
+                --pinentry-mode loopback --passphrase-fd 0 \
+                --local-user "${SIGNING_KEY}!" \
+                --detach-sign --armor --output "${f}.asc" "${f}"
+            echo "Signed ${f}"
+          done
+          echo "Detached signatures produced:"
+          ls -1 *.asc
 
       # Build distro packages (.deb for Debian/Ubuntu, .rpm for Fedora/RHEL).
       # Prior to v0.7.5 these were manual: Pete ran `./scripts/package.sh
@@ -455,7 +514,7 @@ jobs:
           path: |
             releases/${{ steps.version.outputs.version }}/voxtype-*
             releases/${{ steps.version.outputs.version }}/voxtype_*
-            releases/${{ steps.version.outputs.version }}/SHA256SUMS.txt
+            releases/${{ steps.version.outputs.version }}/SHA256SUMS.txt*
           if-no-files-found: error
           retention-days: 30
 
@@ -468,7 +527,7 @@ jobs:
           files: |
             releases/${{ steps.version.outputs.version }}/voxtype-*
             releases/${{ steps.version.outputs.version }}/voxtype_*
-            releases/${{ steps.version.outputs.version }}/SHA256SUMS.txt
+            releases/${{ steps.version.outputs.version }}/SHA256SUMS.txt*
 
       # Sign the GitHub-generated source archive (what `makepkg` for the AUR
       # `voxtype` source PKGBUILD downloads) and upload the detached signature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,36 @@ Fixes #123
 
 Types: `fix`, `feat`, `docs`, `style`, `refactor`, `test`, `chore`
 
+## Refactoring while contributing
+
+If you're already inside a file to fix a bug or add a feature, it's fine to
+clean up what you're touching. The rules are short.
+
+Stay inside the files your change already touches. If you notice something
+ugly in a neighbouring module, open an issue and link it from your PR; don't
+expand the diff. Adjacent cleanup is how PRs grow until they don't ship.
+
+Wait for the third call site before extracting a helper. Two might be a
+coincidence. The same shape happening to recur in places that answer
+different questions is also a coincidence; don't merge those. Genuine
+duplication of a fact across files (the same name spelled out repeatedly, the
+same parse logic copy-pasted) is the case worth fixing.
+
+Put the cleanup in its own commit, separate from the behaviour change. It
+makes the PR easier to review and easier to revert in pieces if needed. If
+you're refactoring something with no test coverage, write a small test that
+pins current behaviour before you change anything.
+
+If your cleanup is going to add more than half a day of work, stop and split.
+Ship the feature; do the refactor as a follow-up PR. Don't invent abstractions
+for a single implementation, and don't split a file just because it's long.
+File splits and other structural decisions are
+[the maintainer's call](docs/REFACTORING.md).
+
+If you're not sure whether a cleanup belongs in your PR, ask in the
+description before doing it. Skipping a refactor is always cheaper than
+reverting one.
+
 ## Code of Conduct
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing. We are committed to providing a welcoming and positive experience for everyone.

--- a/docs/REFACTORING.md
+++ b/docs/REFACTORING.md
@@ -1,0 +1,97 @@
+# Refactoring policy
+
+This is for me when I'm planning releases. Contributor-side cleanup is
+covered in [`CONTRIBUTING.md`](../CONTRIBUTING.md); the difference is
+that contributors clean as they go, and I sometimes ship a whole release
+whose point is structural work.
+
+I treat a tidy codebase as a feature. The cost of letting structure
+decay shows up later as slower feature PRs, recurring bug classes, and
+maintainer reluctance to re-enter modules I haven't touched in months.
+So refactoring competes with features by being scheduled like them, not
+by being squeezed in around them.
+
+## When a release is refactor-themed
+
+Most releases ship features. Some ship structural work instead. I pick
+a refactor theme when one of these is true:
+
+A bug class has recurred. The fix patched a symptom and the mechanism
+that produced it is still there. The liveness check duplication is the
+canonical example: fixed once on the CLI side, still latent in the TUI.
+
+The next feature on the roadmap would force enough structural change
+that doing the structural work first is cheaper than smuggling it into a
+feature PR.
+
+A specific file or function has grown to the point where I burn ten or
+fifteen minutes rebuilding context every time I open it. `daemon.rs::run()`
+at 1580 lines is in this category.
+
+I won't ship a refactor theme just because a release is short on
+features. There has to be a real problem to remove.
+
+## What gets into the release
+
+I admit refactor items by one of five tests. An item earns its spot if
+at least one holds:
+
+1. It's a correctness risk. Duplicate sources of truth, untested critical
+   paths, a class of bug that has surfaced once and could come back.
+2. It's blocking something on the upcoming roadmap. Feature pressure
+   pulls the structural work in.
+3. The same change keeps coming up in PRs. Every new flag adds another
+   override-block copy; every new engine adds another download function.
+4. A file's name no longer predicts its contents. The split is along
+   meaning (subcommands, event types, data vs logic), not line counts.
+5. The same fact is written in two places that can drift. Code that
+   merely looks similar but answers different questions is not the same
+   fact; leave it alone.
+
+The sixteen sentinel files under `runtime_dir/` (`model_override`,
+`cancel`, `meeting_state`...) look alike but are unrelated; merging them
+would invent write-race surface that doesn't exist today. The
+daemon-liveness check, by contrast, asks one question in three places,
+and the three places disagree on macOS.
+
+If none of the five tests holds, the refactor doesn't make the release.
+
+## How items have to be specified
+
+Every item in scope needs a done test that's a yes or no. "Consolidated
+the liveness check" is a vibe; "no file outside `daemon.rs` references
+the legacy `pid` filename, asserted by a test" is a done test.
+
+Before changing code that doesn't already have tests, write one that
+pins the current behaviour. The refactor has to keep every test that
+passed before. If a refactor changes behaviour, it isn't a refactor; it
+just looks like one.
+
+Lock the result in with something the compiler or CI enforces. A
+deletion that makes the wrong path impossible (the strum-derived
+`TranscriptionEngine::name()`) is better than a comment saying "use the
+new helper". A guard test that fails when an old pattern reappears is
+better than relying on discipline.
+
+If a refactor item grows past its planned size, stop and split it.
+
+## Things to avoid
+
+I won't ship a refactor whose justification is that the file is large
+or that the code is ugly. Large and stable is fine. Ugly and unused is
+fine.
+
+I won't bundle behaviour changes inside a refactor PR. If a "while I'm
+here" tweak slips in, the PR isn't behaviour-preserving and review
+costs go up sharply. They go in separate PRs.
+
+I won't extract abstractions from a single call site. The first version
+of an abstraction is almost always wrong about which axis varies; wait
+for two or three concrete uses before pulling out a trait or a generic.
+
+## What to track
+
+Three rough numbers to glance at periodically: how many places encode
+the same fact, how many files I have to touch to add a new model or
+engine, and how much of the config surface is exposed by default versus
+buried under `[advanced]`. Lower is better on all three.

--- a/website/index.html
+++ b/website/index.html
@@ -318,6 +318,16 @@
             <p class="section-subtitle">Recent releases and what they bring</p>
 
             <div class="news-preview-grid">
+                <a href="news/#v075" class="news-preview-card">
+                    <div class="news-preview-meta">
+                        <time datetime="2026-05-28">May 28, 2026</time>
+                        <span class="news-preview-tag">Release</span>
+                    </div>
+                    <h3>v0.7.5: Quickshell OSD, Soniox streaming, meeting-mode rework</h3>
+                    <p>An opt-in Quickshell OSD frontend with a QML-native waveform, engine picker, and meeting controls. A Soniox cloud streaming backend for low-latency dictation. A meeting-mode rebuild around source diarization, VAD sub-windows, and a per-meeting <code>--diarization</code> flag. Release artifacts are now signed end to end in CI by a dedicated release key that <code>yay</code> auto-fetches on first upgrade.</p>
+                    <span class="news-preview-link">Read more &rarr;</span>
+                </a>
+
                 <a href="news/#v073" class="news-preview-card">
                     <div class="news-preview-meta">
                         <time datetime="2026-05-19">May 19, 2026</time>
@@ -919,11 +929,11 @@ sudo pacman -S wtype wl-clipboard libnotify gtk4-layer-shell</code></pre>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install .deb package</span>
-                            <button class="copy-btn" data-copy="sudo apt install ./voxtype_0.7.3-1_amd64.deb">Copy</button>
+                            <button class="copy-btn" data-copy="sudo apt install ./voxtype_0.7.5-1_amd64.deb">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype_0.7.3-1_amd64.deb
-sudo apt install ./voxtype_0.7.3-1_amd64.deb
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.5/voxtype_0.7.5-1_amd64.deb
+sudo apt install ./voxtype_0.7.5-1_amd64.deb
 
 <span class="comment"># Recommended optional dependencies</span>
 sudo apt install wtype wl-clipboard libnotify-bin pipewire-alsa playerctl</code></pre>
@@ -936,11 +946,11 @@ sudo apt install wtype wl-clipboard libnotify-bin pipewire-alsa playerctl</code>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install RPM package</span>
-                            <button class="copy-btn" data-copy="sudo dnf install ./voxtype-0.7.3-1.x86_64.rpm">Copy</button>
+                            <button class="copy-btn" data-copy="sudo dnf install ./voxtype-0.7.5-1.x86_64.rpm">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download and install</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype-0.7.3-1.x86_64.rpm
-sudo dnf install ./voxtype-0.7.3-1.x86_64.rpm
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.5/voxtype-0.7.5-1.x86_64.rpm
+sudo dnf install ./voxtype-0.7.5-1.x86_64.rpm
 
 <span class="comment"># Recommended optional dependencies</span>
 sudo dnf install wtype wl-clipboard libnotify pipewire-alsa playerctl</code></pre>
@@ -961,7 +971,7 @@ brew install --cask voxtype
 <span class="comment"># First launch opens a setup wizard that walks you through</span>
 <span class="comment"># Accessibility permissions, model download, and the FN-key hotkey.</span></code></pre>
                     </div>
-                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-0.7.3-macOS-arm64.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
+                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-0.7.5-macOS-arm64.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
                 </div>
 
                 <div id="nixos" class="tab-content">
@@ -969,16 +979,16 @@ brew install --cask voxtype
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install via flake</span>
-                            <button class="copy-btn" data-copy="nix profile install github:peteonrails/voxtype/v0.7.3#vulkan">Copy</button>
+                            <button class="copy-btn" data-copy="nix profile install github:peteonrails/voxtype/v0.7.5#vulkan">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Imperative install</span>
-nix profile install github:peteonrails/voxtype/v0.7.3#vulkan
+nix profile install github:peteonrails/voxtype/v0.7.5#vulkan
 
 <span class="comment"># Available outputs: default, vulkan, cuda, rocm, osdGtk4, osdNative</span>
-nix build github:peteonrails/voxtype/v0.7.3#osdGtk4
+nix build github:peteonrails/voxtype/v0.7.5#osdGtk4
 
 <span class="comment"># Or pin in your flake inputs</span>
-inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.3";</code></pre>
+inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.5";</code></pre>
                     </div>
                     <p class="install-note" style="margin-top: 1rem;"><strong>Next:</strong> <a href="#quick-start">First-run setup</a> below.</p>
                 </div>
@@ -988,15 +998,15 @@ inputs.voxtype.url = "github:peteonrails/voxtype/v0.7.3";</code></pre>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Download and run</span>
-                            <button class="copy-btn" data-copy="chmod +x voxtype-0.7.3-x86_64.AppImage && ./voxtype-0.7.3-x86_64.AppImage">Copy</button>
+                            <button class="copy-btn" data-copy="chmod +x voxtype-0.7.5-x86_64.AppImage && ./voxtype-0.7.5-x86_64.AppImage">Copy</button>
                         </div>
                         <pre><code><span class="comment"># Download a variant from the latest release</span>
-wget https://github.com/peteonrails/voxtype/releases/download/v0.7.3/voxtype-0.7.3-x86_64.AppImage
-chmod +x voxtype-0.7.3-x86_64.AppImage
+wget https://github.com/peteonrails/voxtype/releases/download/v0.7.5/voxtype-0.7.5-x86_64.AppImage
+chmod +x voxtype-0.7.5-x86_64.AppImage
 
 <span class="comment"># Run directly, or move to ~/.local/bin/ for permanent install</span>
-./voxtype-0.7.3-x86_64.AppImage --help
-mv voxtype-0.7.3-x86_64.AppImage ~/.local/bin/voxtype</code></pre>
+./voxtype-0.7.5-x86_64.AppImage --help
+mv voxtype-0.7.5-x86_64.AppImage ~/.local/bin/voxtype</code></pre>
                     </div>
                     <p class="install-note" style="margin-top: 1rem;"><strong>Next:</strong> <a href="#quick-start">First-run setup</a> below.</p>
                 </div>

--- a/website/news/index.html
+++ b/website/news/index.html
@@ -77,6 +77,92 @@
 
             <!-- v0.7.x Era Posts -->
 
+            <article class="news-article" id="v075">
+                <div class="article-meta">
+                    <time datetime="2026-05-28">May 28, 2026</time>
+                    <span class="article-tag">Release</span>
+                </div>
+                <h2>v0.7.5: Quickshell OSD, Soniox streaming, meeting-mode rework</h2>
+                <div class="article-body">
+                    <p>A larger feature release that bundles work queued behind three hotfix cycles. Three themes: an opt-in Quickshell OSD frontend, a Soniox cloud streaming backend, and a rebuild of meeting mode around source diarization. Release artifacts are now signed end-to-end in CI by a dedicated release key, removing the manual signing step from every cut.</p>
+
+                    <h3>Quickshell OSD frontend (opt-in)</h3>
+                    <p>A QML-native on-screen display that replaces the GTK4 surface for users who already run a Quickshell-based desktop. Three composed surfaces ship with the package: a waveform overlay during recording, an engine picker overlay for switching transcription backends without leaving the keyboard, and a meeting controls overlay for starting and stopping meeting captures. A new <code>voxtype-audio-bridge</code> sidecar streams audio levels to the QML side as NDJSON over a UNIX socket.</p>
+
+                    <p><strong>Why use it:</strong> if you already run Quickshell, the OSD blends into your existing shell instead of pulling in a GTK4 surface. The QML stack composes with Hyprland / Niri layer-shell rules cleanly, and the waveform renders at full compositor refresh rate.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>config.toml</span></div>
+                        <pre><code>[osd]
+frontend = "quickshell"</code></pre>
+                    </div>
+
+                    <p>The default frontend stays <code>gtk4</code>. Run <code>voxtype setup quickshell</code> to install the QML files and the sidecar binary into the right Quickshell config paths. Known issue: the Quickshell overlay captures pointer events across the whole screen (<a href="https://github.com/peteonrails/voxtype/issues/440">#440</a>). v0.7.6 will fix.</p>
+
+                    <h3>Soniox cloud streaming backend (<a href="https://github.com/peteonrails/voxtype/issues/411">#411</a>)</h3>
+                    <p>A new engine that streams audio over a WebSocket to Soniox and types each partial transcript at the cursor as it arrives. Lower end-to-end latency than the local Parakeet streaming pipeline, at the cost of network dependence and a third-party API key.</p>
+
+                    <p><strong>Why use it:</strong> the lowest-latency option when you can tolerate cloud transcription. Good for live captioning, long-form interview dictation, or any case where the half-second cost of local Parakeet streaming feels too long.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>config.toml</span></div>
+                        <pre><code>engine = "soniox"
+
+[soniox]
+api_key = "your-soniox-api-key"</code></pre>
+                    </div>
+
+                    <h3>Meeting mode: source diarization and VAD sub-windows</h3>
+                    <p>Three changes converge: a source-diarization path that attributes each speaker by which input device they came from (<a href="https://github.com/peteonrails/voxtype/issues/341">#341</a>, contributed by sjug), VAD sub-windows that let the ECAPA-TDNN ML diarizer run on shorter chunks for better turn-by-turn accuracy (<a href="https://github.com/peteonrails/voxtype/issues/418">#418</a>), and a per-meeting <code>--diarization</code> CLI flag so you can switch backends without editing the config file (<a href="https://github.com/peteonrails/voxtype/issues/420">#420</a>).</p>
+
+                    <p><strong>Why use it:</strong> meetings with a clear host-plus-remote structure (loopback for remote audio, mic for the host) now get correct speaker labels without any ML cost. The per-meeting flag means you can run one meeting with full ML diarization and the next with cheap source diarization without restarting the daemon.</p>
+
+                    <div class="code-block">
+                        <div class="code-header"><span>per-meeting override</span></div>
+                        <pre><code><span class="comment"># Source-based (fast, works when speakers are on different input devices)</span>
+voxtype meeting start --diarization source
+
+<span class="comment"># ML-based (slower, works on a single mixed audio stream)</span>
+voxtype meeting start --diarization ml</code></pre>
+                    </div>
+
+                    <h3>Release signing migrated to a dedicated CI key (<a href="https://github.com/peteonrails/voxtype/issues/437">#437</a>)</h3>
+                    <p>Every release artifact (binaries, companion <code>.so</code> files, <code>SHA256SUMS.txt</code>, <code>.deb</code>, <code>.rpm</code>, and the GitHub source archive) is now signed in CI by a dedicated release primary key (<code>9CCF7915...</code>) that is cross-signed by the offline maintainer key. Both fingerprints are in <code>voxtype-bin</code>'s <code>validpgpkeys</code>, so <code>yay</code> auto-fetches the new key from a keyserver on first upgrade with no manual <code>gpg --recv-keys</code> step.</p>
+
+                    <p><strong>Why this matters:</strong> v0.7.4 used a back-signed signing subkey that <code>yay</code> could not auto-fetch by keyid, which broke <code>yay -Syu voxtype-bin</code> for every user with a stale local keyring. v0.7.5's standalone primary keyserver-resolves correctly on every keyserver implementation. The signing step itself is also now fully in CI, removing the maintainer-laptop step between tag and release.</p>
+
+                    <h3>Variant safety improvements</h3>
+                    <p>Two changes around the <code>/usr/bin/voxtype</code> dispatcher wrapper:</p>
+                    <ul>
+                        <li><strong>Wrapper decision uses basename, not canonicalize</strong> (<a href="https://github.com/peteonrails/voxtype/issues/443">#443</a>). The previous logic followed symlinks and could pick the wrong dispatch shape when <code>/usr/bin/voxtype</code> already pointed at a non-canonical path. Closed-set basename match is more reliable and doesn't depend on filesystem state.</li>
+                        <li><strong>TUI surfaces engine-vs-binary mismatch</strong> (<a href="https://github.com/peteonrails/voxtype/issues/450">#450</a>). A persistent banner appears across every section when the configured engine cannot be served by the running binary. <code>F2</code> jumps to the General section's variant picker. The daemon also fires a desktop notification at startup so users who do not open the TUI still see the warning.</li>
+                    </ul>
+
+                    <h3>Smaller fixes</h3>
+                    <ul>
+                        <li>Streaming Parakeet validator accepts the <code>bobNight</code> naming convention (closes the v0.7.4 known issue).</li>
+                        <li>Per-language XKB variants for <code>eitype</code> (<a href="https://github.com/peteonrails/voxtype/issues/424">#424</a>, contributed by AlexCzar).</li>
+                        <li>Cohere ONNX remote-path prefix fix for the new <code>onnx/</code> subdirectory layout (<a href="https://github.com/peteonrails/voxtype/issues/363">#363</a>, contributed by jpds).</li>
+                        <li>CPU <code>__cpuid</code> wrapped in <code>unsafe</code> block for rustc 1.91+ (<a href="https://github.com/peteonrails/voxtype/issues/419">#419</a>, contributed by materemias).</li>
+                        <li>NixOS CI workflow now builds on every PR (closes <a href="https://github.com/peteonrails/voxtype/issues/369">#369</a>).</li>
+                        <li><code>wl-copy</code> fallback under X11 sessions (<a href="https://github.com/peteonrails/voxtype/issues/346">#346</a>).</li>
+                        <li><code>dotool</code> daemon fast path (<a href="https://github.com/peteonrails/voxtype/issues/410">#410</a>).</li>
+                        <li>Audio socket listener watchdog (<a href="https://github.com/peteonrails/voxtype/issues/391">#391</a>, <a href="https://github.com/peteonrails/voxtype/issues/392">#392</a>).</li>
+                    </ul>
+
+                    <h3>Acknowledgments</h3>
+                    <ul>
+                        <li><strong>sjug</strong> for the source-diarization patch (<a href="https://github.com/peteonrails/voxtype/issues/341">#341</a>).</li>
+                        <li><strong>AlexCzar</strong> for the per-language XKB variants (<a href="https://github.com/peteonrails/voxtype/issues/424">#424</a>).</li>
+                        <li><strong>jpds</strong> for the Cohere ONNX path fix (<a href="https://github.com/peteonrails/voxtype/issues/363">#363</a>).</li>
+                        <li><strong>materemias</strong> for the rustc 1.91 <code>__cpuid</code> fix (<a href="https://github.com/peteonrails/voxtype/issues/419">#419</a>).</li>
+                    </ul>
+
+                    <h3>Downloads</h3>
+                    <p>Full changelog, signed binaries, and SHA256 sums: <a href="https://github.com/peteonrails/voxtype/releases/tag/v0.7.5">v0.7.5 on GitHub</a>.</p>
+                </div>
+            </article>
+
             <article class="news-article" id="v073">
                 <div class="article-meta">
                     <time datetime="2026-05-19">May 19, 2026</time>


### PR DESCRIPTION
Standard post-release sync. Brings to dev:

- **#447** - CI signs every binary + companion .so + SHA256SUMS.txt in the release job (landed on main during v0.7.5 release shipping)
- **#461** - website v0.7.5 download URLs and news article
- **#462** - refactoring policy (CONTRIBUTING addition + docs/REFACTORING.md)

No conflicts; clean merge against current dev (which has the R2 CDN work plus everything that shipped via dev today).

## Test plan

- [x] Local merge clean, no conflicts.
- [x] CI green on merge PR.