### PR TITLE
macOS: keep the menu bar app out of the Dock

### DIFF
--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
+use tao::platform::macos::{ActivationPolicy, EventLoopExtMacOS};
 use tray_icon::{
     menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
     TrayIconBuilder,
@@ -556,8 +557,16 @@ pub fn run(state_file: PathBuf) -> ! {
     // Set up menu event receiver
     let menu_channel = MenuEvent::receiver();
 
-    // Create event loop
-    let event_loop = EventLoopBuilder::new().build();
+    // Create event loop.
+    //
+    // Accessory activation policy keeps voxtype out of the Dock and the
+    // Cmd-Tab switcher: it owns a status bar item, not a window. tao defaults
+    // to `Regular`, which applies `setActivationPolicy(.regular)` when the
+    // event loop starts and overrides `LSUIElement` in the bundle's
+    // Info.plist, so setting it here is what actually takes effect. Must be
+    // called before `run()`.
+    let mut event_loop = EventLoopBuilder::new().build();
+    event_loop.set_activation_policy(ActivationPolicy::Accessory);
 
     event_loop.run(move |_event, _, control_flow| {
         // Wake every 100ms to check menu events; state updates arrive via kqueue flag


### PR DESCRIPTION
## Description

The macOS menu bar helper shows a Dock icon and appears in Cmd-Tab, even though `LSUIElement` is set in the app bundle's `Info.plist` and the process only owns a status bar item (no window).

Root cause: `src/menubar.rs` builds the tray's event loop with `EventLoopBuilder::new().build()`. tao's own docs state the activation policy "is set to `NSApplicationActivationPolicyRegular` by default," and it applies that policy when the event loop starts, which overrides `LSUIElement` from the bundle. No Info.plist change can fix this; it has to be set on the event loop itself.

Fix: call `EventLoopExtMacOS::set_activation_policy(ActivationPolicy::Accessory)` before `run()`.

Verified with `lsappinfo info -only ApplicationType <ASN>`:
- Before: `ApplicationType=Foreground`
- After: `ApplicationType=UIElement`

Also confirmed the Dock icon and Cmd-Tab entry are gone after installing via `voxtype setup app-bundle`, and that the menu bar item, hotkey, and recording still work normally.

## Related Issue

No existing issue; found this while setting up the menu bar app fresh.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings introduced by this change (the crate has 12 pre-existing clippy errors on `dev`, none touched by this diff; `cargo clippy --all-targets --no-deps --features gpu-metal -- -D warnings` reports the same 12 with or without this branch applied)
- [x] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [x] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [x] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

This is a 2-line fix isolated to `src/menubar.rs`, built and tested on macOS 26.5.2 (Apple Silicon) with `--features gpu-metal`. Opened as a companion to #<SF_SYMBOLS_PR> (native SF Symbols menu bar icon), kept separate since they're independent changes to the same file.
