### PR TITLE
Add optional compact pill OSD style

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Hold a hotkey (default: ScrollLock) while speaking, release to transcribe and ou
 
 - **Hyprland, Niri, Sway, River, GNOME, KDE.** Compositor keybindings everywhere, evdev fallback for X11, Wayland-first typing via wtype with full CJK support. Falls back through dotool → ydotool → clipboard if any layer is unavailable.
 - **Pauses your music.** Auto-pauses Spotify, Plasma media players, anything that speaks MPRIS the moment you start dictating. Resumes on release.
-- **Floating waveform OSD.** Matches your swayosd band by default — same vertical position as volume and brightness — so the level meter sits where you already look for system feedback.
+- **Floating OSD.** The default waveform matches your swayosd band, and the optional compact pill style shows recording energy, processing progress, and completion in a smaller GTK4 surface.
 - **Interactive TUI configure.** `voxtype configure` (also surfaces in Walker / fuzzel / rofi) edits every option in `~/.config/voxtype/config.toml` for you — no hand-editing TOML. Auto-downloads missing models, swaps GPU binaries via pkexec, restarts the daemon when needed.
 - **Push-to-talk or toggle.** Hold to record, or press once to start/stop. Optional audio cues when recording starts/stops.
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -11,7 +11,7 @@
 # State file for external integrations (Waybar, polybar, etc.)
 # Use "auto" for default location ($XDG_RUNTIME_DIR/voxtype/state),
 # a custom path, or "disabled" to turn off. The daemon writes state
-# ("idle", "recording", "transcribing") to this file whenever it changes.
+# ("idle", "recording", "transcribing", "outputting") to this file whenever it changes.
 # Required for `voxtype record toggle` and `voxtype status` commands.
 state_file = "auto"
 
@@ -236,3 +236,28 @@ icon_theme = "emoji"
 # recording = "🎤"
 # transcribing = "⏳"
 # stopped = ""
+
+[osd]
+# Enable the floating on-screen visualizer.
+enabled = true
+
+# OSD frontend: "gtk4" (default), "native", or "quickshell".
+frontend = "gtk4"
+
+# Visual style: "waveform" (default) or "compact-pill".
+# "compact-pill" renders a smaller GTK4 pill with a centered voice glyph,
+# processing bar, and completion checkmark.
+style = "waveform"
+
+# Position and size.
+position = "bottom-center"
+width_px = 400
+height_px = 48
+margin_px = 24
+top_margin = 0.85
+
+# Visual tuning.
+opacity = 0.95
+waveform_window_secs = 3.0
+peak_decay_db_per_sec = 6.0
+waveform_gain = 10.0

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3047,15 +3047,112 @@ Voxtype outputs an `alt` field in JSON that enables Waybar's `format-icons` feat
            "idle": "",
            "recording": "",
            "transcribing": "",
+           "outputting": "",
            "stopped": ""
        },
        "tooltip": true
    }
    ```
 
-The `alt` field values match state names: `idle`, `recording`, `transcribing`, `stopped`.
+The `alt` field values match state names: `idle`, `recording`, `transcribing`, `outputting`, `stopped`.
 
 See [User Manual - Waybar Integration](USER_MANUAL.md#with-waybar-status-indicator) for complete setup instructions.
+
+---
+
+## [osd]
+
+Controls the floating on-screen visualizer.
+
+### enabled
+
+**Type:** Boolean
+**Default:** `true`
+**Required:** No
+
+Enable or disable the OSD process.
+
+### frontend
+
+**Type:** String
+**Default:** `"gtk4"`
+**Required:** No
+
+Selects which OSD frontend the `voxtype-osd` launcher starts.
+
+**Values:**
+- `gtk4` - GTK4 + layer-shell frontend (default)
+- `native` - SCTK + wgpu + egui frontend
+- `quickshell` - QML/Quickshell launcher
+
+### style
+
+**Type:** String
+**Default:** `"waveform"`
+**Required:** No
+
+Selects the visual style drawn inside the OSD surface.
+
+**Values:**
+- `waveform` - Original scrolling waveform with segmented peak meter
+- `compact-pill` - Compact GTK4 pill with a centered voice glyph, processing bar, and completion checkmark
+
+**Example:**
+```toml
+[osd]
+frontend = "gtk4"
+style = "compact-pill"
+```
+
+The native frontend currently renders the waveform style. If `style = "compact-pill"` is set with `frontend = "native"`, the native frontend logs a warning and continues with the waveform renderer.
+
+### width_px / height_px
+
+**Type:** Integer
+**Defaults:** `400` / `48`
+**Required:** No
+
+Surface size in physical pixels.
+
+### position
+
+**Type:** String
+**Default:** `"bottom-center"`
+**Required:** No
+
+Anchor point for the OSD.
+
+**Values:**
+- `bottom-center`
+- `top-center`
+- `bottom-left`
+- `bottom-right`
+- `top-left`
+- `top-right`
+
+### margin_px / top_margin
+
+**Types:** Integer / Float
+**Defaults:** `24` / `0.85`
+**Required:** No
+
+`margin_px` controls corner anchors. Centered anchors use `top_margin`, a fraction of monitor height, so the OSD aligns with swayosd-style system feedback.
+
+### opacity
+
+**Type:** Float
+**Default:** `0.95`
+**Required:** No
+
+Background opacity from `0.0` to `1.0`.
+
+### waveform_window_secs / peak_decay_db_per_sec / waveform_gain
+
+**Types:** Float
+**Defaults:** `3.0` / `6.0` / `10.0`
+**Required:** No
+
+Waveform and level tuning. `waveform_gain` is visual only and does not affect transcription.
 
 ---
 
@@ -3071,6 +3168,7 @@ Path to a state file for external integrations like Waybar or Polybar. When conf
 - `idle` - Ready for input
 - `recording` - Push-to-talk active, capturing audio
 - `transcribing` - Processing audio through Whisper
+- `outputting` - Writing the finished text to the configured output target
 
 **Special values:**
 - `"auto"` - Uses `$XDG_RUNTIME_DIR/voxtype/state` (default, recommended)

--- a/docs/WAYBAR.md
+++ b/docs/WAYBAR.md
@@ -212,13 +212,14 @@ Voxtype outputs an `alt` field in JSON that enables Waybar's native `format-icon
         "idle": "",
         "recording": "",
         "transcribing": "",
+        "outputting": "",
         "stopped": ""
     },
     "tooltip": true
 }
 ```
 
-The `alt` field values are: `idle`, `recording`, `transcribing`, `stopped`.
+The `alt` field values are: `idle`, `recording`, `transcribing`, `outputting`, `stopped`.
 
 **Nerd Font example:**
 ```json
@@ -310,7 +311,7 @@ The `--follow` flag keeps a persistent connection and updates instantly. If you 
    ```bash
    cat $XDG_RUNTIME_DIR/voxtype/state
    ```
-   Should show `idle`, `recording`, or `transcribing`.
+   Should show `idle`, `recording`, `transcribing`, or `outputting`.
 
 3. Test the status command manually:
    ```bash

--- a/src/bin/voxtype_osd.rs
+++ b/src/bin/voxtype_osd.rs
@@ -144,12 +144,13 @@ fn print_help() {
              -V, --version                Show version.\n\
          \n\
          All other arguments are passed through to the chosen frontend\n\
-         (--config, --width-px, --waveform-gain, etc.). See the frontend's\n\
+         (--config, --width-px, --style, --waveform-gain, etc.). See the frontend's\n\
          own --help for the full list.\n\
          \n\
          CONFIG:\n    \
              [osd]\n    \
              frontend = \"gtk4\"  # or \"native\", \"quickshell\"\n\
+             style = \"waveform\" # or \"compact-pill\" on GTK4\n\
          \n\
          ENV:\n    \
              VOXTYPE_OSD_FRONTEND   Same as --frontend.\n    \

--- a/src/bin/voxtype_osd_gtk4.rs
+++ b/src/bin/voxtype_osd_gtk4.rs
@@ -1,8 +1,9 @@
 //! `voxtype-osd-gtk4` — GTK4 + gtk4-layer-shell on-screen mic visualizer
 //! for the Voxtype daemon.
 //!
-//! Renders a click-through, layer-shell-anchored window containing the
-//! scrolling waveform plus a segmented peak meter. Audio frames arrive on
+//! Renders a click-through, layer-shell-anchored window containing either the
+//! original scrolling waveform or an optional compact status pill. Audio
+//! frames arrive on
 //! the daemon's audio Unix socket via [`voxtype::osd::ipc::run_ipc_loop`],
 //! decoded into [`AudioFrame`]s by a tokio runtime on a worker thread, and
 //! pushed into a shared [`FrameRing`] + [`PeakHold`]. The GTK side polls a
@@ -15,21 +16,22 @@
 //!
 //! Run with `RUST_LOG=debug` for verbose logs.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use cairo::{Context, RectangleInt, Region};
+use cairo::{Context, LinearGradient, RectangleInt, Region};
 use clap::Parser;
 use gtk4::glib;
 use gtk4::prelude::*;
-use gtk4::{Application, ApplicationWindow, DrawingArea};
+use gtk4::{Application, ApplicationWindow, CssProvider, DrawingArea};
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 
 use voxtype::audio::levels::{AudioFrame, FRAME_HZ};
-use voxtype::config::Config as VoxtypeConfig;
-use voxtype::osd::config::{OsdConfig, OsdPosition};
+use voxtype::config::{load_config, Config as VoxtypeConfig};
+use voxtype::osd::config::{OsdConfig, OsdPosition, OsdStyle};
 use voxtype::osd::ipc::{resolve_socket_path, run_ipc_loop, FrameRing, DEFAULT_RING_DEPTH};
 use voxtype::osd::theme::ThemeWatcher;
 use voxtype::osd::visual::{peak_meter_fraction, project_envelope, MeterZone, Palette, PeakHold};
@@ -77,11 +79,33 @@ const RENDER_TICK_MS: u32 = 16;
 /// hiding the surface. Matches the BRIEF's "Idle: surface destroyed" rule.
 const IDLE_TIMEOUT_SECS: f32 = 0.15;
 
-/// Number of segments in the vertical peak meter.
-const METER_SEGMENTS: usize = 10;
-
 /// dBFS floor for the peak meter (maps to "empty bar").
 const METER_FLOOR_DBFS: f32 = -60.0;
+
+/// Number of segments in the waveform style's vertical peak meter.
+const METER_SEGMENTS: usize = 10;
+
+/// Odd number of bars so the voice glyph has a true visual center.
+const REACTIVE_BARS: usize = 15;
+
+/// Background room noise is ignored below this visual-energy level.
+const NOISE_GATE_ENTER: f64 = 0.24;
+const NOISE_GATE_EXIT: f64 = 0.14;
+
+/// Easing constants for the voice indicator.
+const ENERGY_ATTACK: f64 = 0.32;
+const ENERGY_RELEASE: f64 = 0.12;
+const REVEAL_IN: f64 = 0.34;
+const REVEAL_OUT: f64 = 0.18;
+const SUCCESS_HOLD_MS: u128 = 860;
+const SUCCESS_DRAW_MS: u128 = 340;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OsdMode {
+    Recording,
+    Processing,
+    Success,
+}
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -129,6 +153,10 @@ struct Args {
     /// Reduce for hot mics (e.g. 4.0); raise for quiet sources (e.g. 14.0).
     #[arg(long, env = "VOXTYPE_OSD_GAIN")]
     waveform_gain: Option<f32>,
+
+    /// Visual style to render: "waveform" or "compact-pill".
+    #[arg(long, env = "VOXTYPE_OSD_STYLE")]
+    style: Option<String>,
 }
 
 /// State shared between the IPC worker and the GTK redraw timer.
@@ -137,6 +165,34 @@ struct SharedState {
     peak: Mutex<PeakHold>,
     last_seq: Mutex<u64>,
     last_frame_at: Mutex<Instant>,
+}
+
+struct VisualState {
+    energy: Cell<f64>,
+    reveal: Cell<f64>,
+    processing_phase: Cell<f64>,
+    success_progress: Cell<f64>,
+    success_started_at: RefCell<Option<Instant>>,
+    was_processing: Cell<bool>,
+    was_outputting: Cell<bool>,
+    mode: Cell<OsdMode>,
+    gate_open: Cell<bool>,
+}
+
+impl VisualState {
+    fn new() -> Self {
+        Self {
+            energy: Cell::new(0.0),
+            reveal: Cell::new(0.0),
+            processing_phase: Cell::new(0.0),
+            success_progress: Cell::new(0.0),
+            success_started_at: RefCell::new(None),
+            was_processing: Cell::new(false),
+            was_outputting: Cell::new(false),
+            mode: Cell::new(OsdMode::Recording),
+            gate_open: Cell::new(false),
+        }
+    }
 }
 
 impl SharedState {
@@ -175,23 +231,37 @@ fn main() -> anyhow::Result<()> {
     if let Some(g) = args.waveform_gain {
         osd_cfg.waveform_gain = g;
     }
+    if let Some(style) = args.style.as_deref() {
+        match OsdStyle::parse_str(style) {
+            Some(style) => osd_cfg.style = style,
+            None => tracing::warn!("Ignoring unknown OSD style '{style}'"),
+        }
+    }
     // peak_decay_db_per_sec has a clap default value, so this always
     // overrides whatever the file said. That's intentional: if the user
     // passes the flag, honor it; if they don't, the clap default kicks in.
     osd_cfg.peak_decay_db_per_sec = args.peak_decay_db_per_sec;
 
     tracing::info!(
-        "voxtype-osd-gtk4 starting; socket={:?} size={}x{} margin={} pos={:?}",
+        "voxtype-osd-gtk4 starting; socket={:?} size={}x{} margin={} pos={:?} style={:?}",
         socket_path,
         osd_cfg.width_px,
         osd_cfg.height_px,
         osd_cfg.margin_px,
         osd_cfg.position,
+        osd_cfg.style,
     );
 
     let theme = ThemeWatcher::new();
     let palette = theme.palette();
 
+    let state_file_path = if matches!(osd_cfg.style, OsdStyle::CompactPill) {
+        load_config(args.config.as_deref())
+            .ok()
+            .and_then(|cfg| cfg.resolve_state_file())
+    } else {
+        None
+    };
     let state = Arc::new(SharedState::new(osd_cfg.peak_decay_db_per_sec));
 
     // Spawn the tokio IPC worker on a side thread.
@@ -208,7 +278,13 @@ fn main() -> anyhow::Result<()> {
     let cfg = osd_cfg.clone();
     let state_for_activate = state.clone();
     app.connect_activate(move |app| {
-        build_window(app, &cfg, palette, state_for_activate.clone());
+        build_window(
+            app,
+            &cfg,
+            palette,
+            state_file_path.clone(),
+            state_for_activate.clone(),
+        );
     });
 
     // GTK's run() consumes argv; we've already parsed via clap, so feed
@@ -318,7 +394,17 @@ fn focused_monitor_height_px() -> Option<i32> {
 
 /// Build the GTK window, attach layer-shell config, mount the DrawingArea,
 /// and start the redraw tick.
-fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc<SharedState>) {
+fn build_window(
+    app: &Application,
+    cfg: &OsdConfig,
+    palette: Palette,
+    state_file_path: Option<PathBuf>,
+    state: Arc<SharedState>,
+) {
+    if matches!(cfg.style, OsdStyle::CompactPill) {
+        install_transparent_css();
+    }
+
     let window = ApplicationWindow::builder()
         .application(app)
         .default_width(cfg.width_px as i32)
@@ -326,6 +412,9 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
         .resizable(false)
         .decorated(false)
         .build();
+    if matches!(cfg.style, OsdStyle::CompactPill) {
+        window.add_css_class("voxtype-osd-window");
+    }
 
     // Layer-shell setup: top layer, no keyboard, anchored per config.
     window.init_layer_shell();
@@ -395,12 +484,29 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
 
     // The drawing area fills the window.
     let drawing_area = DrawingArea::new();
+    if matches!(cfg.style, OsdStyle::CompactPill) {
+        drawing_area.add_css_class("voxtype-osd-canvas");
+    }
     drawing_area.set_content_width(cfg.width_px as i32);
     drawing_area.set_content_height(cfg.height_px as i32);
+    let visual_state = Rc::new(VisualState::new());
+    let visual_for_draw = visual_state.clone();
     let state_for_draw = state.clone();
+    let draw_style = cfg.style;
     let gain = cfg.waveform_gain as f64;
-    drawing_area.set_draw_func(move |_area, cr, w, h| {
-        draw(cr, w, h, &palette, &state_for_draw, gain);
+    drawing_area.set_draw_func(move |_area, cr, w, h| match draw_style {
+        OsdStyle::Waveform => draw_waveform_osd(cr, w, h, &palette, &state_for_draw, gain),
+        OsdStyle::CompactPill => draw_compact_pill(
+            cr,
+            w,
+            h,
+            &palette,
+            visual_for_draw.energy.get(),
+            visual_for_draw.reveal.get(),
+            visual_for_draw.processing_phase.get(),
+            visual_for_draw.success_progress.get(),
+            visual_for_draw.mode.get(),
+        ),
     });
     window.set_child(Some(&drawing_area));
 
@@ -418,6 +524,8 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
     let redraw_state = state.clone();
     let redraw_area = drawing_area.clone();
     let redraw_window = window.clone();
+    let visual_for_tick = visual_state.clone();
+    let tick_style = cfg.style;
     let last_drawn_seq = Cell::new(0u64);
     // Tracks GTK visibility. Starts true because `window.present()` below maps
     // the surface, the first tick's idle check then hides it.
@@ -431,17 +539,104 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
             .map(|t| *t)
             .unwrap_or_else(|_| Instant::now() - Duration::from_secs(3600));
         let idle = last_at.elapsed().as_secs_f32() > IDLE_TIMEOUT_SECS;
+        if matches!(tick_style, OsdStyle::Waveform) {
+            if idle {
+                if visible.get() {
+                    tracing::info!("hiding (idle for {:.2}s)", last_at.elapsed().as_secs_f32());
+                    redraw_window.set_visible(false);
+                    visible.set(false);
+                }
+                return glib::ControlFlow::Continue;
+            }
 
-        if idle {
-            if visible.get() {
-                tracing::info!("hiding (idle for {:.2}s)", last_at.elapsed().as_secs_f32());
-                redraw_window.set_visible(false);
-                visible.set(false);
+            if !visible.get() {
+                tracing::info!(
+                    "showing (frame seq={}, last_at={:.3}s ago)",
+                    cur_seq,
+                    last_at.elapsed().as_secs_f32()
+                );
+                redraw_window.set_visible(true);
+                visible.set(true);
+            }
+
+            // Decay the held peak even when no new frame arrived this tick.
+            if let Ok(mut p) = redraw_state.peak.lock() {
+                let dt = (RENDER_TICK_MS as f32) / 1000.0;
+                let cur_peak = redraw_state
+                    .ring
+                    .lock()
+                    .ok()
+                    .and_then(|r| r.latest())
+                    .map(|f| f.peak_dbfs)
+                    .unwrap_or(-120.0);
+                if cur_peak <= p.held_dbfs {
+                    p.update(cur_peak, dt);
+                }
+            }
+
+            if cur_seq != last_drawn_seq.get() {
+                redraw_area.queue_draw();
+                last_drawn_seq.set(cur_seq);
             }
             return glib::ControlFlow::Continue;
         }
 
-        if !visible.get() {
+        let runtime_state = read_state_file(state_file_path.as_deref());
+        let processing = runtime_state
+            .as_deref()
+            .is_some_and(|state| state == "transcribing");
+        let outputting = runtime_state
+            .as_deref()
+            .is_some_and(|state| state == "outputting");
+        let recording_state = runtime_state
+            .as_deref()
+            .is_some_and(|state| matches!(state, "recording" | "streaming"));
+        let was_processing = visual_for_tick.was_processing.get();
+        let outputting_started = outputting && !visual_for_tick.was_outputting.get();
+        let now = Instant::now();
+        let live_recording = recording_state || (!idle && !processing && !outputting);
+        let completed_after_processing = was_processing
+            && !processing
+            && !live_recording
+            && runtime_state
+                .as_deref()
+                .is_some_and(|state| state == "idle");
+        let success_trigger = outputting_started || completed_after_processing;
+        visual_for_tick.was_processing.set(processing);
+        visual_for_tick.was_outputting.set(outputting);
+        if processing || live_recording {
+            visual_for_tick.success_started_at.replace(None);
+            visual_for_tick.success_progress.set(0.0);
+        } else if success_trigger && visual_for_tick.success_started_at.borrow().is_none() {
+            visual_for_tick.success_started_at.replace(Some(now));
+        }
+        let success_progress = visual_for_tick
+            .success_started_at
+            .borrow()
+            .map(|started_at| {
+                (now.duration_since(started_at).as_millis() as f64 / SUCCESS_DRAW_MS as f64)
+                    .clamp(0.0, 1.0)
+            })
+            .unwrap_or(0.0);
+        let success_visible =
+            visual_for_tick
+                .success_started_at
+                .borrow()
+                .is_some_and(|started_at| {
+                    now.duration_since(started_at).as_millis() <= SUCCESS_HOLD_MS
+                });
+        let success_latched = visual_for_tick.success_started_at.borrow().is_some();
+        visual_for_tick.success_progress.set(success_progress);
+        let active = live_recording || processing || success_visible;
+        visual_for_tick.mode.set(if processing {
+            OsdMode::Processing
+        } else if success_latched && !live_recording {
+            OsdMode::Success
+        } else {
+            OsdMode::Recording
+        });
+
+        if !visible.get() && active {
             tracing::info!(
                 "showing (frame seq={}, last_at={:.3}s ago)",
                 cur_seq,
@@ -471,10 +666,45 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
             }
         }
 
-        if cur_seq != last_drawn_seq.get() {
-            redraw_area.queue_draw();
-            last_drawn_seq.set(cur_seq);
+        let target_reveal = if active { 1.0 } else { 0.0 };
+        let reveal_step = if target_reveal > visual_for_tick.reveal.get() {
+            REVEAL_IN
+        } else {
+            REVEAL_OUT
+        };
+        let reveal = ease_toward(visual_for_tick.reveal.get(), target_reveal, reveal_step);
+        visual_for_tick.reveal.set(reveal);
+
+        let raw_energy = if idle {
+            0.0
+        } else {
+            current_energy(&redraw_state, gain)
+        };
+        let gated = gated_energy(raw_energy, &visual_for_tick);
+        let energy_step = if gated > visual_for_tick.energy.get() {
+            ENERGY_ATTACK
+        } else {
+            ENERGY_RELEASE
+        };
+        let energy = ease_toward(visual_for_tick.energy.get(), gated, energy_step);
+        visual_for_tick.energy.set(energy);
+        if processing {
+            let phase = (visual_for_tick.processing_phase.get() + 0.018) % 2.0;
+            visual_for_tick.processing_phase.set(phase);
         }
+
+        if !active && reveal <= 0.01 && energy <= 0.01 {
+            if visible.get() {
+                tracing::info!("hiding (idle for {:.2}s)", last_at.elapsed().as_secs_f32());
+                redraw_window.set_visible(false);
+                visible.set(false);
+            }
+            visual_for_tick.success_started_at.replace(None);
+            visual_for_tick.success_progress.set(0.0);
+            return glib::ControlFlow::Continue;
+        }
+
+        redraw_area.queue_draw();
         glib::ControlFlow::Continue
     });
 
@@ -483,6 +713,39 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
     // visibility from there. Mapping once at startup keeps Hyprland's
     // layer-shell state machine happy across hide/show cycles.
     window.present();
+}
+
+fn install_transparent_css() {
+    let Some(display) = gtk4::gdk::Display::default() else {
+        return;
+    };
+    let provider = CssProvider::new();
+    provider.load_from_data(
+        "
+        .voxtype-osd-window,
+        .voxtype-osd-window.background,
+        .voxtype-osd-window > *,
+        .voxtype-osd-canvas {
+            background: transparent;
+            background-color: transparent;
+            box-shadow: none;
+            border: none;
+        }
+        ",
+    );
+    gtk4::style_context_add_provider_for_display(
+        &display,
+        &provider,
+        gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+}
+
+fn read_state_file(path: Option<&std::path::Path>) -> Option<String> {
+    let path = path?;
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
 }
 
 /// Set an empty input region on the GdkSurface so clicks pass through.
@@ -496,7 +759,7 @@ fn apply_click_through(window: &ApplicationWindow) {
 }
 
 /// Render the waveform + peak meter into the given Cairo context.
-fn draw(
+fn draw_waveform_osd(
     cr: &Context,
     width: i32,
     height: i32,
@@ -688,4 +951,420 @@ fn draw_peak_meter(
         cr.line_to(x + w, py);
         cr.stroke().ok();
     }
+}
+
+/// Render a compact status pill into the given Cairo context.
+fn draw_compact_pill(
+    cr: &Context,
+    width: i32,
+    height: i32,
+    palette: &Palette,
+    energy: f64,
+    reveal: f64,
+    processing_phase: f64,
+    success_progress: f64,
+    mode: OsdMode,
+) {
+    let w = width as f64;
+    let h = height as f64;
+    if w <= 0.0 || h <= 0.0 {
+        return;
+    }
+
+    // Clear to transparent so the window shape is defined by the pill, not
+    // the rectangular layer-shell surface.
+    cr.set_source_rgba(0.0, 0.0, 0.0, 0.0);
+    cr.set_operator(cairo::Operator::Source);
+    cr.paint().ok();
+    cr.set_operator(cairo::Operator::Over);
+
+    let reveal = ease_out_cubic(reveal.clamp(0.0, 1.0));
+    let fall = (1.0 - reveal).powf(0.72);
+    let opacity = reveal;
+    let slide_y = fall * h * 0.90;
+
+    let pad = 5.0;
+    let panel_x = pad;
+    let panel_y = pad + slide_y;
+    let panel_w = (w - pad * 2.0).max(1.0);
+    let panel_h = ((h - pad * 2.0) * 0.82).max(1.0);
+    let radius = panel_h * 0.5;
+
+    if opacity <= 0.001 {
+        return;
+    }
+
+    draw_panel(
+        cr, panel_x, panel_y, panel_w, panel_h, radius, palette, opacity,
+    );
+
+    let glyph_inset = (panel_h * 0.42).min(panel_w * 0.18);
+    let glyph_x = panel_x + glyph_inset;
+    let glyph_w = panel_w - glyph_inset * 2.0;
+    match mode {
+        OsdMode::Recording => {
+            draw_reactive_glyph(
+                cr, glyph_x, panel_y, glyph_w, panel_h, palette, energy, opacity,
+            );
+        }
+        OsdMode::Processing => {
+            draw_processing_bar(
+                cr,
+                glyph_x,
+                panel_y,
+                glyph_w,
+                panel_h,
+                palette,
+                processing_phase,
+                opacity,
+            );
+        }
+        OsdMode::Success => {
+            draw_success_mark(
+                cr,
+                glyph_x,
+                panel_y,
+                glyph_w,
+                panel_h,
+                palette,
+                success_progress,
+                opacity,
+            );
+        }
+    }
+}
+
+fn draw_panel(
+    cr: &Context,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    radius: f64,
+    palette: &Palette,
+    opacity: f64,
+) {
+    // Soft multi-pass shadow.
+    for (spread, alpha) in [(2.0, 0.08), (5.0, 0.040), (8.0, 0.024)] {
+        rounded_rect(
+            cr,
+            x - spread,
+            y - spread * 0.55,
+            w + spread * 2.0,
+            h + spread * 1.2,
+            radius + spread,
+        );
+        cr.set_source_rgba(0.0, 0.0, 0.0, alpha * opacity);
+        cr.fill().ok();
+    }
+
+    rounded_rect(cr, x, y, w, h, radius);
+    let gradient = LinearGradient::new(x, y, x + w, y + h);
+    gradient.add_color_stop_rgba(
+        0.0,
+        (palette.background.r as f64 * 1.35).min(1.0),
+        (palette.background.g as f64 * 1.35).min(1.0),
+        (palette.background.b as f64 * 1.35).min(1.0),
+        0.82 * opacity,
+    );
+    gradient.add_color_stop_rgba(
+        1.0,
+        palette.background.r as f64 * 0.62,
+        palette.background.g as f64 * 0.62,
+        palette.background.b as f64 * 0.62,
+        0.94 * opacity,
+    );
+    cr.set_source(&gradient).ok();
+    cr.fill().ok();
+
+    rounded_rect(cr, x + 0.5, y + 0.5, w - 1.0, h - 1.0, radius - 0.5);
+    cr.set_source_rgba(1.0, 1.0, 1.0, 0.14 * opacity);
+    cr.set_line_width(1.0);
+    cr.stroke().ok();
+}
+
+fn draw_reactive_glyph(
+    cr: &Context,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    palette: &Palette,
+    energy: f64,
+    opacity: f64,
+) {
+    if w < 1.0 {
+        return;
+    }
+
+    let mid = y + h * 0.5;
+    let bars = REACTIVE_BARS.min(w.floor() as usize);
+    let center = (bars / 2) as f64;
+    let bar_w = (w * 0.044).clamp(2.35, 3.25);
+    let bar_gap = if bars > 1 {
+        ((w - bar_w * bars as f64) / (bars as f64 - 1.0)).clamp(1.5, 6.0)
+    } else {
+        0.0
+    };
+    let used_w = bars as f64 * bar_w + (bars as f64 - 1.0) * bar_gap;
+    let start_x = x + ((w - used_w) * 0.5).max(0.0);
+    let flat_h = 2.4;
+    let max_h = h * 0.70;
+
+    rounded_rect(cr, start_x - 5.0, mid - 0.75, used_w + 10.0, 1.5, 0.75);
+    cr.set_source_rgba(1.0, 1.0, 1.0, 0.055 * opacity);
+    cr.fill().ok();
+
+    let lifted_energy = energy.clamp(0.0, 1.0).powf(0.72);
+    for i in 0..bars {
+        let distance = ((i as f64 - center).abs() / center.max(1.0)).clamp(0.0, 1.0);
+        let bell = (-distance * distance * 6.6).exp();
+        let shoulder = (1.0 - distance).powf(2.4);
+        let profile = (0.12 + bell * 0.78 + shoulder * 0.10).min(1.0);
+        let active_h = max_h * ease_out_cubic(lifted_energy) * profile;
+        let bar_h = (flat_h + active_h).min(h - 12.0).max(flat_h);
+        let px = start_x + i as f64 * (bar_w + bar_gap);
+        let py = mid - bar_h * 0.5;
+
+        let center_weight = 1.0 - distance * 0.28;
+        let alpha = (0.56 + lifted_energy * 0.34) * center_weight * opacity;
+        let white_mix = 0.24 + lifted_energy * 0.18 * center_weight;
+
+        rounded_rect(cr, px, py, bar_w, bar_h, bar_w * 0.5);
+        cr.set_source_rgba(
+            mix_channel(palette.accent.r as f64, 1.0, white_mix),
+            mix_channel(palette.accent.g as f64, 1.0, white_mix),
+            mix_channel(palette.accent.b as f64, 1.0, white_mix),
+            alpha.clamp(0.18, 0.90),
+        );
+        cr.fill().ok();
+    }
+}
+
+fn draw_processing_bar(
+    cr: &Context,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    palette: &Palette,
+    phase: f64,
+    opacity: f64,
+) {
+    if w < 1.0 {
+        return;
+    }
+
+    let track_h = (h * 0.16).clamp(4.0, 7.0);
+    let track_y = y + h * 0.5 - track_h * 0.5;
+    let radius = track_h * 0.5;
+
+    rounded_rect(cr, x, track_y, w, track_h, radius);
+    cr.set_source_rgba(
+        palette.accent.r as f64,
+        palette.accent.g as f64,
+        palette.accent.b as f64,
+        0.18 * opacity,
+    );
+    cr.fill().ok();
+
+    let sweep_w = (w * 0.42).max(track_h * 2.2);
+    let travel = w + sweep_w;
+    let phase = phase.rem_euclid(2.0);
+    let ping_pong = if phase <= 1.0 { phase } else { 2.0 - phase };
+    let sweep_x = x - sweep_w + travel * ease_in_out_sine(ping_pong);
+    let visible_x = sweep_x.max(x);
+    let visible_w = (sweep_x + sweep_w).min(x + w) - visible_x;
+    if visible_w <= 0.0 {
+        return;
+    }
+
+    rounded_rect(cr, visible_x, track_y, visible_w, track_h, radius);
+    let gradient = LinearGradient::new(visible_x, track_y, visible_x + visible_w, track_y);
+    gradient.add_color_stop_rgba(
+        0.0,
+        palette.accent.r as f64,
+        palette.accent.g as f64,
+        palette.accent.b as f64,
+        0.20 * opacity,
+    );
+    gradient.add_color_stop_rgba(
+        0.5,
+        mix_channel(palette.accent.r as f64, 1.0, 0.28),
+        mix_channel(palette.accent.g as f64, 1.0, 0.28),
+        mix_channel(palette.accent.b as f64, 1.0, 0.28),
+        0.92 * opacity,
+    );
+    gradient.add_color_stop_rgba(
+        1.0,
+        palette.accent.r as f64,
+        palette.accent.g as f64,
+        palette.accent.b as f64,
+        0.20 * opacity,
+    );
+    cr.set_source(&gradient).ok();
+    cr.fill().ok();
+}
+
+fn draw_success_mark(
+    cr: &Context,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    palette: &Palette,
+    progress: f64,
+    opacity: f64,
+) {
+    if w < 1.0 {
+        return;
+    }
+
+    let reveal = ease_out_cubic(progress);
+    let center_x = x + w * 0.5;
+    let center_y = y + h * 0.5;
+    let radius = (h * 0.24).clamp(8.0, 13.0);
+
+    cr.arc(
+        center_x,
+        center_y,
+        radius * (0.84 + reveal * 0.16),
+        0.0,
+        std::f64::consts::PI * 2.0,
+    );
+    cr.set_source_rgba(
+        palette.accent.r as f64,
+        palette.accent.g as f64,
+        palette.accent.b as f64,
+        0.16 * opacity * reveal,
+    );
+    cr.fill().ok();
+
+    cr.arc(center_x, center_y, radius, 0.0, std::f64::consts::PI * 2.0);
+    cr.set_source_rgba(
+        mix_channel(palette.accent.r as f64, 1.0, 0.36),
+        mix_channel(palette.accent.g as f64, 1.0, 0.36),
+        mix_channel(palette.accent.b as f64, 1.0, 0.36),
+        0.92 * opacity,
+    );
+    cr.set_line_width(1.35);
+    cr.stroke().ok();
+
+    let draw = ease_in_out_sine(progress);
+    let p1 = (center_x - radius * 0.42, center_y - radius * 0.02);
+    let p2 = (center_x - radius * 0.12, center_y + radius * 0.30);
+    let p3 = (center_x + radius * 0.48, center_y - radius * 0.34);
+    let first_len = 0.42;
+
+    cr.set_source_rgba(
+        mix_channel(palette.accent.r as f64, 1.0, 0.62),
+        mix_channel(palette.accent.g as f64, 1.0, 0.62),
+        mix_channel(palette.accent.b as f64, 1.0, 0.62),
+        0.98 * opacity,
+    );
+    cr.set_line_width(2.1);
+    cr.set_line_cap(cairo::LineCap::Round);
+    cr.set_line_join(cairo::LineJoin::Round);
+    cr.move_to(p1.0, p1.1);
+
+    if draw <= first_len {
+        let t = draw / first_len;
+        cr.line_to(mix_channel(p1.0, p2.0, t), mix_channel(p1.1, p2.1, t));
+    } else {
+        cr.line_to(p2.0, p2.1);
+        let t = (draw - first_len) / (1.0 - first_len);
+        cr.line_to(mix_channel(p2.0, p3.0, t), mix_channel(p2.1, p3.1, t));
+    }
+    cr.stroke().ok();
+}
+
+fn current_energy(state: &Arc<SharedState>, gain: f64) -> f64 {
+    let (amplitude_energy, latest_peak) = match state.ring.lock() {
+        Ok(r) => {
+            let mut weighted = 0.0;
+            let mut total_weight = 0.0;
+            let latest_peak = r.latest().map(|f| f.peak_dbfs).unwrap_or(f32::NEG_INFINITY);
+            for (idx, frame) in r
+                .iter()
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .take(10)
+                .enumerate()
+            {
+                let weight = 1.0 / (idx as f64 + 1.0);
+                let amp = frame.max.abs().max(frame.min.abs()) as f64;
+                weighted += (amp * gain * 0.58).clamp(0.0, 1.0) * weight;
+                total_weight += weight;
+            }
+            let amplitude = if total_weight > 0.0 {
+                weighted / total_weight
+            } else {
+                0.0
+            };
+            (amplitude, latest_peak)
+        }
+        Err(_) => (0.0, f32::NEG_INFINITY),
+    };
+    let peak_energy = peak_meter_fraction(latest_peak, METER_FLOOR_DBFS) as f64;
+    amplitude_energy.max(peak_energy * 0.52).clamp(0.0, 1.0)
+}
+
+fn gated_energy(raw: f64, visual: &VisualState) -> f64 {
+    let open = visual.gate_open.get();
+    if open {
+        if raw < NOISE_GATE_EXIT {
+            visual.gate_open.set(false);
+            0.0
+        } else {
+            remap_energy(raw)
+        }
+    } else if raw >= NOISE_GATE_ENTER {
+        visual.gate_open.set(true);
+        remap_energy(raw)
+    } else {
+        0.0
+    }
+}
+
+fn remap_energy(raw: f64) -> f64 {
+    ((raw - NOISE_GATE_EXIT) / (1.0 - NOISE_GATE_EXIT)).clamp(0.0, 1.0)
+}
+
+fn ease_toward(current: f64, target: f64, amount: f64) -> f64 {
+    current + (target - current) * amount.clamp(0.0, 1.0)
+}
+
+fn ease_out_cubic(t: f64) -> f64 {
+    1.0 - (1.0 - t.clamp(0.0, 1.0)).powi(3)
+}
+
+fn ease_in_out_sine(t: f64) -> f64 {
+    0.5 - 0.5 * (std::f64::consts::PI * t.clamp(0.0, 1.0)).cos()
+}
+
+fn mix_channel(a: f64, b: f64, t: f64) -> f64 {
+    a * (1.0 - t) + b * t
+}
+
+fn rounded_rect(cr: &Context, x: f64, y: f64, w: f64, h: f64, radius: f64) {
+    let r = radius.min(w * 0.5).min(h * 0.5).max(0.0);
+    cr.new_sub_path();
+    cr.arc(x + w - r, y + r, r, -std::f64::consts::FRAC_PI_2, 0.0);
+    cr.arc(x + w - r, y + h - r, r, 0.0, std::f64::consts::FRAC_PI_2);
+    cr.arc(
+        x + r,
+        y + h - r,
+        r,
+        std::f64::consts::FRAC_PI_2,
+        std::f64::consts::PI,
+    );
+    cr.arc(
+        x + r,
+        y + r,
+        r,
+        std::f64::consts::PI,
+        std::f64::consts::PI * 1.5,
+    );
+    cr.close_path();
 }

--- a/src/bin/voxtype_osd_native/main.rs
+++ b/src/bin/voxtype_osd_native/main.rs
@@ -30,7 +30,7 @@ use anyhow::Context as _;
 use clap::Parser;
 
 use voxtype::audio::levels::{AudioFrame, FRAME_HZ};
-use voxtype::osd::config::OsdConfig;
+use voxtype::osd::config::{OsdConfig, OsdStyle};
 use voxtype::osd::ipc::{resolve_socket_path, run_ipc_loop, FrameRing, DEFAULT_RING_DEPTH};
 use voxtype::osd::theme::ThemeWatcher;
 use voxtype::osd::visual::PeakHold;
@@ -83,6 +83,12 @@ struct Args {
     /// Reduce for hot mics (e.g. 4.0); raise for quiet sources (e.g. 14.0).
     #[arg(long, env = "VOXTYPE_OSD_GAIN")]
     waveform_gain: Option<f32>,
+
+    /// Visual style to render. The native frontend currently supports
+    /// "waveform"; "compact-pill" is accepted for config parity but renders
+    /// as waveform.
+    #[arg(long, env = "VOXTYPE_OSD_STYLE")]
+    style: Option<String>,
 }
 
 /// Load the `[osd]` section from the voxtype config file, falling back to
@@ -140,17 +146,30 @@ fn main() -> anyhow::Result<()> {
     if let Some(g) = args.waveform_gain {
         osd_config.waveform_gain = g;
     }
+    if let Some(style) = args.style.as_deref() {
+        match OsdStyle::parse_str(style) {
+            Some(style) => osd_config.style = style,
+            None => tracing::warn!("Ignoring unknown OSD style '{style}'"),
+        }
+    }
 
     if !osd_config.enabled {
         tracing::info!("OSD disabled in config; exiting");
         return Ok(());
     }
 
+    if matches!(osd_config.style, OsdStyle::CompactPill) {
+        tracing::warn!(
+            "compact-pill style is currently implemented by the GTK4 frontend; native will render waveform"
+        );
+    }
+
     tracing::info!(
-        "voxtype-osd-native starting; socket={:?}, size={}x{}",
+        "voxtype-osd-native starting; socket={:?}, size={}x{} style={:?}",
         socket_path,
         osd_config.width_px,
-        osd_config.height_px
+        osd_config.height_px,
+        osd_config.style,
     );
 
     let theme = ThemeWatcher::new();

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -9,7 +9,7 @@ pub const DEFAULT_CONFIG: &str = r#"# Voxtype Configuration
 # State file for external integrations (Waybar, polybar, etc.)
 # Use "auto" for default location ($XDG_RUNTIME_DIR/voxtype/state),
 # a custom path, or "disabled" to turn off. The daemon writes state
-# ("idle", "recording", "transcribing") to this file whenever it changes.
+# ("idle", "recording", "transcribing", "outputting") to this file whenever it changes.
 # Required for `voxtype record toggle` and `voxtype status` commands.
 state_file = "auto"
 
@@ -306,6 +306,31 @@ on_transcription = true
 # recording = "🎤"
 # transcribing = "⏳"
 # stopped = ""
+
+[osd]
+# Enable the floating on-screen visualizer.
+enabled = true
+
+# OSD frontend: "gtk4" (default), "native", or "quickshell".
+frontend = "gtk4"
+
+# Visual style: "waveform" (default) or "compact-pill".
+# "compact-pill" renders a smaller GTK4 pill with a centered voice glyph,
+# processing bar, and completion checkmark.
+style = "waveform"
+
+# Position and size.
+position = "bottom-center"
+width_px = 400
+height_px = 48
+margin_px = 24
+top_margin = 0.85
+
+# Visual tuning.
+opacity = 0.95
+waveform_window_secs = 3.0
+peak_decay_db_per_sec = 6.0
+waveform_gain = 10.0
 
 # [profiles]
 # Named profiles for context-specific post-processing

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -84,8 +84,8 @@ pub struct Config {
     pub meeting: MeetingConfig,
 
     /// Optional path to state file for external integrations (e.g., Waybar)
-    /// When set, the daemon writes current state ("idle", "recording", "transcribing")
-    /// to this file whenever state changes.
+    /// When set, the daemon writes current state ("idle", "recording",
+    /// "transcribing", "outputting") to this file whenever state changes.
     /// Example: "/run/user/1000/voxtype/state" or use "auto" for default location
     #[serde(default = "default_state_file")]
     pub state_file: Option<String>,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2095,6 +2095,7 @@ impl Daemon {
                         *state = State::Outputting {
                             text: final_text.clone(),
                         };
+                        self.update_state("outputting");
 
                         let file_mode = &self.config.output.file_mode;
                         match write_transcription_to_file(&output_path, &final_text, file_mode)
@@ -2220,6 +2221,7 @@ impl Daemon {
                     *state = State::Outputting {
                         text: final_text.clone(),
                     };
+                    self.update_state("outputting");
 
                     let output_options = output::OutputOptions {
                         pre_output_command: output_config.pre_output_command.as_deref(),

--- a/src/osd/config.rs
+++ b/src/osd/config.rs
@@ -58,6 +58,28 @@ impl OsdFrontend {
     }
 }
 
+/// Visual style rendered inside the OSD surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OsdStyle {
+    /// Original scrolling waveform with a segmented peak meter.
+    #[default]
+    Waveform,
+    /// Compact status pill with a centered voice glyph, processing bar, and
+    /// completion checkmark. Implemented by the GTK4 frontend.
+    CompactPill,
+}
+
+impl OsdStyle {
+    pub fn parse_str(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "waveform" => Some(OsdStyle::Waveform),
+            "compact-pill" | "compact" | "pill" => Some(OsdStyle::CompactPill),
+            _ => None,
+        }
+    }
+}
+
 /// All user-facing OSD options. Defaults match BRIEF.md.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -99,6 +121,8 @@ pub struct OsdConfig {
     /// Which OSD frontend the `voxtype-osd` wrapper launches. Defaults to
     /// `Gtk4` since GTK4 ships with most Hyprland setups already.
     pub frontend: OsdFrontend,
+    /// Visual style to draw inside the OSD. Defaults to the original waveform.
+    pub style: OsdStyle,
 }
 
 impl Default for OsdConfig {
@@ -115,6 +139,7 @@ impl Default for OsdConfig {
             peak_decay_db_per_sec: 6.0,
             waveform_gain: 10.0,
             frontend: OsdFrontend::default(),
+            style: OsdStyle::default(),
         }
     }
 }
@@ -135,6 +160,7 @@ mod tests {
         assert!((c.waveform_window_secs - 3.0).abs() < 1e-6);
         assert!((c.peak_decay_db_per_sec - 6.0).abs() < 1e-6);
         assert!((c.waveform_gain - 10.0).abs() < 1e-6);
+        assert_eq!(c.style, OsdStyle::Waveform);
     }
 
     #[test]
@@ -185,6 +211,32 @@ mod tests {
         assert_eq!(v, OsdFrontend::Native);
         let v: OsdFrontend = serde_json::from_str("\"quickshell\"").unwrap();
         assert_eq!(v, OsdFrontend::Quickshell);
+    }
+
+    #[test]
+    fn style_default_is_waveform() {
+        assert_eq!(OsdStyle::default(), OsdStyle::Waveform);
+        assert_eq!(OsdConfig::default().style, OsdStyle::Waveform);
+    }
+
+    #[test]
+    fn style_parse_str_accepts_aliases() {
+        assert_eq!(OsdStyle::parse_str("waveform"), Some(OsdStyle::Waveform));
+        assert_eq!(
+            OsdStyle::parse_str("compact-pill"),
+            Some(OsdStyle::CompactPill)
+        );
+        assert_eq!(OsdStyle::parse_str("compact"), Some(OsdStyle::CompactPill));
+        assert_eq!(OsdStyle::parse_str("pill"), Some(OsdStyle::CompactPill));
+        assert_eq!(OsdStyle::parse_str("nope"), None);
+    }
+
+    #[test]
+    fn style_serde_kebab_case() {
+        let v: OsdStyle = serde_json::from_str("\"waveform\"").unwrap();
+        assert_eq!(v, OsdStyle::Waveform);
+        let v: OsdStyle = serde_json::from_str("\"compact-pill\"").unwrap();
+        assert_eq!(v, OsdStyle::CompactPill);
     }
 
     #[test]

--- a/src/status_json.rs
+++ b/src/status_json.rs
@@ -113,6 +113,7 @@ pub fn format_state_json(
         "recording" => (&icons.recording, "Recording..."),
         "streaming" => (&icons.streaming, "Streaming live..."),
         "transcribing" => (&icons.transcribing, "Transcribing..."),
+        "outputting" => (&icons.transcribing, "Outputting..."),
         "idle" => (&icons.idle, "Voxtype ready - hold hotkey to record"),
         "stopped" => (&icons.stopped, "Voxtype not running"),
         _ => (&icons.idle, "Unknown state"),
@@ -221,6 +222,10 @@ mod tests {
         assert_eq!(
             format_state_json("transcribing", &icons, None),
             r#"{"text": "T", "alt": "transcribing", "class": "transcribing", "tooltip": "Transcribing..."}"#,
+        );
+        assert_eq!(
+            format_state_json("outputting", &icons, None),
+            r#"{"text": "T", "alt": "outputting", "class": "outputting", "tooltip": "Outputting..."}"#,
         );
         assert_eq!(
             format_state_json("idle", &icons, None),

--- a/src/tui/osd_section.rs
+++ b/src/tui/osd_section.rs
@@ -2,7 +2,8 @@
 //!
 //! Surfaces every field on `[osd]` from `OsdConfig` (src/osd/config.rs) so
 //! users can tune the floating waveform/level surface without leaving the
-//! TUI. The OSD binaries (voxtype-osd, voxtype-osd-gtk4, voxtype-osd-native)
+//! TUI. The OSD binaries (voxtype-osd, voxtype-osd-gtk4,
+//! voxtype-osd-native, voxtype-osd-quickshell)
 //! re-read this table at launch — the daemon doesn't load it, so a save
 //! here only takes effect for OSD restarts, not the next dictation.
 
@@ -23,6 +24,7 @@ use super::config_editor::{ConfigEditor, EditorError};
 pub struct OsdState {
     pub enabled: bool,
     pub frontend: String,
+    pub style: String,
     pub position: String,
     pub width_px: i64,
     pub height_px: i64,
@@ -35,7 +37,7 @@ pub struct OsdState {
     pub field: Field,
     pub feedback: Option<(FeedbackLevel, String)>,
     pub dirty_since_load: bool,
-    /// True when neither voxtype-osd-gtk4 nor voxtype-osd-native is on
+    /// True when no OSD frontend binary is on
     /// PATH. The config-form still works (you can edit the table), but the
     /// daemon has nothing to launch and the OSD won't render. Surfaced as
     /// a yellow banner above the form so users don't save in vain.
@@ -46,6 +48,7 @@ pub struct OsdState {
 pub enum Field {
     Enabled,
     Frontend,
+    Style,
     Position,
     WidthPx,
     HeightPx,
@@ -61,6 +64,7 @@ impl Field {
     const ALL: &'static [Field] = &[
         Field::Enabled,
         Field::Frontend,
+        Field::Style,
         Field::Position,
         Field::WidthPx,
         Field::HeightPx,
@@ -75,7 +79,8 @@ impl Field {
 
 const TABLE: &str = "osd";
 
-const FRONTEND_CHOICES: &[&str] = &["gtk4", "native"];
+const FRONTEND_CHOICES: &[&str] = &["gtk4", "native", "quickshell"];
+const STYLE_CHOICES: &[&str] = &["waveform", "compact-pill"];
 const POSITION_CHOICES: &[&str] = &[
     "bottom-center",
     "top-center",
@@ -107,6 +112,9 @@ impl OsdState {
             frontend: ed
                 .get_string(TABLE, "frontend")
                 .unwrap_or_else(|| "gtk4".to_string()),
+            style: ed
+                .get_string(TABLE, "style")
+                .unwrap_or_else(|| "waveform".to_string()),
             position: ed
                 .get_string(TABLE, "position")
                 .unwrap_or_else(|| "bottom-center".to_string()),
@@ -135,6 +143,7 @@ impl OsdState {
         };
         ed.set_bool(TABLE, "enabled", self.enabled);
         ed.set_string(TABLE, "frontend", &self.frontend);
+        ed.set_string(TABLE, "style", &self.style);
         ed.set_string(TABLE, "position", &self.position);
         ed.set_int(TABLE, "width_px", self.width_px);
         ed.set_int(TABLE, "height_px", self.height_px);
@@ -180,6 +189,7 @@ impl OsdState {
         match self.field {
             Field::Enabled => self.enabled = !self.enabled,
             Field::Frontend => self.frontend = cycle_str(FRONTEND_CHOICES, &self.frontend, delta),
+            Field::Style => self.style = cycle_str(STYLE_CHOICES, &self.style, delta),
             Field::Position => self.position = cycle_str(POSITION_CHOICES, &self.position, delta),
             Field::WidthPx => self.width_px = cycle_int(WIDTH_CHOICES, self.width_px, delta),
             Field::HeightPx => self.height_px = cycle_int(HEIGHT_CHOICES, self.height_px, delta),
@@ -217,10 +227,13 @@ fn osd_binary_available() -> bool {
     const CANDIDATES: &[&str] = &[
         "/usr/bin/voxtype-osd-gtk4",
         "/usr/bin/voxtype-osd-native",
+        "/usr/bin/voxtype-osd-quickshell",
         "/usr/lib/voxtype/voxtype-osd-gtk4",
         "/usr/lib/voxtype/voxtype-osd-native",
+        "/usr/lib/voxtype/voxtype-osd-quickshell",
         "/usr/local/bin/voxtype-osd-gtk4",
         "/usr/local/bin/voxtype-osd-native",
+        "/usr/local/bin/voxtype-osd-quickshell",
     ];
     if CANDIDATES.iter().any(|p| Path::new(p).exists()) {
         return true;
@@ -234,6 +247,7 @@ fn osd_binary_available() -> bool {
             }
             if Path::new(dir).join("voxtype-osd-gtk4").exists()
                 || Path::new(dir).join("voxtype-osd-native").exists()
+                || Path::new(dir).join("voxtype-osd-quickshell").exists()
             {
                 return true;
             }
@@ -300,6 +314,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
             "Frontend",
             state.frontend.clone(),
         ),
+        FormRowSpec::new(state.field == Field::Style, "Style", state.style.clone()),
         FormRowSpec::new(
             state.field == Field::Position,
             "Position",
@@ -352,8 +367,8 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
     // save/error feedback wins if the user has interacted, so this only
     // shows on first render of an unconfigured install.
     let missing_msg = "OSD binaries not installed. Saving the config will work but \
-                       nothing will render until voxtype-osd-gtk4 (Arch: gtk4-layer-shell) \
-                       or voxtype-osd-native is installed.";
+                       nothing will render until voxtype-osd-gtk4 (Arch: gtk4-layer-shell), \
+                       voxtype-osd-native, or voxtype-osd-quickshell is installed.";
     let feedback_pair = match state.feedback.as_ref() {
         Some((lvl, msg)) => Some((*lvl, msg.as_str())),
         None if state.binary_missing => Some((FeedbackLevel::Warn, missing_msg)),
@@ -394,12 +409,12 @@ fn guidance_for_field(state: &OsdState) -> Vec<Line<'_>> {
             heading("Enabled"),
             Line::from(""),
             Line::from(
-                "Master switch for the floating OSD. When off, both \
-                 voxtype-osd-gtk4 and voxtype-osd-native exit immediately at \
+                "Master switch for the floating OSD. When off, OSD frontends \
+                 exit immediately at \
                  launch and the daemon doesn't render anything on screen.",
             ),
             Line::from(""),
-            dim("Per-state visibility (idle/recording/transcribing) is fixed: the OSD always shows during recording."),
+            dim("Per-state visibility (idle/recording/transcribing/outputting) is fixed: the OSD always shows during recording."),
         ],
         Field::Frontend => vec![
             heading("Frontend"),
@@ -416,7 +431,24 @@ fn guidance_for_field(state: &OsdState) -> Vec<Line<'_>> {
             Line::from("  native  SCTK + wgpu + egui. Skips GTK4 entirely if you want to"),
             Line::from("          avoid GTK in your stack. Slightly heavier first-paint."),
             Line::from(""),
+            Line::from("  quickshell  QML/Quickshell frontend. Requires `voxtype setup quickshell`."),
+            Line::from(""),
             dim("If the chosen binary isn't on PATH, the wrapper falls back to whichever it finds and logs a warning."),
+        ],
+        Field::Style => vec![
+            heading("Style"),
+            Line::from(""),
+            Line::from(
+                "Visual style drawn inside the OSD surface. This changes the \
+                 indicator only; recording and transcription behavior stay \
+                 the same.",
+            ),
+            Line::from(""),
+            Line::from("  waveform      Original scrolling waveform plus peak meter. Default."),
+            Line::from("  compact-pill  Compact GTK4 pill with a voice glyph, processing"),
+            Line::from("                bar, and completion checkmark."),
+            Line::from(""),
+            dim("Non-GTK4 frontends currently render their default waveform-style UI."),
         ],
         Field::Position => vec![
             heading("Position"),


### PR DESCRIPTION
## Summary

<img width="134" height="70" alt="image" src="https://github.com/user-attachments/assets/75437c84-7895-490e-b5e2-738243dbf197" />
<img width="123" height="76" alt="image" src="https://github.com/user-attachments/assets/1366c533-cbe0-477a-8ca1-60f3ae9cc31a" />
<img width="132" height="66" alt="image" src="https://github.com/user-attachments/assets/673436f1-214c-4290-8c3f-7a9fc52bfce8" />


This PR adds an optional compact OSD style for users who prefer a smaller, state-oriented dictation indicator. The existing waveform OSD remains the default.

The new style is enabled with:

```toml
[osd]
style = "compact-pill"
```

It currently renders in the GTK4 frontend and covers the recording, processing, and completion states.

## What changed

- Added `[osd] style = "waveform" | "compact-pill"` with `waveform` as the default.
- Added a compact GTK4 pill renderer with:
  - centered reactive voice glyph while recording
  - ping-pong processing bar while transcribing
  - completion checkmark after output starts/finishes
- Preserved the existing waveform renderer and made it the default path.
- Added `outputting` as a state-file value so OSD/status integrations can distinguish text insertion from transcription.
- Surfaced the new style option in `voxtype configure`.
- Updated the default config, README, configuration docs, and Waybar docs.

## Notes

The compact pill style is implemented in the GTK4 frontend. Non-GTK4 frontends accept the `style` config for parity, but currently continue rendering their default waveform-style UI when `compact-pill` is selected.

This intentionally avoids adding a large set of visual tuning options. The first version only adds the style switch, keeping the config surface small and preserving current behavior for existing users.

## Testing

```bash
cargo check --features osd-gtk4 --bin voxtype --bin voxtype-osd --bin voxtype-osd-gtk4
cargo check --features osd-native --bin voxtype-osd-native
cargo test --lib osd::config
git diff --check
```

All checks passed.
