### PR TITLE
Make Soniox unconditional, and fix the engine lists that dropped it (supersedes #441)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ hound = "3"  # WAV file reading/writing
 # HTTP client for remote transcription
 ureq = { version = "2", features = ["json"] }
 
-# WebSocket client for Soniox streaming backend (optional)
-tokio-tungstenite = { version = "0.24", optional = true, features = ["rustls-tls-webpki-roots"] }
-futures-util = { version = "0.3", optional = true }
+# WebSocket client for Soniox streaming backend
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"
 # Async HTTP client for Soniox async transcription API (multipart upload + poll)
-reqwest = { version = "0.12", optional = true, default-features = false, features = ["json", "multipart", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 
 # JSON parsing (for CLI backend)
 serde_json = "1"
@@ -242,8 +242,10 @@ omnilingual-tensorrt = ["omnilingual", "onnx-tensorrt-enabled"]
 cohere = ["onnx-common", "dep:half", "dep:tokenizers"]
 cohere-cuda = ["cohere", "onnx-cuda-enabled"]
 cohere-tensorrt = ["cohere", "onnx-tensorrt-enabled"]
-# Soniox cloud streaming WebSocket STT backend (no local model, just a network client)
-soniox = ["dep:tokio-tungstenite", "dep:futures-util", "dep:reqwest"]
+# Soniox is unconditional. Its deps (tokio-tungstenite, futures-util, reqwest)
+# add ~1-2 MB after LTO+strip and ride alongside ureq, which every binary
+# already ships for model downloads. Treating it like remote.rs (also always
+# compiled) keeps the engine surface uniform across release flavors.
 # No cohere-migraphx feature: MIGraphX 7.2 still fails on the
 # onnx-community q4 export. Original blocker was MatMulNBits bits=8
 # (cstr int8); q4 has bits=4 which is supported, but its zero_points

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1623,13 +1623,13 @@ language_hints = ["hu", "en"]
 
 ### Building from Source
 
-Source builds need the `soniox` Cargo feature:
+Soniox is built unconditionally; no Cargo feature flag is required:
 
 ```bash
-cargo build --release --features soniox
+cargo build --release
 ```
 
-The `soniox` feature is independent of the other engine features and adds a small WebSocket client (tokio-tungstenite + rustls) plus an async HTTP client (reqwest) for the async API. It can be combined with any local engine feature, e.g. `--features "soniox parakeet"` for a binary that runs Parakeet locally and Soniox in the cloud depending on the `engine` setting.
+The Soniox backend pulls in a small WebSocket client (tokio-tungstenite + rustls) and an async HTTP client (reqwest) for the async API. They ship in every release binary so the engine surface stays uniform across flavors.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -76,7 +76,7 @@ config changes; restart it with `systemctl --user restart voxtype` for the
 new engine to take effect.
 
 **Notes:**
-- All engines except Whisper require an ONNX-enabled binary (`voxtype-*-onnx-*`)
+- Whisper, Remote Whisper, and Soniox run in every binary. The other engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) require an ONNX-enabled binary (`voxtype-*-onnx-*`)
 - Each ONNX engine reads its own `[<engine>]` section (e.g. `[parakeet]`, `[cohere]`)
 - See [PARAKEET.md](PARAKEET.md) for detailed Parakeet setup instructions
 - See [MOONSHINE.md](MOONSHINE.md) for detailed Moonshine setup instructions

--- a/docs/MODEL_SELECTION_GUIDE.md
+++ b/docs/MODEL_SELECTION_GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide helps you choose the right transcription engine and model for voxtype v0.6.0. The choice depends on your language, hardware, and how you use dictation.
 
-Voxtype has seven transcription engines. Two are bundled with the standard binary (Whisper and Remote Whisper). The other five require the ONNX binary variant.
+Voxtype has eight transcription engines. Three ship in every binary — Whisper (local), Remote Whisper (HTTP API), and Soniox (cloud streaming). The other five require the ONNX binary variant.
 
 ---
 

--- a/docs/MODEL_SELECTION_GUIDE.md
+++ b/docs/MODEL_SELECTION_GUIDE.md
@@ -17,9 +17,9 @@ Voxtype has seven transcription engines. Two are bundled with the standard binar
 | **Paraformer** | zh, en | Encoder-predictor-decoder | 220 - 487 MB | Fast | No | ONNX |
 | **Dolphin** | 40+ langs, 22 Chinese dialects | CTC E-Branchformer | 198 MB | Fast | No | ONNX |
 | **Omnilingual** | 1600+ | CTC wav2vec2 | 3.9 GB | Moderate | No | ONNX |
-| **Soniox** (cloud) | 60+ | Cloud (WebSocket / REST) | n/a (no local model) | Cloud-bound | Yes | Soniox feature |
+| **Soniox** (cloud) | 60+ | Cloud (WebSocket / REST) | n/a (no local model) | Cloud-bound | Yes | Built-in |
 
-**Soniox** is different from the others — it's a paid cloud service over WebSocket / REST. No local model, no GPU. Sub-second partial latency. Strong for non-English languages where local Whisper-based engines struggle on lower-end hardware. Requires `cargo build --features soniox` and a `SONIOX_API_KEY`. See [SONIOX.md](SONIOX.md) for the full story.
+**Soniox** is different from the others — it's a paid cloud service over WebSocket / REST. No local model, no GPU. Sub-second partial latency. Strong for non-English languages where local Whisper-based engines struggle on lower-end hardware. Ships in every release binary; you only need a `SONIOX_API_KEY`. See [SONIOX.md](SONIOX.md) for the full story.
 
 ---
 

--- a/docs/SONIOX.md
+++ b/docs/SONIOX.md
@@ -23,10 +23,7 @@ Soniox is paid SaaS. Sign up at [console.soniox.com](https://console.soniox.com)
 
 ## Requirements
 
-- voxtype built with the `soniox` Cargo feature:
-  ```bash
-  cargo build --release --features soniox
-  ```
+- voxtype (Soniox ships in every release binary; no feature flag needed)
 - A Soniox API key (free tier credits available)
 - Outbound HTTPS / WebSocket (wss://) access
 

--- a/docs/SONIOX.md
+++ b/docs/SONIOX.md
@@ -23,9 +23,10 @@ Soniox is paid SaaS. Sign up at [console.soniox.com](https://console.soniox.com)
 
 ## Requirements
 
-- voxtype (Soniox ships in every release binary; no feature flag needed)
 - A Soniox API key (free tier credits available)
 - Outbound HTTPS / WebSocket (wss://) access
+
+Soniox ships in every release binary; no build flag needed.
 
 No local model files. No GPU.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1113,7 +1113,7 @@ async_max_wait_secs = 300
 
 ### Post-stop "Streaming Error: Soniox server error (408): Request timeout"
 
-This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release v0.7.3 or later includes it).
+This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release v0.7.5 or later includes it).
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1113,7 +1113,7 @@ async_max_wait_secs = 300
 
 ### Post-stop "Streaming Error: Soniox server error (408): Request timeout"
 
-This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release after v0.7.2 + soniox).
+This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release v0.7.3 or later includes it).
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -471,7 +471,7 @@ on_transcription = true
 
 For a cloud streaming alternative to the local engines above, voxtype supports [Soniox](https://soniox.com). Different trade-off space: paid SaaS, no local model, 60+ languages with strong Hungarian/EU coverage, sub-second partials at the cursor.
 
-Build with `--features soniox`, set `SONIOX_API_KEY`, and:
+Soniox ships in every release binary. Set `SONIOX_API_KEY` and:
 
 ```toml
 engine = "soniox"

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -64,7 +64,6 @@ pub enum TranscriptionEngine {
     /// Requires: cargo build --features cohere
     Cohere,
     /// Use Soniox (cloud streaming WebSocket STT).
-    /// Requires: cargo build --features soniox
     Soniox,
 }
 

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -77,6 +77,27 @@ impl TranscriptionEngine {
     pub fn name(self) -> &'static str {
         self.into()
     }
+
+    /// Comma-separated list of every variant's canonical name. Cached behind
+    /// a `OnceLock` so callers get a `&'static str` without rebuilding it
+    /// each time. Use this in any user-facing string that lists engines so
+    /// a new variant added to the enum automatically appears everywhere
+    /// without a manual table to keep in sync.
+    ///
+    /// The `crate::cli::ENGINE_NAMES_CSV` constant intentionally duplicates
+    /// this value as a string literal because `build.rs` includes the CLI
+    /// module via `#[path]` and cannot reach into `crate::config`; a test
+    /// pins that constant against this method's output.
+    pub fn names_csv() -> &'static str {
+        use strum::IntoEnumIterator;
+        static NAMES: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+        NAMES.get_or_init(|| {
+            Self::iter()
+                .map(|e| e.name())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/config/engines/soniox.rs
+++ b/src/config/engines/soniox.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use super::super::default_true;
 
 /// Soniox cloud streaming WebSocket STT configuration
-/// Requires: cargo build --features soniox
 ///
 /// Soniox is a paid cloud STT provider. API key required:
 /// either set `api_key` here or via the `SONIOX_API_KEY` env var.

--- a/src/config_set.rs
+++ b/src/config_set.rs
@@ -20,26 +20,11 @@ use std::path::PathBuf;
 use crate::config::TranscriptionEngine;
 use crate::tui::{ConfigEditor, EditorError};
 
-/// All engine identifiers accepted by `voxtype config set engine`.
-///
-/// Kept in sync with [`TranscriptionEngine`] and with `ENGINE_CHOICES` in
-/// `src/tui/engine.rs`. If a new engine is added there, add it here too.
-pub const ENGINE_NAMES: &[&str] = &[
-    "whisper",
-    "parakeet",
-    "moonshine",
-    "sensevoice",
-    "paraformer",
-    "dolphin",
-    "omnilingual",
-    "cohere",
-];
-
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigSetError {
     #[error(
-        "unknown engine '{0}'. Valid engines: whisper, parakeet, moonshine, \
-         sensevoice, paraformer, dolphin, omnilingual, cohere"
+        "unknown engine '{0}'. Valid engines: {}",
+        TranscriptionEngine::names_csv()
     )]
     UnknownEngine(String),
 
@@ -58,21 +43,13 @@ pub enum ConfigSetError {
 
 /// Is the engine name one we recognize at all?
 ///
-/// Equivalent to parsing through [`TranscriptionEngine`]'s serde
-/// representation but avoids deserializing a whole config to check one
-/// field.
+/// Iterates the [`TranscriptionEngine`] variants and matches the exact
+/// canonical lowercase name. Case-sensitive (so callers can detect typos
+/// like `"Whisper"` before applying them to config). New engine variants
+/// are picked up automatically via `strum::EnumIter`.
 pub fn parse_engine(name: &str) -> Option<TranscriptionEngine> {
-    match name {
-        "whisper" => Some(TranscriptionEngine::Whisper),
-        "parakeet" => Some(TranscriptionEngine::Parakeet),
-        "moonshine" => Some(TranscriptionEngine::Moonshine),
-        "sensevoice" => Some(TranscriptionEngine::SenseVoice),
-        "paraformer" => Some(TranscriptionEngine::Paraformer),
-        "dolphin" => Some(TranscriptionEngine::Dolphin),
-        "omnilingual" => Some(TranscriptionEngine::Omnilingual),
-        "cohere" => Some(TranscriptionEngine::Cohere),
-        _ => None,
-    }
+    use strum::IntoEnumIterator;
+    TranscriptionEngine::iter().find(|e| e.name() == name)
 }
 
 /// Was this binary compiled with the feature needed to run the given engine?
@@ -123,6 +100,7 @@ mod tests {
     use super::*;
     use std::fs;
     use std::io::Write;
+    use strum::IntoEnumIterator;
 
     fn temp_config(contents: &str) -> (tempfile::TempDir, PathBuf) {
         let dir = tempfile::tempdir().unwrap();
@@ -134,8 +112,25 @@ mod tests {
 
     #[test]
     fn parse_engine_accepts_known_names() {
-        for name in ENGINE_NAMES {
+        for engine in TranscriptionEngine::iter() {
+            let name = engine.name();
             assert!(parse_engine(name).is_some(), "should accept '{}'", name);
+        }
+    }
+
+    /// Pins the user-facing error message to the enum so a new variant can't
+    /// land without showing up in `voxtype config set engine <bogus>` output.
+    /// Caught the post-#476 drift where `soniox` was missing from this list.
+    #[test]
+    fn unknown_engine_error_lists_every_variant() {
+        let display = format!("{}", ConfigSetError::UnknownEngine("bogus".to_string()));
+        for engine in TranscriptionEngine::iter() {
+            assert!(
+                display.contains(engine.name()),
+                "ConfigSetError::UnknownEngine display is missing variant '{}': {}",
+                engine.name(),
+                display
+            );
         }
     }
 
@@ -245,9 +240,9 @@ mod tests {
         // Pick the first non-whisper engine whose feature is NOT compiled
         // into this test binary. Skip the test entirely if every engine is
         // compiled in (e.g. a maximalist CI build).
-        let target = ENGINE_NAMES
-            .iter()
-            .find(|n| **n != "whisper" && !engine_feature_compiled(n));
+        let target = TranscriptionEngine::iter()
+            .map(|e| e.name())
+            .find(|n| *n != "whisper" && !engine_feature_compiled(n));
         let Some(name) = target else {
             eprintln!("skipping: all engine features are compiled in this build");
             return;
@@ -255,7 +250,7 @@ mod tests {
         let (_dir, path) = temp_config("");
         let err = set_engine(path, name).unwrap_err();
         match err {
-            ConfigSetError::FeatureNotCompiled(n) => assert_eq!(&n, *name),
+            ConfigSetError::FeatureNotCompiled(n) => assert_eq!(n, name),
             other => panic!("expected FeatureNotCompiled, got {:?}", other),
         }
     }

--- a/src/config_set.rs
+++ b/src/config_set.rs
@@ -54,24 +54,32 @@ pub fn parse_engine(name: &str) -> Option<TranscriptionEngine> {
 
 /// Was this binary compiled with the feature needed to run the given engine?
 ///
-/// Whisper is always available; everything else is gated on the
-/// corresponding Cargo feature flag. This is the source-of-truth check that
-/// matches what the TUI shows on source builds (see
-/// `EngineState::refresh_binary_match` in `src/tui/engine.rs`). The TUI's
-/// `compiled_features()` list in `src/setup/binary.rs` is incomplete (it
-/// only enumerates parakeet + GPU features), so we evaluate `cfg!` directly
-/// here rather than going through that helper.
+/// Whisper and Soniox are unconditional (Soniox was un-feature-gated in
+/// #441); every other engine is gated on the corresponding Cargo feature.
+/// This is the source-of-truth check that matches what the TUI shows on
+/// source builds (see `EngineState::refresh_binary_match` in
+/// `src/tui/engine.rs`). The TUI's `compiled_features()` list in
+/// `src/setup/binary.rs` is incomplete (it only enumerates parakeet + GPU
+/// features), so we evaluate `cfg!` directly here rather than going
+/// through that helper.
+///
+/// Matches `TranscriptionEngine` exhaustively so adding a new variant
+/// produces a compile error here, not a silent `false` at runtime. The
+/// previous wildcard arm hid `soniox` from this check for several months.
 pub fn engine_feature_compiled(name: &str) -> bool {
-    match name {
-        "whisper" => true,
-        "parakeet" => cfg!(feature = "parakeet"),
-        "moonshine" => cfg!(feature = "moonshine"),
-        "sensevoice" => cfg!(feature = "sensevoice"),
-        "paraformer" => cfg!(feature = "paraformer"),
-        "dolphin" => cfg!(feature = "dolphin"),
-        "omnilingual" => cfg!(feature = "omnilingual"),
-        "cohere" => cfg!(feature = "cohere"),
-        _ => false,
+    let Some(engine) = parse_engine(name) else {
+        return false;
+    };
+    match engine {
+        TranscriptionEngine::Whisper => true,
+        TranscriptionEngine::Soniox => true,
+        TranscriptionEngine::Parakeet => cfg!(feature = "parakeet"),
+        TranscriptionEngine::Moonshine => cfg!(feature = "moonshine"),
+        TranscriptionEngine::SenseVoice => cfg!(feature = "sensevoice"),
+        TranscriptionEngine::Paraformer => cfg!(feature = "paraformer"),
+        TranscriptionEngine::Dolphin => cfg!(feature = "dolphin"),
+        TranscriptionEngine::Omnilingual => cfg!(feature = "omnilingual"),
+        TranscriptionEngine::Cohere => cfg!(feature = "cohere"),
     }
 }
 

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -16,7 +16,6 @@ pub mod cli;
 #[cfg(feature = "parakeet")]
 pub mod parakeet_streaming;
 pub mod remote;
-#[cfg(feature = "soniox")]
 pub mod soniox;
 pub mod streaming;
 pub mod subprocess;
@@ -269,7 +268,6 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
             "Cohere engine requested but voxtype was not compiled with --features cohere"
                 .to_string(),
         )),
-        #[cfg(feature = "soniox")]
         TranscriptionEngine::Soniox => {
             let cfg = config.soniox.as_ref().ok_or_else(|| {
                 TranscribeError::InitFailed(
@@ -278,11 +276,6 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
             })?;
             Ok(Box::new(soniox::SonioxTranscriber::new(cfg.clone())?))
         }
-        #[cfg(not(feature = "soniox"))]
-        TranscriptionEngine::Soniox => Err(TranscribeError::InitFailed(
-            "Soniox engine requested but voxtype was not compiled with --features soniox"
-                .to_string(),
-        )),
     }
 }
 

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -19,8 +19,10 @@ use super::common::{
     self, FeedbackLevel as CommonFeedback, FormRowSpec, TextInput, TextInputResult,
 };
 use super::config_editor::{ConfigEditor, EditorError};
+use crate::config::TranscriptionEngine;
 use crate::setup::binary::{self, EngineFamily, InstallKind, Variant};
 use crate::setup::model;
+use strum::IntoEnumIterator;
 
 #[derive(Debug, Clone)]
 pub struct EngineState {
@@ -223,17 +225,6 @@ pub enum FieldId {
     CoThreads,
     CoOnDemandLoading,
 }
-
-const ENGINE_CHOICES: &[&str] = &[
-    "whisper",
-    "parakeet",
-    "moonshine",
-    "sensevoice",
-    "paraformer",
-    "dolphin",
-    "omnilingual",
-    "cohere",
-];
 
 /// Cohere Transcribe officially supports these 14 languages. Token IDs are
 /// looked up by name from tokens.txt at runtime, so the TUI only needs to
@@ -787,9 +778,8 @@ impl EngineState {
                 // matching feature; on a source build it means the running
                 // binary was compiled with that feature flag.
                 let installed = installed_engine_choices();
-                let filtered: Vec<&'static str> = ENGINE_CHOICES
-                    .iter()
-                    .copied()
+                let filtered: Vec<&'static str> = TranscriptionEngine::iter()
+                    .map(|e| e.name())
                     .filter(|e| installed.contains(e))
                     .collect();
                 if filtered.is_empty() {


### PR DESCRIPTION
Rebase of @materemias's #441 onto current `dev`, plus the two commits that were stranded on the frozen `rc/1.0.0` branch. Gates the v1.0.0 re-cut.

Please close #441 in favour of this. The four Soniox commits are @materemias's work with authorship preserved; this branch only rebases them and adds the two follow-ups.

## Why the follow-ups have to travel with it

`077bf02` and `bbb9822` were written during rc1 smoke testing and committed straight to `rc/1.0.0`. They exist nowhere else, not even on the #441 branch, so re-cutting the RC off `dev` would have silently dropped them.

They also fix bugs that are live on `dev` right now:

- `src/config_set.rs::ENGINE_NAMES` lists 8 engines and omits `soniox`, as does the `UnknownEngine` error text users are shown
- `engine_feature_compiled` has no soniox arm, so it falls through `_ => false`

Net effect on today's `dev`: `voxtype config set engine soniox` fails with "unknown engine" even though Soniox has been a valid `TranscriptionEngine` variant since v0.7.5.

`bbb9822` is only correct once the feature gate is gone, which is why the two cannot be separated. Taking the follow-ups without #441 would report Soniox as compiled into binaries that do not have it.

`077bf02` also replaces the hand-maintained lists with `TranscriptionEngine::iter()` and adds `names_csv()`, and `bbb9822` makes `engine_feature_compiled` dispatch on enum variants so the compiler catches the next drift instead of a wildcard swallowing it.

## Verification

Rebased onto `dev` with no conflicts; both cherry-picks applied clean.

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` 837 + 54 passing, 0 failures

Functional check against an isolated `XDG_CONFIG_HOME`:

```
$ voxtype config set engine soniox
Set engine = "soniox" in .../voxtype/config.toml
Restart voxtype to apply: systemctl --user restart voxtype
```

## Trade-off

Soniox's deps (tokio-tungstenite, futures-util, reqwest) become unconditional, which @materemias measured at roughly 1-2 MB after LTO and strip. They ride alongside `ureq`, which every binary already ships for model downloads.

Co-authored-by: Mate Remias <materemias@gmail.com>