### PR TITLE
Add GNOME-style GTK4 pill OSD

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -225,6 +225,11 @@ on_transcription = true
 # - quickshell: QML frontend with recipe/style customization
 frontend = "gtk4"
 
+# GTK4 visual variant: classic waveform + peak meter, or GNOME-style pill.
+# Each variant supplies defaults for size, margin, and opacity.
+# Ignored by native and quickshell.
+gtk4_variant = "classic"
+
 # Quickshell style customization. These fields are ignored by gtk4/native.
 # style can be "default", an installed package name, or a package path.
 style = "default"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3506,9 +3506,16 @@ the `voxtype-osd` wrapper launches via `[osd] frontend`.
 ```toml
 [osd]
 frontend = "gtk4"           # Default. Uses voxtype-osd-gtk4.
+gtk4_variant = "classic"    # Or "pill" for the GNOME-style pill.
 # frontend = "native"       # wgpu/egui-based (voxtype-osd-native).
 # frontend = "quickshell"   # QML/Quickshell launcher (voxtype-osd-quickshell).
 ```
+
+When geometry is omitted, `classic` defaults to 400x48, margin 24, and opacity
+0.95; `pill` defaults to 196x58, margin 59, and opacity 1.0. Explicit size,
+margin, and opacity values override those defaults. Pill center positions use
+the corresponding screen edge and `margin_px`; classic center positions retain
+the existing fractional `top_margin` placement.
 
 If you pick `"quickshell"`, install the QML tree first so the launcher can
 find it:

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -298,6 +298,18 @@ files under `$XDG_RUNTIME_DIR/voxtype/`. The OSD itself does not need a
 keybinding; it activates automatically when the daemon enters the
 recording state.
 
+The GTK4 frontend can use a GNOME-style pill instead of the classic waveform
+and peak meter:
+
+```toml
+[osd]
+frontend = "gtk4"
+gtk4_variant = "pill"
+```
+
+The pill defaults to 196x58 with a 59-pixel edge margin. Existing `width_px`,
+`height_px`, `margin_px`, and `opacity` values remain explicit overrides.
+
 Quickshell also supports OSD customization through `[osd]`:
 
 ```toml

--- a/flake.nix
+++ b/flake.nix
@@ -405,6 +405,8 @@
             rust-analyzer
             rustfmt
             clippy
+            gtk4-layer-shell
+            gtk4
           ] ++ runtimeDeps;
         };
       }) // {

--- a/src/bin/voxtype_osd_gtk4.rs
+++ b/src/bin/voxtype_osd_gtk4.rs
@@ -1,8 +1,8 @@
 //! `voxtype-osd-gtk4` — GTK4 + gtk4-layer-shell on-screen mic visualizer
 //! for the Voxtype daemon.
 //!
-//! Renders a click-through, layer-shell-anchored window containing the
-//! scrolling waveform plus a segmented peak meter. Audio frames arrive on
+//! Renders either the classic waveform + peak meter or a GNOME-style pill
+//! with voice-history bars. Audio frames arrive on
 //! the daemon's audio Unix socket via [`voxtype::osd::ipc::run_ipc_loop`],
 //! decoded into [`AudioFrame`]s by a tokio runtime on a worker thread, and
 //! pushed into a shared [`FrameRing`] + [`PeakHold`]. The GTK side polls a
@@ -16,6 +16,7 @@
 //! Run with `RUST_LOG=debug` for verbose logs.
 
 use std::cell::Cell;
+use std::f64::consts::PI;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -29,10 +30,12 @@ use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 
 use voxtype::audio::levels::{AudioFrame, FRAME_HZ};
 use voxtype::config::Config as VoxtypeConfig;
-use voxtype::osd::config::{OsdConfig, OsdPosition};
+use voxtype::osd::config::{Gtk4Variant, OsdConfig, OsdPosition};
 use voxtype::osd::ipc::{resolve_socket_path, run_ipc_loop, FrameRing, DEFAULT_RING_DEPTH};
 use voxtype::osd::theme::ThemeWatcher;
-use voxtype::osd::visual::{peak_meter_fraction, project_envelope, MeterZone, Palette, PeakHold};
+use voxtype::osd::visual::{
+    peak_meter_fraction, project_bar_levels, project_envelope, MeterZone, Palette, PeakHold,
+};
 
 /// Load the `[osd]` section from the voxtype config file, falling back to
 /// `OsdConfig::default()` on any error (file missing, unreadable, parse
@@ -42,16 +45,16 @@ use voxtype::osd::visual::{peak_meter_fraction, project_envelope, MeterZone, Pal
 /// is a side car, and a malformed config shouldn't prevent it from running
 /// with sensible defaults — the user will see the daemon complain about
 /// the same file separately.
-fn load_osd_config_from_file(explicit: Option<&std::path::Path>) -> OsdConfig {
+fn load_osd_config_from_file(explicit: Option<&std::path::Path>) -> (OsdConfig, GeometryOverrides) {
     let path = explicit
         .map(std::path::Path::to_path_buf)
         .or_else(VoxtypeConfig::default_path);
     let Some(path) = path else {
-        return OsdConfig::default();
+        return (OsdConfig::default(), GeometryOverrides::default());
     };
     let content = match std::fs::read_to_string(&path) {
         Ok(s) => s,
-        Err(_) => return OsdConfig::default(),
+        Err(_) => return (OsdConfig::default(), GeometryOverrides::default()),
     };
 
     #[derive(serde::Deserialize, Default)]
@@ -60,10 +63,21 @@ fn load_osd_config_from_file(explicit: Option<&std::path::Path>) -> OsdConfig {
         osd: Option<OsdConfig>,
     }
 
-    match toml::from_str::<PartialConfig>(&content) {
-        Ok(p) => p.osd.unwrap_or_default(),
-        Err(_) => OsdConfig::default(),
-    }
+    let document = match toml::from_str::<toml::Value>(&content) {
+        Ok(document) => document,
+        Err(_) => return (OsdConfig::default(), GeometryOverrides::default()),
+    };
+    let overrides = document
+        .get("osd")
+        .and_then(toml::Value::as_table)
+        .map(GeometryOverrides::from_table)
+        .unwrap_or_default();
+    let config = document
+        .try_into::<PartialConfig>()
+        .ok()
+        .and_then(|partial| partial.osd)
+        .unwrap_or_default();
+    (config, overrides)
 }
 
 /// Application id for the GTK4 frontend.
@@ -82,6 +96,31 @@ const METER_SEGMENTS: usize = 10;
 
 /// dBFS floor for the peak meter (maps to "empty bar").
 const METER_FLOOR_DBFS: f32 = -60.0;
+
+const PILL_HORIZONTAL_PADDING: f64 = 18.0;
+
+/// Geometry fields explicitly present in `[osd]`.
+///
+/// Serde fills omitted fields with `OsdConfig::default()`, so this mask lets
+/// variant defaults fill only omitted values without overriding user choices.
+#[derive(Default)]
+struct GeometryOverrides {
+    width_px: bool,
+    height_px: bool,
+    margin_px: bool,
+    opacity: bool,
+}
+
+impl GeometryOverrides {
+    fn from_table(table: &toml::map::Map<String, toml::Value>) -> Self {
+        Self {
+            width_px: table.contains_key("width_px"),
+            height_px: table.contains_key("height_px"),
+            margin_px: table.contains_key("margin_px"),
+            opacity: table.contains_key("opacity"),
+        }
+    }
+}
 
 #[derive(Parser, Debug, Clone)]
 #[command(
@@ -108,6 +147,14 @@ struct Args {
     #[arg(long, default_value = "0", env = "VOXTYPE_OSD_LOG_EVERY")]
     log_every: u32,
 
+    /// GTK4 visual variant.
+    #[arg(
+        long,
+        env = "VOXTYPE_OSD_GTK4_VARIANT",
+        value_parser = ["classic", "pill"]
+    )]
+    variant: Option<String>,
+
     /// Held-peak decay rate in dB/sec.
     #[arg(long, default_value = "6.0", env = "VOXTYPE_OSD_PEAK_DECAY")]
     peak_decay_db_per_sec: f32,
@@ -123,6 +170,10 @@ struct Args {
     /// Margin from the screen edge in physical pixels.
     #[arg(long, env = "VOXTYPE_OSD_MARGIN")]
     margin_px: Option<u32>,
+
+    /// Background opacity 0.0..=1.0.
+    #[arg(long, env = "VOXTYPE_OSD_OPACITY")]
+    opacity: Option<f32>,
 
     /// Visual gain applied to audio samples before drawing the waveform.
     /// Higher = waveform fills more of the vertical for quiet inputs.
@@ -162,7 +213,13 @@ fn main() -> anyhow::Result<()> {
     let socket_path = resolve_socket_path(args.socket.clone());
 
     // Layer config: defaults < config file [osd] < CLI/env overrides.
-    let mut osd_cfg = load_osd_config_from_file(args.config.as_deref());
+    let (mut osd_cfg, geometry_overrides) = load_osd_config_from_file(args.config.as_deref());
+    let variant = args
+        .variant
+        .as_deref()
+        .and_then(Gtk4Variant::parse_str)
+        .unwrap_or(osd_cfg.gtk4_variant);
+    apply_variant_defaults(&mut osd_cfg, variant, &geometry_overrides);
     if let Some(w) = args.width_px {
         osd_cfg.width_px = w;
     }
@@ -171,6 +228,9 @@ fn main() -> anyhow::Result<()> {
     }
     if let Some(m) = args.margin_px {
         osd_cfg.margin_px = m;
+    }
+    if let Some(o) = args.opacity {
+        osd_cfg.opacity = o.clamp(0.0, 1.0);
     }
     if let Some(g) = args.waveform_gain {
         osd_cfg.waveform_gain = g;
@@ -181,7 +241,8 @@ fn main() -> anyhow::Result<()> {
     osd_cfg.peak_decay_db_per_sec = args.peak_decay_db_per_sec;
 
     tracing::info!(
-        "voxtype-osd-gtk4 starting; socket={:?} size={}x{} margin={} pos={:?}",
+        "voxtype-osd-gtk4 starting; variant={:?} socket={:?} size={}x{} margin={} pos={:?}",
+        variant,
         socket_path,
         osd_cfg.width_px,
         osd_cfg.height_px,
@@ -200,6 +261,7 @@ fn main() -> anyhow::Result<()> {
         socket_path,
         args.reconnect_secs,
         args.log_every,
+        variant == Gtk4Variant::Pill,
     );
 
     // GTK application owns the main thread.
@@ -208,7 +270,7 @@ fn main() -> anyhow::Result<()> {
     let cfg = osd_cfg.clone();
     let state_for_activate = state.clone();
     app.connect_activate(move |app| {
-        build_window(app, &cfg, palette, state_for_activate.clone());
+        build_window(app, &cfg, palette, variant, state_for_activate.clone());
     });
 
     // GTK's run() consumes argv; we've already parsed via clap, so feed
@@ -221,12 +283,33 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn apply_variant_defaults(
+    config: &mut OsdConfig,
+    variant: Gtk4Variant,
+    overrides: &GeometryOverrides,
+) {
+    let defaults = variant.defaults();
+    if !overrides.width_px {
+        config.width_px = defaults.width_px;
+    }
+    if !overrides.height_px {
+        config.height_px = defaults.height_px;
+    }
+    if !overrides.margin_px {
+        config.margin_px = defaults.margin_px;
+    }
+    if !overrides.opacity {
+        config.opacity = defaults.opacity;
+    }
+}
+
 /// Spawn the tokio runtime + IPC loop on a dedicated thread.
 fn spawn_ipc_worker(
     state: Arc<SharedState>,
     socket_path: PathBuf,
     reconnect_secs: f32,
     log_every: u32,
+    reset_history_after_idle: bool,
 ) {
     std::thread::Builder::new()
         .name("voxtype-osd-ipc".into())
@@ -247,7 +330,20 @@ fn spawn_ipc_worker(
             let mut last_log = Instant::now();
 
             let on_frame = move |frame: AudioFrame| {
+                let now = Instant::now();
+                let new_recording = state
+                    .last_frame_at
+                    .lock()
+                    .map(|mut last_frame_at| {
+                        let was_idle = last_frame_at.elapsed().as_secs_f32() > IDLE_TIMEOUT_SECS;
+                        *last_frame_at = now;
+                        was_idle
+                    })
+                    .unwrap_or(false);
                 if let Ok(mut r) = state.ring.lock() {
+                    if reset_history_after_idle && new_recording {
+                        r.clear();
+                    }
                     r.push(frame);
                 }
                 if let Ok(mut p) = state.peak.lock() {
@@ -255,9 +351,6 @@ fn spawn_ipc_worker(
                 }
                 if let Ok(mut s) = state.last_seq.lock() {
                     *s = s.wrapping_add(1);
-                }
-                if let Ok(mut t) = state.last_frame_at.lock() {
-                    *t = Instant::now();
                 }
 
                 total += 1;
@@ -316,9 +409,26 @@ fn focused_monitor_height_px() -> Option<i32> {
     None
 }
 
+fn edge_anchors(position: OsdPosition) -> (bool, bool, bool, bool) {
+    match position {
+        OsdPosition::BottomCenter => (false, true, false, false),
+        OsdPosition::BottomLeft => (false, true, true, false),
+        OsdPosition::BottomRight => (false, true, false, true),
+        OsdPosition::TopCenter => (true, false, false, false),
+        OsdPosition::TopLeft => (true, false, true, false),
+        OsdPosition::TopRight => (true, false, false, true),
+    }
+}
+
 /// Build the GTK window, attach layer-shell config, mount the DrawingArea,
 /// and start the redraw tick.
-fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc<SharedState>) {
+fn build_window(
+    app: &Application,
+    cfg: &OsdConfig,
+    palette: Palette,
+    variant: Gtk4Variant,
+    state: Arc<SharedState>,
+) {
     let window = ApplicationWindow::builder()
         .application(app)
         .default_width(cfg.width_px as i32)
@@ -326,6 +436,9 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
         .resizable(false)
         .decorated(false)
         .build();
+    if variant == Gtk4Variant::Pill {
+        install_transparent_window_style(&window);
+    }
 
     // Layer-shell setup: top layer, no keyboard, anchored per config.
     window.init_layer_shell();
@@ -346,7 +459,7 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
         OsdPosition::BottomCenter | OsdPosition::TopCenter
     );
 
-    if centered {
+    if centered && variant == Gtk4Variant::Classic {
         // Resolve monitor height to translate the fractional offset into
         // pixels. Falls back to a conservative 1080 if the display can't be
         // queried (extremely rare on Wayland-only systems where layer-shell
@@ -361,15 +474,9 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
         window.set_anchor(Edge::Right, false);
         window.set_margin(Edge::Top, top_px);
     } else {
-        // Corner positions: legacy anchor + uniform pixel margin behavior.
-        let (anchor_top, anchor_bottom, anchor_left, anchor_right) = match cfg.position {
-            OsdPosition::BottomLeft => (false, true, true, false),
-            OsdPosition::BottomRight => (false, true, false, true),
-            OsdPosition::TopLeft => (true, false, true, false),
-            OsdPosition::TopRight => (true, false, false, true),
-            // Centered branch is handled above; unreachable here.
-            OsdPosition::BottomCenter | OsdPosition::TopCenter => unreachable!(),
-        };
+        // Pill positions use direct edge anchoring; classic corner positions
+        // retain the same uniform margin behavior.
+        let (anchor_top, anchor_bottom, anchor_left, anchor_right) = edge_anchors(cfg.position);
         window.set_anchor(Edge::Top, anchor_top);
         window.set_anchor(Edge::Bottom, anchor_bottom);
         window.set_anchor(Edge::Left, anchor_left);
@@ -399,8 +506,10 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
     drawing_area.set_content_height(cfg.height_px as i32);
     let state_for_draw = state.clone();
     let gain = cfg.waveform_gain as f64;
-    drawing_area.set_draw_func(move |_area, cr, w, h| {
-        draw(cr, w, h, &palette, &state_for_draw, gain);
+    let opacity = cfg.opacity.clamp(0.0, 1.0);
+    drawing_area.set_draw_func(move |_area, cr, w, h| match variant {
+        Gtk4Variant::Classic => draw_classic(cr, w, h, &palette, &state_for_draw, gain, opacity),
+        Gtk4Variant::Pill => draw_pill(cr, w, h, &state_for_draw, gain, opacity),
     });
     window.set_child(Some(&drawing_area));
 
@@ -485,6 +594,22 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
     window.present();
 }
 
+fn install_transparent_window_style(window: &ApplicationWindow) {
+    let Some(display) = gtk4::gdk::Display::default() else {
+        return;
+    };
+    let provider = gtk4::CssProvider::new();
+    provider.load_from_data(
+        "window.voxtype-osd-pill { background-color: transparent; background-image: none; box-shadow: none; }",
+    );
+    gtk4::style_context_add_provider_for_display(
+        &display,
+        &provider,
+        gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+    window.add_css_class("voxtype-osd-pill");
+}
+
 /// Set an empty input region on the GdkSurface so clicks pass through.
 fn apply_click_through(window: &ApplicationWindow) {
     let Some(surface) = window.surface() else {
@@ -496,13 +621,14 @@ fn apply_click_through(window: &ApplicationWindow) {
 }
 
 /// Render the waveform + peak meter into the given Cairo context.
-fn draw(
+fn draw_classic(
     cr: &Context,
     width: i32,
     height: i32,
     palette: &Palette,
     state: &Arc<SharedState>,
     gain: f64,
+    opacity: f32,
 ) {
     let w = width as f64;
     let h = height as f64;
@@ -515,7 +641,7 @@ fn draw(
         palette.background.r as f64,
         palette.background.g as f64,
         palette.background.b as f64,
-        palette.background.a as f64,
+        f64::from(opacity),
     );
     cr.set_operator(cairo::Operator::Source);
     cr.paint().ok();
@@ -527,14 +653,12 @@ fn draw(
     let gap = (w * 0.01).max(2.0);
     let wave_width = (w - meter_width - gap).max(0.0);
 
-    draw_waveform(cr, 0.0, 0.0, wave_width, h, palette, state, gain);
+    draw_waveform(cr, wave_width, h, palette, state, gain);
     draw_peak_meter(cr, wave_width + gap, 0.0, meter_width, h, palette, state);
 }
 
 fn draw_waveform(
     cr: &Context,
-    x: f64,
-    y: f64,
     w: f64,
     h: f64,
     palette: &Palette,
@@ -556,7 +680,7 @@ fn draw_waveform(
     };
     let cols = project_envelope(&frames, n_columns);
 
-    let mid = y + h * 0.5;
+    let mid = h * 0.5;
     let half = h * 0.5;
 
     // Mirrored envelope filled polygon. We trace the top edge left-to-right
@@ -571,7 +695,7 @@ fn draw_waveform(
     cr.new_path();
     // Top edge.
     for (i, col) in cols.iter().enumerate() {
-        let px = x + i as f64 + 0.5;
+        let px = i as f64 + 0.5;
         let py = mid - sample_to_pixels(col.max, half, gain);
         if i == 0 {
             cr.move_to(px, py);
@@ -581,7 +705,7 @@ fn draw_waveform(
     }
     // Bottom edge, right-to-left.
     for (i, col) in cols.iter().enumerate().rev() {
-        let px = x + i as f64 + 0.5;
+        let px = i as f64 + 0.5;
         let py = mid - sample_to_pixels(col.min, half, gain);
         cr.line_to(px, py);
     }
@@ -596,8 +720,8 @@ fn draw_waveform(
         0.15,
     );
     cr.set_line_width(1.0);
-    cr.move_to(x, mid);
-    cr.line_to(x + w, mid);
+    cr.move_to(0.0, mid);
+    cr.line_to(w, mid);
     cr.stroke().ok();
 }
 
@@ -687,5 +811,120 @@ fn draw_peak_meter(
         cr.move_to(x, py);
         cr.line_to(x + w, py);
         cr.stroke().ok();
+    }
+}
+
+fn draw_pill(
+    cr: &Context,
+    width: i32,
+    height: i32,
+    state: &Arc<SharedState>,
+    gain: f64,
+    opacity: f32,
+) {
+    let width = f64::from(width);
+    let height = f64::from(height);
+    if width <= 0.0 || height <= 0.0 {
+        return;
+    }
+
+    cr.set_operator(cairo::Operator::Source);
+    cr.set_source_rgba(0.0, 0.0, 0.0, 0.0);
+    cr.paint().ok();
+    cr.set_operator(cairo::Operator::Over);
+
+    rounded_rectangle(cr, 0.0, 0.0, width, height, height * 0.5);
+    cr.set_source_rgba(0.180, 0.180, 0.200, f64::from(opacity));
+    cr.fill().ok();
+
+    let bars_x = PILL_HORIZONTAL_PADDING;
+    let bars_width = (width - PILL_HORIZONTAL_PADDING * 2.0).max(1.0);
+    let bar_count = (bars_width / 8.0).round().clamp(12.0, 42.0) as usize;
+    let (frames, capacity) = match state.ring.lock() {
+        Ok(ring) => (ring.iter().collect::<Vec<_>>(), ring.capacity()),
+        Err(_) => return,
+    };
+    let levels = project_bar_levels(&frames, bar_count, capacity, gain as f32);
+    draw_history_bars(cr, bars_x, height * 0.5, bars_width, height, &levels);
+}
+
+fn draw_history_bars(cr: &Context, x: f64, center_y: f64, width: f64, height: f64, levels: &[f32]) {
+    if levels.is_empty() {
+        return;
+    }
+    let slot = width / levels.len() as f64;
+    let bar_width = (slot * 0.48).clamp(2.5, 5.0);
+    let min_height = (height * 0.075).max(3.0);
+    let max_height = height * 0.52;
+
+    for (index, level) in levels.iter().enumerate() {
+        let response = f64::from(*level).sqrt();
+        let bar_height = min_height + response * (max_height - min_height);
+        let age = (index + 1) as f64 / levels.len() as f64;
+        let alpha = if *level > 0.0 {
+            0.42 + age * 0.56
+        } else {
+            0.14
+        };
+        let bar_x = x + index as f64 * slot + (slot - bar_width) * 0.5;
+        rounded_rectangle(
+            cr,
+            bar_x,
+            center_y - bar_height * 0.5,
+            bar_width,
+            bar_height,
+            bar_width * 0.5,
+        );
+        cr.set_source_rgba(0.96, 0.96, 0.97, alpha);
+        cr.fill().ok();
+    }
+}
+
+fn rounded_rectangle(cr: &Context, x: f64, y: f64, width: f64, height: f64, radius: f64) {
+    let radius = radius.min(width * 0.5).min(height * 0.5).max(0.0);
+    cr.new_sub_path();
+    cr.arc(x + width - radius, y + radius, radius, -PI * 0.5, 0.0);
+    cr.arc(
+        x + width - radius,
+        y + height - radius,
+        radius,
+        0.0,
+        PI * 0.5,
+    );
+    cr.arc(x + radius, y + height - radius, radius, PI * 0.5, PI);
+    cr.arc(x + radius, y + radius, radius, PI, PI * 1.5);
+    cr.close_path();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pill_defaults_preserve_explicit_geometry_and_position() {
+        let mut config = OsdConfig {
+            width_px: 320,
+            position: OsdPosition::TopCenter,
+            ..OsdConfig::default()
+        };
+        let overrides = GeometryOverrides {
+            width_px: true,
+            ..GeometryOverrides::default()
+        };
+
+        apply_variant_defaults(&mut config, Gtk4Variant::Pill, &overrides);
+
+        assert_eq!(config.width_px, 320);
+        assert_eq!(config.height_px, 58);
+        assert_eq!(config.margin_px, 59);
+        assert_eq!(config.opacity, 1.0);
+        assert_eq!(config.position, OsdPosition::TopCenter);
+
+        // Pill center positions anchor to the requested edge rather than
+        // sharing classic's fractional top-margin path.
+        assert_eq!(
+            edge_anchors(OsdPosition::TopCenter),
+            (true, false, false, false)
+        );
     }
 }

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -295,6 +295,11 @@ on_transcription = true
 # - quickshell: QML frontend with recipe/style customization
 frontend = "gtk4"
 
+# GTK4 visual variant: classic waveform + peak meter, or GNOME-style pill.
+# Each variant supplies defaults for size, margin, and opacity.
+# Ignored by native and quickshell.
+gtk4_variant = "classic"
+
 # Quickshell style customization. These fields are ignored by gtk4/native.
 # style can be "default", an installed package name, or a package path.
 style = "default"

--- a/src/osd/config.rs
+++ b/src/osd/config.rs
@@ -60,6 +60,51 @@ impl OsdFrontend {
     }
 }
 
+/// Visual variant rendered by the GTK4 frontend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Gtk4Variant {
+    #[default]
+    Classic,
+    Pill,
+}
+
+/// Geometry defaults associated with a GTK4 visual variant.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Gtk4VariantDefaults {
+    pub width_px: u32,
+    pub height_px: u32,
+    pub margin_px: u32,
+    pub opacity: f32,
+}
+
+impl Gtk4Variant {
+    pub const fn defaults(self) -> Gtk4VariantDefaults {
+        match self {
+            Self::Classic => Gtk4VariantDefaults {
+                width_px: 400,
+                height_px: 48,
+                margin_px: 24,
+                opacity: 0.95,
+            },
+            Self::Pill => Gtk4VariantDefaults {
+                width_px: 196,
+                height_px: 58,
+                margin_px: 59,
+                opacity: 1.0,
+            },
+        }
+    }
+
+    pub fn parse_str(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "classic" => Some(Self::Classic),
+            "pill" => Some(Self::Pill),
+            _ => None,
+        }
+    }
+}
+
 /// Palette source for Quickshell OSD recipes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -338,6 +383,8 @@ pub struct OsdConfig {
     /// Which OSD frontend the `voxtype-osd` wrapper launches. Defaults to
     /// `Gtk4` since GTK4 ships with most Hyprland setups already.
     pub frontend: OsdFrontend,
+    /// Visual variant for the GTK4 frontend. Ignored by other frontends.
+    pub gtk4_variant: Gtk4Variant,
     /// Quickshell style name, package name, or package path.
     pub style: String,
     /// Palette source for Quickshell OSD recipes.
@@ -357,18 +404,21 @@ pub struct OsdConfig {
 
 impl Default for OsdConfig {
     fn default() -> Self {
+        let gtk4_variant = Gtk4Variant::default();
+        let gtk4_defaults = gtk4_variant.defaults();
         Self {
             enabled: true,
-            width_px: 400,
-            height_px: 48,
+            width_px: gtk4_defaults.width_px,
+            height_px: gtk4_defaults.height_px,
             position: OsdPosition::BottomCenter,
-            margin_px: 24,
+            margin_px: gtk4_defaults.margin_px,
             top_margin: 0.85,
-            opacity: 0.95,
+            opacity: gtk4_defaults.opacity,
             waveform_window_secs: 3.0,
             peak_decay_db_per_sec: 6.0,
             waveform_gain: 10.0,
             frontend: OsdFrontend::default(),
+            gtk4_variant,
             style: "default".to_string(),
             palette: None,
             layout: OsdLayout::default(),
@@ -396,6 +446,7 @@ mod tests {
         assert!((c.peak_decay_db_per_sec - 6.0).abs() < 1e-6);
         assert!((c.waveform_gain - 10.0).abs() < 1e-6);
         assert_eq!(c.style, "default");
+        assert_eq!(c.gtk4_variant, Gtk4Variant::Classic);
         assert_eq!(c.palette, None);
         assert_eq!(c.layout, OsdLayout::Compact);
         assert!(c.plugin_path.is_none());
@@ -457,12 +508,25 @@ mod tests {
     }
 
     #[test]
+    fn gtk4_variant_serde_and_parsing() {
+        let v: Gtk4Variant = serde_json::from_str("\"pill\"").unwrap();
+        assert_eq!(v, Gtk4Variant::Pill);
+        assert_eq!(
+            Gtk4Variant::parse_str("classic"),
+            Some(Gtk4Variant::Classic)
+        );
+        assert_eq!(Gtk4Variant::parse_str("pill"), Some(Gtk4Variant::Pill));
+        assert_eq!(Gtk4Variant::parse_str("unknown"), None);
+    }
+
+    #[test]
     fn config_partial_toml_uses_defaults() {
         let toml_src = "width_px = 800\n";
         let c: OsdConfig = toml::from_str(toml_src).unwrap();
         assert_eq!(c.width_px, 800);
         // All other fields default
         assert_eq!(c.height_px, 48);
+        assert_eq!(c.gtk4_variant, Gtk4Variant::Classic);
         assert!(c.enabled);
     }
 

--- a/src/osd/visual.rs
+++ b/src/osd/visual.rs
@@ -221,6 +221,47 @@ pub fn project_envelope(frames: &[AudioFrame], n_columns: usize) -> Vec<Envelope
     out
 }
 
+/// Project audio history into evenly-spaced vertical bar levels.
+///
+/// Unlike [`project_envelope`], a partially-filled history remains aligned to
+/// the right. This lets a fresh recording visibly grow from right to left
+/// instead of stretching its first frame across the whole OSD.
+pub fn project_bar_levels(
+    frames: &[AudioFrame],
+    n_bars: usize,
+    history_capacity: usize,
+    gain: f32,
+) -> Vec<f32> {
+    let mut levels = vec![0.0; n_bars];
+    if frames.is_empty() || n_bars == 0 || history_capacity == 0 {
+        return levels;
+    }
+
+    let frames = if frames.len() > history_capacity {
+        &frames[frames.len() - history_capacity..]
+    } else {
+        frames
+    };
+    let history_start = history_capacity - frames.len();
+
+    for (bar, level) in levels.iter_mut().enumerate() {
+        let start = bar * history_capacity / n_bars;
+        let end = (((bar + 1) * history_capacity) / n_bars)
+            .max(start + 1)
+            .min(history_capacity);
+        if end <= history_start {
+            continue;
+        }
+
+        for frame in &frames[start.max(history_start) - history_start..end - history_start] {
+            let amplitude = frame.min.abs().max(frame.max.abs());
+            *level = level.max((amplitude * gain).clamp(0.0, 1.0));
+        }
+    }
+
+    levels
+}
+
 /// Map a dBFS peak to a normalized 0.0..=1.0 fill level for the meter.
 ///
 /// `floor_dbfs` is the dBFS value that maps to 0.0 (typically -60 dBFS for
@@ -350,5 +391,31 @@ mod tests {
         for c in cols {
             assert_eq!(c, EnvelopeColumn::SILENT);
         }
+    }
+
+    #[test]
+    fn bars_keep_partial_history_right_aligned() {
+        let frames = vec![frame(0, -0.1, 0.2, -20.0), frame(1, -0.3, 0.1, -10.0)];
+        let levels = project_bar_levels(&frames, 4, 4, 2.0);
+        assert_eq!(levels, vec![0.0, 0.0, 0.4, 0.6]);
+    }
+
+    #[test]
+    fn bars_aggregate_peaks_and_clamp_gain() {
+        let frames = vec![
+            frame(0, -0.1, 0.2, -20.0),
+            frame(1, -0.4, 0.1, -10.0),
+            frame(2, -0.2, 0.8, -3.0),
+            frame(3, -0.1, 0.2, -20.0),
+        ];
+        let levels = project_bar_levels(&frames, 2, 4, 2.0);
+        assert_eq!(levels, vec![0.8, 1.0]);
+    }
+
+    #[test]
+    fn bars_sample_short_history_without_gaps() {
+        let frames = vec![frame(0, -0.1, 0.2, -20.0), frame(1, -0.3, 0.1, -10.0)];
+        let levels = project_bar_levels(&frames, 4, 2, 2.0);
+        assert_eq!(levels, vec![0.4, 0.4, 0.6, 0.6]);
     }
 }

--- a/src/tui/osd_section.rs
+++ b/src/tui/osd_section.rs
@@ -18,11 +18,13 @@ use ratatui::{
 use super::app::{Action, App};
 use super::common::{self, FeedbackLevel, FormRowSpec};
 use super::config_editor::{ConfigEditor, EditorError};
+use crate::osd::config::Gtk4Variant;
 
 #[derive(Debug, Clone)]
 pub struct OsdState {
     pub enabled: bool,
     pub frontend: String,
+    pub gtk4_variant: String,
     pub style: String,
     pub palette: String,
     pub layout: String,
@@ -49,6 +51,7 @@ pub struct OsdState {
 pub enum Field {
     Enabled,
     Frontend,
+    Gtk4Variant,
     Style,
     Palette,
     Layout,
@@ -67,6 +70,7 @@ impl Field {
     const ALL: &'static [Field] = &[
         Field::Enabled,
         Field::Frontend,
+        Field::Gtk4Variant,
         Field::Style,
         Field::Palette,
         Field::Layout,
@@ -85,6 +89,7 @@ impl Field {
 const TABLE: &str = "osd";
 
 const FRONTEND_CHOICES: &[&str] = &["gtk4", "native", "quickshell"];
+const GTK4_VARIANT_CHOICES: &[&str] = &["classic", "pill"];
 const STYLE_CHOICES: &[&str] = &["default"];
 const PALETTE_CHOICES: &[&str] = &["auto", "omarchy", "fallback", "package", "custom"];
 const LAYOUT_CHOICES: &[&str] = &["compact", "wide", "minimal", "tile", "orb", "custom"];
@@ -100,9 +105,9 @@ const POSITION_CHOICES: &[&str] = &[
 // Preset cycles for numeric fields. Picked to cover the common range
 // without forcing inline text edit; users who need a value off the cycle
 // list can still hand-edit ~/.config/voxtype/config.toml.
-const WIDTH_CHOICES: &[i64] = &[200, 300, 400, 500, 600, 800, 1000];
-const HEIGHT_CHOICES: &[i64] = &[32, 40, 48, 56, 64, 80, 96];
-const MARGIN_CHOICES: &[i64] = &[0, 8, 16, 24, 32, 48, 64];
+const WIDTH_CHOICES: &[i64] = &[196, 200, 300, 400, 500, 600, 800, 1000];
+const HEIGHT_CHOICES: &[i64] = &[32, 40, 48, 56, 58, 64, 80, 96];
+const MARGIN_CHOICES: &[i64] = &[0, 8, 16, 24, 32, 48, 59, 64];
 // Mirrors swayosd's `--top-margin` semantics. Default 0.85 matches the
 // position users already see for volume/brightness panels.
 const TOP_MARGIN_CHOICES: &[f64] = &[0.50, 0.60, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95];
@@ -114,11 +119,18 @@ const GAIN_CHOICES: &[f64] = &[1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 15.0, 20.0];
 impl OsdState {
     pub fn load() -> Result<Self, EditorError> {
         let ed = ConfigEditor::load()?;
+        let gtk4_variant = ed
+            .get_string(TABLE, "gtk4_variant")
+            .unwrap_or_else(|| "classic".to_string());
+        let defaults = Gtk4Variant::parse_str(&gtk4_variant)
+            .unwrap_or_default()
+            .defaults();
         Ok(Self {
             enabled: ed.get_bool(TABLE, "enabled").unwrap_or(true),
             frontend: ed
                 .get_string(TABLE, "frontend")
                 .unwrap_or_else(|| "gtk4".to_string()),
+            gtk4_variant,
             style: ed
                 .get_string(TABLE, "style")
                 .unwrap_or_else(|| "default".to_string()),
@@ -131,11 +143,19 @@ impl OsdState {
             position: ed
                 .get_string(TABLE, "position")
                 .unwrap_or_else(|| "bottom-center".to_string()),
-            width_px: ed.get_int(TABLE, "width_px").unwrap_or(400),
-            height_px: ed.get_int(TABLE, "height_px").unwrap_or(48),
-            margin_px: ed.get_int(TABLE, "margin_px").unwrap_or(24),
+            width_px: ed
+                .get_int(TABLE, "width_px")
+                .unwrap_or(i64::from(defaults.width_px)),
+            height_px: ed
+                .get_int(TABLE, "height_px")
+                .unwrap_or(i64::from(defaults.height_px)),
+            margin_px: ed
+                .get_int(TABLE, "margin_px")
+                .unwrap_or(i64::from(defaults.margin_px)),
             top_margin: ed.get_float(TABLE, "top_margin").unwrap_or(0.85),
-            opacity: ed.get_float(TABLE, "opacity").unwrap_or(0.95),
+            opacity: ed
+                .get_float(TABLE, "opacity")
+                .unwrap_or(f64::from(defaults.opacity)),
             waveform_window_secs: ed.get_float(TABLE, "waveform_window_secs").unwrap_or(3.0),
             peak_decay_db_per_sec: ed.get_float(TABLE, "peak_decay_db_per_sec").unwrap_or(6.0),
             waveform_gain: ed.get_float(TABLE, "waveform_gain").unwrap_or(10.0),
@@ -156,6 +176,7 @@ impl OsdState {
         };
         ed.set_bool(TABLE, "enabled", self.enabled);
         ed.set_string(TABLE, "frontend", &self.frontend);
+        ed.set_string(TABLE, "gtk4_variant", &self.gtk4_variant);
         ed.set_string(TABLE, "style", &self.style);
         if self.palette == "auto" {
             ed.unset(TABLE, "palette");
@@ -208,6 +229,16 @@ impl OsdState {
         match self.field {
             Field::Enabled => self.enabled = !self.enabled,
             Field::Frontend => self.frontend = cycle_str(FRONTEND_CHOICES, &self.frontend, delta),
+            Field::Gtk4Variant => {
+                self.gtk4_variant = cycle_str(GTK4_VARIANT_CHOICES, &self.gtk4_variant, delta);
+                let defaults = Gtk4Variant::parse_str(&self.gtk4_variant)
+                    .unwrap_or_default()
+                    .defaults();
+                self.width_px = i64::from(defaults.width_px);
+                self.height_px = i64::from(defaults.height_px);
+                self.margin_px = i64::from(defaults.margin_px);
+                self.opacity = f64::from(defaults.opacity);
+            }
             Field::Style => {
                 // Only cycle between built-in names. A custom package
                 // name/path isn't in STYLE_CHOICES, and cycling would
@@ -342,6 +373,11 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
             "Frontend",
             state.frontend.clone(),
         ),
+        FormRowSpec::new(
+            state.field == Field::Gtk4Variant,
+            "GTK4 variant",
+            state.gtk4_variant.clone(),
+        ),
         FormRowSpec::new(state.field == Field::Style, "Style", state.style.clone()),
         FormRowSpec::new(
             state.field == Field::Palette,
@@ -470,6 +506,18 @@ fn guidance_for_field(state: &OsdState) -> Vec<Line<'_>> {
             Line::from(""),
             dim("If the chosen binary isn't on PATH, the wrapper falls back to whichever it finds and logs a warning."),
         ],
+        Field::Gtk4Variant => vec![
+            heading("GTK4 variant"),
+            Line::from(""),
+            Line::from("Visual treatment used when Frontend is gtk4."),
+            Line::from(""),
+            Line::from("  classic  scrolling waveform with segmented peak meter"),
+            Line::from("  pill     GNOME-style pill with vertical voice-history bars"),
+            Line::from(""),
+            dim("Changing the variant applies its default size, margin, and opacity."),
+            Line::from(""),
+            dim("Ignored by native and quickshell. Default: classic."),
+        ],
         Field::Style => vec![
             heading("Style"),
             Line::from(""),
@@ -524,7 +572,7 @@ fn guidance_for_field(state: &OsdState) -> Vec<Line<'_>> {
                  envelope, narrower compresses it.",
             ),
             Line::from(""),
-            dim("Default: 400. Cycles through 200/300/400/500/600/800/1000."),
+            dim("Defaults: classic 400; pill 196."),
         ],
         Field::HeightPx => vec![
             heading("Height (px)"),
@@ -535,19 +583,17 @@ fn guidance_for_field(state: &OsdState) -> Vec<Line<'_>> {
                  range.",
             ),
             Line::from(""),
-            dim("Default: 48. Cycles through 32/40/48/56/64/80/96."),
+            dim("Defaults: classic 48; pill 58."),
         ],
         Field::MarginPx => vec![
             heading("Margin (px)"),
             Line::from(""),
             Line::from(
-                "Distance from the screen edge for corner anchors \
-                 (top-left, bottom-right, etc.). Ignored for centered \
-                 positions — those use Top margin (fraction) instead, so \
-                 the OSD lands in the same band as swayosd.",
+                "Distance from the screen edge. Pill and corner placements use \
+                 this; classic centered positions use Top margin instead.",
             ),
             Line::from(""),
-            dim("Default: 24."),
+            dim("Defaults: classic 24; pill 59."),
         ],
         Field::TopMargin => vec![
             heading("Top margin (fraction)"),
@@ -560,8 +606,8 @@ fn guidance_for_field(state: &OsdState) -> Vec<Line<'_>> {
             ),
             Line::from(""),
             Line::from(
-                "Only used when Position is bottom-center or top-center. \
-                 Corner anchors keep using Margin (px).",
+                "Only used by classic when Position is bottom-center or \
+                 top-center. Pill and corner placements use Margin (px).",
             ),
             Line::from(""),
             dim("Default: 0.85 (matches swayosd). 0.0 = top of screen, 1.0 = bottom."),
@@ -574,7 +620,7 @@ fn guidance_for_field(state: &OsdState) -> Vec<Line<'_>> {
                  opaque). The waveform draws on top regardless.",
             ),
             Line::from(""),
-            dim("Default: 0.95."),
+            dim("Defaults: classic 0.95; pill 1.0."),
         ],
         Field::WaveformWindowSecs => vec![
             heading("Waveform window (seconds)"),


### PR DESCRIPTION
## Description

Adds an optional GNOME-style pill variant to the GTK4 OSD. The existing classic variant remains the default.

```toml
[osd]
gtk4_variant = "pill"
```

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

Tested on NixOS unstable. Verified that scaling is respected on my monitor and that existing width, height, position, margin, and opacity options are respected.

## Documentation

- [x] I have updated documentation as needed
- [ ] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [ ] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

A demonstration video is attached.

[Screencast_20260715_213953.webm](https://github.com/user-attachments/assets/4590be86-72fc-42c9-8fae-d2ffe4082320)
