### PR TITLE
Credit OldJobobo in README and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 flake.nix @peteonrails @digunix @DuskyElf
 flake.lock @peteonrails @digunix @DuskyElf
 nix/ @peteonrails @digunix @DuskyElf
+
+# Quickshell UI
+quickshell/ @peteonrails @OldJobobo

--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ We want to hear from you! Voxtype is a young project and your feedback helps mak
 - [Sami Jawhar](https://github.com/sjawhar) - Eager input processing wiring
 - [KaiStarkk](https://github.com/KaiStarkk) - Post-process trim and fallback_on_empty options
 - [graysky](https://github.com/graysky2) - Flash attention config fix
+- [OldJobobo](https://github.com/OldJobobo) - Quickshell OSD theming, Omarchy theme state path support, configurable media ducking, degenerate Whisper transcript retry; co-owns `quickshell/`
 
 ## License
 


### PR DESCRIPTION
Four merged PRs and no entry in the contributors list:

| PR | Merged | What |
|---|---|---|
| #501 | 2026-06-24 | Quickshell OSD theming support |
| #517 | 2026-07-13 | Support new Omarchy theme state path |
| #520 | 2026-07-13 | Configurable media ducking during recording |
| #521 | 2026-08-06 | Retry degenerate Whisper transcripts |

Adds the README contributors entry and the `quickshell/` CODEOWNERS ownership, so Quickshell changes route to a reviewer who knows that tree.

#517 is worth singling out: it is the reason voxtype reads Omarchy Quattro's theme state path at all, which makes it load-bearing for v1.0.0 Quattro compatibility.

The CODEOWNERS line reproduces the edit that was sitting uncommitted in the working tree, with the handle cased as `@OldJobobo` to match the GitHub account.