### PR TITLE
fix(meeting): prefer default sink's monitor for loopback auto-detect

### DIFF
--- a/src/audio/dual_capture.rs
+++ b/src/audio/dual_capture.rs
@@ -244,7 +244,15 @@ impl DualCapture {
             .args(["get-default-sink"])
             .output()
             .ok()?;
-        let sink = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !output.status.success() {
+            return None;
+        }
+        let sink = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
         if sink.is_empty() {
             return None;
         }

--- a/src/audio/dual_capture.rs
+++ b/src/audio/dual_capture.rs
@@ -209,7 +209,22 @@ impl DualCapture {
                 }
             }
         }
-        // Fall back to any monitor source
+        // Second pass: the default sink's monitor. When nothing is actively
+        // playing at start, this is where remote audio will land — far more
+        // reliable than grabbing whatever monitor happens to sort first, which
+        // is often an AEC reference sink (e.g. "echo-cancel-sink.monitor") that
+        // is permanently silent and yields an empty loopback transcript.
+        if let Some(default_monitor) = Self::default_sink_monitor() {
+            let exists = stdout
+                .lines()
+                .any(|l| l.split('\t').nth(1) == Some(default_monitor.as_str()));
+            if exists {
+                tracing::debug!("Using default sink monitor: {}", default_monitor);
+                return Some(default_monitor);
+            }
+        }
+
+        // Last resort: any monitor source
         for line in stdout.lines() {
             let fields: Vec<&str> = line.split('\t').collect();
             if fields.len() >= 2 {
@@ -221,6 +236,19 @@ impl DualCapture {
             }
         }
         None
+    }
+
+    /// The default sink's monitor source name (`<default-sink>.monitor`) via pactl.
+    fn default_sink_monitor() -> Option<String> {
+        let output = std::process::Command::new("pactl")
+            .args(["get-default-sink"])
+            .output()
+            .ok()?;
+        let sink = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if sink.is_empty() {
+            return None;
+        }
+        Some(format!("{}.monitor", sink))
     }
 
     /// Check if loopback capture is active


### PR DESCRIPTION
## Problem

In meeting mode, `loopback_device = "auto"` can capture a silent monitor, producing a transcript with the **remote participants' side entirely blank** and no error logged.

`find_monitor_source()` (`src/audio/dual_capture.rs`) picks the loopback monitor once at meeting start:
1. First monitor with status `RUNNING`, else
2. the **first** `.monitor` in `pactl`'s source list.

On a system with a WebRTC AEC module loaded (`libpipewire-module-echo-cancel`), that first-listed monitor is the AEC reference sink's monitor — `echo-cancel-sink.monitor`, described "AEC Reference Sink (do not use)" — which nothing ever plays to, so it's permanently silent. If no monitor is `RUNNING` at the instant the meeting starts (remote audio hasn't begun, or a brief silence), auto grabs it and the whole call's loopback is empty.

## Fix

Add a middle fallback between the two existing passes: the **default sink's monitor** (`<default-sink>.monitor` via `pactl get-default-sink`), used only if it's present in the source list. That's where remote audio actually lands, so it selects the correct stream regardless of whether anything is playing at start. The arbitrary first-monitor pick stays only as a last resort.

## Verification

- `cargo fmt`, `cargo clippy --lib -- -D warnings`: clean
- `cargo test dual_capture`: 4 passed

Verified the failure and fix against a live setup (speakers + WebRTC AEC): `auto` was selecting `echo-cancel-sink.monitor`; the default sink's monitor (`alsa_output.*.analog-stereo.monitor`) is the one carrying remote audio.

## Note

No unit test added — selection shells out to `pactl` and there's no subprocess mocking in this module (the existing `find_monitor_source` is likewise untested); a real test would shell out to a live audio server and be flaky in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)