### PR TITLE
fix: add `--` separator before text argument in eitype output

### DIFF
--- a/src/output/eitype.rs
+++ b/src/output/eitype.rs
@@ -104,6 +104,7 @@ impl EitypeOutput {
         tracing::debug!("Running: {}", debug_args.join(" "));
 
         let output = cmd
+            .arg("--")
             .arg(text)
             .stdout(Stdio::null())
             .stderr(Stdio::piped())


### PR DESCRIPTION
## Description

When transcribed text starts with a dash (e.g. `- list item`), eitype interprets it as a CLI flag and fails:

```
eitype failed: error: unexpected argument '- ' found
  tip: to pass '- ' as a value, use '-- - '
```

Voxtype falls back to the next driver in the chain, so the text still gets typed, but the preferred eitype path is silently skipped on every dash-prefixed transcription.

The wtype and ydotool drivers already guard against this:

```rust
// src/output/wtype.rs:85
.arg("--")

// src/output/ydotool.rs:115
cmd.arg("--").arg(text);
```

The eitype driver was missing the same `--` end-of-options separator. This adds it in `type_text()`. The `paste.rs` eitype call sites only pass structured flag arguments (`-M`, `-k`, `return`), not user text, so they are not affected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

Reproduction:
1. Dictate any text that Whisper transcribes with a leading dash (bullet lists, markdown)
2. With `driver_order = ["eitype", ...]`, observe the warning in `journalctl --user -u voxtype`
3. After the fix, the same text is typed via eitype without falling back

## Documentation

- [x] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [x] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)