### PR TITLE
fix(flake): enable Cohere in ONNX packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
           "paraformer"
           "dolphin"
           "omnilingual"
+          "cohere"
         ];
 
         onnxCudaFeatures = [
@@ -65,6 +66,7 @@
           "paraformer-cuda"
           "dolphin-cuda"
           "omnilingual-cuda"
+          "cohere-cuda"
         ];
 
         # Only Parakeet has AMD GPU support (via MIGraphX); other engines run on CPU


### PR DESCRIPTION
## Summary
- add `cohere` to the ONNX CPU feature set
- add `cohere-cuda` to the ONNX CUDA feature set
- leave MIGraphX unchanged because there is no `cohere-migraphx` feature and the source notes Cohere is not currently supported there

## Test
- `nix flake show --json --no-write-lock-file`