### PR TITLE
Fix remote Whisper model and Unicode output fallback

### DIFF
--- a/src/model_manager.rs
+++ b/src/model_manager.rs
@@ -83,9 +83,10 @@ impl ModelManager {
             return self.get_transcriber(None);
         }
 
-        // For remote backend, create transcriber with model override
+        // For remote backend, preserve configured remote_model unless the
+        // caller supplied an explicit runtime model override.
         if self.config.effective_mode() == WhisperMode::Remote {
-            return self.create_remote_transcriber(&model_name);
+            return self.create_remote_transcriber(model);
         }
 
         // For CLI backend, create transcriber each time (no caching needed)
@@ -102,14 +103,15 @@ impl ModelManager {
         self.get_or_load_cached(&model_name)
     }
 
-    /// Create a remote transcriber with model override
+    /// Create a remote transcriber with optional runtime model override
     fn create_remote_transcriber(
         &self,
-        model: &str,
+        model_override: Option<&str>,
     ) -> Result<Arc<dyn Transcriber>, TranscribeError> {
         let mut config = self.config.clone();
-        // Override remote_model with requested model
-        config.remote_model = Some(model.to_string());
+        if let Some(model) = model_override {
+            config.remote_model = Some(model.to_string());
+        }
         let transcriber = transcribe::remote::RemoteTranscriber::new(&config)?;
         Ok(Arc::new(transcriber))
     }
@@ -310,8 +312,9 @@ impl ModelManager {
             return Ok(prepared.transcriber);
         }
 
-        // No prepared transcriber, get normally
-        self.get_transcriber(Some(&model_name))
+        // No prepared transcriber, get normally. Preserve None so remote mode
+        // can use whisper.remote_model instead of the local default model.
+        self.get_transcriber(model)
     }
 
     /// Get the list of currently loaded models (for debugging/status)
@@ -327,6 +330,10 @@ impl ModelManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc::{self, Receiver};
+    use std::thread::JoinHandle;
 
     fn test_config() -> WhisperConfig {
         WhisperConfig {
@@ -339,6 +346,54 @@ mod tests {
             cold_model_timeout_secs: 300,
             ..Default::default()
         }
+    }
+
+    fn spawn_remote_transcription_server() -> (String, Receiver<String>, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let (tx, rx) = mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 1024];
+            let mut header_end = None;
+            let mut content_length = None;
+
+            while header_end.is_none()
+                || request.len() < header_end.unwrap() + content_length.unwrap_or(0)
+            {
+                let read = stream.read(&mut buffer).unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+
+                if header_end.is_none() {
+                    if let Some(pos) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                        let end = pos + 4;
+                        let headers = String::from_utf8_lossy(&request[..end]);
+                        content_length = headers.lines().find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        });
+                        header_end = Some(end);
+                    }
+                }
+            }
+
+            let body = header_end
+                .map(|end| String::from_utf8_lossy(&request[end..]).to_string())
+                .unwrap_or_default();
+            tx.send(body).unwrap();
+
+            let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\n\r\n{\"text\":\"ok\"}";
+            stream.write_all(response).unwrap();
+        });
+
+        (endpoint, rx, handle)
     }
 
     #[test]
@@ -367,5 +422,26 @@ mod tests {
         assert_eq!(manager.max_loaded, 2);
         assert_eq!(manager.cold_timeout, Duration::from_secs(300));
         assert!(manager.loaded_models.is_empty());
+    }
+
+    #[test]
+    fn test_remote_prepared_transcriber_uses_remote_model_without_override() {
+        let (endpoint, body_rx, server) = spawn_remote_transcription_server();
+        let config = WhisperConfig {
+            mode: Some(WhisperMode::Remote),
+            model: "large-v3-turbo".to_string(),
+            remote_endpoint: Some(endpoint),
+            remote_model: Some("whisper-large-v3-turbo".to_string()),
+            ..Default::default()
+        };
+        let mut manager = ModelManager::new(&config, None);
+
+        let transcriber = manager.get_prepared_transcriber(None).unwrap();
+        assert_eq!(transcriber.transcribe(&[0.0; 160]).unwrap(), "ok");
+
+        let body = body_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(body.contains("name=\"model\"\r\n\r\nwhisper-large-v3-turbo\r\n"));
+        assert!(!body.contains("name=\"model\"\r\n\r\nlarge-v3-turbo\r\n"));
+        server.join().unwrap();
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -303,6 +303,19 @@ fn create_driver_output(
     }
 }
 
+#[cfg(not(target_os = "macos"))]
+fn create_paste_output(config: &OutputConfig, pre_type_delay_ms: u32) -> Box<dyn TextOutput> {
+    Box::new(paste::PasteOutput::new(
+        config.auto_submit,
+        config.append_text.clone(),
+        config.paste_keys.clone(),
+        config.type_delay_ms,
+        pre_type_delay_ms,
+        config.restore_clipboard,
+        config.restore_clipboard_delay_ms,
+    ))
+}
+
 /// Factory function that returns a fallback chain of output methods
 pub fn create_output_chain(config: &OutputConfig) -> Vec<Box<dyn TextOutput>> {
     create_output_chain_with_override(config, None)
@@ -365,7 +378,15 @@ pub fn create_output_chain_with_override(
                     );
                 }
 
+                let mut paste_fallback_inserted = false;
                 for driver in driver_order.iter() {
+                    if config.fallback_to_clipboard
+                        && !paste_fallback_inserted
+                        && matches!(driver, OutputDriver::Clipboard | OutputDriver::Xclip)
+                    {
+                        chain.push(create_paste_output(config, pre_type_delay_ms));
+                        paste_fallback_inserted = true;
+                    }
                     chain.push(create_driver_output(*driver, config, pre_type_delay_ms));
                 }
 
@@ -374,6 +395,9 @@ pub fn create_output_chain_with_override(
                     && config.driver_order.is_some()
                     && !driver_order.contains(&OutputDriver::Clipboard)
                 {
+                    if !paste_fallback_inserted {
+                        chain.push(create_paste_output(config, pre_type_delay_ms));
+                    }
                     chain.push(Box::new(clipboard::ClipboardOutput::new(
                         config.append_text.clone(),
                     )));
@@ -465,6 +489,18 @@ fn is_keystroke_method(name: &str) -> bool {
     matches!(name, "wtype" | "eitype" | "dotool" | "ydotool") || name.starts_with("paste")
 }
 
+/// dotool/ydotool synthesize key events through the active keyboard layout.
+/// They can exit successfully while non-ASCII text is not inserted when the
+/// active layout cannot produce those characters. Prefer layout-independent
+/// methods (wtype/eitype/paste) for Unicode text.
+fn needs_layout_independent_output(text: &str) -> bool {
+    text.chars().any(|c| !c.is_ascii())
+}
+
+fn is_layout_dependent_text_method(name: &str) -> bool {
+    matches!(name, "dotool" | "ydotool")
+}
+
 /// Try each output method in the chain until one succeeds
 /// Pre/post output commands are run before and after typing (for compositor integration).
 pub async fn output_with_fallback(
@@ -474,6 +510,7 @@ pub async fn output_with_fallback(
 ) -> Result<(), OutputError> {
     // Normalize curly quotes to ASCII to prevent line break issues with keyboard tools
     let normalized_text = normalize_quotes(text);
+    let needs_layout_independent_output = needs_layout_independent_output(normalized_text.as_ref());
 
     // If the modifier guard is enabled, snapshot kernel-level key state and
     // wait for any held modifiers to be released. This prevents typed letters
@@ -529,6 +566,14 @@ pub async fn output_with_fallback(
             continue;
         }
 
+        if needs_layout_independent_output && is_layout_dependent_text_method(output.name()) {
+            tracing::debug!(
+                "{} skipped for non-ASCII text; trying layout-independent output",
+                output.name()
+            );
+            continue;
+        }
+
         if !output.is_available().await {
             tracing::debug!("{} not available, trying next", output.name());
             continue;
@@ -560,6 +605,37 @@ pub async fn output_with_fallback(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
+
+    struct FakeOutput {
+        name: &'static str,
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl TextOutput for FakeOutput {
+        async fn output(&self, _text: &str) -> Result<(), OutputError> {
+            self.calls.lock().unwrap().push(self.name);
+            Ok(())
+        }
+
+        async fn is_available(&self) -> bool {
+            true
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+    }
+
+    fn output_options_without_hooks() -> OutputOptions<'static> {
+        OutputOptions {
+            pre_output_command: None,
+            post_output_command: None,
+            wait_for_modifier_release: false,
+            modifier_release_timeout: std::time::Duration::from_millis(0),
+        }
+    }
 
     #[test]
     fn test_normalize_quotes_no_change() {
@@ -622,6 +698,75 @@ mod tests {
         assert!(is_keystroke_method("paste (clipboard + keystroke)"));
         assert!(!is_keystroke_method("clipboard (wl-copy)"));
         assert!(!is_keystroke_method("clipboard (xclip/xsel)"));
+    }
+
+    #[tokio::test]
+    async fn test_non_ascii_text_skips_layout_dependent_dotool() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let chain: Vec<Box<dyn TextOutput>> = vec![
+            Box::new(FakeOutput {
+                name: "dotool",
+                calls: calls.clone(),
+            }),
+            Box::new(FakeOutput {
+                name: "paste (clipboard + keystroke)",
+                calls: calls.clone(),
+            }),
+        ];
+
+        output_with_fallback(&chain, "السلام عليكم", output_options_without_hooks())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            ["paste (clipboard + keystroke)"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ascii_text_can_use_dotool() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let chain: Vec<Box<dyn TextOutput>> = vec![
+            Box::new(FakeOutput {
+                name: "dotool",
+                calls: calls.clone(),
+            }),
+            Box::new(FakeOutput {
+                name: "paste (clipboard + keystroke)",
+                calls: calls.clone(),
+            }),
+        ];
+
+        output_with_fallback(&chain, "hello", output_options_without_hooks())
+            .await
+            .unwrap();
+
+        assert_eq!(calls.lock().unwrap().as_slice(), ["dotool"]);
+    }
+
+    #[test]
+    fn test_type_chain_adds_paste_before_clipboard_fallback() {
+        let config = OutputConfig {
+            mode: crate::config::OutputMode::Type,
+            driver_order: Some(vec![OutputDriver::Dotool, OutputDriver::Clipboard]),
+            fallback_to_clipboard: true,
+            ..OutputConfig::default()
+        };
+
+        let names: Vec<&str> = create_output_chain(&config)
+            .iter()
+            .map(|output| output.name())
+            .collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "dotool",
+                "paste (clipboard + keystroke)",
+                "clipboard (wl-copy)"
+            ]
+        );
     }
 
     #[test]

--- a/src/output/paste.rs
+++ b/src/output/paste.rs
@@ -128,6 +128,24 @@ impl ParsedKeystroke {
 
         Ok(args)
     }
+
+    /// Convert to dotool commands
+    /// e.g., "ctrl+v" -> "key ctrl+v\n"
+    fn to_dotool_commands(&self, key_delay_ms: u32) -> String {
+        let chord = if self.modifiers.is_empty() {
+            self.key.clone()
+        } else {
+            format!("{}+{}", self.modifiers.join("+"), self.key)
+        };
+
+        let mut commands = String::new();
+        if key_delay_ms > 0 {
+            commands.push_str(&format!("keydelay {}\n", key_delay_ms));
+            commands.push_str(&format!("keyhold {}\n", key_delay_ms));
+        }
+        commands.push_str(&format!("key {}\n", chord));
+        commands
+    }
 }
 
 /// Convert a key name to its evdev code
@@ -563,6 +581,18 @@ impl PasteOutput {
             .unwrap_or(false)
     }
 
+    /// Check if dotool is available
+    async fn is_dotool_available(&self) -> bool {
+        Command::new("which")
+            .arg("dotool")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
     /// Check if ydotool is available (installed and daemon running)
     async fn is_ydotool_available(&self) -> bool {
         // Check if ydotool exists
@@ -653,6 +683,56 @@ impl PasteOutput {
         Ok(())
     }
 
+    /// Simulate paste keystroke using dotool
+    async fn simulate_paste_dotool(&self) -> Result<(), OutputError> {
+        let commands = self.keystroke.to_dotool_commands(self.type_delay_ms);
+        tracing::debug!(
+            "Running: dotool {}",
+            commands.trim_end().replace('\n', "; ")
+        );
+
+        let mut child = Command::new("dotool")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    OutputError::DotoolNotFound
+                } else {
+                    OutputError::CtrlVFailed(e.to_string())
+                }
+            })?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(commands.as_bytes())
+                .await
+                .map_err(|e| OutputError::CtrlVFailed(e.to_string()))?;
+            drop(stdin);
+        }
+
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| OutputError::CtrlVFailed(e.to_string()))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("uinput") || stderr.contains("permission") {
+                return Err(OutputError::CtrlVFailed(
+                    "dotool uinput permission denied. Is user in 'input' group?".to_string(),
+                ));
+            }
+            return Err(OutputError::CtrlVFailed(format!(
+                "dotool failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Simulate paste keystroke using ydotool
     async fn simulate_paste_ydotool(&self) -> Result<(), OutputError> {
         let args = self.keystroke.to_ydotool_args().map_err(|e| {
@@ -705,7 +785,7 @@ impl PasteOutput {
         Ok(())
     }
 
-    /// Simulate paste keystroke, trying wtype first, then eitype, then ydotool
+    /// Simulate paste keystroke, trying wtype first, then eitype, then dotool, then ydotool
     async fn simulate_paste_keystroke(&self) -> Result<(), OutputError> {
         // Try wtype first (preferred - no daemon needed)
         if self.is_wtype_available().await {
@@ -733,6 +813,19 @@ impl PasteOutput {
             }
         }
 
+        // Try dotool (uinput, no daemon; useful when compositor rejects wtype)
+        if self.is_dotool_available().await {
+            match self.simulate_paste_dotool().await {
+                Ok(()) => {
+                    tracing::debug!("Paste keystroke sent via dotool");
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::debug!("dotool paste failed: {}, trying ydotool", e);
+                }
+            }
+        }
+
         // Fall back to ydotool
         if self.is_ydotool_available().await {
             match self.simulate_paste_ydotool().await {
@@ -748,7 +841,7 @@ impl PasteOutput {
         }
 
         Err(OutputError::CtrlVFailed(
-            "No keystroke tool available (tried wtype, eitype, ydotool)".to_string(),
+            "No keystroke tool available (tried wtype, eitype, dotool, ydotool)".to_string(),
         ))
     }
 
@@ -943,20 +1036,22 @@ impl TextOutput for PasteOutput {
         // Check if wtype, eitype, or ydotool is available for keystroke simulation
         let wtype_available = self.is_wtype_available().await;
         let eitype_available = self.is_eitype_available().await;
+        let dotool_available = self.is_dotool_available().await;
         let ydotool_available = self.is_ydotool_available().await;
 
-        if !wtype_available && !eitype_available && !ydotool_available {
+        if !wtype_available && !eitype_available && !dotool_available && !ydotool_available {
             tracing::debug!(
                 "paste mode unavailable: no keystroke tool available \
-                (wtype needs WAYLAND_DISPLAY, eitype needs libei, ydotool needs daemon running)"
+                (wtype needs WAYLAND_DISPLAY, eitype needs libei, dotool needs uinput, ydotool needs daemon running)"
             );
             return false;
         }
 
         tracing::debug!(
-            "paste mode available (wtype: {}, eitype: {}, ydotool: {})",
+            "paste mode available (wtype: {}, eitype: {}, dotool: {}, ydotool: {})",
             wtype_available,
             eitype_available,
+            dotool_available,
             ydotool_available
         );
         true
@@ -995,5 +1090,20 @@ mod tests {
         assert!(debug_str.contains("[5 bytes]"));
         assert!(debug_str.contains("text/plain"));
         assert!(!debug_str.contains("[1, 2, 3"));
+    }
+
+    #[test]
+    fn test_ctrl_v_to_dotool_command() {
+        let keystroke = ParsedKeystroke::parse("ctrl+v").unwrap();
+        assert_eq!(keystroke.to_dotool_commands(0), "key ctrl+v\n");
+    }
+
+    #[test]
+    fn test_shift_insert_to_dotool_command_with_delay() {
+        let keystroke = ParsedKeystroke::parse("shift+insert").unwrap();
+        assert_eq!(
+            keystroke.to_dotool_commands(12),
+            "keydelay 12\nkeyhold 12\nkey shift+insert\n"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the remote Whisper/Groq path from issue #496 and the follow-up output failure found while validating it with Arabic text.

## What Changed

- Preserve `[whisper].remote_model` when remote mode is used without a per-recording model override.
- Keep explicit `--model` / model modifier behavior working by only overriding `remote_model` when the caller actually supplies a runtime model.
- Avoid direct `dotool`/`ydotool` text typing for non-ASCII output, because those drivers are layout-dependent and can report success while inserting nothing or wrong characters.
- Insert paste-mode fallback before clipboard-only fallback in `mode = "type"`.
- Allow paste mode to send the paste shortcut through `dotool key ctrl+v`, which covers compositors that reject `wtype` and systems without a running `ydotoold`.

## Root Cause

`ModelManager::get_prepared_transcriber(None)` converted the absence of a runtime model override into `config.model`. Remote mode then wrote that local model name into `remote_model`, so OpenAI-compatible APIs like Groq received the wrong model.

After fixing that, Groq returned correct Arabic text, but the output chain stopped at direct `dotool` typing. `dotool` and `ydotool` synthesize layout-dependent key events, so they are not reliable for Unicode text when the active layout/compositor cannot produce those characters. The new path uses clipboard paste for non-ASCII text while still sending the paste keystroke automatically.

Closes #496.

## Validation

- `cargo fmt --check`
- `cargo test` (834 passed)
- Manual Groq validation with:
  - `remote_endpoint = "https://api.groq.com/openai"`
  - `remote_model = "whisper-large-v3-turbo"`
  - Arabic transcription on a compositor without virtual-keyboard protocol support
  - observed output path: skip direct `dotool`/`ydotool`, `wtype` fails, paste succeeds via `dotool key ctrl+v`
