### PR TITLE
fix: resolve Soniox model per-mode instead of swapping (Option<String>)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1508,7 +1508,7 @@ terms_file = "/home/me/dotfiles/voxtype-terms.json"
 **Default:** `false`
 **Required:** No
 
-Use the Soniox **async transcription API** (file upload + poll) instead of the realtime WebSocket. Different model (`stt-async-v5`), different accuracy profile, batch only — no live partials, no flicker, push-to-talk compatible.
+Use the Soniox **async transcription API** (file upload + poll) instead of the realtime WebSocket. Different model (`stt-async-v5` by default, unless `model` is set explicitly), different accuracy profile, batch only — no live partials, no flicker, push-to-talk compatible.
 
 When `true`:
 - Audio buffered while recording. On release, voxtype uploads the WAV to `https://api.soniox.com/v1/files`, creates a transcription job, polls until complete, fetches the transcript, then types it at the cursor in one shot.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1409,10 +1409,10 @@ export SONIOX_API_KEY="your-key-here"
 ### model
 
 **Type:** String
-**Default:** `"stt-rt-v5"`
+**Default:** unset (auto-selected per mode)
 **Required:** No
 
-Soniox model identifier. The current realtime model is `stt-rt-v5`. When `async_api = true`, a `model` left at a realtime default (`stt-rt-v4` or `stt-rt-v5`) is swapped to `stt-async-v5`; set `model` to any other value to override.
+Soniox model identifier. Leave it unset (the default) and voxtype picks the model for the active mode: `stt-rt-v5` for the realtime WebSocket, or `stt-async-v5` when `async_api = true` (including meeting mode, which always uses the async API). Set an explicit value to override — an explicit `model` is used verbatim in both modes, with no auto-swap, so only pin it if you specifically want that exact model in whichever mode runs.
 
 ### language_hints
 
@@ -1513,7 +1513,7 @@ Use the Soniox **async transcription API** (file upload + poll) instead of the r
 When `true`:
 - Audio buffered while recording. On release, voxtype uploads the WAV to `https://api.soniox.com/v1/files`, creates a transcription job, polls until complete, fetches the transcript, then types it at the cursor in one shot.
 - `streaming` and `type_partials` are ignored.
-- `model` defaults to `stt-async-v5`. A `model` left at a realtime default (`stt-rt-v4` or `stt-rt-v5`) is also swapped to `stt-async-v5`; any other explicit `model` is used as-is (override only if you know what you're doing).
+- `model` resolves to `stt-async-v5` when left unset; an explicit `model` is used verbatim (override only if you know what you're doing).
 - Push-to-talk is **not** auto-promoted to toggle (no live cursor typing means no compositor-state clobbering).
 
 Latency: typical 15s recording → ~1s upload + 2-5s processing = 3-6s total wait after release. Compare to realtime which streams partials as you speak.
@@ -1533,7 +1533,7 @@ Maximum total wait time (seconds) for an async API job to complete. If exceeded,
 | Option | CLI Flag | Environment Variable | Default | Description |
 |--------|----------|---------------------|---------|-------------|
 | `api_key` | `--soniox-api-key` | `SONIOX_API_KEY` | none (required) | Soniox API key |
-| `model` | - | - | realtime: `"stt-rt-v5"`; async: `"stt-async-v5"` | Soniox model identifier |
+| `model` | - | - | unset → realtime `stt-rt-v5`, async `stt-async-v5` | Explicit value used verbatim in both modes |
 | `language_hints` | - | - | `["hu", "en"]` | Language preference |
 | `language_hints_strict` | - | - | `true` | Restrict output to hinted languages (ignored if empty) |
 | `streaming` | - | - | `true` | Live WebSocket vs batch-on-release (realtime only) |

--- a/docs/SONIOX.md
+++ b/docs/SONIOX.md
@@ -145,7 +145,7 @@ See [CONFIGURATION.md → [soniox]](CONFIGURATION.md#soniox) for the full field-
 | Field | Default | Notes |
 |---|---|---|
 | `api_key` | env: `SONIOX_API_KEY` | Required |
-| `model` | realtime: `stt-rt-v5`; async: `stt-async-v5` | Advanced override |
+| `model` | unset → realtime `stt-rt-v5`, async `stt-async-v5` | Explicit value used verbatim in both modes |
 | `language_hints` | `["hu", "en"]` | Empty = auto-detect |
 | `language_hints_strict` | `true` | Restrict output to hinted languages (no-op if hints empty) |
 | `streaming` | `true` | Realtime live; ignored if `async_api` |

--- a/src/config/engines/soniox.rs
+++ b/src/config/engines/soniox.rs
@@ -4,6 +4,13 @@ use serde::{Deserialize, Serialize};
 
 use super::super::default_true;
 
+/// Default realtime (WebSocket) model id, used when `model` is unset.
+pub const DEFAULT_REALTIME_MODEL: &str = "stt-rt-v5";
+
+/// Default async (REST) model id, used when `model` is unset and `async_api`
+/// is enabled (including meeting mode).
+pub const DEFAULT_ASYNC_MODEL: &str = "stt-async-v5";
+
 /// Soniox cloud streaming WebSocket STT configuration
 /// Requires: cargo build --features soniox
 ///
@@ -15,9 +22,13 @@ pub struct SonioxConfig {
     #[serde(default)]
     pub api_key: Option<String>,
 
-    /// Soniox model name. Default: "stt-rt-v5".
-    #[serde(default = "default_soniox_model")]
-    pub model: String,
+    /// Soniox model id. When unset (the default), voxtype picks the model
+    /// for the active mode: `stt-rt-v5` for the realtime WebSocket, or
+    /// `stt-async-v5` when `async_api = true` (including meeting mode, which
+    /// always uses the async API). Set an explicit value to override; an
+    /// explicit model is used verbatim in both modes (no auto-swap).
+    #[serde(default)]
+    pub model: Option<String>,
 
     /// Language hints (ISO 639-1 codes). Default: ["hu", "en"].
     /// Empty array means auto-detect.
@@ -67,8 +78,8 @@ pub struct SonioxConfig {
     /// Use the Soniox async transcription API (file upload + poll) instead
     /// of the realtime WebSocket. Higher accuracy, PTT-compatible, batch
     /// only (no live partials). When true, overrides `streaming` and
-    /// `type_partials`. Default model becomes `stt-async-v5`.
-    /// Default: false.
+    /// `type_partials`. With `model` unset, the default model becomes
+    /// `stt-async-v5`. Default: false.
     #[serde(default)]
     pub async_api: bool,
 
@@ -78,8 +89,17 @@ pub struct SonioxConfig {
     pub async_max_wait_secs: u64,
 }
 
-fn default_soniox_model() -> String {
-    "stt-rt-v5".to_string()
+impl SonioxConfig {
+    /// Resolve the Soniox model id for the active mode. An explicit `model`
+    /// is used verbatim; when unset, the per-mode default is chosen
+    /// (`stt-async-v5` under `async_api`, otherwise `stt-rt-v5`).
+    pub fn resolved_model(&self) -> &str {
+        match self.model.as_deref() {
+            Some(m) => m,
+            None if self.async_api => DEFAULT_ASYNC_MODEL,
+            None => DEFAULT_REALTIME_MODEL,
+        }
+    }
 }
 
 fn default_soniox_language_hints() -> Vec<String> {
@@ -94,7 +114,7 @@ impl Default for SonioxConfig {
     fn default() -> Self {
         Self {
             api_key: None,
-            model: default_soniox_model(),
+            model: None,
             language_hints: default_soniox_language_hints(),
             language_hints_strict: true,
             streaming: true,
@@ -105,5 +125,53 @@ impl Default for SonioxConfig {
             async_api: false,
             async_max_wait_secs: default_soniox_async_max_wait_secs(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_model_resolves_to_realtime_default() {
+        let cfg = SonioxConfig::default();
+        assert!(!cfg.async_api);
+        assert_eq!(cfg.resolved_model(), DEFAULT_REALTIME_MODEL);
+    }
+
+    #[test]
+    fn unset_model_resolves_to_async_default_under_async_api() {
+        let cfg = SonioxConfig {
+            async_api: true,
+            ..Default::default()
+        };
+        assert_eq!(cfg.resolved_model(), DEFAULT_ASYNC_MODEL);
+    }
+
+    #[test]
+    fn explicit_model_is_used_verbatim_in_both_modes() {
+        let realtime = SonioxConfig {
+            model: Some("stt-rt-v5".into()),
+            async_api: false,
+            ..Default::default()
+        };
+        assert_eq!(realtime.resolved_model(), "stt-rt-v5");
+
+        // Explicit model survives async_api: no auto-swap. A user who pins a
+        // model owns the choice in both modes.
+        let async_pinned = SonioxConfig {
+            model: Some("stt-rt-v5".into()),
+            async_api: true,
+            ..Default::default()
+        };
+        assert_eq!(async_pinned.resolved_model(), "stt-rt-v5");
+    }
+
+    #[test]
+    fn unset_model_omitted_from_serialized_toml() {
+        // None must not write a `model = ...` line, so meeting mode keeps
+        // resolving to the async default for default configs.
+        let toml = toml::to_string(&SonioxConfig::default()).unwrap();
+        assert!(!toml.contains("model"), "unexpected model key in:\n{toml}");
     }
 }

--- a/src/config/engines/soniox.rs
+++ b/src/config/engines/soniox.rs
@@ -172,6 +172,9 @@ mod tests {
         // None must not write a `model = ...` line, so meeting mode keeps
         // resolving to the async default for default configs.
         let toml = toml::to_string(&SonioxConfig::default()).unwrap();
-        assert!(!toml.contains("model"), "unexpected model key in:\n{toml}");
+        assert!(
+            !toml.contains("model ="),
+            "unexpected model key in:\n{toml}"
+        );
     }
 }

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -357,7 +357,7 @@ impl Config {
             TranscriptionEngine::Soniox => self
                 .soniox
                 .as_ref()
-                .map(|s| s.model.as_str())
+                .map(|s| s.resolved_model())
                 .unwrap_or("soniox (not configured)"),
         }
     }

--- a/src/transcribe/soniox.rs
+++ b/src/transcribe/soniox.rs
@@ -141,7 +141,7 @@ fn load_context_terms(config: &SonioxConfig) -> Result<Vec<String>, TranscribeEr
 }
 
 impl SonioxTranscriber {
-    pub fn new(mut config: SonioxConfig) -> Result<Self, TranscribeError> {
+    pub fn new(config: SonioxConfig) -> Result<Self, TranscribeError> {
         let api_key = config
             .api_key
             .clone()
@@ -152,18 +152,12 @@ impl SonioxTranscriber {
                 )
             })?;
 
-        // User left the default realtime model with async_api enabled —
-        // swap to the current async-default model.
-        if config.async_api && matches!(config.model.as_str(), "stt-rt-v4" | "stt-rt-v5") {
-            config.model = "stt-async-v5".to_string();
-        }
-
         let context_terms = load_context_terms(&config)?;
 
         if config.async_api {
             tracing::info!(
                 "Soniox backend configured: mode=async, model={}, language_hints={:?} (strict={}), context_terms={}",
-                config.model,
+                config.resolved_model(),
                 config.language_hints,
                 config.language_hints_strict,
                 context_terms.len(),
@@ -171,7 +165,7 @@ impl SonioxTranscriber {
         } else {
             tracing::info!(
                 "Soniox backend configured: mode=realtime, model={}, streaming={}, language_hints={:?} (strict={}), context_terms={}",
-                config.model,
+                config.resolved_model(),
                 config.streaming,
                 config.language_hints,
                 config.language_hints_strict,
@@ -209,7 +203,7 @@ impl SonioxTranscriber {
         // works either way because we drive `{"type":"finalize"}` explicitly.
         let mut obj = serde_json::json!({
             "api_key": self.api_key,
-            "model": self.config.model,
+            "model": self.config.resolved_model(),
             "audio_format": AUDIO_FORMAT,
             "sample_rate": SAMPLE_RATE,
             "num_channels": 1,
@@ -735,7 +729,7 @@ impl SonioxTranscriber {
 
         // 2. Create transcription job.
         let mut body = serde_json::json!({
-            "model": self.config.model,
+            "model": self.config.resolved_model(),
             "file_id": file_id,
         });
         if !self.config.language_hints.is_empty() {
@@ -1157,7 +1151,7 @@ mod tests {
     fn cfg_with_key(key: Option<&str>) -> SonioxConfig {
         SonioxConfig {
             api_key: key.map(|s| s.to_string()),
-            model: "stt-rt-v5".into(),
+            model: None,
             language_hints: vec!["hu".into(), "en".into()],
             language_hints_strict: true,
             streaming: true,
@@ -1176,27 +1170,24 @@ mod tests {
         cfg.async_api = true;
         let t = SonioxTranscriber::new(cfg).unwrap();
         assert!(t.as_streaming().is_none());
-        assert_eq!(t.config.model, "stt-async-v5");
+        // Unset model resolves to the async default under async_api.
+        assert_eq!(t.config.resolved_model(), "stt-async-v5");
     }
 
     #[test]
-    fn async_api_swaps_legacy_v4_realtime_default() {
-        // Backwards-compat: a config left on the old realtime default
-        // (`stt-rt-v4`) still routes to the current async default under async_api.
-        let mut cfg = cfg_with_key(Some("k"));
-        cfg.async_api = true;
-        cfg.model = "stt-rt-v4".into();
-        let t = SonioxTranscriber::new(cfg).unwrap();
-        assert_eq!(t.config.model, "stt-async-v5");
+    fn unset_model_resolves_to_realtime_default() {
+        let t = SonioxTranscriber::new(cfg_with_key(Some("k"))).unwrap();
+        assert_eq!(t.config.resolved_model(), "stt-rt-v5");
     }
 
     #[test]
-    fn async_api_keeps_explicit_model_override() {
+    fn explicit_model_is_used_verbatim_under_async_api() {
+        // No auto-swap: a pinned model is sent as-is to whichever API is active.
         let mut cfg = cfg_with_key(Some("k"));
         cfg.async_api = true;
-        cfg.model = "stt-async-experimental".into();
+        cfg.model = Some("stt-async-experimental".into());
         let t = SonioxTranscriber::new(cfg).unwrap();
-        assert_eq!(t.config.model, "stt-async-experimental");
+        assert_eq!(t.config.resolved_model(), "stt-async-experimental");
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #504 (base: `feature/soniox-v5`). Retarget to `dev` once #504 merges.

## Problem

Soniox has a single `model` config field shared by the realtime WebSocket and async REST paths. The swap heuristic (`stt-rt-*` → `stt-async-v5` under `async_api`) couldn't distinguish "user explicitly set `stt-rt-v5`" from "user left the default" — both are the same string — so an *explicit* realtime pin still got silently rewritten under `async_api`/meeting mode. The docs had to warn about this surprise.

## Change

Make `model` an `Option<String>` (None = unset) and resolve at the use site:

- **Unset** → per-mode default: `stt-rt-v5` (realtime) or `stt-async-v5` (async, including meeting mode, which always uses async).
- **Explicit** → used verbatim in both modes, no auto-swap.

A single `resolved_model()` method centralizes this; the swap block in `SonioxTranscriber::new` is gone, and the WS init frame, async request body, logging, and `Config::model_name()` all route through it. No second config field added.

## Backwards compatibility

- Default configs are unaffected: `None` still resolves to `stt-async-v5` in meeting mode.
- `None` is omitted from serialized TOML (verified by test), so nothing writes an explicit `model` into a user's config. `save_config` is dead code, `config_set` does comment-preserving surgical edits, and the shipped template has no `[soniox] model` line — so a `model` value is present only if hand-typed.
- **One behavior change:** a user who *explicitly* pinned `model = "stt-rt-v5"` (or `stt-rt-v4`) *and* uses async/meeting mode previously got auto-swapped to `stt-async-v5`; now the explicit pin is honored as-is. Rare, and arguably the more correct reading of an explicit override.

## Tests

- New resolver tests in `config/engines/soniox.rs` (run without the `soniox` feature): unset→realtime, unset+async→async, explicit-verbatim-in-both-modes, and `None`-omitted-from-TOML.
- Updated transcriber tests for the new semantics.
- fmt, clippy (`-D warnings`), build (default + `soniox`), and lib tests all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)