### PR TITLE
Add v0.7.6 release verification tests

### DIFF
--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -93,6 +93,18 @@ verification.
 |------|----------------|
 | [Meeting Mode](smoke_tests/meeting-mode.md) | Lifecycle, list, show, export, delete, speaker labels, AI summary, error handling, dual audio, diarization backends |
 
+## v0.7.6 release verification
+
+Tests for bug fixes and tweaks introduced in v0.7.6.
+
+| Test | Issue |
+|------|-------|
+| [TUI Audio/VAD float serialization](smoke_tests/v076/tui-audio-vad-float-serialization.md) | [#451](https://github.com/peteonrails/voxtype/issues/451) |
+| [Engine vs binary mismatch detection](smoke_tests/v076/engine-binary-mismatch-detection.md) | [#450](https://github.com/peteonrails/voxtype/issues/450) |
+| [Setup retry-hint](smoke_tests/v076/setup-retry-hint.md) | [#449](https://github.com/peteonrails/voxtype/issues/449) |
+| [Streaming + non-streaming model fail-fast](smoke_tests/v076/streaming-model-fail-fast.md) | [#442](https://github.com/peteonrails/voxtype/issues/442) |
+| [Model downloads via Cloudflare R2](smoke_tests/v076/models-cdn-r2.md) | (CDN rollout) |
+
 ## v0.6.6 release verification
 
 Tests for bug fixes and enhancements introduced in v0.6.6.

--- a/docs/smoke_tests/v076/engine-binary-mismatch-detection.md
+++ b/docs/smoke_tests/v076/engine-binary-mismatch-detection.md
@@ -1,0 +1,85 @@
+# Engine vs binary mismatch detection (#450)
+
+A persistent red banner appears on every TUI section when the configured
+engine cannot be served by the running binary (e.g. `engine = "parakeet"`
+but `/usr/bin/voxtype` dispatches to a CPU Whisper variant). F2 jumps to
+the General variant picker. The daemon also fires a desktop notification
+at startup so users who never open the TUI still see the warning.
+
+This file also covers the strum-derived `TranscriptionEngine::name()`
+refactor that the variant-check logic depends on: adding a new engine
+no longer requires updating a separate name lookup table, and the wrong
+spelling is mechanically impossible at compile time.
+
+## Unit tests
+
+```bash
+cargo test --lib setup::variant_check -- --nocapture
+# Expected: 5 tests pass:
+#   whisper_engine_never_mismatches
+#   parakeet_on_cpu_whisper_binary_is_mismatch
+#   parakeet_on_onnx_binary_is_not_mismatch
+#   source_install_recommends_rebuild
+#   every_non_whisper_engine_has_a_required_feature
+```
+
+## Structural verification
+
+```bash
+grep -c "variant_mismatch\|VariantMismatch" src/tui/app.rs src/tui/mod.rs src/daemon.rs
+# Expected: references in all three
+
+grep -c "KeyCode::F(2)" src/tui/mod.rs
+# Expected: 1 (the F2 binding to jump to General)
+
+grep -c "jump_to_section" src/tui/app.rs src/tui/mod.rs
+# Expected: 2+ (definition + at least one caller)
+```
+
+Engine name dedup (no manual name tables outside config.rs):
+
+```bash
+grep -c 'TranscriptionEngine::Parakeet => "parakeet"' src/menubar.rs src/setup/variant_check.rs src/config.rs
+# Expected: 0 in menubar and variant_check; the only allowed home is
+# config.rs (where strum derives it from the variant identifier).
+
+grep -c '\.name()' src/menubar.rs src/setup/variant_check.rs
+# Expected: 2+
+```
+
+## Runtime test (package install required; source builds use the rebuild path)
+
+1. Force a mismatch: edit `config.toml` to use a Parakeet engine while
+   `/usr/bin/voxtype` is the CPU variant:
+   ```toml
+   engine = "parakeet"
+
+   [parakeet]
+   model = "parakeet-unified-en-0.6b"
+   ```
+
+2. Confirm the wrapper is the CPU variant (not ONNX):
+   ```bash
+   readlink -f /usr/bin/voxtype
+   # Expected: voxtype-avx2 or voxtype-avx512 (NOT voxtype-onnx-*)
+   ```
+
+3. `systemctl --user restart voxtype`
+   Expected: desktop notification "Voxtype: parakeet unavailable"
+
+4. `voxtype configure`
+   Expected: red banner across every section reading:
+   ```
+   ! engine = parakeet but voxtype-avx2 was built without --features parakeet
+     Fix: press F2 to open the variant picker, or run sudo voxtype setup onnx --enable
+   ```
+
+5. Press F2 from any section
+   Expected: jumps to General; variant matrix focused
+
+6. Press `?` in the TUI
+   Expected: help overlay lists `F2  Jump to General (variant picker)` under Global
+
+7. Fix the mismatch via the variant picker (or `sudo voxtype setup onnx --enable`)
+8. Restart the daemon, re-open the TUI
+   Expected: banner gone

--- a/docs/smoke_tests/v076/models-cdn-r2.md
+++ b/docs/smoke_tests/v076/models-cdn-r2.md
@@ -1,0 +1,86 @@
+# Model downloads use Cloudflare R2 with sha256 verification
+
+`voxtype setup --download --model <name>` now fetches from
+`https://models.voxtype.io/<engine>/<model>/manifest.json` and validates
+each file's sha256 against the manifest. The five legacy per-engine
+download functions collapsed into one `download_artifact<T: ModelArtifact>`.
+HuggingFace remains as a fallback for users behind firewalls that block R2.
+
+This is the v0.7.1 roadmap item that finally landed in v0.7.6.
+
+## Structural verification
+
+```bash
+grep -c "MODELS_BASE_URL\|ModelArtifact\|download_artifact" src/setup/model.rs src/setup/manifest.rs
+# Expected: 10+ across the two files
+```
+
+Confirm legacy per-engine download helpers are gone:
+
+```bash
+grep -c "fn download_parakeet_model_by_info\|fn download_moonshine_model_by_info\|fn download_cohere_model_by_info\|fn download_sensevoice_model_by_info\|fn download_onnx_model" src/setup/model.rs
+# Expected: 0 (all consolidated into download_artifact<T: ModelArtifact>)
+```
+
+## Manifest fetch (no model required)
+
+```bash
+curl -sS https://models.voxtype.io/parakeet/parakeet-unified-en-0.6b/manifest.json | jq '{version, model, engine, files: (.files | length)}'
+# Expected:
+#   { "version": 1,
+#     "model": "parakeet-unified-en-0.6b",
+#     "engine": "parakeet",
+#     "files": 5 }
+```
+
+## End-to-end download test
+
+Run against an isolated `XDG_DATA_HOME` so the test doesn't touch a real install:
+
+```bash
+rm -rf /tmp/voxtype-r2-test
+mkdir -p /tmp/voxtype-r2-test
+XDG_DATA_HOME=/tmp/voxtype-r2-test voxtype setup --download --model parakeet-unified-en-0.6b
+# Expected: "Downloading parakeet-unified-en-0.6b (5 files via https://models.voxtype.io/parakeet/...)"
+# Expected: each of the 5 files downloads to 100% with no sha256 mismatch error
+
+ls -la /tmp/voxtype-r2-test/voxtype/models/parakeet-unified-en-0.6b/
+# Expected: encoder.onnx, encoder.onnx.data, decoder_joint.onnx, tokenizer.model, vocab.txt
+```
+
+Verify sha256 matches the manifest:
+
+```bash
+sha256sum /tmp/voxtype-r2-test/voxtype/models/parakeet-unified-en-0.6b/tokenizer.model
+# Compare against the value in the manifest from the curl step above
+```
+
+## Cached-file revalidation
+
+Re-running setup --download should skip files whose sha256 already matches
+the manifest rather than re-downloading them:
+
+```bash
+XDG_DATA_HOME=/tmp/voxtype-r2-test voxtype setup --download --model parakeet-unified-en-0.6b
+# Expected: completes fast; output indicates files were validated rather than re-fetched
+```
+
+## Mirror script
+
+The R2 mirror script no longer aborts the whole run when one upstream HF
+file 404s; it warns, skips the offending model, and prints a summary at
+the end.
+
+```bash
+./scripts/mirror-models-to-r2.sh --all --dry-run 2>&1 | tail -20
+# Expected: per-model "[mirror] foo/bar <- huggingface.co/..." lines
+# Expected if any model has a stale registry entry: a final
+# "WARNING: N model(s) skipped" summary listing them.
+```
+
+Confirm process-substitution is used (so `SKIPPED_MODELS` survives the loop):
+
+```bash
+grep -c "done < <(" scripts/mirror-models-to-r2.sh
+# Expected: 1+
+```

--- a/docs/smoke_tests/v076/setup-retry-hint.md
+++ b/docs/smoke_tests/v076/setup-retry-hint.md
@@ -1,0 +1,53 @@
+# Setup retry-hint echoes invoked subcommand (#449)
+
+Previously, running `voxtype setup gpu --enable` without root suggested
+retrying as `sudo voxtype setup onnx --enable`, which is a different
+command. Now the retry hint matches the subcommand the user invoked, with
+`switch_to` deriving the hint from the variant family for the TUI path.
+
+## Structural verification
+
+```bash
+grep -c "Try: sudo voxtype " src/setup/binary.rs
+# Expected: 3 (the three error paths)
+
+grep -c "retry_hint" src/setup/binary.rs src/setup/gpu.rs
+# Expected: 5+ (param threaded through callers)
+```
+
+Confirm the literal `setup onnx --enable` hint is no longer hard-coded in
+`binary.rs` (it's still in the wrapper script's audit comment, which is
+intentional: wrappers are only generated for ONNX variants).
+
+```bash
+grep -c 'Try: sudo voxtype setup onnx' src/setup/binary.rs
+# Expected: 0
+```
+
+## Runtime tests
+
+These require not having sudo cached and ideally running as a user
+without write access to `/usr/bin/voxtype` (e.g., a stock package install).
+
+### Path 1: `setup gpu`
+
+```bash
+voxtype setup gpu --enable 2>&1 | grep "Try:"
+# Expected: Try: sudo voxtype setup gpu --enable
+```
+
+### Path 2: `setup onnx`
+
+```bash
+voxtype setup onnx --enable 2>&1 | grep "Try:"
+# Expected: Try: sudo voxtype setup onnx --enable
+```
+
+### Path 3: TUI variant picker
+
+Without sudo cached, pick a Whisper variant in the TUI's General section
+and observe the on-screen error after pkexec cancellation. The retry
+hint should be `Try: sudo voxtype setup gpu --enable`.
+
+Then pick an ONNX variant under the same conditions. The retry hint
+should be `Try: sudo voxtype setup onnx --enable`.

--- a/docs/smoke_tests/v076/streaming-model-fail-fast.md
+++ b/docs/smoke_tests/v076/streaming-model-fail-fast.md
@@ -1,0 +1,55 @@
+# Streaming + non-streaming model fail-fast (#442)
+
+Pairing `[parakeet] streaming = true` with a non-streaming model
+(e.g. `parakeet-tdt-0.6b-v3`) used to either fail opaquely on
+`Failed to open tokenizer.model` or crash mid-chunk with an ONNX Gather
+shape error. Now the streaming pipeline checks the registry before
+loading and bails out with a message that names the model and the
+streaming-compatible alternative.
+
+## Unit test
+
+```bash
+cargo test --features parakeet --lib \
+  transcribe::parakeet_streaming::tests::new_rejects_streaming_on_known_incompatible_model \
+  -- --nocapture
+# Expected: passes; error message names the model and the recommended replacement.
+```
+
+## Structural verification
+
+```bash
+grep -c "is_known_parakeet_model\|is_streaming_compatible_parakeet" \
+  src/setup/model.rs src/transcribe/parakeet_streaming.rs
+# Expected: 4+ (both helpers plus their call sites)
+```
+
+## Runtime test (requires `--features parakeet`)
+
+1. Set config to a non-streaming Parakeet model with streaming on:
+   ```bash
+   cat <<EOF >> ~/.config/voxtype/config.toml
+   engine = "parakeet"
+   [parakeet]
+   model = "parakeet-tdt-0.6b-v3"
+   streaming = true
+   EOF
+   ```
+
+2. Restart the daemon and inspect the journal:
+   ```bash
+   systemctl --user restart voxtype
+   journalctl --user -u voxtype --since "30 seconds ago" | grep -A8 "Parakeet streaming"
+   ```
+
+   Expected error body:
+   ```
+   Parakeet streaming is enabled but model `parakeet-tdt-0.6b-v3` does not
+   support cache-aware streaming.
+   Fix one of:
+     - Disable streaming in config.toml under [parakeet]:
+         streaming = false
+     - Or switch to the streaming-compatible model:
+         voxtype setup model parakeet-unified-en-0.6b
+     and set [parakeet] model = "parakeet-unified-en-0.6b" in config.toml.
+   ```

--- a/docs/smoke_tests/v076/tui-audio-vad-float-serialization.md
+++ b/docs/smoke_tests/v076/tui-audio-vad-float-serialization.md
@@ -1,0 +1,54 @@
+# TUI Audio/VAD float serialization (#451)
+
+The TUI used to write `volume = "0.70"` and `threshold = "0.50"` as quoted
+strings, which the daemon's serde config rejected with `invalid type:
+string "0.70", expected f32`. Saving any Audio or VAD change broke the
+daemon on next start. Now serialized as bare TOML floats, with legacy
+string and int forms still tolerated on load so existing configs migrate
+on first save.
+
+## Unit tests
+
+```bash
+cargo test --lib tui::config_editor::tests::set_f32 -- --nocapture
+cargo test --lib tui::config_editor::tests::get_f32_or -- --nocapture
+# Expected: set_f32_writes_toml_number_not_string passes
+# Expected: get_f32_or_recovers_legacy_string_and_int_forms passes
+```
+
+## Structural verification
+
+```bash
+grep -c "set_string.*format!" src/tui/audio.rs src/tui/vad_section.rs
+# Expected: 0 (the anti-pattern is gone)
+
+grep -c "set_f32\|get_f32_or" src/tui/audio.rs src/tui/vad_section.rs
+# Expected: 4+ (each section reads + writes)
+```
+
+## Runtime test
+
+1. Open the TUI: `voxtype configure`
+2. Audio section, change Volume, Save
+3. Inspect `~/.config/voxtype/config.toml`:
+   ```bash
+   grep -A1 "audio.feedback" ~/.config/voxtype/config.toml
+   # Expected: volume = 0.7 (bare number, no quotes)
+   ```
+4. `systemctl --user restart voxtype`
+   Expected: daemon starts cleanly, no f32 parse error in journalctl
+
+## Migration test
+
+Hand-edit a quoted volume back in, then save via the TUI:
+
+```bash
+sed -i 's/^volume = 0\./volume = "0./; s/^\(volume = "0\.[0-9]*\)$/\1"/' ~/.config/voxtype/config.toml
+```
+
+Open the TUI, save, re-check:
+
+```bash
+grep volume ~/.config/voxtype/config.toml
+# Expected: bare TOML number again after the save (auto-migration worked)
+```


### PR DESCRIPTION
## Summary

Rebased onto post-#466 dev and reshaped as five new files under `docs/smoke_tests/v076/` plus a release-verification table in the index. Mirrors the v0.6.6 layout.

| File | Issue |
|------|-------|
| `tui-audio-vad-float-serialization.md` | [#451](https://github.com/peteonrails/voxtype/issues/451) — TUI float serialization fix |
| `engine-binary-mismatch-detection.md` | [#450](https://github.com/peteonrails/voxtype/issues/450) — banner + F2 + daemon notification |
| `setup-retry-hint.md` | [#449](https://github.com/peteonrails/voxtype/issues/449) — retry hint echoes invoked subcommand |
| `streaming-model-fail-fast.md` | [#442](https://github.com/peteonrails/voxtype/issues/442) — streaming + incompatible model rejection |
| `models-cdn-r2.md` | v0.7.1 CDN item, landed in v0.7.6 |

The strum-derived `TranscriptionEngine::name()` refactor is verified inside `engine-binary-mismatch-detection.md` because `variant_check.rs` is its main consumer.

## Test plan

- [ ] Skim the five new files for tone / phrasing
- [ ] Confirm the index `v0.7.6 release verification` table renders above the v0.6.6 table
- [ ] Walk a fresh build through each subsection against this checklist before tagging v0.7.6