### PR TITLE
TUI: support xfce4-terminal

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -143,7 +143,7 @@ voxtype configure
 The TUI is also surfaced as a `.desktop` entry, so it shows up in Walker,
 fuzzel, rofi, KRunner, and GNOME Activities as **"Voxtype Configuration"**.
 The launcher script picks the first available terminal emulator (`$TERMINAL`,
-then ghostty / alacritty / kitty / foot / wezterm / konsole / xterm) and
+then ghostty / alacritty / kitty / foot / wezterm / konsole / xterm / xfce4-terminal) and
 sets the window class to `voxtype` so compositors can float it.
 
 #### Sections

--- a/packaging/scripts/voxtype-configure-launcher
+++ b/packaging/scripts/voxtype-configure-launcher
@@ -12,7 +12,7 @@
 set -eu
 
 # Order of preference. $TERMINAL wins if it's set and resolvable.
-candidates="${TERMINAL:-} ghostty alacritty kitty foot wezterm konsole gnome-terminal xterm"
+candidates="${TERMINAL:-} ghostty alacritty kitty foot wezterm konsole gnome-terminal xterm xfce4-terminal"
 
 term=""
 for c in $candidates; do
@@ -25,7 +25,7 @@ done
 
 if [ -z "$term" ]; then
     notify-send -a Voxtype "Voxtype Configuration" \
-        "No terminal emulator found. Install ghostty, alacritty, kitty, foot, wezterm, or xterm." \
+        "No terminal emulator found. Install ghostty, alacritty, kitty, foot, wezterm, xterm or xfce4-terminal." \
         2>/dev/null || true
     echo "voxtype-configure-launcher: no terminal emulator found" >&2
     exit 1
@@ -68,6 +68,9 @@ case "$term" in
         ;;
     gnome-terminal)
         exec "$term" -- voxtype configure
+        ;;
+    xfce4-terminal)
+        exec "$term" --geometry 110x34 --command="voxtype configure"
         ;;
     *)
         # Unknown but available terminal — fall through with -e.


### PR DESCRIPTION
Add support for xfce4-terminal as an option for voxtype-configure-launcher

<!--
PRs target the `dev` branch, not `main`.

Branch flow: `dev` (default for PRs) -> `rc/x.y.z` (release candidate, triggers
the full build matrix) -> `main` (release-tagged) -> tag `vX.Y.Z`.

Open your PR as a draft while CI is red. Mark Ready for Review once the
`ci-success` aggregator check passes.
-->

## Description

Add support for xfce4-terminal as an option for voxtype-configure-launcher

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

## Documentation

- [x] I have updated documentation as needed
- [ ] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [x] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

Any additional information reviewers should know.
