### PR TITLE
Merge main into dev ahead of the v1.0.0 re-cut

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,7 +360,7 @@ Based on open issues and project direction.
 
 ### Non-Goals
 
-- Windows/macOS support (Linux-first, Wayland-native)
+- Windows support (Linux-first, Wayland-native)
 - GUI configuration (GTK/Qt/web). A TUI (`voxtype configure`) is supported and
   surfaced as a desktop-file launcher entry; CLI and config file remain the
   primary interfaces for scripting and headless setups.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,6 +19,12 @@ Voxtype looks for configuration in the following locations (in order):
 3. `/etc/voxtype/config.toml` (system-wide default)
 4. Built-in defaults
 
+`$XDG_CONFIG_HOME` overrides `~/.config` on every platform, macOS included.
+Models follow the same scheme under `$XDG_DATA_HOME` (default `~/.local/share`).
+A macOS install that predates this and stored files under
+`~/Library/Application Support/voxtype` keeps working until you move them into
+`~/.config/voxtype` and `~/.local/share/voxtype`.
+
 ## Configuration Sections
 
 ---

--- a/docs/INSTALL_MACOS.md
+++ b/docs/INSTALL_MACOS.md
@@ -85,7 +85,10 @@ This shows:
 
 ## Configuration
 
-Config file: `~/Library/Application Support/voxtype/config.toml`
+Config file: `~/.config/voxtype/config.toml`, honoring `$XDG_CONFIG_HOME` if set.
+
+Older installs that wrote to `~/Library/Application Support/voxtype/config.toml`
+keep using it until you move the file to `~/.config/voxtype/`.
 
 ```toml
 # Transcription engine

--- a/src/config.rs
+++ b/src/config.rs
@@ -2487,10 +2487,9 @@ impl Config {
     /// System-wide config path used as a fallback when no user config exists.
     pub const SYSTEM_PATH: &'static str = "/etc/voxtype/config.toml";
 
-    /// Get the default user config file path (XDG)
+    /// Default user config file path: `<config_dir>/config.toml`.
     pub fn default_path() -> Option<PathBuf> {
-        directories::ProjectDirs::from("", "", "voxtype")
-            .map(|dirs| dirs.config_dir().join("config.toml"))
+        Self::config_dir().map(|dir| dir.join("config.toml"))
     }
 
     /// Get the system-wide config file path.
@@ -2540,17 +2539,46 @@ impl Config {
             })
     }
 
-    /// Get the config directory path
+    /// Voxtype's user config directory, honoring `$XDG_CONFIG_HOME` (default
+    /// `~/.config`) on every platform including macOS, where the `directories`
+    /// crate would use `~/Library/Application Support` and ignore XDG (#448).
     pub fn config_dir() -> Option<PathBuf> {
-        directories::ProjectDirs::from("", "", "voxtype")
-            .map(|dirs| dirs.config_dir().to_path_buf())
+        Self::xdg_dir(
+            "XDG_CONFIG_HOME",
+            ".config",
+            directories::ProjectDirs::from("", "", "voxtype").map(|d| d.config_dir().to_path_buf()),
+        )
     }
 
-    /// Get the data directory path (for models)
+    /// Voxtype's user data directory (parent of the models dir), honoring
+    /// `$XDG_DATA_HOME` (default `~/.local/share`); same scheme as [`Config::config_dir`].
     pub fn data_dir() -> PathBuf {
-        directories::ProjectDirs::from("", "", "voxtype")
-            .map(|dirs| dirs.data_dir().to_path_buf())
-            .unwrap_or_else(|| PathBuf::from("."))
+        Self::xdg_dir(
+            "XDG_DATA_HOME",
+            ".local/share",
+            directories::ProjectDirs::from("", "", "voxtype").map(|d| d.data_dir().to_path_buf()),
+        )
+        .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    /// Resolve a `voxtype` user dir. An explicit absolute `$xdg_var` wins;
+    /// otherwise `$HOME/<default_rel>/voxtype`. Falls back to an existing
+    /// `legacy` platform-native dir so an upgrade never orphans a prior install.
+    fn xdg_dir(xdg_var: &str, default_rel: &str, legacy: Option<PathBuf>) -> Option<PathBuf> {
+        if let Some(base) = std::env::var_os(xdg_var)
+            .map(PathBuf::from)
+            .filter(|p| p.is_absolute())
+        {
+            return Some(base.join("voxtype"));
+        }
+        let xdg = std::env::var_os("HOME")
+            .filter(|h| !h.is_empty())
+            .map(|h| PathBuf::from(h).join(default_rel).join("voxtype"));
+        match (xdg, legacy) {
+            (Some(x), Some(l)) if x != l && !x.exists() && l.exists() => Some(l),
+            (Some(x), _) => Some(x),
+            (None, l) => l,
+        }
     }
 
     /// Get the models directory path
@@ -4728,5 +4756,42 @@ mod tests {
             output.dotool_xkb_variant,
             Some("explicit-dotool".to_string())
         );
+    }
+
+    #[test]
+    fn xdg_dir_resolution() {
+        // Mutates $HOME / $XDG_CONFIG_HOME, like the other env tests here.
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::remove_var("XDG_CONFIG_HOME");
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        let xdg = tmp.path().join(".config/voxtype");
+        let legacy = tmp.path().join("Library/Application Support/voxtype");
+        let resolve = || Config::xdg_dir("XDG_CONFIG_HOME", ".config", Some(legacy.clone()));
+
+        // Fresh install: XDG path, even before it exists.
+        assert_eq!(resolve(), Some(xdg.clone()));
+        // Only the legacy dir exists (upgrade): keep it, do not orphan config.
+        std::fs::create_dir_all(&legacy).unwrap();
+        assert_eq!(resolve(), Some(legacy.clone()));
+        // Once the XDG dir exists too, it wins.
+        std::fs::create_dir_all(&xdg).unwrap();
+        assert_eq!(resolve(), Some(xdg));
+        // Explicit absolute XDG_CONFIG_HOME overrides everything.
+        std::env::set_var("XDG_CONFIG_HOME", "/tmp/voxtype-xdg-abs");
+        assert_eq!(
+            Config::config_dir(),
+            Some(PathBuf::from("/tmp/voxtype-xdg-abs/voxtype"))
+        );
+
+        match prev_xdg {
+            Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
     }
 }

--- a/src/meeting/storage.rs
+++ b/src/meeting/storage.rs
@@ -53,9 +53,7 @@ impl Default for StorageConfig {
 impl StorageConfig {
     /// Get the default storage path
     pub fn default_storage_path() -> PathBuf {
-        directories::ProjectDirs::from("", "", "voxtype")
-            .map(|dirs| dirs.data_dir().join("meetings"))
-            .unwrap_or_else(|| PathBuf::from("~/.local/share/voxtype/meetings"))
+        crate::config::Config::data_dir().join("meetings")
     }
 
     /// Get the database path

--- a/src/transcribe/cohere.rs
+++ b/src/transcribe/cohere.rs
@@ -542,12 +542,7 @@ fn resolve_model_path(name: &str) -> Result<PathBuf, TranscribeError> {
     if let Ok(env) = std::env::var("VOXTYPE_COHERE_MODEL_DIR") {
         return Ok(PathBuf::from(env));
     }
-    let dirs = directories::ProjectDirs::from("io", "voxtype", "voxtype").ok_or_else(|| {
-        TranscribeError::ModelNotFound(
-            "Could not resolve model directory (no ProjectDirs)".to_string(),
-        )
-    })?;
-    Ok(dirs.data_dir().join("models").join(name))
+    Ok(crate::config::Config::models_dir().join(name))
 }
 
 fn build_session(

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -965,10 +965,7 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
 /// resolution path so the TUI's "is this downloaded?" check matches what
 /// the daemon will look for at load time.
 fn model_dir_on_disk(name: &str) -> std::path::PathBuf {
-    if let Some(dirs) = directories::ProjectDirs::from("io", "voxtype", "voxtype") {
-        return dirs.data_dir().join("models").join(name);
-    }
-    std::path::PathBuf::from(name)
+    crate::config::Config::models_dir().join(name)
 }
 
 /// True when the model directory exists with at least one file in it. We


### PR DESCRIPTION
Phase 1 of the v1.0.0 re-cut. `main` and `dev` had diverged since 2026-05-30, and #456 (Honor XDG_CONFIG_HOME on macOS) was the only commit `main` carried alone. Since v1.0.0 ships macOS, that fix needs to be on the branch v1 is cut from.

## The conflict

`src/config.rs` was deleted on `dev` by the config-module split (#469) and modified on `main` by #456, so git produced a modify/delete conflict rather than a textual one. Note that `git merge-tree` does not surface this class as conflict markers, so a marker grep reports the merge as clean when it is not.

Ported by hand into `src/config/root.rs`:

- `default_path` now derives from `config_dir` instead of resolving its own `ProjectDirs`
- `config_dir` and `data_dir` route through the new `xdg_dir` helper, so `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME` are honored on every platform including macOS
- an existing legacy platform-native dir still wins when the XDG dir does not exist yet, so upgrades never orphan a config or downloaded models
- `xdg_dir_resolution` moved into the `root.rs` tests module, next to the code it covers

The three call sites the original commit unified (meeting storage, cohere model dir, TUI model check) merged cleanly and already route through `Config`.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` — 798 + 54 passing, 0 failures, including the ported `xdg_dir_resolution`

Closes nothing on its own; unblocks the v1.0.0 re-cut.