### PR TITLE
Support new Omarchy theme state path

### DIFF
--- a/quickshell/voxtype-shared/Theme.qml
+++ b/quickshell/voxtype-shared/Theme.qml
@@ -10,8 +10,9 @@ pragma Singleton
 //   import "voxtype-shared" as VT
 //   VT.Theme.accentColor = "#6E89C2"
 //
-// Wave 2 will add a loader that reads
-// `~/.config/omarchy/current/theme/colors.toml` and maps `accent`,
+// Wave 2 will add a loader that reads the active Omarchy theme colors from
+// `~/.local/state/omarchy/current/theme/colors.toml`, falling back to the
+// legacy `~/.config/omarchy/current/theme/colors.toml`, and maps `accent`,
 // `background`, `color1`/`2`/`3` onto these properties.
 
 import QtQuick

--- a/src/osd/theme.rs
+++ b/src/osd/theme.rs
@@ -1,10 +1,11 @@
 //! Omarchy theme integration.
 //!
 //! On startup, both OSD frontends read the active Omarchy theme and map it
-//! to a [`Palette`] used by the renderer. The active theme lives at
-//! `~/.config/omarchy/current/theme/colors.toml`, which is a TOML file with
-//! a flat structure: `background`, `foreground`, `accent`, plus the ANSI
-//! palette `color0`..=`color15`.
+//! to a [`Palette`] used by the renderer. The active theme usually lives at
+//! `~/.local/state/omarchy/current/theme/colors.toml`, with older installs
+//! using `~/.config/omarchy/current/theme/colors.toml`. The colors file has a
+//! flat structure: `background`, `foreground`, `accent`, plus the ANSI palette
+//! `color0`..=`color15`.
 //!
 //! Mapping:
 //!
@@ -26,12 +27,19 @@ use serde::Deserialize;
 
 use crate::osd::visual::{Color, Palette};
 
-/// Canonical Omarchy "current theme" directory.
-pub fn omarchy_theme_dir() -> Option<PathBuf> {
+/// Candidate Omarchy "current theme" directories, ordered newest to oldest.
+pub fn omarchy_theme_dirs() -> Option<Vec<PathBuf>> {
     let home = std::env::var_os("HOME")?;
-    let mut p = PathBuf::from(home);
-    p.push(".config/omarchy/current/theme");
-    Some(p)
+    let home = PathBuf::from(home);
+    Some(vec![
+        home.join(".local/state/omarchy/current/theme"),
+        home.join(".config/omarchy/current/theme"),
+    ])
+}
+
+/// Preferred Omarchy "current theme" directory.
+pub fn omarchy_theme_dir() -> Option<PathBuf> {
+    omarchy_theme_dirs()?.into_iter().next()
 }
 
 #[derive(Deserialize, Default)]
@@ -63,20 +71,21 @@ fn parse_hex(s: &str) -> Option<Color> {
 /// fallbacks apply too: a theme that only defines `accent` keeps the
 /// fallback values for everything else.
 pub fn load_palette() -> Palette {
-    let Some(dir) = omarchy_theme_dir() else {
+    let Some(dirs) = omarchy_theme_dirs() else {
         return Palette::fallback();
     };
-    let path = dir.join("colors.toml");
-    let content = match fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(_) => return Palette::fallback(),
-    };
-    let parsed: OmarchyColors = match toml::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return Palette::fallback(),
-    };
 
-    palette_from(parsed)
+    for path in dirs.into_iter().map(|dir| dir.join("colors.toml")) {
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(parsed) = toml::from_str(&content) else {
+            continue;
+        };
+        return palette_from(parsed);
+    }
+
+    Palette::fallback()
 }
 
 fn palette_from(c: OmarchyColors) -> Palette {
@@ -149,7 +158,15 @@ mod tests {
     fn theme_dir_resolves_under_home() {
         std::env::set_var("HOME", "/tmp/fakehome");
         let p = omarchy_theme_dir().unwrap();
-        assert!(p.ends_with(".config/omarchy/current/theme"));
+        assert!(p.ends_with(".local/state/omarchy/current/theme"));
+    }
+
+    #[test]
+    fn theme_dirs_include_legacy_config_fallback() {
+        std::env::set_var("HOME", "/tmp/fakehome");
+        let dirs = omarchy_theme_dirs().unwrap();
+        assert!(dirs[0].ends_with(".local/state/omarchy/current/theme"));
+        assert!(dirs[1].ends_with(".config/omarchy/current/theme"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Support Omarchy's new active theme state path for Voxtype OSD theming.

Voxtype previously looked for the active Omarchy theme colors under:

`~/.config/omarchy/current/theme/colors.toml`

Newer Omarchy installs now expose the active theme under:

`~/.local/state/omarchy/current/theme/colors.toml`

This change updates the OSD theme loader to prefer the new state path while preserving compatibility with older installs by falling back to the legacy config path.

## Changes

- Add ordered Omarchy theme directory candidates:
  - `~/.local/state/omarchy/current/theme`
  - `~/.config/omarchy/current/theme`
- Update `load_palette()` to try each candidate `colors.toml` before falling back to the built-in palette.
- Keep existing partial-theme behavior: missing or invalid individual color fields still inherit fallback palette values.
- Update Quickshell shared theme comments to document the new path and legacy fallback.

## Compatibility

This is backward compatible with existing Omarchy setups that still use the legacy config path. Users on newer Omarchy versions should now get their active theme colors picked up automatically.

## Validation

- `cargo test osd::theme`
- `cargo fmt --check`
- `git diff origin/dev...HEAD --check`