### PR TITLE
fix: improve input startup and streaming output reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ website/docs
 # Local agent worktrees and ephemeral plans
 .claude/worktrees/
 PLAN-*.md
+
+# CodeGraph index + machine-local runtime state (daemon.pid, sockets)
+.codegraph/

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -363,6 +363,24 @@ Maximum recording duration in seconds. Recording automatically stops after this 
 max_duration_secs = 120  # Allow 2-minute recordings
 ```
 
+### wait_for_device
+
+**Type:** Boolean
+**Default:** `true`
+**Required:** No
+
+Wait for the input device to deliver real audio before playing the recording-start cue and showing the OSD (up to 1.5 seconds).
+
+Audio sources resuming from idle suspend (PipeWire suspends them after a few seconds without use) produce roughly half a second of digital silence before real samples flow. Anything spoken into that window is never captured. With this gate enabled, the "listening" signals only appear once the device is actually delivering audio, so speaking as soon as you see or hear the cue is safe.
+
+Disable this if your input source emits exact digital silence when the room is quiet (for example, some noise-suppression filters); with such sources the cue would otherwise always lag by the 1.5-second timeout.
+
+**Example:**
+```toml
+[audio]
+wait_for_device = false  # Signal recording start immediately
+```
+
 ---
 
 ## [audio.feedback]
@@ -3203,6 +3221,7 @@ Any config file setting can be overridden via environment variable. These are ap
 | `VOXTYPE_AUDIO_DEVICE` | string | `audio.device` |
 | `VOXTYPE_MAX_DURATION_SECS` | integer | `audio.max_duration_secs` |
 | `VOXTYPE_AUDIO_FEEDBACK` | bool | `audio.feedback.enabled` |
+| `VOXTYPE_WAIT_FOR_DEVICE` | bool | `audio.wait_for_device` |
 
 **Output:**
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -300,6 +300,24 @@ aplay test.wav
 max_duration_secs = 120  # 2 minutes
 ```
 
+### First word missing when dictation starts
+
+**Symptom:** The first word (or first syllable) of an utterance is lost, but only when you start dictating after a few seconds of not using the microphone. Dictating again right away works fine.
+
+**Cause:** The audio server suspends idle capture devices to save power (PipeWire/WirePlumber does this after about 5 seconds by default). A resuming device delivers around half a second of digital silence before real samples flow, so speech in that window is never captured.
+
+Voxtype works around this with the `wait_for_device` gate (enabled by default): the recording-start sound, notification, and OSD are held back until the device delivers real audio. Wait for the cue before speaking and nothing is lost.
+
+**If you still lose the first word:**
+- Make sure `wait_for_device` has not been disabled in your config
+- Wait for the start cue (sound or OSD) before speaking; enable audio feedback with `[audio.feedback] enabled = true` if you have no visible indicator
+
+**If the start cue feels delayed instead:** your source may emit exact digital silence when the room is quiet (some noise-suppression filters do), which makes the gate wait its full 1.5-second timeout. Disable it:
+```toml
+[audio]
+wait_for_device = false
+```
+
 ---
 
 ## Transcription Issues

--- a/src/app/config_show.rs
+++ b/src/app/config_show.rs
@@ -67,6 +67,7 @@ pub(crate) async fn show_config(config: &config::Config) -> anyhow::Result<()> {
     println!("  device = {:?}", config.audio.device);
     println!("  sample_rate = {}", config.audio.sample_rate);
     println!("  max_duration_secs = {}", config.audio.max_duration_secs);
+    println!("  wait_for_device = {}", config.audio.wait_for_device);
 
     println!("\n[audio.feedback]");
     println!("  enabled = {}", config.audio.feedback.enabled);

--- a/src/app/overrides.rs
+++ b/src/app/overrides.rs
@@ -185,6 +185,11 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
     if cli.pause_media {
         config.audio.pause_media = true;
     }
+    apply_bool_override(
+        &mut config.audio.wait_for_device,
+        cli.wait_for_device,
+        cli.no_wait_for_device,
+    );
 
     // Output overrides
     if let Some(ref append_text) = cli.append_text {

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -37,3 +37,99 @@ pub trait AudioCapture: Send + Sync {
 pub fn create_capture(config: &AudioConfig) -> Result<Box<dyn AudioCapture>, AudioError> {
     Ok(Box::new(cpal_capture::CpalCapture::new(config)?))
 }
+
+/// Wait until the capture stream delivers a chunk containing real signal
+/// (any non-zero sample).
+///
+/// Input devices resuming from idle suspend (PipeWire/WirePlumber suspends
+/// sources after ~5s idle) deliver exact digital zeros for ~0.5s before
+/// real samples flow. Audio spoken into that window is never captured, so
+/// the daemon gates its "listening" cues (start sound, OSD, notification)
+/// on this returning. A live mic always has a noise floor, so any non-zero
+/// sample means the device is warm.
+///
+/// Returns the chunk that contained the signal once one is seen. Callers
+/// whose downstream consumes this channel as audio input (the streaming
+/// transcriber) must forward that chunk — it may hold the onset of speech
+/// when the user started talking during warm-up. Returns `None` on timeout
+/// (some virtual sources, e.g. noise suppressors, emit exact zeros in a
+/// quiet room — recording must start anyway) or if the channel closes.
+pub async fn wait_for_signal(
+    chunk_rx: &mut mpsc::Receiver<Vec<f32>>,
+    timeout: std::time::Duration,
+) -> Option<Vec<f32>> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let started = std::time::Instant::now();
+
+    loop {
+        match tokio::time::timeout_at(deadline, chunk_rx.recv()).await {
+            Ok(Some(chunk)) => {
+                if chunk.iter().any(|&s| s != 0.0) {
+                    tracing::debug!(
+                        "Audio device warm after {:.0}ms",
+                        started.elapsed().as_secs_f32() * 1000.0
+                    );
+                    return Some(chunk);
+                }
+            }
+            Ok(None) => {
+                tracing::warn!("Audio stream closed while waiting for device warm-up");
+                return None;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "No signal from audio device within {}ms (suspended source still \
+                     resuming, or a source that emits exact silence); starting anyway",
+                    timeout.as_millis()
+                );
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn wait_for_signal_returns_the_first_nonzero_chunk() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0, 0.01, 0.0]).await.unwrap();
+
+        let chunk = wait_for_signal(&mut rx, Duration::from_secs(5)).await;
+        assert_eq!(chunk, Some(vec![0.0, 0.01, 0.0]));
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_skips_leading_silent_chunks() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0; 160]).await.unwrap();
+        tx.send(vec![0.0; 160]).await.unwrap();
+        tx.send(vec![0.0, -0.02]).await.unwrap();
+
+        let chunk = wait_for_signal(&mut rx, Duration::from_secs(5)).await;
+        assert_eq!(chunk, Some(vec![0.0, -0.02]));
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_times_out_on_pure_silence() {
+        let (tx, mut rx) = mpsc::channel(8);
+        tx.send(vec![0.0; 160]).await.unwrap();
+        // Keep tx alive so the channel doesn't close; only the timeout
+        // can end the wait.
+        let result = wait_for_signal(&mut rx, Duration::from_millis(100)).await;
+        drop(tx);
+
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn wait_for_signal_returns_none_when_channel_closes() {
+        let (tx, mut rx) = mpsc::channel::<Vec<f32>>(8);
+        drop(tx);
+
+        assert_eq!(wait_for_signal(&mut rx, Duration::from_secs(5)).await, None);
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -77,7 +77,11 @@ pub async fn wait_for_signal(
                 return None;
             }
             Err(_) => {
-                tracing::warn!(
+                // INFO, not WARN: this fires on every recording start for
+                // sources that emit exact digital silence (by design the
+                // gate must give up and start anyway), so WARN would be
+                // perpetual noise rather than something actionable.
+                tracing::info!(
                     "No signal from audio device within {}ms (suspended source still \
                      resuming, or a source that emits exact silence); starting anyway",
                     timeout.as_millis()

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -240,6 +240,23 @@ pub struct Cli {
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub pause_media: bool,
 
+    /// Wait for the input device to deliver audio before signaling recording start (default)
+    #[arg(long, help_heading = "Audio", hide_short_help = true)]
+    pub wait_for_device: bool,
+
+    /// Start immediately without waiting for input device warm-up
+    #[arg(
+        long,
+        help_heading = "Audio",
+        hide_short_help = true,
+        conflicts_with = "wait_for_device",
+        long_help = "Start immediately without waiting for input device warm-up.\n\
+        By default, voxtype delays the recording-start cue (sound, OSD, notification)\n\
+        until the input device delivers real audio, because devices resuming from\n\
+        idle suspend produce ~0.5s of silence in which speech is lost."
+    )]
+    pub no_wait_for_device: bool,
+
     // -- Output (delivery, timing, file output, hooks) --
     /// Force clipboard mode (don't try to type)
     #[arg(long, help_heading = "Output")]

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -240,7 +240,7 @@ pub struct Cli {
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub pause_media: bool,
 
-    /// Wait for the input device to deliver audio before signaling recording start (default)
+    /// Wait for input device warm-up before signaling recording start (overrides a config that disables it; on by default)
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub wait_for_device: bool,
 

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -29,6 +29,13 @@ pub struct AudioConfig {
     #[serde(default)]
     pub pause_media_ignored_players: Vec<String>,
 
+    /// Wait for the input device to deliver real audio before playing the
+    /// recording-start cue and showing the OSD. Devices resuming from idle
+    /// suspend produce ~0.5s of digital silence; without this gate, users
+    /// who speak as soon as they see/hear the cue lose their first word.
+    #[serde(default = "default_audio_wait_for_device")]
+    pub wait_for_device: bool,
+
     /// Audio feedback settings
     #[serde(default)]
     pub feedback: AudioFeedbackConfig,
@@ -42,6 +49,7 @@ impl Default for AudioConfig {
             max_duration_secs: default_audio_max_duration_secs(),
             pause_media: false,
             pause_media_ignored_players: Vec::new(),
+            wait_for_device: default_audio_wait_for_device(),
             feedback: AudioFeedbackConfig::default(),
         }
     }
@@ -57,6 +65,10 @@ fn default_audio_sample_rate() -> u32 {
 
 fn default_audio_max_duration_secs() -> u32 {
     60
+}
+
+fn default_audio_wait_for_device() -> bool {
+    true
 }
 
 /// Audio feedback configuration for sound cues
@@ -90,5 +102,24 @@ impl Default for AudioFeedbackConfig {
             theme: default_sound_theme(),
             volume: default_volume(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_for_device_defaults_to_true() {
+        assert!(AudioConfig::default().wait_for_device);
+        // Old configs without the field must keep the default
+        let cfg: AudioConfig = toml::from_str("").unwrap();
+        assert!(cfg.wait_for_device);
+    }
+
+    #[test]
+    fn wait_for_device_can_be_disabled() {
+        let cfg: AudioConfig = toml::from_str("wait_for_device = false").unwrap();
+        assert!(!cfg.wait_for_device);
     }
 }

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -49,6 +49,13 @@ sample_rate = 16000
 # Maximum recording duration in seconds (safety limit)
 max_duration_secs = 60
 
+# Wait for the input device to deliver real audio before playing the
+# recording-start cue and showing the OSD (up to 1.5s). Input devices
+# resuming from idle suspend produce ~0.5s of silence; speaking into that
+# window loses the first word. Disable if your source emits exact digital
+# silence when quiet (e.g. some noise suppressors) and the cue feels late.
+# wait_for_device = true
+
 # Pause MPRIS media players (Spotify, Firefox, etc.) when recording starts,
 # resume them when recording stops. Talks D-Bus directly; no external
 # playerctl binary required.

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -104,6 +104,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     if let Ok(val) = std::env::var("VOXTYPE_PAUSE_MEDIA") {
         config.audio.pause_media = parse_bool_env(&val);
     }
+    if let Ok(val) = std::env::var("VOXTYPE_WAIT_FOR_DEVICE") {
+        config.audio.wait_for_device = parse_bool_env(&val);
+    }
 
     // Output
     if let Ok(mode) = std::env::var("VOXTYPE_OUTPUT_MODE") {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -380,6 +380,12 @@ fn read_trimmed_nonempty(path: &std::path::Path) -> Option<String> {
 /// sync with the `value_parser` list on `MeetingAction::Start::diarization`.
 const ALLOWED_DIARIZATION_OVERRIDES: &[&str] = &["simple", "ml"];
 
+/// How long to wait for a resuming input device to deliver real samples
+/// before starting anyway. Suspended PipeWire/ALSA sources take ~0.5s to
+/// warm up; sources that emit exact digital silence (noise suppressors in
+/// a quiet room) would otherwise stall forever.
+const DEVICE_WARMUP_TIMEOUT: Duration = Duration::from_millis(1500);
+
 /// Validate a diarization backend override against the allowlist.
 ///
 /// The CLI's clap `value_parser` already rejects bad values at parse time, but
@@ -806,7 +812,20 @@ impl Daemon {
     async fn start_recording_capture(&mut self) -> std::result::Result<Box<dyn AudioCapture>, ()> {
         match audio::create_capture(&self.config.audio) {
             Ok(mut capture) => match capture.start().await {
-                Ok(chunk_rx) => {
+                Ok(mut chunk_rx) => {
+                    // Hold back the "listening" cues (start sound, OSD,
+                    // state change — all downstream of this return) until
+                    // the device delivers real samples, so users don't
+                    // speak into a suspended source's warm-up silence.
+                    // Discarding the consumed chunks (including the returned
+                    // signal chunk) is safe ONLY because CpalCapture
+                    // accumulates every sample in its internal buffer
+                    // independently of this channel — here the channel just
+                    // feeds the OSD level emitter. A capture backend without
+                    // that dual path must forward the returned chunk instead.
+                    if self.config.audio.wait_for_device {
+                        let _ = audio::wait_for_signal(&mut chunk_rx, DEVICE_WARMUP_TIMEOUT).await;
+                    }
                     if let Some(hub) = &self.level_hub {
                         // Cancel any prior emitter (defensive; should be idle).
                         if let Some(handle) = self.level_emitter_task.take() {
@@ -1080,10 +1099,27 @@ impl Daemon {
     {
         match audio::create_capture(&self.config.audio) {
             Ok(mut capture) => match capture.start().await {
-                Ok(chunk_rx) => {
+                Ok(mut chunk_rx) => {
+                    // Same warm-up gate as start_recording_capture; also
+                    // keeps a resuming device's leading zeros out of the
+                    // streaming backend.
+                    let warm_chunk = if self.config.audio.wait_for_device {
+                        audio::wait_for_signal(&mut chunk_rx, DEVICE_WARMUP_TIMEOUT).await
+                    } else {
+                        None
+                    };
                     // Bounded; backed-up streaming backend drops chunks
                     // rather than back-pressuring the capture.
                     let (streaming_tx, streaming_rx) = tokio::sync::mpsc::channel::<Vec<f32>>(64);
+
+                    // Unlike the batch path, this channel IS the
+                    // transcriber's audio input, and the chunk that proved
+                    // the device warm may already hold the onset of speech
+                    // (user talking during warm-up). Hand it on first so
+                    // nothing is clipped. Cannot fail: channel is empty.
+                    if let Some(chunk) = warm_chunk {
+                        let _ = streaming_tx.try_send(chunk);
+                    }
 
                     if let Some(handle) = self.level_emitter_task.take() {
                         handle.abort();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -892,7 +892,7 @@ impl Daemon {
 
         *audio_capture = Some(capture);
         *streaming_handle = Some(handle);
-        *streaming_session = Some(StreamingSession::new());
+        *streaming_session = Some(StreamingSession::new(self.config.output.type_delay_ms));
         *streaming_chain = Some(output::create_output_chain(&self.config.output));
         *state = State::Streaming {
             started_at: std::time::Instant::now(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1116,7 +1116,9 @@ impl Daemon {
                     // transcriber's audio input, and the chunk that proved
                     // the device warm may already hold the onset of speech
                     // (user talking during warm-up). Hand it on first so
-                    // nothing is clipped. Cannot fail: channel is empty.
+                    // nothing is clipped. The send cannot fail at this
+                    // point: the channel was just created and streaming_rx
+                    // is a local we still hold.
                     if let Some(chunk) = warm_chunk {
                         let _ = streaming_tx.try_send(chunk);
                     }

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -51,9 +51,12 @@ use super::TextOutput;
 use crate::error::OutputError;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::OnceLock;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+
+static SLOW_PATH_WARNING_EMITTED: OnceLock<()> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DotoolInvocation {
@@ -104,6 +107,7 @@ impl DotoolOutput {
         if let Some(ref layout) = xkb_layout {
             tracing::debug!("dotool: using keyboard layout '{}'", layout);
         }
+        Self::maybe_warn_slow_path(xkb_layout.as_deref(), xkb_variant.as_deref());
         Self {
             type_delay_ms,
             pre_type_delay_ms,
@@ -141,6 +145,23 @@ impl DotoolOutput {
             .open(&path)
             .ok()?;
         Some(path)
+    }
+
+    /// Warn if user has XKB override configured while dotoold is running.
+    fn maybe_warn_slow_path(xkb_layout: Option<&str>, xkb_variant: Option<&str>) {
+        if (xkb_layout.is_some() || xkb_variant.is_some()) && Self::daemon_pipe_path().is_some() {
+            let _ = SLOW_PATH_WARNING_EMITTED.get_or_init(|| {
+                if xkb_variant.is_some() {
+                    tracing::error!(
+                        "dotool configuration warning: XKB variant override detected while dotoold is running; dotoolc cannot receive per-call layout/variant hints, so voxtype will use direct dotool (~750ms vs ~3ms per output). If a fixed layout without variants is enough, configure DOTOOL_XKB_LAYOUT on dotoold and remove voxtype's dotool XKB override; otherwise this slowdown is expected."
+                    );
+                } else {
+                    tracing::error!(
+                        "dotool configuration warning: XKB layout override detected while dotoold is running; voxtype will use direct dotool (~750ms vs ~3ms per output). For the fast path, move DOTOOL_XKB_LAYOUT to dotoold's service environment and remove voxtype's dotool XKB layout override."
+                    );
+                }
+            });
+        }
     }
 
     fn build_commands(&self, text: &str) -> String {
@@ -434,5 +455,10 @@ mod tests {
     fn daemon_pipe_detection_respects_env_var() {
         let _guard = DotoolPipeEnvGuard::set("/nonexistent/dotool-pipe-test");
         assert!(DotoolOutput::daemon_pipe_path().is_none());
+    }
+    #[test]
+    fn maybe_warn_slow_path_does_not_panic() {
+        DotoolOutput::maybe_warn_slow_path(None, None);
+        DotoolOutput::maybe_warn_slow_path(Some("us"), None);
     }
 }

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -147,7 +147,7 @@ impl DotoolOutput {
         Some(path)
     }
 
-    /// Warn if user has XKB override configured while dotoold is running.
+    /// Emit a visible configuration error when XKB overrides force the slow direct-dotool path.
     fn maybe_warn_slow_path(xkb_layout: Option<&str>, xkb_variant: Option<&str>) {
         if (xkb_layout.is_some() || xkb_variant.is_some()) && Self::daemon_pipe_path().is_some() {
             let _ = SLOW_PATH_WARNING_EMITTED.get_or_init(|| {
@@ -456,8 +456,10 @@ mod tests {
         let _guard = DotoolPipeEnvGuard::set("/nonexistent/dotool-pipe-test");
         assert!(DotoolOutput::daemon_pipe_path().is_none());
     }
+
     #[test]
     fn maybe_warn_slow_path_does_not_panic() {
+        let _guard = DotoolPipeEnvGuard::set("/nonexistent/dotool-pipe-test");
         DotoolOutput::maybe_warn_slow_path(None, None);
         DotoolOutput::maybe_warn_slow_path(Some("us"), None);
     }

--- a/src/output/streaming.rs
+++ b/src/output/streaming.rs
@@ -67,15 +67,26 @@ pub struct StreamingSession {
     typed_chars: usize,
     /// Most recent partial text (for status only; never typed).
     partial: String,
+    /// Inter-key delay (ms) applied to backspace bursts, mirroring the
+    /// type path's `type_delay_ms`. Without it, revision backspaces fire
+    /// with dotool's tiny default `keydelay` (~2ms) — well under one
+    /// display frame — so KWin coalesces them and drops events. That
+    /// corrupts self-corrections two ways: a dropped backspace leaves a
+    /// stray character, and the un-spaced last backspace lets the
+    /// following retype's leading character (often a space) coalesce too.
+    type_delay_ms: u32,
 }
 
 impl StreamingSession {
-    /// Create a new empty session.
-    pub fn new() -> Self {
+    /// Create a new empty session. `type_delay_ms` is the configured
+    /// inter-key delay; it is applied to backspace bursts so they match
+    /// the type path's compositor-safe pacing.
+    pub fn new(type_delay_ms: u32) -> Self {
         Self {
             finalized_text: String::new(),
             typed_chars: 0,
             partial: String::new(),
+            type_delay_ms,
         }
     }
 
@@ -218,7 +229,7 @@ impl StreamingSession {
         // Cap backspace at what we've actually typed.
         let n = backspace.min(self.typed_chars);
         if n > 0 {
-            let emitted = emit_backspaces(n).await;
+            let emitted = emit_backspaces(n, self.type_delay_ms).await;
             if emitted == 0 {
                 // No backspace-capable backend ran. The cursor still
                 // shows the old partial — DO NOT touch our bookkeeping,
@@ -271,7 +282,7 @@ impl StreamingSession {
             return Ok(());
         }
 
-        if emit_backspaces(count).await > 0 {
+        if emit_backspaces(count, self.type_delay_ms).await > 0 {
             self.typed_chars = 0;
             return Ok(());
         }
@@ -286,42 +297,56 @@ impl StreamingSession {
     }
 }
 
-impl Default for StreamingSession {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Backspace `count` chars using the first available method.
-/// Returns the actual number of backspaces emitted.
-async fn emit_backspaces(count: usize) -> usize {
+/// Returns the actual number of backspaces emitted. `type_delay_ms`
+/// paces the key events so the compositor doesn't coalesce them (see
+/// [`StreamingSession::type_delay_ms`]).
+async fn emit_backspaces(count: usize, type_delay_ms: u32) -> usize {
     if count == 0 {
         return 0;
     }
-    if try_wtype_backspaces(count).await {
+    if try_wtype_backspaces(count, type_delay_ms).await {
         return count;
     }
-    if try_dotool_backspaces(count).await {
+    if try_dotool_backspaces(count, type_delay_ms).await {
         return count;
     }
-    if try_ydotool_backspaces(count).await {
+    if try_ydotool_backspaces(count, type_delay_ms).await {
         return count;
     }
     0
 }
 
-async fn try_wtype_backspaces(count: usize) -> bool {
-    // wtype invocation: `wtype -k BackSpace` repeated. Build args
-    // dynamically to send N keypresses in a single subprocess.
+async fn try_wtype_backspaces(count: usize, type_delay_ms: u32) -> bool {
+    // wtype invocation: `wtype -k BackSpace` repeated, sent as a single
+    // subprocess. See `build_wtype_backspace_args` for the `-s` pacing.
     let mut cmd = Command::new("wtype");
-    for _ in 0..count {
-        cmd.arg("-k").arg("BackSpace");
-    }
+    cmd.args(build_wtype_backspace_args(count, type_delay_ms));
     cmd.stdout(Stdio::null()).stderr(Stdio::null());
     matches!(cmd.status().await, Ok(s) if s.success())
 }
 
-async fn try_dotool_backspaces(count: usize) -> bool {
+/// Build the wtype argument list for `count` backspaces.
+///
+/// wtype's `-d` only paces inter-keystroke delay *when typing text*; it
+/// has NO effect on discrete `-k` key presses. The right knob is `-s
+/// TIME` ("sleep before interpreting the following options"), placed
+/// before each `-k` so the BackSpace presses are spaced out and the
+/// compositor doesn't coalesce them.
+fn build_wtype_backspace_args(count: usize, type_delay_ms: u32) -> Vec<String> {
+    let mut args = Vec::with_capacity(count * 4);
+    for _ in 0..count {
+        if type_delay_ms > 0 {
+            args.push("-s".to_string());
+            args.push(type_delay_ms.to_string());
+        }
+        args.push("-k".to_string());
+        args.push("BackSpace".to_string());
+    }
+    args
+}
+
+async fn try_dotool_backspaces(count: usize, type_delay_ms: u32) -> bool {
     // Prefer `dotoolc` whenever dotoold is actually accepting input.
     // Spawning raw `dotool` creates a *new* uinput keyboard per call;
     // KDE Plasma can drop events on the typing keyboard while these
@@ -344,10 +369,7 @@ async fn try_dotool_backspaces(count: usize) -> bool {
         Err(_) => return false,
     };
     if let Some(mut stdin) = child.stdin.take() {
-        let mut buf = String::with_capacity(count * "key backspace\n".len());
-        for _ in 0..count {
-            buf.push_str("key backspace\n");
-        }
+        let buf = build_dotool_backspace_commands(count, type_delay_ms);
         if stdin.write_all(buf.as_bytes()).await.is_err() {
             return false;
         }
@@ -356,11 +378,40 @@ async fn try_dotool_backspaces(count: usize) -> bool {
     matches!(child.wait().await, Ok(s) if s.success())
 }
 
-async fn try_ydotool_backspaces(count: usize) -> bool {
+/// Build the dotool command stream for `count` backspaces.
+///
+/// `key` events obey dotool's `keydelay`/`keyhold` (NOT `typedelay`/
+/// `typehold`, which only apply to `type`). The defaults (~2ms) are far
+/// below one display frame, so without pacing KWin coalesces the
+/// backspaces and drops some — leaving a stray character after a
+/// self-correction. Match the type path's `type_delay_ms`.
+fn build_dotool_backspace_commands(count: usize, type_delay_ms: u32) -> String {
+    if count == 0 {
+        // No keys to send — don't emit bare keydelay/keyhold that would
+        // mutate dotool's persistent state for nothing.
+        return String::new();
+    }
+    let mut buf = String::with_capacity(count * "key backspace\n".len() + 32);
+    if type_delay_ms > 0 {
+        buf.push_str(&format!("keydelay {}\n", type_delay_ms));
+        buf.push_str(&format!("keyhold {}\n", type_delay_ms));
+    }
+    for _ in 0..count {
+        buf.push_str("key backspace\n");
+    }
+    buf
+}
+
+async fn try_ydotool_backspaces(count: usize, type_delay_ms: u32) -> bool {
     // ydotool key 14:1 14:0 sends BackSpace press+release. Linux key
-    // codes: BackSpace = 14.
+    // codes: BackSpace = 14. `-d` paces key events like the dotool/wtype
+    // paths; ydotool's own default (12ms) wouldn't track the user's
+    // configured type_delay_ms.
     let mut cmd = Command::new("ydotool");
     cmd.arg("key");
+    if type_delay_ms > 0 {
+        cmd.arg("-d").arg(type_delay_ms.to_string());
+    }
     for _ in 0..count {
         cmd.arg("14:1").arg("14:0");
     }
@@ -427,7 +478,7 @@ mod tests {
     async fn commits_segment_and_tracks_typed_chars() {
         let rec = std::sync::Arc::new(RecordingOutput::new());
         let chain = chain_with(rec.clone());
-        let mut session = StreamingSession::new();
+        let mut session = StreamingSession::new(0);
 
         session
             .commit_segment(&chain, "hello", None, None, None)
@@ -451,7 +502,7 @@ mod tests {
         // must use scalars to send one BackSpace per visible char.
         let rec = std::sync::Arc::new(RecordingOutput::new());
         let chain = chain_with(rec.clone());
-        let mut session = StreamingSession::new();
+        let mut session = StreamingSession::new(0);
         session
             .commit_segment(&chain, "你好世", None, None, None)
             .await
@@ -463,7 +514,7 @@ mod tests {
     async fn empty_segment_is_noop() {
         let rec = std::sync::Arc::new(RecordingOutput::new());
         let chain = chain_with(rec.clone());
-        let mut session = StreamingSession::new();
+        let mut session = StreamingSession::new(0);
         session
             .commit_segment(&chain, "", None, None, None)
             .await
@@ -474,7 +525,7 @@ mod tests {
 
     #[tokio::test]
     async fn partial_buffer_is_replaced_not_appended() {
-        let mut session = StreamingSession::new();
+        let mut session = StreamingSession::new(0);
         session.observe_partial("hel".into());
         assert_eq!(session.partial(), "hel");
         session.observe_partial("hell".into());
@@ -490,7 +541,7 @@ mod tests {
     async fn finalize_clears_partial() {
         let rec = std::sync::Arc::new(RecordingOutput::new());
         let chain = chain_with(rec.clone());
-        let mut session = StreamingSession::new();
+        let mut session = StreamingSession::new(0);
         session.observe_partial("hel".into());
         session
             .commit_segment(&chain, "hello", None, None, None)
@@ -501,9 +552,57 @@ mod tests {
 
     #[tokio::test]
     async fn rewind_with_zero_chars_is_ok() {
-        let mut session = StreamingSession::new();
+        let mut session = StreamingSession::new(0);
         // Should succeed without spawning anything.
         session.rewind().await.unwrap();
         assert_eq!(session.typed_chars(), 0);
+    }
+
+    #[test]
+    fn dotool_backspaces_set_keydelay_and_keyhold_not_typedelay() {
+        // `key backspace` is paced by keydelay/keyhold; typedelay only
+        // affects `type`. Setting the wrong knob would leave backspaces
+        // at dotool's ~2ms default and let KWin coalesce them.
+        let cmds = build_dotool_backspace_commands(3, 17);
+        assert_eq!(
+            cmds,
+            "keydelay 17\nkeyhold 17\nkey backspace\nkey backspace\nkey backspace\n"
+        );
+        assert!(!cmds.contains("typedelay"));
+        assert!(!cmds.contains("typehold"));
+    }
+
+    #[test]
+    fn dotool_backspaces_omit_pacing_when_delay_is_zero() {
+        // type_delay_ms == 0 means the user opted out of delays (e.g. a
+        // compositor without the coalescing bug); don't force any.
+        let cmds = build_dotool_backspace_commands(2, 0);
+        assert_eq!(cmds, "key backspace\nkey backspace\n");
+    }
+
+    #[test]
+    fn dotool_backspaces_zero_count_emits_nothing() {
+        // No keys → no commands, so a stray call can't mutate dotool's
+        // persistent keydelay/keyhold for nothing.
+        assert_eq!(build_dotool_backspace_commands(0, 17), "");
+        assert_eq!(build_dotool_backspace_commands(0, 0), "");
+    }
+
+    #[test]
+    fn wtype_backspaces_sleep_before_each_key() {
+        // `-s TIME` (sleep before the next option) paces discrete `-k`
+        // presses; wtype's `-d` would be a no-op here (it only spaces
+        // keystrokes when typing text). One `-s` precedes each `-k`.
+        let args = build_wtype_backspace_args(2, 17);
+        assert_eq!(
+            args,
+            vec!["-s", "17", "-k", "BackSpace", "-s", "17", "-k", "BackSpace"]
+        );
+    }
+
+    #[test]
+    fn wtype_backspaces_omit_delay_when_zero() {
+        let args = build_wtype_backspace_args(2, 0);
+        assert_eq!(args, vec!["-k", "BackSpace", "-k", "BackSpace"]);
     }
 }


### PR DESCRIPTION
## Summary
- warn once when a Voxtype dotool XKB override forces direct dotool despite a running dotoold, with separate guidance for layout-only and variant overrides
- pace streaming backspace bursts using the configured output delay to avoid dropped/coalesced replacement events
- add audio device warm-up gating (wait_for_device) so recording-start cues wait for real input samples and reduce missed first words

## Verification
- cargo fmt --check
- cargo test dotool