### PR TITLE
macOS: draw menu bar icon with SF Symbols instead of emoji

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,8 +3620,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3643,7 +3674,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
  "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3661,6 +3730,17 @@ dependencies = [
  "bitflags 2.10.0",
  "block2",
  "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5987,6 +6067,9 @@ dependencies = [
  "nix 0.29.0",
  "notify",
  "num_cpus",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "ort",
  "parakeet-rs",
  "pidlock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,18 @@ mac-notification-sys = "0.6"  # Native macOS notifications
 # (Issue #352). Linux daemon doesn't use either, so they live here.
 rdev = "0.5.3"
 tray-icon = "0.21.3"
+# AppKit bindings for rendering SF Symbols into the tray icon
+# (src/menubar.rs::sf_symbol_icon). Versions match what tao/tray-icon
+# already pull in, so this adds no extra compilation.
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSString", "NSGeometry"] }
+objc2-app-kit = { version = "0.3", features = [
+    "NSImage",
+    "NSImageRep",
+    "NSBitmapImageRep",
+    "NSGraphicsContext",
+    "NSGraphics",
+] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Input handling (evdev for kernel-level key events)

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -5,6 +5,9 @@
 
 use crate::config::{ActivationMode, Config, OutputMode, TranscriptionEngine};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use objc2::AnyThread;
+use objc2_app_kit::{NSBitmapImageRep, NSDeviceRGBColorSpace, NSGraphicsContext, NSImage};
+use objc2_foundation::{NSPoint, NSRect, NSSize, NSString};
 use pidlock::Pidlock;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -13,7 +16,7 @@ use std::time::{Duration, Instant};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
 use tray_icon::{
     menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
-    TrayIconBuilder,
+    Icon, TrayIconBuilder,
 };
 
 /// Current voxtype state
@@ -35,12 +38,24 @@ impl VoxtypeState {
         }
     }
 
+    /// Emoji glyph, used as the tray *title* when SF Symbols are unavailable.
     fn icon(&self) -> &'static str {
         match self {
             VoxtypeState::Idle => "🎙",
             VoxtypeState::Recording => "🔴",
             VoxtypeState::Transcribing => "⏳",
             VoxtypeState::Stopped => "⬛",
+        }
+    }
+
+    /// SF Symbol name for this state, drawn as a template image so the icon
+    /// picks up the menu bar's tint in both light and dark mode.
+    fn sf_symbol(&self) -> &'static str {
+        match self {
+            VoxtypeState::Idle => "mic",
+            VoxtypeState::Recording => "waveform.circle.fill",
+            VoxtypeState::Transcribing => "hourglass",
+            VoxtypeState::Stopped => "mic.slash",
         }
     }
 
@@ -475,6 +490,58 @@ fn build_menu(config: &Config) -> (Menu, MenuItem) {
     (menu, status_item)
 }
 
+/// Rasterize an SF Symbol into a `tray_icon::Icon`.
+///
+/// The result is drawn as a template image: only the alpha channel matters, so
+/// AppKit tints it to match the menu bar in light mode, dark mode, and while
+/// the menu is highlighted. Returns `None` if the symbol doesn't exist on this
+/// macOS version or the bitmap can't be allocated, letting callers fall back to
+/// the emoji title.
+fn sf_symbol_icon(name: &str) -> Option<Icon> {
+    // Menu bar icons are 18pt; rasterize at 2x so they stay sharp on Retina.
+    const POINTS: f64 = 18.0;
+    const PX: usize = 36;
+
+    unsafe {
+        let symbol = NSImage::imageWithSystemSymbolName_accessibilityDescription(
+            &NSString::from_str(name),
+            None,
+        )?;
+        symbol.setTemplate(true);
+        symbol.setSize(NSSize::new(POINTS, POINTS));
+
+        let rep = NSBitmapImageRep::initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel(
+            NSBitmapImageRep::alloc(),
+            std::ptr::null_mut(),
+            PX as isize,
+            PX as isize,
+            8,
+            4,
+            true,
+            false,
+            NSDeviceRGBColorSpace,
+            (PX * 4) as isize,
+            32,
+        )?;
+
+        let context = NSGraphicsContext::graphicsContextWithBitmapImageRep(&rep)?;
+        NSGraphicsContext::saveGraphicsState_class();
+        NSGraphicsContext::setCurrentContext(Some(&context));
+        symbol.drawInRect(NSRect::new(
+            NSPoint::new(0.0, 0.0),
+            NSSize::new(PX as f64, PX as f64),
+        ));
+        NSGraphicsContext::restoreGraphicsState_class();
+
+        let bitmap = rep.bitmapData();
+        if bitmap.is_null() {
+            return None;
+        }
+        let rgba = std::slice::from_raw_parts(bitmap as *const u8, PX * PX * 4).to_vec();
+        Icon::from_rgba(rgba, PX as u32, PX as u32).ok()
+    }
+}
+
 /// Run the menu bar application
 /// This should be called from the main thread
 /// Note: This function never returns (runs the macOS event loop)
@@ -516,12 +583,16 @@ pub fn run(state_file: PathBuf) -> ! {
     let _ = status_item.set_text(initial_state.status_text());
 
     // Create tray icon
-    let tray = TrayIconBuilder::new()
+    // Prefer a native SF Symbol; fall back to the emoji title if the symbol
+    // isn't available (older macOS, renamed symbol, allocation failure).
+    let mut tray_builder = TrayIconBuilder::new()
         .with_tooltip("Voxtype")
-        .with_title(initial_state.icon())
-        .with_menu(Box::new(menu))
-        .build()
-        .expect("Failed to create tray icon");
+        .with_menu(Box::new(menu));
+    tray_builder = match sf_symbol_icon(initial_state.sf_symbol()) {
+        Some(icon) => tray_builder.with_icon(icon).with_icon_as_template(true),
+        None => tray_builder.with_title(initial_state.icon()),
+    };
+    let tray = tray_builder.build().expect("Failed to create tray icon");
 
     println!("Menu bar is running. Look for the icon in your menu bar.");
     println!("Press Ctrl+C to stop.\n");
@@ -695,7 +766,15 @@ pub fn run(state_file: PathBuf) -> ! {
             let new_state = read_state_from_file(&state_file);
 
             if new_state != last_state {
-                let _ = tray.set_title(Some(new_state.icon()));
+                match sf_symbol_icon(new_state.sf_symbol()) {
+                    Some(icon) => {
+                        let _ = tray.set_icon(Some(icon));
+                        tray.set_icon_as_template(true);
+                    }
+                    None => {
+                        tray.set_title(Some(new_state.icon()));
+                    }
+                }
                 let _ = status_item.set_text(new_state.status_text());
                 last_state = new_state;
             }


### PR DESCRIPTION
## Description

The macOS menu bar icon is drawn by setting the status item's *title* to an emoji glyph. Emoji render in full colour at a fixed weight, so the item never matches the surrounding system menu bar icons and doesn't respond to light/dark mode or the menu-open highlight the way native icons do.

This renders the same state icons as SF Symbols instead, rasterized into a template `tray_icon::Icon` so AppKit tints them like any other menu bar icon:

| State        | SF Symbol name         |
|--------------|-------------------------|
| idle         | `mic`                   |
| recording    | `waveform.circle.fill`  |
| transcribing | `hourglass`             |
| stopped      | `mic.slash`             |

`VoxtypeState::icon()` (the emoji) is kept as a fallback: if `sf_symbol_icon()` returns `None` (symbol renamed/removed on some macOS version, or the bitmap can't be allocated), the code falls back to the previous emoji title rather than failing.

The `objc2` / `objc2-app-kit` / `objc2-foundation` crates used to call `NSImage(systemSymbolName:)` were already pulled in transitively via `tao` and `tray-icon`, so declaring them as direct dependencies adds no extra compilation (~1 min incremental build in my testing).

## Related Issue

No existing issue; happy to open one if preferred.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings introduced by this change (the crate has 12 pre-existing clippy errors on `dev`; this branch has 10, and the 2 fixed were touched incidentally while editing `menubar.rs`, not part of the feature itself)
- [x] I have run `cargo fmt`

## Documentation

- [ ] I have updated documentation as needed
- [x] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [x] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

Built and tested on macOS 26.5.2 (Apple Silicon) with `--features gpu-metal`; confirmed the icon renders as a proper monochrome template in both light and dark menu bar.

Opened as a companion to #554 (keep the menu bar app out of the Dock), kept separate since they're independent changes to the same file and I wanted each reviewable/mergeable on its own.

Open to feedback on the specific symbol choices, `waveform.circle.fill` in particular felt like the closest match to "recording" but I don't have strong opinions on it.
