### PR TITLE
Gate recording-start cues on audio device warm-up

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -363,6 +363,24 @@ Maximum recording duration in seconds. Recording automatically stops after this 
 max_duration_secs = 120  # Allow 2-minute recordings
 ```
 
+### wait_for_device
+
+**Type:** Boolean
+**Default:** `true`
+**Required:** No
+
+Wait for the input device to deliver real audio before playing the recording-start cue and showing the OSD (up to 1.5 seconds).
+
+Audio sources resuming from idle suspend (PipeWire suspends them after a few seconds without use) produce roughly half a second of digital silence before real samples flow. Anything spoken into that window is never captured. With this gate enabled, the "listening" signals only appear once the device is actually delivering audio, so speaking as soon as you see or hear the cue is safe.
+
+Disable this if your input source emits exact digital silence when the room is quiet (for example, some noise-suppression filters); with such sources the cue would otherwise always lag by the 1.5-second timeout.
+
+**Example:**
+```toml
+[audio]
+wait_for_device = false  # Signal recording start immediately
+```
+
 ---
 
 ## [audio.feedback]
@@ -3203,6 +3221,7 @@ Any config file setting can be overridden via environment variable. These are ap
 | `VOXTYPE_AUDIO_DEVICE` | string | `audio.device` |
 | `VOXTYPE_MAX_DURATION_SECS` | integer | `audio.max_duration_secs` |
 | `VOXTYPE_AUDIO_FEEDBACK` | bool | `audio.feedback.enabled` |
+| `VOXTYPE_WAIT_FOR_DEVICE` | bool | `audio.wait_for_device` |
 
 **Output:**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -438,6 +438,24 @@ duck_media_volume_percent = 34
 duck_media_fade_ms = 150
 ```
 
+### wait_for_device
+
+**Type:** Boolean
+**Default:** `true`
+**Required:** No
+
+Wait for the input device to deliver real audio before playing the recording-start cue and showing the OSD (up to 1.5 seconds).
+
+Audio sources resuming from idle suspend (PipeWire suspends them after a few seconds without use) produce roughly half a second of digital silence before real samples flow. Anything spoken into that window is never captured. With this gate enabled, the "listening" signals only appear once the device is actually delivering audio, so speaking as soon as you see or hear the cue is safe.
+
+Disable this if your input source emits exact digital silence when the room is quiet (for example, some noise-suppression filters); with such sources the cue would otherwise always lag by the 1.5-second timeout.
+
+**Example:**
+```toml
+[audio]
+wait_for_device = false  # Signal recording start immediately
+```
+
 ---
 
 ## [audio.feedback]
@@ -3281,6 +3299,7 @@ Any config file setting can be overridden via environment variable. These are ap
 | `VOXTYPE_DUCK_MEDIA` | bool | `audio.duck_media` |
 | `VOXTYPE_DUCK_MEDIA_VOLUME_PERCENT` | integer | `audio.duck_media_volume_percent` |
 | `VOXTYPE_AUDIO_FEEDBACK` | bool | `audio.feedback.enabled` |
+| `VOXTYPE_WAIT_FOR_DEVICE` | bool | `audio.wait_for_device` |
 
 **Output:**
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -300,6 +300,24 @@ aplay test.wav
 max_duration_secs = 120  # 2 minutes
 ```
 
+### First word missing when dictation starts
+
+**Symptom:** The first word (or first syllable) of an utterance is lost, but only when you start dictating after a few seconds of not using the microphone. Dictating again right away works fine.
+
+**Cause:** The audio server suspends idle capture devices to save power (PipeWire/WirePlumber does this after about 5 seconds by default). A resuming device delivers around half a second of digital silence before real samples flow, so speech in that window is never captured.
+
+Voxtype works around this with the `wait_for_device` gate (enabled by default): the recording-start sound, notification, and OSD are held back until the device delivers real audio. Wait for the cue before speaking and nothing is lost.
+
+**If you still lose the first word:**
+- Make sure `wait_for_device` has not been disabled in your config
+- Wait for the start cue (sound or OSD) before speaking; enable audio feedback with `[audio.feedback] enabled = true` if you have no visible indicator
+
+**If the start cue feels delayed instead:** your source may emit exact digital silence when the room is quiet (some noise-suppression filters do), which makes the gate wait its full 1.5-second timeout. Disable it:
+```toml
+[audio]
+wait_for_device = false
+```
+
 ---
 
 ## Transcription Issues

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -302,6 +302,24 @@ aplay test.wav
 max_duration_secs = 120  # 2 minutes
 ```
 
+### First word missing when dictation starts
+
+**Symptom:** The first word (or first syllable) of an utterance is lost, but only when you start dictating after a few seconds of not using the microphone. Dictating again right away works fine.
+
+**Cause:** The audio server suspends idle capture devices to save power (PipeWire/WirePlumber does this after about 5 seconds by default). A resuming device delivers around half a second of digital silence before real samples flow, so speech in that window is never captured.
+
+Voxtype works around this with the `wait_for_device` gate (enabled by default): the recording-start sound, notification, and OSD are held back until the device delivers real audio. Wait for the cue before speaking and nothing is lost.
+
+**If you still lose the first word:**
+- Make sure `wait_for_device` has not been disabled in your config
+- Wait for the start cue (sound or OSD) before speaking; enable audio feedback with `[audio.feedback] enabled = true` if you have no visible indicator
+
+**If the start cue feels delayed instead:** your source may emit exact digital silence when the room is quiet (some noise-suppression filters do), which makes the gate wait its full 1.5-second timeout. Disable it:
+```toml
+[audio]
+wait_for_device = false
+```
+
 ---
 
 ## Transcription Issues

--- a/src/app/config_show.rs
+++ b/src/app/config_show.rs
@@ -67,6 +67,7 @@ pub(crate) async fn show_config(config: &config::Config) -> anyhow::Result<()> {
     println!("  device = {:?}", config.audio.device);
     println!("  sample_rate = {}", config.audio.sample_rate);
     println!("  max_duration_secs = {}", config.audio.max_duration_secs);
+    println!("  wait_for_device = {}", config.audio.wait_for_device);
 
     println!("\n[audio.feedback]");
     println!("  enabled = {}", config.audio.feedback.enabled);

--- a/src/app/config_show.rs
+++ b/src/app/config_show.rs
@@ -87,6 +87,7 @@ pub(crate) async fn show_config(config: &config::Config) -> anyhow::Result<()> {
     println!("  device = {:?}", config.audio.device);
     println!("  sample_rate = {}", config.audio.sample_rate);
     println!("  max_duration_secs = {}", config.audio.max_duration_secs);
+    println!("  wait_for_device = {}", config.audio.wait_for_device);
 
     println!("\n[audio.feedback]");
     println!("  enabled = {}", config.audio.feedback.enabled);

--- a/src/app/overrides.rs
+++ b/src/app/overrides.rs
@@ -185,6 +185,11 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
     if cli.pause_media {
         config.audio.pause_media = true;
     }
+    apply_bool_override(
+        &mut config.audio.wait_for_device,
+        cli.wait_for_device,
+        cli.no_wait_for_device,
+    );
 
     // Output overrides
     if let Some(ref append_text) = cli.append_text {

--- a/src/app/overrides.rs
+++ b/src/app/overrides.rs
@@ -194,6 +194,11 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
     if let Some(fade_ms) = cli.duck_media_fade_ms {
         config.audio.duck_media_fade_ms = fade_ms;
     }
+    apply_bool_override(
+        &mut config.audio.wait_for_device,
+        cli.wait_for_device,
+        cli.no_wait_for_device,
+    );
 
     // Output overrides
     if let Some(ref append_text) = cli.append_text {

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -37,3 +37,99 @@ pub trait AudioCapture: Send + Sync {
 pub fn create_capture(config: &AudioConfig) -> Result<Box<dyn AudioCapture>, AudioError> {
     Ok(Box::new(cpal_capture::CpalCapture::new(config)?))
 }
+
+/// Wait until the capture stream delivers a chunk containing real signal
+/// (any non-zero sample).
+///
+/// Input devices resuming from idle suspend (PipeWire/WirePlumber suspends
+/// sources after ~5s idle) deliver exact digital zeros for ~0.5s before
+/// real samples flow. Audio spoken into that window is never captured, so
+/// the daemon gates its "listening" cues (start sound, OSD, notification)
+/// on this returning. A live mic always has a noise floor, so any non-zero
+/// sample means the device is warm.
+///
+/// Returns the chunk that contained the signal once one is seen. Callers
+/// whose downstream consumes this channel as audio input (the streaming
+/// transcriber) must forward that chunk — it may hold the onset of speech
+/// when the user started talking during warm-up. Returns `None` on timeout
+/// (some virtual sources, e.g. noise suppressors, emit exact zeros in a
+/// quiet room — recording must start anyway) or if the channel closes.
+pub async fn wait_for_signal(
+    chunk_rx: &mut mpsc::Receiver<Vec<f32>>,
+    timeout: std::time::Duration,
+) -> Option<Vec<f32>> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let started = std::time::Instant::now();
+
+    loop {
+        match tokio::time::timeout_at(deadline, chunk_rx.recv()).await {
+            Ok(Some(chunk)) => {
+                if chunk.iter().any(|&s| s != 0.0) {
+                    tracing::debug!(
+                        "Audio device warm after {:.0}ms",
+                        started.elapsed().as_secs_f32() * 1000.0
+                    );
+                    return Some(chunk);
+                }
+            }
+            Ok(None) => {
+                tracing::warn!("Audio stream closed while waiting for device warm-up");
+                return None;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "No signal from audio device within {}ms (suspended source still \
+                     resuming, or a source that emits exact silence); starting anyway",
+                    timeout.as_millis()
+                );
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn wait_for_signal_returns_the_first_nonzero_chunk() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0, 0.01, 0.0]).await.unwrap();
+
+        let chunk = wait_for_signal(&mut rx, Duration::from_secs(5)).await;
+        assert_eq!(chunk, Some(vec![0.0, 0.01, 0.0]));
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_skips_leading_silent_chunks() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0; 160]).await.unwrap();
+        tx.send(vec![0.0; 160]).await.unwrap();
+        tx.send(vec![0.0, -0.02]).await.unwrap();
+
+        let chunk = wait_for_signal(&mut rx, Duration::from_secs(5)).await;
+        assert_eq!(chunk, Some(vec![0.0, -0.02]));
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_times_out_on_pure_silence() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0; 160]).await.unwrap();
+        // Keep tx alive so the channel doesn't close; only the timeout
+        // can end the wait.
+        let result = wait_for_signal(&mut rx, Duration::from_millis(100)).await;
+        drop(tx);
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_returns_none_when_channel_closes() {
+        let (tx, mut rx) = mpsc::channel::<Vec<f32>>(8);
+        drop(tx);
+
+        assert_eq!(wait_for_signal(&mut rx, Duration::from_secs(5)).await, None);
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -77,7 +77,11 @@ pub async fn wait_for_signal(
                 return None;
             }
             Err(_) => {
-                tracing::warn!(
+                // INFO, not WARN: this fires on every recording start for
+                // sources that emit exact digital silence (by design the
+                // gate must give up and start anyway), so WARN would be
+                // perpetual noise rather than something actionable.
+                tracing::info!(
                     "No signal from audio device within {}ms (suspended source still \
                      resuming, or a source that emits exact silence); starting anyway",
                     timeout.as_millis()

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -38,3 +38,99 @@ pub trait AudioCapture: Send + Sync {
 pub fn create_capture(config: &AudioConfig) -> Result<Box<dyn AudioCapture>, AudioError> {
     Ok(Box::new(cpal_capture::CpalCapture::new(config)?))
 }
+
+/// Wait until the capture stream delivers a chunk containing real signal
+/// (any non-zero sample).
+///
+/// Input devices resuming from idle suspend (PipeWire/WirePlumber suspends
+/// sources after ~5s idle) deliver exact digital zeros for ~0.5s before
+/// real samples flow. Audio spoken into that window is never captured, so
+/// the daemon gates its "listening" cues (start sound, OSD, notification)
+/// on this returning. A live mic always has a noise floor, so any non-zero
+/// sample means the device is warm.
+///
+/// Returns the chunk that contained the signal once one is seen. Callers
+/// whose downstream consumes this channel as audio input (the streaming
+/// transcriber) must forward that chunk — it may hold the onset of speech
+/// when the user started talking during warm-up. Returns `None` on timeout
+/// (some virtual sources, e.g. noise suppressors, emit exact zeros in a
+/// quiet room — recording must start anyway) or if the channel closes.
+pub async fn wait_for_signal(
+    chunk_rx: &mut mpsc::Receiver<Vec<f32>>,
+    timeout: std::time::Duration,
+) -> Option<Vec<f32>> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let started = std::time::Instant::now();
+
+    loop {
+        match tokio::time::timeout_at(deadline, chunk_rx.recv()).await {
+            Ok(Some(chunk)) => {
+                if chunk.iter().any(|&s| s != 0.0) {
+                    tracing::debug!(
+                        "Audio device warm after {:.0}ms",
+                        started.elapsed().as_secs_f32() * 1000.0
+                    );
+                    return Some(chunk);
+                }
+            }
+            Ok(None) => {
+                tracing::warn!("Audio stream closed while waiting for device warm-up");
+                return None;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "No signal from audio device within {}ms (suspended source still \
+                     resuming, or a source that emits exact silence); starting anyway",
+                    timeout.as_millis()
+                );
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn wait_for_signal_returns_the_first_nonzero_chunk() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0, 0.01, 0.0]).await.unwrap();
+
+        let chunk = wait_for_signal(&mut rx, Duration::from_secs(5)).await;
+        assert_eq!(chunk, Some(vec![0.0, 0.01, 0.0]));
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_skips_leading_silent_chunks() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0; 160]).await.unwrap();
+        tx.send(vec![0.0; 160]).await.unwrap();
+        tx.send(vec![0.0, -0.02]).await.unwrap();
+
+        let chunk = wait_for_signal(&mut rx, Duration::from_secs(5)).await;
+        assert_eq!(chunk, Some(vec![0.0, -0.02]));
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_times_out_on_pure_silence() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0; 160]).await.unwrap();
+        // Keep tx alive so the channel doesn't close; only the timeout
+        // can end the wait.
+        let result = wait_for_signal(&mut rx, Duration::from_millis(100)).await;
+        drop(tx);
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_returns_none_when_channel_closes() {
+        let (tx, mut rx) = mpsc::channel::<Vec<f32>>(8);
+        drop(tx);
+
+        assert_eq!(wait_for_signal(&mut rx, Duration::from_secs(5)).await, None);
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -78,7 +78,11 @@ pub async fn wait_for_signal(
                 return None;
             }
             Err(_) => {
-                tracing::warn!(
+                // INFO, not WARN: this fires on every recording start for
+                // sources that emit exact digital silence (by design the
+                // gate must give up and start anyway), so WARN would be
+                // perpetual noise rather than something actionable.
+                tracing::info!(
                     "No signal from audio device within {}ms (suspended source still \
                      resuming, or a source that emits exact silence); starting anyway",
                     timeout.as_millis()

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -240,6 +240,23 @@ pub struct Cli {
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub pause_media: bool,
 
+    /// Wait for the input device to deliver audio before signaling recording start (default)
+    #[arg(long, help_heading = "Audio", hide_short_help = true)]
+    pub wait_for_device: bool,
+
+    /// Start immediately without waiting for input device warm-up
+    #[arg(
+        long,
+        help_heading = "Audio",
+        hide_short_help = true,
+        conflicts_with = "wait_for_device",
+        long_help = "Start immediately without waiting for input device warm-up.\n\
+        By default, voxtype delays the recording-start cue (sound, OSD, notification)\n\
+        until the input device delivers real audio, because devices resuming from\n\
+        idle suspend produce ~0.5s of silence in which speech is lost."
+    )]
+    pub no_wait_for_device: bool,
+
     // -- Output (delivery, timing, file output, hooks) --
     /// Force clipboard mode (don't try to type)
     #[arg(long, help_heading = "Output")]

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -240,7 +240,7 @@ pub struct Cli {
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub pause_media: bool,
 
-    /// Wait for the input device to deliver audio before signaling recording start (default)
+    /// Wait for input device warm-up before signaling recording start (overrides a config that disables it; on by default)
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub wait_for_device: bool,
 

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -262,7 +262,7 @@ pub struct Cli {
     )]
     pub duck_media_fade_ms: Option<u32>,
 
-    /// Wait for the input device to deliver audio before signaling recording start (default)
+    /// Wait for input device warm-up before signaling recording start (overrides a config that disables it; on by default)
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub wait_for_device: bool,
 

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -262,6 +262,23 @@ pub struct Cli {
     )]
     pub duck_media_fade_ms: Option<u32>,
 
+    /// Wait for the input device to deliver audio before signaling recording start (default)
+    #[arg(long, help_heading = "Audio", hide_short_help = true)]
+    pub wait_for_device: bool,
+
+    /// Start immediately without waiting for input device warm-up
+    #[arg(
+        long,
+        help_heading = "Audio",
+        hide_short_help = true,
+        conflicts_with = "wait_for_device",
+        long_help = "Start immediately without waiting for input device warm-up.\n\
+        By default, voxtype delays the recording-start cue (sound, OSD, notification)\n\
+        until the input device delivers real audio, because devices resuming from\n\
+        idle suspend produce ~0.5s of silence in which speech is lost."
+    )]
+    pub no_wait_for_device: bool,
+
     // -- Output (delivery, timing, file output, hooks) --
     /// Force clipboard mode (don't try to type)
     #[arg(long, help_heading = "Output")]

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -29,6 +29,13 @@ pub struct AudioConfig {
     #[serde(default)]
     pub pause_media_ignored_players: Vec<String>,
 
+    /// Wait for the input device to deliver real audio before playing the
+    /// recording-start cue and showing the OSD. Devices resuming from idle
+    /// suspend produce ~0.5s of digital silence; without this gate, users
+    /// who speak as soon as they see/hear the cue lose their first word.
+    #[serde(default = "default_audio_wait_for_device")]
+    pub wait_for_device: bool,
+
     /// Audio feedback settings
     #[serde(default)]
     pub feedback: AudioFeedbackConfig,
@@ -42,6 +49,7 @@ impl Default for AudioConfig {
             max_duration_secs: default_audio_max_duration_secs(),
             pause_media: false,
             pause_media_ignored_players: Vec::new(),
+            wait_for_device: default_audio_wait_for_device(),
             feedback: AudioFeedbackConfig::default(),
         }
     }
@@ -57,6 +65,10 @@ fn default_audio_sample_rate() -> u32 {
 
 fn default_audio_max_duration_secs() -> u32 {
     60
+}
+
+fn default_audio_wait_for_device() -> bool {
+    true
 }
 
 /// Audio feedback configuration for sound cues
@@ -90,5 +102,24 @@ impl Default for AudioFeedbackConfig {
             theme: default_sound_theme(),
             volume: default_volume(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_for_device_defaults_to_true() {
+        assert!(AudioConfig::default().wait_for_device);
+        // Old configs without the field must keep the default
+        let cfg: AudioConfig = toml::from_str("").unwrap();
+        assert!(cfg.wait_for_device);
+    }
+
+    #[test]
+    fn wait_for_device_can_be_disabled() {
+        let cfg: AudioConfig = toml::from_str("wait_for_device = false").unwrap();
+        assert!(!cfg.wait_for_device);
     }
 }

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -43,6 +43,13 @@ pub struct AudioConfig {
     #[serde(default = "default_duck_media_fade_ms")]
     pub duck_media_fade_ms: u32,
 
+    /// Wait for the input device to deliver real audio before playing the
+    /// recording-start cue and showing the OSD. Devices resuming from idle
+    /// suspend produce ~0.5s of digital silence; without this gate, users
+    /// who speak as soon as they see/hear the cue lose their first word.
+    #[serde(default = "default_audio_wait_for_device")]
+    pub wait_for_device: bool,
+
     /// Audio feedback settings
     #[serde(default)]
     pub feedback: AudioFeedbackConfig,
@@ -59,6 +66,7 @@ impl Default for AudioConfig {
             duck_media: false,
             duck_media_volume_percent: default_duck_media_volume_percent(),
             duck_media_fade_ms: default_duck_media_fade_ms(),
+            wait_for_device: default_audio_wait_for_device(),
             feedback: AudioFeedbackConfig::default(),
         }
     }
@@ -88,6 +96,10 @@ fn default_duck_media_volume_percent() -> u8 {
 
 fn default_duck_media_fade_ms() -> u32 {
     150
+}
+
+fn default_audio_wait_for_device() -> bool {
+    true
 }
 
 /// Audio feedback configuration for sound cues
@@ -121,5 +133,24 @@ impl Default for AudioFeedbackConfig {
             theme: default_sound_theme(),
             volume: default_volume(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_for_device_defaults_to_true() {
+        assert!(AudioConfig::default().wait_for_device);
+        // Old configs without the field must keep the default
+        let cfg: AudioConfig = toml::from_str("").unwrap();
+        assert!(cfg.wait_for_device);
+    }
+
+    #[test]
+    fn wait_for_device_can_be_disabled() {
+        let cfg: AudioConfig = toml::from_str("wait_for_device = false").unwrap();
+        assert!(!cfg.wait_for_device);
     }
 }

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -49,6 +49,13 @@ sample_rate = 16000
 # Maximum recording duration in seconds (safety limit)
 max_duration_secs = 60
 
+# Wait for the input device to deliver real audio before playing the
+# recording-start cue and showing the OSD (up to 1.5s). Input devices
+# resuming from idle suspend produce ~0.5s of silence; speaking into that
+# window loses the first word. Disable if your source emits exact digital
+# silence when quiet (e.g. some noise suppressors) and the cue feels late.
+# wait_for_device = true
+
 # Pause MPRIS media players (Spotify, Firefox, etc.) when recording starts,
 # resume them when recording stops. Talks D-Bus directly; no external
 # playerctl binary required.

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -49,6 +49,13 @@ sample_rate = 16000
 # Maximum recording duration in seconds (safety limit)
 max_duration_secs = 60
 
+# Wait for the input device to deliver real audio before playing the
+# recording-start cue and showing the OSD (up to 1.5s). Input devices
+# resuming from idle suspend produce ~0.5s of silence; speaking into that
+# window loses the first word. Disable if your source emits exact digital
+# silence when quiet (e.g. some noise suppressors) and the cue feels late.
+# wait_for_device = true
+
 # Pause MPRIS media players (Spotify, Firefox, etc.) before recording starts,
 # then resume them as soon as recording stops. Talks D-Bus directly; no external
 # playerctl binary required.

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -104,6 +104,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     if let Ok(val) = std::env::var("VOXTYPE_PAUSE_MEDIA") {
         config.audio.pause_media = parse_bool_env(&val);
     }
+    if let Ok(val) = std::env::var("VOXTYPE_WAIT_FOR_DEVICE") {
+        config.audio.wait_for_device = parse_bool_env(&val);
+    }
 
     // Output
     if let Ok(mode) = std::env::var("VOXTYPE_OUTPUT_MODE") {

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -117,6 +117,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
             config.audio.duck_media_fade_ms = n;
         }
     }
+    if let Ok(val) = std::env::var("VOXTYPE_WAIT_FOR_DEVICE") {
+        config.audio.wait_for_device = parse_bool_env(&val);
+    }
 
     // Output
     if let Ok(mode) = std::env::var("VOXTYPE_OUTPUT_MODE") {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -380,6 +380,12 @@ fn read_trimmed_nonempty(path: &std::path::Path) -> Option<String> {
 /// sync with the `value_parser` list on `MeetingAction::Start::diarization`.
 const ALLOWED_DIARIZATION_OVERRIDES: &[&str] = &["simple", "ml"];
 
+/// How long to wait for a resuming input device to deliver real samples
+/// before starting anyway. Suspended PipeWire/ALSA sources take ~0.5s to
+/// warm up; sources that emit exact digital silence (noise suppressors in
+/// a quiet room) would otherwise stall forever.
+const DEVICE_WARMUP_TIMEOUT: Duration = Duration::from_millis(1500);
+
 /// Validate a diarization backend override against the allowlist.
 ///
 /// The CLI's clap `value_parser` already rejects bad values at parse time, but
@@ -806,7 +812,20 @@ impl Daemon {
     async fn start_recording_capture(&mut self) -> std::result::Result<Box<dyn AudioCapture>, ()> {
         match audio::create_capture(&self.config.audio) {
             Ok(mut capture) => match capture.start().await {
-                Ok(chunk_rx) => {
+                Ok(mut chunk_rx) => {
+                    // Hold back the "listening" cues (start sound, OSD,
+                    // state change — all downstream of this return) until
+                    // the device delivers real samples, so users don't
+                    // speak into a suspended source's warm-up silence.
+                    // Discarding the consumed chunks (including the returned
+                    // signal chunk) is safe ONLY because CpalCapture
+                    // accumulates every sample in its internal buffer
+                    // independently of this channel — here the channel just
+                    // feeds the OSD level emitter. A capture backend without
+                    // that dual path must forward the returned chunk instead.
+                    if self.config.audio.wait_for_device {
+                        let _ = audio::wait_for_signal(&mut chunk_rx, DEVICE_WARMUP_TIMEOUT).await;
+                    }
                     if let Some(hub) = &self.level_hub {
                         // Cancel any prior emitter (defensive; should be idle).
                         if let Some(handle) = self.level_emitter_task.take() {
@@ -1080,10 +1099,27 @@ impl Daemon {
     {
         match audio::create_capture(&self.config.audio) {
             Ok(mut capture) => match capture.start().await {
-                Ok(chunk_rx) => {
+                Ok(mut chunk_rx) => {
+                    // Same warm-up gate as start_recording_capture; also
+                    // keeps a resuming device's leading zeros out of the
+                    // streaming backend.
+                    let warm_chunk = if self.config.audio.wait_for_device {
+                        audio::wait_for_signal(&mut chunk_rx, DEVICE_WARMUP_TIMEOUT).await
+                    } else {
+                        None
+                    };
                     // Bounded; backed-up streaming backend drops chunks
                     // rather than back-pressuring the capture.
                     let (streaming_tx, streaming_rx) = tokio::sync::mpsc::channel::<Vec<f32>>(64);
+
+                    // Unlike the batch path, this channel IS the
+                    // transcriber's audio input, and the chunk that proved
+                    // the device warm may already hold the onset of speech
+                    // (user talking during warm-up). Hand it on first so
+                    // nothing is clipped. Cannot fail: channel is empty.
+                    if let Some(chunk) = warm_chunk {
+                        let _ = streaming_tx.try_send(chunk);
+                    }
 
                     if let Some(handle) = self.level_emitter_task.take() {
                         handle.abort();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1116,7 +1116,9 @@ impl Daemon {
                     // transcriber's audio input, and the chunk that proved
                     // the device warm may already hold the onset of speech
                     // (user talking during warm-up). Hand it on first so
-                    // nothing is clipped. Cannot fail: channel is empty.
+                    // nothing is clipped. The send cannot fail at this
+                    // point: the channel was just created and streaming_rx
+                    // is a local we still hold.
                     if let Some(chunk) = warm_chunk {
                         let _ = streaming_tx.try_send(chunk);
                     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1334,7 +1334,9 @@ impl Daemon {
                     // transcriber's audio input, and the chunk that proved
                     // the device warm may already hold the onset of speech
                     // (user talking during warm-up). Hand it on first so
-                    // nothing is clipped. Cannot fail: channel is empty.
+                    // nothing is clipped. The send cannot fail at this
+                    // point: the channel was just created and streaming_rx
+                    // is a local we still hold.
                     if let Some(chunk) = warm_chunk {
                         let _ = streaming_tx.try_send(chunk);
                     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -412,6 +412,12 @@ fn read_trimmed_nonempty(path: &std::path::Path) -> Option<String> {
 /// sync with the `value_parser` list on `MeetingAction::Start::diarization`.
 const ALLOWED_DIARIZATION_OVERRIDES: &[&str] = &["simple", "ml"];
 
+/// How long to wait for a resuming input device to deliver real samples
+/// before starting anyway. Suspended PipeWire/ALSA sources take ~0.5s to
+/// warm up; sources that emit exact digital silence (noise suppressors in
+/// a quiet room) would otherwise stall forever.
+const DEVICE_WARMUP_TIMEOUT: Duration = Duration::from_millis(1500);
+
 /// Validate a diarization backend override against the allowlist.
 ///
 /// The CLI's clap `value_parser` already rejects bad values at parse time, but
@@ -1016,7 +1022,20 @@ impl Daemon {
         cleanup_cancel_file();
         match audio::create_capture(&self.config.audio) {
             Ok(mut capture) => match capture.start().await {
-                Ok(chunk_rx) => {
+                Ok(mut chunk_rx) => {
+                    // Hold back the "listening" cues (start sound, OSD,
+                    // state change — all downstream of this return) until
+                    // the device delivers real samples, so users don't
+                    // speak into a suspended source's warm-up silence.
+                    // Discarding the consumed chunks (including the returned
+                    // signal chunk) is safe ONLY because CpalCapture
+                    // accumulates every sample in its internal buffer
+                    // independently of this channel — here the channel just
+                    // feeds the OSD level emitter. A capture backend without
+                    // that dual path must forward the returned chunk instead.
+                    if self.config.audio.wait_for_device {
+                        let _ = audio::wait_for_signal(&mut chunk_rx, DEVICE_WARMUP_TIMEOUT).await;
+                    }
                     if let Some(hub) = &self.level_hub {
                         // Cancel any prior emitter (defensive; should be idle).
                         if let Some(handle) = self.level_emitter_task.take() {
@@ -1298,10 +1317,27 @@ impl Daemon {
     {
         match audio::create_capture(&self.config.audio) {
             Ok(mut capture) => match capture.start().await {
-                Ok(chunk_rx) => {
+                Ok(mut chunk_rx) => {
+                    // Same warm-up gate as start_recording_capture; also
+                    // keeps a resuming device's leading zeros out of the
+                    // streaming backend.
+                    let warm_chunk = if self.config.audio.wait_for_device {
+                        audio::wait_for_signal(&mut chunk_rx, DEVICE_WARMUP_TIMEOUT).await
+                    } else {
+                        None
+                    };
                     // Bounded; backed-up streaming backend drops chunks
                     // rather than back-pressuring the capture.
                     let (streaming_tx, streaming_rx) = tokio::sync::mpsc::channel::<Vec<f32>>(64);
+
+                    // Unlike the batch path, this channel IS the
+                    // transcriber's audio input, and the chunk that proved
+                    // the device warm may already hold the onset of speech
+                    // (user talking during warm-up). Hand it on first so
+                    // nothing is clipped. Cannot fail: channel is empty.
+                    if let Some(chunk) = warm_chunk {
+                        let _ = streaming_tx.try_send(chunk);
+                    }
 
                     if let Some(handle) = self.level_emitter_task.take() {
                         handle.abort();


### PR DESCRIPTION
## Problem

Input sources resuming from idle suspend (PipeWire/WirePlumber suspends sources after a few seconds without use) deliver roughly half a second of exact digital silence before real samples flow. The recording-start sound, OSD, and notification fired as soon as the cpal stream opened, so users who spoke on cue lost their first word to the dead window. The audio in that window is never delivered by the device, so it cannot be recovered after the fact; the only fix is to not invite the user to speak until the device is live.

## Fix

Hold the listening cues back until the capture stream delivers a chunk containing a non-zero sample. A live mic always has a noise floor; resume silence is exact zeros. The gate has a 1.5s timeout so sources that emit true digital silence (some noise suppressors in a quiet room) can never stall recording start.

- `audio::wait_for_signal` consumes chunks until signal, returning the chunk that proved the device warm
- Both the batch and streaming capture paths run the gate before the start cue, OSD level emitter, and state transition
- The streaming path forwards the returned chunk to the transcriber (that channel is its only audio input and the chunk may already hold speech onset); the batch path can discard it because CpalCapture independently accumulates every sample in its internal buffer
- The streaming backend no longer receives the leading zero chunks

## Configuration

New `[audio] wait_for_device` option, default `true` (old configs pick it up automatically; the previous behavior effectively lost audio, so the gate is on by default). Also `--wait-for-device` / `--no-wait-for-device` CLI flags and the `VOXTYPE_WAIT_FOR_DEVICE` env var. Documented in CONFIGURATION.md and TROUBLESHOOTING.md (new "First word missing when dictation starts" entry).

## Measurements (PipeWire + EasyEffects, ALC1220 mic)

| Scenario | Warm-up before cue |
|---|---|
| Cold start (source idle-suspended) | 0.3-0.9s depending on EasyEffects version |
| Warm start (back-to-back dictation) | 40-70ms |

Verified live with the `Audio device warm after NNNms` debug log; speaking on cue no longer loses the first word.

## Known follow-ups (reviewed, deliberately out of scope)

- Hotkey release/cancel events queue behind the gate (up to 1.5s) because it awaits inside the event-loop arm; a quick tap plays the cue late and immediately stops (sub-0.3s recordings are already discarded by the min-duration guard). Proper fix is a cancellable pending-recording state.
- Meeting mode (DualCapture) is not gated; DualCapture::start() discards the mic receiver, so the gate needs an API change there.
- A failed streaming start falls back to batch and runs the gate a second time (fast on a warm device; 2x1.5s worst case on always-silent sources).

## Testing

- 6 new unit tests (gate behavior incl. timeout/closed-channel paths; config default and override parsing)
- cargo fmt, clippy -D warnings, full test suite (834 passed)
- Manual verification on a live Hyprland + PipeWire setup with Soniox streaming and batch paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)