### PR TITLE
Refresh Quickshell READMEs to reflect the shipped frontend

### DIFF
--- a/quickshell/README.md
+++ b/quickshell/README.md
@@ -1,73 +1,102 @@
-# Voxtype Quickshell OSD (proof of concept)
+# Voxtype Quickshell Frontend
 
-A Quickshell-based on-screen indicator for the voxtype daemon, intended as a
-drop-in alternative to the GTK4 OSD (`voxtype-osd-gtk4`) for users running a
-Quickshell-based desktop shell (Omarchy 4+, end_4/dots-hyprland, custom shells).
+A Quickshell/QML frontend for the voxtype daemon, shipped since v0.7.5 as an
+alternative to the GTK4 (`voxtype-osd-gtk4`) and native (`voxtype-osd-native`)
+OSD frontends. Intended for users running a Quickshell-based desktop shell
+(Omarchy 4+, end_4/dots-hyprland, custom shells).
 
-## Status
+## Contents
 
-POC, not yet a shipped feature. Reads voxtype's state file and shows a small
-overlay card with state-specific icon + color. The waveform / peak-meter visual
-that the GTK4 OSD renders is not yet ported (the GTK4 binary draws audio frames
-streamed over a Unix socket; the QML port of that visualizer is the v0.7.3+
-scope).
+| File | Purpose |
+|------|---------|
+| `shell.qml` | Composition root. Wires the shared state and audio bridges into each widget. |
+| `OsdSurface.qml` | Recording HUD: state icon + tint, scrolling waveform (3-second window, 100 Hz), and peak meter with held-peak tick. Visible whenever the daemon is not idle. |
+| `EnginePicker.qml` | Floating panel listing every transcription engine, with the active one marked. Switches engines via `voxtype config set engine <name>`. Engines not compiled into the running binary are shown dimmed. |
+| `MeetingControls.qml` | Meeting status panel (title, elapsed time, chunk count) with Start / Stop / Pause / Resume buttons that shell out to `voxtype meeting <action>`. |
+| `voxtype-shared/` | Shared QML module: `Theme` (palette/sizing singleton), `StateReader` (daemon state file watcher), `AudioBridge` (wrapper around the `voxtype-audio-bridge` sidecar). See [voxtype-shared/README.md](voxtype-shared/README.md). |
 
-## Run standalone
+## Install
+
+The packaged builds (AUR, deb, rpm) install the QML tree system-wide at
+`/usr/share/voxtype/quickshell/` and the audio bridge at
+`/usr/lib/voxtype/voxtype-audio-bridge`, so no extra step is needed there.
+For source builds, or to get a per-user copy you can customize:
 
 ```bash
-qs -p quickshell/voxtype-osd/shell.qml
+voxtype setup quickshell
 ```
 
-While running, watch the corner of your screen as you press your voxtype
-hotkey: the card appears with a red border + microphone icon during
-`recording`, a blue border + radio-tower icon during `streaming`, an amber
-border + clock icon during `transcribing`, and disappears when the daemon
-returns to `idle`.
+This copies the QML files to `$XDG_DATA_HOME/voxtype/quickshell/`
+(`~/.local/share/voxtype/quickshell/` by default), symlinks
+`voxtype-audio-bridge` into `~/.local/bin/` so the waveform can find it on
+PATH, and prints compositor binding examples for the popup widgets. See
+`voxtype setup quickshell --help` for `--target`, `--source`, `--force`,
+`--bridge`, and `--skip-bridge` options.
+
+To make the daemon's OSD supervisor launch this frontend:
+
+```toml
+[osd]
+frontend = "quickshell"
+```
+
+## Run
+
+The `voxtype-osd-quickshell` launcher finds the installed QML tree
+(`--qml-path` / `VOXTYPE_OSD_QML_PATH` override, then the per-user copy,
+then `/usr/share/voxtype/quickshell/`, then `quickshell/` relative to the
+current directory) and execs `qs -d -p <dir>`:
+
+```bash
+voxtype-osd-quickshell
+```
+
+To run directly from a repo checkout during development:
+
+```bash
+qs -p quickshell
+```
+
+Press your voxtype hotkey and watch the screen edge: the OSD card appears
+with a red tint and live waveform during `recording`, blue during
+`streaming`, amber during `transcribing`, and disappears at `idle`.
+
+## Toggling the popup widgets
+
+The engine picker and meeting controls are toggled by touching flag files
+under `$XDG_RUNTIME_DIR/voxtype/`, which the QML watches via `FileView`:
+
+```bash
+# Hyprland examples (see `voxtype setup quickshell --print-bindings`
+# for Sway and River equivalents)
+bind = SUPER, E, exec, mkdir -p $XDG_RUNTIME_DIR/voxtype && touch $XDG_RUNTIME_DIR/voxtype/engine-picker.flag
+bind = SUPER, M, exec, mkdir -p $XDG_RUNTIME_DIR/voxtype && touch $XDG_RUNTIME_DIR/voxtype/meeting-controls.flag
+```
 
 ## How it works
 
-- `FileView { path: "$XDG_RUNTIME_DIR/voxtype/state"; watchChanges: true }`
-  reads the daemon's state file. Quickshell's `FileView` element re-reads on
-  every change, so the OSD follows the daemon's state machine without
-  polling.
-- `PanelWindow` with `WlrLayershell` overlay configures the surface as a
-  click-through overlay-layer window with no keyboard focus, matching the
-  GTK4 version's surface semantics.
-- `visible: shell.state !== "idle"` hides the card whenever the daemon goes
-  back to idle. No timers or animation; the toggle is purely reactive to
-  state file changes.
+- **State**: `StateReader` watches `$XDG_RUNTIME_DIR/voxtype/state` with a
+  `FileView { watchChanges: true }`, so the UI follows the daemon's state
+  machine without polling.
+- **Audio**: Quickshell cannot read Unix domain sockets natively, so the
+  `voxtype-audio-bridge` sidecar reads the daemon's audio socket
+  (`$XDG_RUNTIME_DIR/voxtype/audio.sock`) and emits one NDJSON line per
+  frame on stdout. `AudioBridge` spawns it via Quickshell's `Process`
+  element and parses peak / RMS / VAD values for the waveform and meter.
+  `shell.qml` creates a single `AudioBridge` and passes it to widgets so
+  only one sidecar process runs.
+- **Surfaces**: each widget is a `PanelWindow` on the `WlrLayer.Overlay`
+  layer with no keyboard focus, matching the GTK4 frontend's surface
+  semantics.
+- **No new daemon IPC**: the picker and meeting controls read existing
+  files (`config.toml`, `meeting_state`) and shell out to existing CLI
+  commands (`voxtype config set`, `voxtype meeting <action>`,
+  `voxtype info variants --json`).
 
-## Drop into an Omarchy shell config
+## Documentation
 
-If you're running the omarchy-shell, copy this directory under the shell's
-plugin tree and import it from the shell entry:
-
-```bash
-mkdir -p ~/.local/share/omarchy-shell/default/quickshell/omarchy-shell/plugins/voxtype-osd
-cp quickshell/voxtype-osd/shell.qml ~/.local/share/omarchy-shell/default/quickshell/omarchy-shell/plugins/voxtype-osd/VoxtypeOsd.qml
-```
-
-Then add `VoxtypeOsd { }` to the plugin registry in `shell.qml`.
-
-## What this POC does not (yet) cover
-
-- The audio waveform + peak-meter visualizer rendered by `voxtype-osd-gtk4`.
-  That requires reading the daemon's audio Unix socket
-  (`$XDG_RUNTIME_DIR/voxtype/audio.sock`) and decoding the `AudioFrame` IPC
-  format from `src/osd/ipc.rs`. Quickshell does not expose Unix domain socket
-  reads natively; the integration path would either:
-  1. Add a tiny side process that reads the socket and emits decoded frame
-     values as text lines on stdout, which Quickshell's `Process` element
-     consumes via `stdout`.
-  2. Add a custom Quickshell module (Qt6 C++) that exposes a `Socket` type to
-     QML.
-- A `voxtype setup quickshell` installer (mirrors `voxtype setup compositor`)
-  that drops the QML files into the right location and updates the user's
-  Quickshell config to import them.
-- TUI / config integration so `osd.frontend = "quickshell"` chooses this
-  visualizer when the daemon's OSD supervisor decides to spawn one.
-
-These are v0.7.3+ scope, not v0.7.2.
+- [User manual: `voxtype setup quickshell`](../docs/USER_MANUAL.md#voxtype-setup-quickshell)
+- [Configuration: OSD frontend selection](../docs/CONFIGURATION.md#osd-frontend)
 
 ## License
 

--- a/quickshell/voxtype-shared/README.md
+++ b/quickshell/voxtype-shared/README.md
@@ -1,9 +1,9 @@
 # voxtype-shared
 
 Shared Quickshell QML modules used by every voxtype QML frontend: the
-OSD card, the engine picker menu, and (eventually) the meeting controls
-canvas. Extracted so the frontends don't each ship their own copy of
-theme constants, state file watcher, and audio bridge wrapper.
+waveform OSD, the engine picker, and the meeting controls panel.
+Extracted so the frontends don't each ship their own copy of theme
+constants, state file watcher, and audio bridge wrapper.
 
 ## Modules
 
@@ -103,7 +103,8 @@ user's Quickshell config tree.
 
 ## Scope
 
-These modules are the foundation for v0.7.3 Wave 2 work: the waveform
-OSD, the engine picker menu, and the meeting controls panel. None of
-those frontends ship yet; this commit only lands the shared modules
-plus a refactor of the existing OSD proof-of-concept to consume them.
+These modules back the three Quickshell widgets that ship with voxtype
+since v0.7.5: `OsdSurface`, `EnginePicker`, and `MeetingControls` (see
+[../README.md](../README.md)). `shell.qml` instantiates one `StateReader`
+and one `AudioBridge` and passes them to the widgets so only a single
+sidecar process runs.


### PR DESCRIPTION
## Summary

`quickshell/README.md` and `quickshell/voxtype-shared/README.md` still described the v0.7.2-era proof of concept and were wrong on nearly every claim now that the frontend ships (since v0.7.5):

- **Status**: said "POC, not yet a shipped feature" — the frontend ships with packaging, the `voxtype-osd-quickshell` launcher, and the `voxtype setup quickshell` installer.
- **Waveform**: said "not yet ported" — `OsdSurface.qml` renders the scrolling waveform and peak meter, fed by the `voxtype-audio-bridge` sidecar (the README's speculative "integration path option 1", long since implemented).
- **Run command**: `qs -p quickshell/voxtype-osd/shell.qml` pointed at a directory layout that no longer exists. Corrected to `voxtype-osd-quickshell` (with its search-path order) and `qs -p quickshell` for repo checkouts.
- **Missing widgets**: `EnginePicker`, `MeetingControls`, and the `voxtype-shared` module weren't mentioned. Added a contents table plus the flag-file toggle bindings.
- **Install instructions**: manual Omarchy copy steps replaced by `voxtype setup quickshell` and the `[osd] frontend = "quickshell"` config snippet.
- **"Does not yet cover" section**: all three items shipped; replaced with links to the user manual and configuration guide.

`voxtype-shared/README.md` had the same staleness in miniature ("None of those frontends ship yet", "v0.7.3 Wave 2 work"); its module/property tables were still accurate and are untouched.

Docs only, no code changes.

## Follow-up

After merge, cherry-pick to `rc/1.0.0`.