### PR TITLE
Stop reporting GPU backends as active when they cannot load (closes #444)

### DIFF
--- a/packaging/arch-bin-rc/PKGBUILD
+++ b/packaging/arch-bin-rc/PKGBUILD
@@ -41,6 +41,7 @@ optdepends=(
     'cuda: GPU acceleration via CUDA 13 for ONNX engines (NVIDIA GPUs, requires driver 580+)'
     'cuda12.6: GPU acceleration via CUDA 12 for ONNX engines (older NVIDIA setups)'
     'rocm-hip-runtime: GPU acceleration via MIGraphX for ONNX engines (AMD GPUs)'
+    'migraphx: required alongside rocm-hip-runtime for the MIGraphX provider (#444)'
     'ollama: local AI summarization for meeting mode'
     'gtk4-layer-shell: runtime for the GTK4 on-screen mic visualizer (voxtype-osd-gtk4)'
     'quickshell: Quickshell-based on-screen display frontend (opt in via [osd] frontend = "quickshell")'

--- a/src/setup/gpu.rs
+++ b/src/setup/gpu.rs
@@ -17,7 +17,7 @@
 //!
 //! This sets VK_LOADER_DRIVERS_SELECT internally to filter Vulkan ICDs.
 
-use super::binary::install_active_binary;
+use super::binary::{install_active_binary, resolve_active_binary};
 use std::fs;
 use std::os::unix::fs::symlink;
 use std::path::Path;
@@ -43,35 +43,33 @@ fn get_active_binary_path() -> &'static str {
     VOXTYPE_BIN
 }
 
-/// Check if the current symlink points to a Parakeet binary
-/// Follows symlink chains to find the final target
+/// Resolve the real binary `/usr/bin/voxtype` dispatches to.
+///
+/// GPU and ONNX installs replace the symlink with a shell wrapper that
+/// `exec`s the binary by canonical path, so ORT's provider lookup lands in
+/// the right subdirectory. `fs::canonicalize` on that wrapper returns the
+/// wrapper itself, whose filename is just "voxtype", which used to make
+/// every check below conclude no ONNX backend was active. `setup onnx
+/// --status` already resolved this correctly via `resolve_active_binary`;
+/// share that instead of keeping a second, wrapper-blind implementation.
+fn resolved_active_binary_name() -> Option<String> {
+    let resolved = resolve_active_binary(get_active_binary_path())?;
+    resolved
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+}
+
+/// Check if the active binary is a Parakeet/ONNX binary
 fn is_parakeet_binary_active() -> bool {
-    let active_bin = get_active_binary_path();
-    // Use canonicalize to resolve all symlinks and get the final target
-    if let Ok(resolved) = fs::canonicalize(active_bin) {
-        if let Some(target_name) = resolved.file_name() {
-            if let Some(name) = target_name.to_str() {
-                return name.contains("onnx") || name.contains("parakeet");
-            }
-        }
-    }
-    false
+    resolved_active_binary_name()
+        .map(|name| name.contains("onnx") || name.contains("parakeet"))
+        .unwrap_or(false)
 }
 
 /// Get the name of the active Parakeet backend binary
 fn detect_active_parakeet_backend() -> Option<String> {
-    let active_bin = get_active_binary_path();
-    // Use canonicalize to resolve all symlinks and get the final target
-    if let Ok(resolved) = fs::canonicalize(active_bin) {
-        if let Some(target_name) = resolved.file_name() {
-            if let Some(name) = target_name.to_str() {
-                if name.contains("onnx") || name.contains("parakeet") {
-                    return Some(name.to_string());
-                }
-            }
-        }
-    }
-    None
+    resolved_active_binary_name().filter(|name| name.contains("onnx") || name.contains("parakeet"))
 }
 
 /// Parse `ldd` output for dependencies the dynamic linker could not resolve.

--- a/src/setup/gpu.rs
+++ b/src/setup/gpu.rs
@@ -74,6 +74,80 @@ fn detect_active_parakeet_backend() -> Option<String> {
     None
 }
 
+/// Parse `ldd` output for dependencies the dynamic linker could not resolve.
+///
+/// Lines of interest look like `\tlibmigraphx_c.so.3 => not found`.
+fn parse_ldd_missing(output: &str) -> Vec<String> {
+    let mut missing: Vec<String> = output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let (name, rest) = line.split_once("=>")?;
+            if rest.trim() == "not found" {
+                Some(name.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    missing.sort();
+    missing.dedup();
+    missing
+}
+
+/// Shared libraries an ONNX GPU execution provider needs but cannot resolve.
+///
+/// The GPU binaries dlopen `libonnxruntime_providers_<ep>.so` at runtime,
+/// relative to their own location. When the system libraries that provider
+/// links against are absent, ORT fails to register the execution provider and
+/// falls back to CPU without saying so. Reporting "Active backend: ONNX GPU
+/// (MIGraphX)" in that state tells the user the opposite of the truth (#444:
+/// the Arch package shipped voxtype-onnx-migraphx with no migraphx dependency).
+///
+/// Returns `None` when the check cannot be performed (no provider library
+/// alongside the binary, or no `ldd`), and `Some(vec![])` when every
+/// dependency resolves.
+fn unresolved_provider_deps(binary_name: &str) -> Option<Vec<String>> {
+    let resolved = fs::canonicalize(Path::new(VOXTYPE_LIB_DIR).join(binary_name)).ok()?;
+    let dir = resolved.parent()?;
+
+    // Providers sit next to the binary; ORT locates them via /proc/self/exe.
+    let provider = ["migraphx", "cuda", "rocm"]
+        .iter()
+        .map(|ep| dir.join(format!("libonnxruntime_providers_{ep}.so")))
+        .find(|p| p.exists())?;
+
+    let output = Command::new("ldd").arg(&provider).output().ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        return None;
+    }
+    Some(parse_ldd_missing(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Warn when the active GPU backend cannot actually load its execution
+/// provider, so `--status` stops advertising acceleration that is not running.
+fn warn_if_provider_unloadable(binary_name: &str) {
+    let Some(missing) = unresolved_provider_deps(binary_name) else {
+        return;
+    };
+    if missing.is_empty() {
+        return;
+    }
+
+    println!();
+    println!("  WARNING: this backend is selected but cannot load. ONNX Runtime will");
+    println!("           fall back to CPU. Missing shared libraries:");
+    for lib in &missing {
+        println!("             {lib}");
+    }
+    if binary_name.contains("migraphx") || binary_name.contains("rocm") {
+        println!("           Install the AMD runtime, e.g. on Arch:");
+        println!("             sudo pacman -S migraphx rocm-hip-runtime");
+    } else if binary_name.contains("cuda") {
+        println!("           Install the matching NVIDIA CUDA runtime for this variant.");
+    }
+}
+
 /// Available backend variants
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Backend {
@@ -512,6 +586,7 @@ pub fn show_status() {
                 "  Binary: {}",
                 Path::new(VOXTYPE_LIB_DIR).join(&target).display()
             );
+            warn_if_provider_unloadable(&target);
         } else {
             println!("Active backend: Parakeet (unknown variant)");
         }
@@ -836,6 +911,10 @@ pub fn enable() -> anyhow::Result<()> {
         }
 
         println!("Switched to ONNX ({}) backend.", backend_name);
+        // Selecting a backend whose execution provider cannot load is how
+        // users end up believing they have GPU acceleration while running on
+        // CPU (#444). Say so at the point of the switch, not just in --status.
+        warn_if_provider_unloadable(backend_binary);
         println!();
         println!("Restart voxtype to use GPU acceleration:");
         println!("  systemctl --user restart voxtype");
@@ -991,4 +1070,47 @@ fn switch_backend_tiered_parakeet(binary_name: &str) -> anyhow::Result<()> {
     }
 
     install_active_binary(active_bin, &binary_path, "setup onnx --enable")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ldd_missing_finds_unresolved_deps() {
+        // Shape of ldd output on a host without the AMD runtime installed,
+        // which is the #444 failure: the provider is present, its deps are not.
+        let output = "\tlinux-vdso.so.1 (0x00007ffd1b5f2000)\n\
+                      \tlibmigraphx_c.so.3 => not found\n\
+                      \tlibamdhip64.so.7 => not found\n\
+                      \tlibstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f83de9ce000)\n\
+                      \tlibc.so.6 => /usr/lib/libc.so.6 (0x00007f83de645000)\n";
+        assert_eq!(
+            parse_ldd_missing(output),
+            vec!["libamdhip64.so.7", "libmigraphx_c.so.3"]
+        );
+    }
+
+    #[test]
+    fn parse_ldd_missing_empty_when_all_resolve() {
+        let output =
+            "\tlibmigraphx_c.so.3 => /opt/rocm/lib/libmigraphx_c.so.3 (0x00007f83e06e9000)\n\
+                      \tlibc.so.6 => /usr/lib/libc.so.6 (0x00007f83de645000)\n";
+        assert!(parse_ldd_missing(output).is_empty());
+    }
+
+    #[test]
+    fn parse_ldd_missing_ignores_static_and_vdso_lines() {
+        // Lines without "=>" must not be mistaken for dependencies.
+        let output = "\tlinux-vdso.so.1 (0x00007ffd1b5f2000)\n\
+                      \t/lib64/ld-linux-x86-64.so.2 (0x00007f83e0a1c000)\n\
+                      \tstatically linked\n";
+        assert!(parse_ldd_missing(output).is_empty());
+    }
+
+    #[test]
+    fn parse_ldd_missing_dedupes() {
+        let output = "\tlibfoo.so.1 => not found\n\tlibfoo.so.1 => not found\n";
+        assert_eq!(parse_ldd_missing(output), vec!["libfoo.so.1"]);
+    }
 }


### PR DESCRIPTION
Fixes #444. Wanted before the Omarchy Quattro compatibility testing, because a status lie makes a green test result meaningless.

## The lie

`setup gpu --status` built its answer entirely from the symlink target's filename:

```rust
"voxtype-onnx-migraphx" => "ONNX GPU (MIGraphX)",
```

Nothing verified the execution provider could load. The GPU binaries dlopen `libonnxruntime_providers_<ep>.so` from their own directory; when the system libraries that provider links against are missing, ORT fails to register the EP and falls back to CPU without surfacing anything. The user is told they have GPU acceleration and measures CPU speed.

## The check

Resolve the provider library next to the real binary, run `ldd`, and report any `=> not found` dependencies. On a healthy AMD host every dependency resolves through `/opt/rocm`:

```
libmigraphx_c.so.3 => /opt/rocm/lib/libmigraphx_c.so.3
libamdhip64.so.7 => /opt/rocm/lib/libamdhip64.so.7
```

On the reporter's host those same lines read `not found`, which is precisely the state that used to print "active". Output becomes:

```
Active backend: ONNX GPU (MIGraphX)
  Binary: /usr/lib/voxtype/voxtype-onnx-migraphx

  WARNING: this backend is selected but cannot load. ONNX Runtime will
           fall back to CPU. Missing shared libraries:
             libamdhip64.so.7
             libmigraphx_c.so.3
           Install the AMD runtime, e.g. on Arch:
             sudo pacman -S migraphx rocm-hip-runtime
```

The same check runs on `--enable`, since selecting an unloadable backend is where the false belief starts rather than where it gets discovered.

## Packaging half

`packaging/arch-bin-rc/PKGBUILD` listed `rocm-hip-runtime` but not `migraphx`. The provider needs `libmigraphx_c.so.3`, which ships in the `migraphx` package, so the optdepend was incomplete. Added it.

Left as optdepends rather than depends: making ROCm a hard dependency would pull it onto every Arch install including CPU-only ones.

Note `packaging/arch-bin/` (the stable channel) is a gitignored nested AUR repo, so its PKGBUILD needs the same edit applied out-of-band.

## Verification

- 4 unit tests on the `ldd` parser: unresolved deps, all-resolved, lines without `=>` (vdso, "statically linked"), and dedupe
- `cargo clippy --all-targets -- -D warnings` clean, `cargo test` 802 passing
- Confirmed against the real provider libraries in `/usr/lib/voxtype/migraphx/` that a healthy host produces no `not found` lines

Not verified end to end: reproducing the failing case needs a host without the AMD runtime, and this machine has ROCm installed and runs Whisper CPU, so the ONNX status branch was not reachable without modifying the install. The parser is covered by tests against captured real output; the Quattro VM is the natural place to exercise the whole path.