### PR TITLE
fix: `Build (Nix)` NodeJS 20 deprecation warning

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -33,7 +33,7 @@ jobs:
           - label: onnx
             package: onnx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main


### PR DESCRIPTION
<!--
PRs target the `dev` branch, not `main`.

Branch flow: `dev` (default for PRs) -> `rc/x.y.z` (release candidate, triggers
the full build matrix) -> `main` (release-tagged) -> tag `vX.Y.Z`.

Open your PR as a draft while CI is red. Mark Ready for Review once the
`ci-success` aggregator check passes.
-->

## Description

This fixes a `Node.js 20 actions are deprecated` warning in the `Build (Nix)` workflow.

## Related Issue

Fixes #492

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [x] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [x] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)