### PR TITLE
Install the OSD frontends and audio-bridge into the deb and rpm (closes #488)

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -463,6 +463,38 @@ else
     cp "${SCRIPT_DIR}/voxtype-wrapper.sh" "$STAGING/usr/bin/voxtype"
     chmod 755 "$STAGING/usr/bin/voxtype"
 fi
+# OSD frontends and the audio-bridge sidecar. Dockerfile.onnx builds these
+# four alongside the onnx-avx2 binary and they ship as their own release
+# assets, but until v0.7.6 the deb/rpm never installed them, so
+# `voxtype setup quickshell` could not find the bridge and the OSD stayed
+# empty for package users (#488). Layout mirrors the voxtype-bin AUR
+# package, which had it right.
+#
+# The voxtype-osd launcher probes its own parent directory, so it finds
+# voxtype-osd-gtk4 and voxtype-osd-quickshell in /usr/lib/voxtype without
+# them being on PATH. Only the launcher gets a /usr/bin symlink.
+install_companion_binary() {
+    local asset="$1"        # release-asset suffix, e.g. osd-gtk4
+    local dest="$2"         # absolute path under $STAGING
+    local src="${RELEASE_DIR}/voxtype-${VERSION}-linux-${TARGET_ARCH}-${asset}"
+    if [[ ! -f "$src" ]]; then
+        echo "  warning: ${src##*/} not found, skipping" >&2
+        return 0
+    fi
+    install -Dm755 "$src" "$dest"
+}
+install_companion_binary osd "$STAGING/usr/lib/voxtype/voxtype-osd"
+install_companion_binary osd-gtk4 "$STAGING/usr/lib/voxtype/voxtype-osd-gtk4"
+install_companion_binary osd-quickshell "$STAGING/usr/lib/voxtype/voxtype-osd-quickshell"
+if [[ -f "$STAGING/usr/lib/voxtype/voxtype-osd" ]]; then
+    ln -sf /usr/lib/voxtype/voxtype-osd "$STAGING/usr/bin/voxtype-osd"
+fi
+
+# voxtype-audio-bridge: NDJSON sidecar that streams audio levels over a
+# UNIX socket to the Quickshell OSD. Lives in /usr/bin because the
+# quickshell launcher exec's it directly by basename.
+install_companion_binary audio-bridge "$STAGING/usr/bin/voxtype-audio-bridge"
+
 cp config/default.toml "$STAGING/etc/voxtype/config.toml"
 cp packaging/systemd/voxtype.service "$STAGING/usr/lib/systemd/user/"
 cp README.md "$STAGING/usr/share/doc/voxtype/"


### PR DESCRIPTION
Phase 2 of the v1.0.0 re-cut. Fixes #488.

## Narrower than it looks

The binaries were never missing from the build. `Dockerfile.onnx` has built all four companion binaries since v0.7.5, and they ship as their own release assets on v0.7.5 (`voxtype-0.7.5-linux-x86_64-osd`, `-osd-gtk4`, `-osd-quickshell`, `-audio-bridge`). The `voxtype-bin` AUR package downloads and installs them correctly, which is why this only ever reproduced for deb and rpm users.

The single defect is that `scripts/package.sh` never copied them into the staging tree. The deb shipped the Quickshell QML tree to `/usr/share/voxtype/quickshell` with none of the binaries that drive it, so `voxtype setup quickshell` failed its bridge lookup and the OSD waveform stayed empty.

## Layout

Mirrors the `voxtype-bin` AUR package, which had it right:

| Binary | Destination | Why |
|---|---|---|
| `voxtype-osd` | `/usr/lib/voxtype/` + `/usr/bin` symlink | launcher is the user-facing entry point |
| `voxtype-osd-gtk4` | `/usr/lib/voxtype/` | launcher probes its own parent dir |
| `voxtype-osd-quickshell` | `/usr/lib/voxtype/` | same |
| `voxtype-audio-bridge` | `/usr/bin/` | quickshell launcher execs it by basename, so it must be on PATH |

Missing companions warn and skip rather than aborting, because the aarch64 build produces only `osd` and `osd-gtk4`.

No dependency changes. `voxtype-osd-gtk4` needs gtk4-layer-shell at runtime, but the AUR treats that as an optdepend and forcing GTK4 onto headless deb installs would be worse than the binary erroring when invoked.

## Verification

Built a real deb from stub binaries and inspected the payload:

```
-rwxr-xr-x  ./usr/lib/voxtype/voxtype-osd-quickshell
-rwxr-xr-x  ./usr/lib/voxtype/voxtype-osd-gtk4
-rwxr-xr-x  ./usr/lib/voxtype/voxtype-osd
lrwxrwxrwx  ./usr/bin/voxtype-osd -> /usr/lib/voxtype/voxtype-osd
-rwxr-xr-x  ./usr/bin/voxtype-audio-bridge
```

Also confirmed the skip path: removing the two companions produces warnings and still packages cleanly. Both `package.sh` validators (CPU instruction check and `validate-release.sh`) correctly rejected the stub binaries, so they were bypassed only for this layout test.

Worth a real end-to-end check against actual v1.0.0 binaries during the RC soak, since stubs cannot exercise the launcher's runtime probe.