### PR TITLE
Retry degenerate Whisper transcripts

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -394,6 +394,11 @@ If you experience phrase repetition (e.g., "word word word"), make sure this set
 
 **Cause:** Known Whisper behavior with silence or noise.
 
+Whisper may also occasionally return a punctuation-only transcript, such as a
+lone dash (`-`), even when the recording contains speech. Voxtype treats this
+as a degenerate decode: it retries the same audio once with a more conservative
+decode path, then drops the result if the retry is still punctuation-only.
+
 **Solutions:**
 1. Use a larger model for better accuracy
 2. Avoid recording ambient noise

--- a/src/transcribe/whisper.rs
+++ b/src/transcribe/whisper.rs
@@ -77,6 +77,100 @@ impl WhisperTranscriber {
         })
     }
 
+    fn build_params<'a, 'b>(
+        &'a self,
+        selected_language: Option<&'a str>,
+        duration_secs: f32,
+        retry: bool,
+    ) -> FullParams<'a, 'b> {
+        let mut params = if retry {
+            FullParams::new(SamplingStrategy::BeamSearch {
+                beam_size: 5,
+                patience: -1.0,
+            })
+        } else {
+            FullParams::new(SamplingStrategy::Greedy { best_of: 1 })
+        };
+
+        match selected_language {
+            Some(lang) => params.set_language(Some(lang)),
+            None => params.set_language(None),
+        }
+
+        params.set_translate(self.translate);
+        params.set_n_threads(self.threads as i32);
+
+        // Disable output we don't need
+        params.set_print_special(false);
+        params.set_print_progress(false);
+        params.set_print_realtime(false);
+        params.set_print_timestamps(false);
+
+        // Improve transcription quality
+        params.set_suppress_blank(true);
+        params.set_suppress_nst(true);
+
+        // Prevent hallucination/looping by not conditioning on previous text.
+        params.set_no_context(true);
+
+        // Set initial prompt if configured
+        if let Some(prompt) = &self.initial_prompt {
+            params.set_initial_prompt(prompt);
+            tracing::debug!("Using initial prompt: {:?}", prompt);
+        }
+
+        // Single-segment mode is faster for normal short dictation, but when
+        // retrying a degenerate decode, let Whisper segment normally.
+        if duration_secs < 30.0 && !retry {
+            params.set_single_segment(true);
+        }
+
+        // Context-window reduction speeds up the normal path. Keep retries at
+        // the model's default context so a too-small window cannot repeat the
+        // same degenerate output.
+        if self.context_window_optimization && !retry {
+            if let Some(audio_ctx) = calculate_audio_ctx(duration_secs) {
+                params.set_audio_ctx(audio_ctx);
+                tracing::info!(
+                    "Audio context optimization: using audio_ctx={} for {:.2}s clip",
+                    audio_ctx,
+                    duration_secs
+                );
+            }
+        }
+
+        params
+    }
+
+    fn run_full(
+        &self,
+        samples: &[f32],
+        selected_language: Option<&str>,
+        duration_secs: f32,
+        retry: bool,
+    ) -> Result<String, TranscribeError> {
+        let mut state = self
+            .ctx
+            .create_state()
+            .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?;
+        let params = self.build_params(selected_language, duration_secs, retry);
+
+        state
+            .full(params, samples)
+            .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?;
+
+        let mut text = String::new();
+        for segment in state.as_iter() {
+            text.push_str(
+                segment
+                    .to_str()
+                    .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?,
+            );
+        }
+
+        Ok(text.trim().to_string())
+    }
+
     /// Select the best language from allowed languages using Whisper's language detection.
     ///
     /// This runs the mel spectrogram computation and language detection head to get
@@ -187,75 +281,28 @@ impl Transcriber for WhisperTranscriber {
             *guard = selected_language.clone();
         }
 
-        // Configure parameters
-        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        let mut result =
+            self.run_full(samples, selected_language.as_deref(), duration_secs, false)?;
 
-        // Set language
-        match &selected_language {
-            Some(lang) => params.set_language(Some(lang)),
-            None => params.set_language(None),
-        }
-
-        params.set_translate(self.translate);
-        params.set_n_threads(self.threads as i32);
-
-        // Disable output we don't need
-        params.set_print_special(false);
-        params.set_print_progress(false);
-        params.set_print_realtime(false);
-        params.set_print_timestamps(false);
-
-        // Improve transcription quality
-        params.set_suppress_blank(true);
-        params.set_suppress_nst(true);
-
-        // Prevent hallucination/looping by not conditioning on previous text
-        // This is especially important for short clips where Whisper can repeat itself
-        params.set_no_context(true);
-
-        // Set initial prompt if configured
-        if let Some(prompt) = &self.initial_prompt {
-            params.set_initial_prompt(prompt);
-            tracing::debug!("Using initial prompt: {:?}", prompt);
-        }
-
-        // For short recordings, use single segment mode
-        if duration_secs < 30.0 {
-            params.set_single_segment(true);
-        }
-
-        // Optimize context window for short clips
-        if self.context_window_optimization {
-            // Prevent hallucination/looping by not conditioning on previous text
-            // This is especially important for short clips where Whisper can repeat itself
-            params.set_no_context(true);
-
-            if let Some(audio_ctx) = calculate_audio_ctx(duration_secs) {
-                params.set_audio_ctx(audio_ctx);
-                tracing::info!(
-                    "Audio context optimization: using audio_ctx={} for {:.2}s clip",
-                    audio_ctx,
-                    duration_secs
+        if duration_secs >= 1.0 && is_degenerate_transcript(&result) {
+            tracing::warn!(
+                "Whisper returned degenerate transcript {:?} for {:.2}s audio; retrying with beam search",
+                result,
+                duration_secs
+            );
+            let retry_result =
+                self.run_full(samples, selected_language.as_deref(), duration_secs, true)?;
+            if is_degenerate_transcript(&retry_result) {
+                tracing::warn!(
+                    "Whisper retry also returned degenerate transcript {:?}; treating as empty",
+                    retry_result
                 );
+                result.clear();
+            } else {
+                tracing::info!("Whisper retry recovered transcript");
+                result = retry_result;
             }
         }
-
-        // Run inference
-        state
-            .full(params, samples)
-            .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?;
-
-        // Collect all segments using iterator API
-        let mut text = String::new();
-        for segment in state.as_iter() {
-            text.push_str(
-                segment
-                    .to_str()
-                    .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?,
-            );
-        }
-
-        let result = text.trim().to_string();
 
         tracing::info!(
             "Transcription completed in {:.2}s: {:?}",
@@ -273,6 +320,15 @@ impl Transcriber for WhisperTranscriber {
     fn last_detected_language(&self) -> Option<String> {
         self.last_language.lock().ok().and_then(|g| g.clone())
     }
+}
+
+fn is_degenerate_transcript(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+
+    !trimmed.chars().any(|c| c.is_alphanumeric())
 }
 
 /// Resolve model name to file path
@@ -472,5 +528,19 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_degenerate_transcript_detection() {
+        assert!(is_degenerate_transcript(""));
+        assert!(is_degenerate_transcript("   "));
+        assert!(is_degenerate_transcript("-"));
+        assert!(is_degenerate_transcript(" - \n"));
+        assert!(is_degenerate_transcript("..."));
+        assert!(is_degenerate_transcript("—"));
+
+        assert!(!is_degenerate_transcript("- Implement phase 1"));
+        assert!(!is_degenerate_transcript("hello"));
+        assert!(!is_degenerate_transcript("123"));
     }
 }


### PR DESCRIPTION
## Description

Adds a retry path for local Whisper transcription when the first decode returns a degenerate transcript, such as a lone dash or punctuation-only output. The normal fast greedy decode remains unchanged for usable results. When the first result has no alphanumeric characters for audio of at least one second, VoxType retries the same audio with beam search and normal segmentation. If the retry is still degenerate, the transcription is treated as empty instead of sending junk downstream.

This also extracts shared Whisper parameter setup into a helper so the normal and retry decode paths stay consistent.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

Additional local validation:

- `cargo fmt --check`
- `cargo check`
- `cargo test transcribe::whisper::tests`
- `cargo test`
- `cargo clippy -- -D warnings`
- Documentation note added to `docs/TROUBLESHOOTING.md`

## Documentation

- [x] I have updated documentation as needed
- [ ] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [x] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

Local validation passes. The PR was opened as draft per repository guidance and is ready once the remaining GitHub checks finish cleanly.
