### PR TITLE
Fix TUI freeze when opening the Audio section (was: Hotkey tab freeze, #541)

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -370,8 +370,15 @@ pub(crate) async fn dispatch(
             run_info_command(action)?;
         }
 
-        Commands::Configure { force_package_mode } => {
-            voxtype::tui::run(force_package_mode)?;
+        Commands::Configure {
+            force_package_mode,
+            probe_audio_devices,
+        } => {
+            if probe_audio_devices {
+                voxtype::tui::probe_audio_devices();
+            } else {
+                voxtype::tui::run(force_package_mode)?;
+            }
         }
 
         Commands::Status {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -98,6 +98,12 @@ pub enum Commands {
         /// Render as if installed from a package (for testing source builds).
         #[arg(long, hide = true)]
         force_package_mode: bool,
+
+        /// Print detected audio input devices (one per line) and exit.
+        /// Used internally by the TUI to probe devices in a subprocess, so
+        /// an ALSA hang or crash during probing can't take the TUI with it.
+        #[arg(long, hide = true)]
+        probe_audio_devices: bool,
     },
 
     /// Show daemon status (for Waybar/polybar integration)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -291,6 +291,14 @@ impl App {
         }
     }
 
+    /// Give sections with background work a chance to fold results in.
+    /// Called once per event-loop tick (so at least every poll interval).
+    pub fn poll_background(&mut self) {
+        if let Some(audio) = self.audio.as_mut() {
+            audio.poll_device_scan();
+        }
+    }
+
     pub fn refresh_inventory(&mut self) {
         self.inventory = build_inventory(self.force_package_mode);
         self.daemon_running = is_daemon_running();

--- a/src/tui/audio.rs
+++ b/src/tui/audio.rs
@@ -9,6 +9,10 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
     Frame,
 };
+use std::io::Read;
+use std::process::Stdio;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use super::app::{Action, App};
 use super::common::{
@@ -16,7 +20,7 @@ use super::common::{
 };
 use super::config_editor::{ConfigEditor, EditorError};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AudioState {
     pub device: String,
     pub max_duration_secs: u32,
@@ -30,9 +34,21 @@ pub struct AudioState {
     pub field: Field,
     pub feedback: Option<Feedback>,
     pub dirty_since_load: bool,
-    /// Cached device list (default + everything cpal finds). Loaded once.
+    /// Device list: "default" (and the configured device) immediately, plus
+    /// everything the background probe finds once it completes.
     pub device_choices: Vec<String>,
+    pub scan_status: ScanStatus,
+    /// Wired to the probe thread; drained by [`AudioState::poll_device_scan`].
+    scan_rx: Option<mpsc::Receiver<Option<Vec<String>>>>,
     pub editing: Option<TextEdit>,
+}
+
+/// Progress of the background device probe shown in the Device guidance pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanStatus {
+    Scanning,
+    Done,
+    Failed,
 }
 
 #[derive(Debug, Clone)]
@@ -111,9 +127,37 @@ impl AudioState {
             field: Field::Device,
             feedback: None,
             dirty_since_load: false,
-            device_choices: enumerate_input_devices(),
+            device_choices: initial_device_choices(&ed),
+            scan_status: ScanStatus::Scanning,
+            scan_rx: start_device_scan(),
             editing: None,
         })
+    }
+
+    /// Fold in the background probe's result if it has arrived. Non-blocking;
+    /// called once per event-loop tick. Returns true when state changed.
+    pub fn poll_device_scan(&mut self) -> bool {
+        let Some(rx) = &self.scan_rx else {
+            return false;
+        };
+        match rx.try_recv() {
+            Ok(Some(devices)) => {
+                for d in devices {
+                    if !self.device_choices.contains(&d) {
+                        self.device_choices.push(d);
+                    }
+                }
+                self.scan_status = ScanStatus::Done;
+                self.scan_rx = None;
+                true
+            }
+            Ok(None) | Err(mpsc::TryRecvError::Disconnected) => {
+                self.scan_status = ScanStatus::Failed;
+                self.scan_rx = None;
+                true
+            }
+            Err(mpsc::TryRecvError::Empty) => false,
+        }
     }
 
     fn is_text_field(field: Field) -> bool {
@@ -191,9 +235,15 @@ impl AudioState {
             Ok(fresh) => {
                 let field = self.field;
                 let cached = self.device_choices.clone();
+                let scan_status = self.scan_status;
+                let scan_rx = self.scan_rx.take();
                 *self = fresh;
                 self.field = field;
+                // Keep the original probe and its result; reverting field
+                // edits doesn't change what devices exist.
                 self.device_choices = cached;
+                self.scan_status = scan_status;
+                self.scan_rx = scan_rx;
                 self.feedback = Some(Feedback {
                     level: FeedbackLevel::Ok,
                     message: "Reverted unsaved changes".to_string(),
@@ -269,11 +319,103 @@ impl AudioState {
     }
 }
 
+/// Immediate device list shown while the background probe runs: "default"
+/// plus whatever the config currently points at, so the current selection is
+/// always cyclable even before (or without) probe results.
+fn initial_device_choices(ed: &ConfigEditor) -> Vec<String> {
+    let mut out = vec!["default".to_string()];
+    if let Some(dev) = ed.get_string("audio", "device") {
+        if !dev.is_empty() && dev != "default" {
+            out.push(dev);
+        }
+    }
+    out
+}
+
+/// Kick off the device probe on a background thread. The probe runs in a
+/// short-lived `voxtype configure --probe-audio-devices` subprocess because
+/// ALSA device probing can misbehave in ways a thread can't contain: dsnoop
+/// opens have been observed to block forever in an ioctl, and libasound can
+/// die on SIGFPE while probing hw params (both seen on PipeWire systems).
+/// In-process, either takes the whole TUI down; in a child, the thread kills
+/// it after a timeout and the TUI just shows "scan failed".
+fn start_device_scan() -> Option<mpsc::Receiver<Option<Vec<String>>>> {
+    let exe = std::env::current_exe().ok()?;
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(probe_input_devices_via_subprocess(&exe));
+    });
+    Some(rx)
+}
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn probe_input_devices_via_subprocess(exe: &std::path::Path) -> Option<Vec<String>> {
+    let mut child = std::process::Command::new(exe)
+        .args(["configure", "--probe-audio-devices"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let deadline = Instant::now() + PROBE_TIMEOUT;
+    let success = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status.success(),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    };
+    if !success {
+        return None;
+    }
+
+    // The child has exited, so this read is bounded; the device list is far
+    // smaller than the pipe buffer, so the child never blocked writing it.
+    let mut out = String::new();
+    child.stdout.take()?.read_to_string(&mut out).ok()?;
+    Some(
+        out.lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(String::from)
+            .collect(),
+    )
+}
+
+/// Entry point for the hidden `--probe-audio-devices` flag: print one input
+/// device name per line. Runs in the subprocess spawned by
+/// [`start_device_scan`].
+pub fn print_input_devices() {
+    // Watchdog: probing can hang forever in an ALSA ioctl. The parent kills
+    // us after PROBE_TIMEOUT, but not if it already exited (user quit the
+    // TUI early) — self-terminate so a hung probe can't linger as an orphan.
+    std::thread::spawn(|| {
+        std::thread::sleep(PROBE_TIMEOUT + Duration::from_secs(5));
+        std::process::exit(2);
+    });
+    for name in enumerate_input_devices() {
+        println!("{}", name);
+    }
+}
+
 fn enumerate_input_devices() -> Vec<String> {
     // ALSA's PCM probing prints "Cannot open device /dev/dsp" and similar
-    // messages to stderr for every device cpal touches. Inside the TUI's
-    // alternate screen those lines paint over our frame and corrupt the
-    // next redraw. Silence stderr for the duration of the probe.
+    // messages to stderr for every device cpal touches. Callers may run this
+    // with stderr on a terminal (hidden CLI flag); silence it for the
+    // duration of the probe.
     let _silenced = SilencedStderr::install();
 
     let mut out = vec!["default".to_string()];
@@ -435,14 +577,26 @@ fn guidance_for_field(state: &AudioState) -> Vec<Line<'_>> {
     match state.field {
         Field::Device => {
             let count = state.device_choices.len().saturating_sub(1);
-            vec![
-                heading("Input device"),
-                Line::from(""),
-                Line::from(format!(
+            let scan_line = match state.scan_status {
+                ScanStatus::Scanning => Line::from(Span::styled(
+                    "Scanning audio devices…",
+                    Style::default().fg(Color::Gray),
+                )),
+                ScanStatus::Failed => Line::from(Span::styled(
+                    "Device scan failed or timed out — type a device name \
+                     manually (Enter to edit).",
+                    Style::default().fg(Color::Yellow),
+                )),
+                ScanStatus::Done => Line::from(format!(
                     "Detected {} device{} via cpal.",
                     count,
                     if count == 1 { "" } else { "s" }
                 )),
+            };
+            vec![
+                heading("Input device"),
+                Line::from(""),
+                scan_line,
                 Line::from(""),
                 Line::from(
                     "\"default\" follows whatever PipeWire/PulseAudio is set \

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -50,6 +50,13 @@ use section::Section;
 
 type Tui = Terminal<CrosstermBackend<Stdout>>;
 
+/// Entry point for the hidden `voxtype configure --probe-audio-devices`
+/// flag: print detected input devices and exit. See
+/// `audio::start_device_scan` for why this runs in its own process.
+pub fn probe_audio_devices() {
+    audio::print_input_devices();
+}
+
 pub fn run(force_package_mode: bool) -> anyhow::Result<()> {
     let mut terminal = enter_terminal()?;
     let result = event_loop(&mut terminal, force_package_mode);
@@ -81,6 +88,7 @@ fn event_loop(terminal: &mut Tui, force_package_mode: bool) -> anyhow::Result<()
     let general_refresh_interval = Duration::from_secs(2);
 
     loop {
+        app.poll_background();
         terminal.draw(|f| draw(f, &app))?;
 
         if !event::poll(Duration::from_millis(250))? {


### PR DESCRIPTION
## Summary

Fixes #541 — the "Hotkey tab freeze" turned out to be an Audio-section bug wearing a Hotkey costume.

`AudioState::load()` enumerated capture devices via cpal/ALSA synchronously on the UI thread when the Audio section first opened. On this PipeWire system (Arch/Omarchy) that probe:

- **blocks forever** in an ALSA dsnoop open — core dump shows the main thread stuck in `snd_pcm_open → snd_pcm_dsnoop_open → snd_pcm_prepare → ioctl` that never returns, and
- can even **crash with SIGFPE** inside libasound's hw-params probing (second core dump from the same enumeration path).

Because the hang happens inside the key handler *before the next draw*, the last painted frame still shows the previously selected section — Hotkey — which is why #541 (and its reporter, me) blamed the Hotkey tab. Sidebar order is General → Engine → Hotkey → Audio, so "navigate down past Hotkey" was really "open Audio".

## Fix

Move the probe off the UI thread and out of the process:

- The Audio section renders immediately with `["default"` + the configured device] and shows *"Scanning audio devices…"* in the Device guidance pane.
- A background thread runs the probe in a short-lived `voxtype configure --probe-audio-devices` subprocess (hidden flag). Subprocess isolation contains both failure modes: a hung probe is killed after 10s (pane then hints to type a device name manually), and a SIGFPE kills only the child. This follows the pattern of the existing GPU subprocess isolation and the TUI shelling out to `voxtype setup model`.
- The probe child self-terminates via a watchdog thread, so it can't linger as an orphan if the user quits the TUI before the parent's timeout fires.
- The event loop polls for completion each tick (≤250ms), folding results into the device cycler when they arrive.

## Testing

- Before: navigating General→…→Audio froze the TUI on nearly every attempt on this machine (PipeWire + pipewire-alsa); one attempt died with SIGFPE.
- After: 5/5 navigation runs clean; device list ("Detected 20 devices via cpal") appears within ~2s when the probe succeeds; when the probe hangs, the TUI stays fully responsive and shows the failure hint after 10s.
- `cargo test --lib tui::` 39 passed, `cargo clippy` clean, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
