### PR TITLE
Fix 100% CPU spin when an input device is unplugged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,15 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "evdev"
-version = "0.12.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6055a93a963297befb0f4f6e18f314aec9767a4bbe88b151126df2433610a7"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
 dependencies = [
  "bitvec",
  "cfg-if",
  "libc",
- "nix 0.23.2",
- "thiserror 1.0.69",
+ "nix",
 ]
 
 [[package]]
@@ -1534,7 +1533,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "rustc_version",
 ]
 
@@ -3207,15 +3206,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -3450,19 +3440,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -3471,7 +3448,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -4629,7 +4606,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5738,7 +5715,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -5984,7 +5961,7 @@ dependencies = [
  "libc",
  "mac-notification-sys",
  "ndarray 0.16.1",
- "nix 0.29.0",
+ "nix",
  "notify",
  "num_cpus",
  "ort",
@@ -7324,7 +7301,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix 0.29.0",
+ "nix",
  "ordered-stream",
  "rand 0.8.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ tray-icon = "0.21.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Input handling (evdev for kernel-level key events)
-evdev = "0.12"
+evdev = "0.13.2"
 inotify = "0.10"  # Watch /dev/input for device hotplug
 nix = { version = "0.29", features = ["signal", "process"] }  # Unix signals for IPC
 # MPRIS media-player control over the session bus. Talking D-Bus directly

--- a/src/error.rs
+++ b/src/error.rs
@@ -184,10 +184,3 @@ pub enum MeetingError {
 
 /// Result type alias using VoxtypeError
 pub type Result<T> = std::result::Result<T, VoxtypeError>;
-
-#[cfg(target_os = "linux")]
-impl From<evdev::Error> for HotkeyError {
-    fn from(e: evdev::Error) -> Self {
-        HotkeyError::Evdev(e.to_string())
-    }
-}

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -227,6 +227,23 @@ impl DeviceManager {
     fn try_open_device(&mut self, path: &PathBuf) {
         match Device::open(path) {
             Ok(device) => {
+                // Skip virtual keyboards created by text-injection tools
+                // (dotool, ydotool, xdotool). voxtype types its transcription out
+                // through one of these; grabbing it back is pointless and, when the
+                // tool tears down its short-lived uinput device, leaves a stale fd
+                // that spins fetch_events() at 100% CPU. See issue #445.
+                let is_injection_device = device
+                    .name()
+                    .map(|n| {
+                        let n = n.to_ascii_lowercase();
+                        n.contains("dotool") || n.contains("wtype") || n.contains("xdotool")
+                    })
+                    .unwrap_or(false);
+                if is_injection_device {
+                    tracing::debug!("Skipping virtual injection keyboard: {:?}", device.name());
+                    return;
+                }
+
                 // Check if device has keyboard capabilities
                 let has_keys = device
                     .supported_keys()
@@ -355,6 +372,23 @@ impl DeviceManager {
         let mut error_paths = Vec::new();
 
         for (path, device) in &mut self.devices {
+            // Detect a hung-up / disconnected fd before reading. When a uinput
+            // device (e.g. dotool's virtual keyboard) is destroyed, its fd can be
+            // left in a state where fetch_events() never returns ENODEV and instead
+            // spins at 100% CPU. poll() reliably reports POLLHUP/POLLERR/POLLNVAL for
+            // such a dead fd, so we drop it before ever calling fetch_events().
+            let mut pfd = libc::pollfd {
+                fd: device.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let pret = unsafe { libc::poll(&mut pfd, 1, 0) };
+            if pret > 0 && (pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)) != 0 {
+                tracing::debug!("Device hung up (POLLHUP/POLLERR): {:?}", path);
+                error_paths.push(path.clone());
+                continue;
+            }
+
             match device.fetch_events() {
                 Ok(device_events) => {
                     for event in device_events {
@@ -363,15 +397,14 @@ impl DeviceManager {
                         }
                     }
                 }
-                Err(ref e) if e.raw_os_error() == Some(libc::ENODEV) => {
-                    tracing::debug!("Device gone (ENODEV): {:?}", path);
-                    error_paths.push(path.clone());
-                }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // No events available, this is normal for non-blocking
                 }
                 Err(e) => {
-                    tracing::trace!("Device read error on {:?}: {}", path, e);
+                    // Any other error (ENODEV, EIO, ...) means the device is gone or
+                    // unusable - drop it rather than retrying forever.
+                    tracing::debug!("Device read error on {:?}: {} - removing", path, e);
+                    error_paths.push(path.clone());
                 }
             }
         }

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -11,7 +11,7 @@
 use super::{HotkeyEvent, HotkeyListener};
 use crate::config::HotkeyConfig;
 use crate::error::HotkeyError;
-use evdev::{Device, InputEventKind, Key};
+use evdev::{Device, EventType, KeyCode as Key};
 use inotify::{Inotify, WatchMask};
 use std::collections::{HashMap, HashSet};
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -380,8 +380,8 @@ impl DeviceManager {
             match device.fetch_events() {
                 Ok(device_events) => {
                     for event in device_events {
-                        if let InputEventKind::Key(key) = event.kind() {
-                            events.push((key, event.value()));
+                        if event.event_type() == EventType::KEY {
+                            events.push((Key::new(event.code()), event.value()));
                         }
                     }
                 }
@@ -878,7 +878,7 @@ mod tests {
 
     #[test]
     fn poll_guard_drops_real_torn_down_evdev_device() {
-        use evdev::{uinput::VirtualDeviceBuilder, AttributeSet};
+        use evdev::{uinput::VirtualDevice, AttributeSet};
         use std::thread::sleep;
         use std::time::Duration;
 
@@ -888,7 +888,7 @@ mod tests {
         // against a genuine evdev fd torn down by UI_DEV_DESTROY.
         let mut keys = AttributeSet::<Key>::new();
         keys.insert(Key::KEY_PLAYPAUSE);
-        let builder = match VirtualDeviceBuilder::new() {
+        let builder = match VirtualDevice::builder() {
             Ok(b) => b,
             Err(e) => {
                 eprintln!("skipping: uinput unavailable ({e})");
@@ -975,6 +975,105 @@ mod tests {
             flagged,
             "guard failed to flag a torn-down evdev fd; poll_events would spin"
         );
+    }
+
+    #[test]
+    fn synced_fetch_recovers_multiple_held_keys_after_overflow() {
+        use evdev::{uinput::VirtualDevice, AttributeSet, InputEvent};
+        use std::thread::sleep;
+        use std::time::Duration;
+
+        // evdev 0.12 loses the absolute key-code offset while compensating after
+        // SYN_DROPPED. Multiple held keys can then make fetch_events() loop forever.
+        // Create enough key traffic to overflow the kernel ring and require that
+        // both held keys are restored by the next synchronized fetch.
+        let mut keys = AttributeSet::<Key>::new();
+        for code in 1..59 {
+            keys.insert(Key::new(code));
+        }
+
+        let builder = match VirtualDevice::builder() {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping: uinput unavailable ({e})");
+                return;
+            }
+        };
+        let builder = builder.name("voxtype-test-dotool-sync-overflow");
+        let builder = match builder.with_keys(&keys) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping: with_keys failed ({e})");
+                return;
+            }
+        };
+        let mut output = match builder.build() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("skipping: build failed ({e})");
+                return;
+            }
+        };
+
+        let node = match output.enumerate_dev_nodes_blocking() {
+            Ok(mut nodes) => match nodes.next() {
+                Some(Ok(path)) => path,
+                _ => {
+                    eprintln!("skipping: no event node for virtual device");
+                    return;
+                }
+            },
+            Err(e) => {
+                eprintln!("skipping: enumerate_dev_nodes failed ({e})");
+                return;
+            }
+        };
+
+        let mut input = None;
+        for _ in 0..50 {
+            match Device::open(&node) {
+                Ok(device) => {
+                    input = Some(device);
+                    break;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                    sleep(Duration::from_millis(20));
+                }
+                Err(e) => {
+                    eprintln!("skipping: cannot open {node:?} ({e})");
+                    return;
+                }
+            }
+        }
+        let Some(mut input) = input else {
+            eprintln!("skipping: {node:?} never became readable");
+            return;
+        };
+
+        let key_event = |key: Key, value| InputEvent::new(EventType::KEY.0, key.code(), value);
+        let key_click = |key: Key| [key_event(key, 1), key_event(key, 0)];
+
+        output.emit(&[key_event(Key::KEY_A, 1)]).unwrap();
+        output.emit(&[key_event(Key::KEY_B, 1)]).unwrap();
+        for _ in 0..30 {
+            output.emit(&key_click(Key::KEY_DOT)).unwrap();
+        }
+
+        // The overflow batch is discarded and marks the reader for state recovery.
+        assert_eq!(input.fetch_events().unwrap().count(), 0);
+        output.emit(&key_click(Key::KEY_DOT)).unwrap();
+
+        let recovered: Vec<_> = input.fetch_events().unwrap().collect();
+        for key in [Key::KEY_A, Key::KEY_B] {
+            assert!(
+                recovered.iter().any(|event| {
+                    event.event_type() == EventType::KEY
+                        && event.code() == key.code()
+                        && event.value() == 1
+                }),
+                "missing recovered press for {key:?}: {recovered:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -234,10 +234,7 @@ impl DeviceManager {
                 // that spins fetch_events() at 100% CPU. See issue #445.
                 let is_injection_device = device
                     .name()
-                    .map(|n| {
-                        let n = n.to_ascii_lowercase();
-                        n.contains("dotool") || n.contains("wtype") || n.contains("xdotool")
-                    })
+                    .map(is_injection_keyboard)
                     .unwrap_or(false);
                 if is_injection_device {
                     tracing::debug!("Skipping virtual injection keyboard: {:?}", device.name());
@@ -818,9 +815,40 @@ fn parse_prefixed_keycode(s: &str) -> Result<Option<Key>, HotkeyError> {
     Ok(Some(Key::new(kernel_code)))
 }
 
+/// Returns true if a device name belongs to a text-injection virtual keyboard
+/// (dotool, ydotool, wtype, xdotool). voxtype types its transcription out through
+/// one of these; grabbing it back is pointless and, when the tool tears down its
+/// short-lived uinput device, leaves a stale fd that spins fetch_events() at 100%
+/// CPU. See issue #445.
+fn is_injection_keyboard(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    n.contains("dotool") || n.contains("wtype") || n.contains("xdotool")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn injection_keyboards_are_skipped() {
+        // "dotool" substring also covers ydotool
+        assert!(is_injection_keyboard("dotool"));
+        assert!(is_injection_keyboard("ydotool"));
+        assert!(is_injection_keyboard("ydotool virtual keyboard"));
+        assert!(is_injection_keyboard("wtype"));
+        assert!(is_injection_keyboard("xdotool"));
+        // case-insensitive
+        assert!(is_injection_keyboard("YDOTOOL Virtual Device"));
+    }
+
+    #[test]
+    fn real_keyboards_are_not_skipped() {
+        assert!(!is_injection_keyboard("AT Translated Set 2 keyboard"));
+        assert!(!is_injection_keyboard("Logitech USB Keyboard"));
+        assert!(!is_injection_keyboard("Apple Inc. Magic Keyboard"));
+        assert!(!is_injection_keyboard("Keychron K2"));
+        assert!(!is_injection_keyboard("Power Button"));
+    }
 
     #[test]
     fn test_parse_key_name() {

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -232,10 +232,7 @@ impl DeviceManager {
                 // through one of these; grabbing it back is pointless and, when the
                 // tool tears down its short-lived uinput device, leaves a stale fd
                 // that spins fetch_events() at 100% CPU. See issue #445.
-                let is_injection_device = device
-                    .name()
-                    .map(is_injection_keyboard)
-                    .unwrap_or(false);
+                let is_injection_device = device.name().map(is_injection_keyboard).unwrap_or(false);
                 if is_injection_device {
                     tracing::debug!("Skipping virtual injection keyboard: {:?}", device.name());
                     return;
@@ -957,7 +954,10 @@ mod tests {
         let fd = dev.as_raw_fd();
 
         // While the device is alive the guard must NOT flag it.
-        assert!(!fd_is_hung_up(fd), "live evdev device wrongly flagged hung up");
+        assert!(
+            !fd_is_hung_up(fd),
+            "live evdev device wrongly flagged hung up"
+        );
 
         // Tear it down (UI_DEV_DESTROY on drop) and wait briefly for the kernel
         // to mark the now-orphaned fd. Without the guard, poll_events() would

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -14,7 +14,7 @@ use crate::error::HotkeyError;
 use evdev::{Device, InputEventKind, Key};
 use inotify::{Inotify, WatchMask};
 use std::collections::{HashMap, HashSet};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
@@ -374,13 +374,7 @@ impl DeviceManager {
             // left in a state where fetch_events() never returns ENODEV and instead
             // spins at 100% CPU. poll() reliably reports POLLHUP/POLLERR/POLLNVAL for
             // such a dead fd, so we drop it before ever calling fetch_events().
-            let mut pfd = libc::pollfd {
-                fd: device.as_raw_fd(),
-                events: libc::POLLIN,
-                revents: 0,
-            };
-            let pret = unsafe { libc::poll(&mut pfd, 1, 0) };
-            if pret > 0 && (pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)) != 0 {
+            if fd_is_hung_up(device.as_raw_fd()) {
                 tracing::debug!("Device hung up (POLLHUP/POLLERR): {:?}", path);
                 error_paths.push(path.clone());
                 continue;
@@ -825,6 +819,23 @@ fn is_injection_keyboard(name: &str) -> bool {
     n.contains("dotool") || n.contains("wtype") || n.contains("xdotool")
 }
 
+/// Return true if `fd` is hung up, errored, or invalid according to poll().
+///
+/// When a uinput device (e.g. dotool's virtual keyboard) is destroyed, its
+/// still-open fd can stop returning ENODEV from fetch_events() and instead spin
+/// one thread at 100% CPU. poll() reliably reports POLLHUP/POLLERR/POLLNVAL for
+/// such a dead fd, so poll_events() drops it before ever calling fetch_events().
+/// See issue #445.
+fn fd_is_hung_up(fd: RawFd) -> bool {
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let pret = unsafe { libc::poll(&mut pfd, 1, 0) };
+    pret > 0 && (pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)) != 0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -848,6 +859,122 @@ mod tests {
         assert!(!is_injection_keyboard("Apple Inc. Magic Keyboard"));
         assert!(!is_injection_keyboard("Keychron K2"));
         assert!(!is_injection_keyboard("Power Button"));
+    }
+
+    // --- poll-guard (anti-spin) coverage for issue #445 --------------------
+
+    #[test]
+    fn poll_guard_ignores_live_fd_but_flags_hangup() {
+        // A live pipe (write end open, no data) must NOT be flagged: poll()
+        // returns no revents, so poll_events() still calls fetch_events().
+        let mut fds = [0 as libc::c_int; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0, "pipe() failed");
+        let (rd, wr) = (fds[0], fds[1]);
+        assert!(!fd_is_hung_up(rd), "live fd must not be reported hung up");
+
+        // Closing the write end hangs up the read end -> POLLHUP -> flagged,
+        // which is exactly the condition poll_events() drops to avoid spinning.
+        assert_eq!(unsafe { libc::close(wr) }, 0);
+        assert!(fd_is_hung_up(rd), "hung-up fd must be flagged for removal");
+        unsafe { libc::close(rd) };
+    }
+
+    #[test]
+    fn poll_guard_drops_real_torn_down_evdev_device() {
+        use evdev::{uinput::VirtualDeviceBuilder, AttributeSet};
+        use std::thread::sleep;
+        use std::time::Duration;
+
+        // Build a NON-keyboard virtual device (one media key, no A/Z/Enter) so a
+        // real voxtype instance's keyboard filter ignores it and is unaffected by
+        // this test. The poll() guard is key-agnostic, so this still exercises it
+        // against a genuine evdev fd torn down by UI_DEV_DESTROY.
+        let mut keys = AttributeSet::<Key>::new();
+        keys.insert(Key::KEY_PLAYPAUSE);
+        let builder = match VirtualDeviceBuilder::new() {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping: uinput unavailable ({e})");
+                return;
+            }
+        };
+        let builder = builder.name("voxtype-test-nonkbd");
+        let builder = match builder.with_keys(&keys) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping: with_keys failed ({e})");
+                return;
+            }
+        };
+        let mut vdev = match builder.build() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("skipping: build failed ({e})");
+                return;
+            }
+        };
+
+        // Resolve the /dev/input/eventN node the kernel created for it.
+        let node = match vdev.enumerate_dev_nodes_blocking() {
+            Ok(mut it) => match it.next() {
+                Some(Ok(p)) => p,
+                _ => {
+                    eprintln!("skipping: no dev node for virtual device");
+                    return;
+                }
+            },
+            Err(e) => {
+                eprintln!("skipping: enumerate_dev_nodes failed ({e})");
+                return;
+            }
+        };
+
+        // The kernel creates the event node before udev relabels it to group
+        // `input`; retry briefly to beat that race before giving up.
+        let mut opened = None;
+        for _ in 0..50 {
+            match Device::open(&node) {
+                Ok(d) => {
+                    opened = Some(d);
+                    break;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                    sleep(Duration::from_millis(20));
+                }
+                Err(e) => {
+                    eprintln!("skipping: cannot open {node:?} ({e})");
+                    return;
+                }
+            }
+        }
+        let dev = match opened {
+            Some(d) => d,
+            None => {
+                eprintln!("skipping: {node:?} never became readable (udev perms)");
+                return;
+            }
+        };
+        let fd = dev.as_raw_fd();
+
+        // While the device is alive the guard must NOT flag it.
+        assert!(!fd_is_hung_up(fd), "live evdev device wrongly flagged hung up");
+
+        // Tear it down (UI_DEV_DESTROY on drop) and wait briefly for the kernel
+        // to mark the now-orphaned fd. Without the guard, poll_events() would
+        // spin on this fd at 100% CPU; with it, the fd is detected and dropped.
+        drop(vdev);
+        let mut flagged = false;
+        for _ in 0..50 {
+            if fd_is_hung_up(fd) {
+                flagged = true;
+                break;
+            }
+            sleep(Duration::from_millis(20));
+        }
+        assert!(
+            flagged,
+            "guard failed to flag a torn-down evdev fd; poll_events would spin"
+        );
     }
 
     #[test]

--- a/src/output/modifier_guard.rs
+++ b/src/output/modifier_guard.rs
@@ -16,7 +16,7 @@
 //! in mid-session) is handled implicitly without needing inotify watchers in
 //! the output path.
 
-use evdev::{AttributeSet, Device, Key};
+use evdev::{AttributeSet, Device, KeyCode as Key};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
When an input device is removed while voxtype is running, the listener kept polling a file descriptor that was already gone. poll() returned right away every time with POLLHUP, so the loop ran flat out and pinned a core at 100%.

This checks for the hang up flags (POLLHUP, POLLERR, POLLNVAL) and drops the dead descriptor instead of spinning on it. I also tightened the keyboard name filter so injected or virtual devices are not grabbed by mistake.

I added tests for both paths. One uses a pipe to trigger a hang up in a deterministic way. The other creates a real virtual input device, opens its event node, destroys it, and checks that the guard flags the orphaned descriptor so poll_events drops it.

I ran the full suite on my machine and confirmed a live instance stays idle the whole time.

Closes #445
