### PR TITLE
Stop telling users playerctl is required for media pausing

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -62,6 +62,12 @@ sample_rate = 16000
 # Maximum recording duration in seconds (safety limit)
 max_duration_secs = 60
 
+# Pause MPRIS media players (Spotify, Firefox, etc.) when recording starts and
+# resume them when it stops. Talks D-Bus directly, so no playerctl binary is
+# required. Distros that ship playerctl-free (Omarchy Quattro, for example) can
+# enable this safely.
+# pause_media = false
+
 # Lower active media stream volume while recording, then restore it as soon as
 # recording stops. This is separate from pause_media; enable one behavior or
 # the other depending on whether you want media paused or only quieter.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -61,7 +61,7 @@ Older distros (Ubuntu 22.04, Debian Bookworm, Fedora 39) can [build from source]
 | `ydotool` | Fallback (X11/TTY) | Requires a daemon |
 | `wl-clipboard` | Recommended | Clipboard fallback |
 | `libnotify` | Optional | Desktop notifications |
-| `playerctl` | Optional | Pause MPRIS players while recording |
+| `playerctl` | Not needed | Media pausing talks D-Bus directly since v1.0.0; earlier versions shelled out to it |
 | `gtk4-layer-shell` | Optional | Runtime for the GTK4 OSD visualizer |
 
 > **PipeWire users:** install `pipewire-alsa` so ALSA-based apps like Voxtype can capture audio. Without it you get "device not available" errors.
@@ -150,7 +150,7 @@ sudo apt install ./voxtype_0.7.5-1_amd64.deb
 Recommended optional packages:
 
 ```bash
-sudo apt install wtype wl-clipboard libnotify-bin playerctl pipewire-alsa
+sudo apt install wtype wl-clipboard libnotify-bin pipewire-alsa
 ```
 
 The .deb ships every Linux binary variant (avx2, avx512, vulkan, plus ONNX CPU/CUDA/MIGraphX) under `/usr/lib/voxtype/`. Run `sudo voxtype setup gpu --enable` after install to pick a GPU binary.
@@ -167,7 +167,7 @@ sudo dnf install ./voxtype-0.7.5-1.x86_64.rpm
 Recommended optional packages:
 
 ```bash
-sudo dnf install wtype wl-clipboard libnotify playerctl pipewire-alsa
+sudo dnf install wtype wl-clipboard libnotify pipewire-alsa
 ```
 
 Fedora's ydotool ships as a system service that needs extra setup. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md#ydotool-daemon-not-running) if you need ydotool specifically; otherwise `wtype` (Wayland) or `dotool` (KDE/GNOME Wayland) is the better default.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -16,6 +16,7 @@ Solutions to common issues when using Voxtype.
   - [Wrong characters on non-US keyboard layouts](#wrong-characters-on-non-us-keyboard-layouts-yz-swapped-qwertz-azerty)
 - [Performance Issues](#performance-issues)
 - [Soniox Backend Issues](#soniox-backend-issues)
+- [Media Does Not Pause While Recording (Omarchy Quattro)](#media-does-not-pause-while-recording-omarchy-quattro)
 - [Quickshell OSD Issues](#quickshell-osd-issues)
 - [Systemd Service Issues](#systemd-service-issues)
 - [Debug Mode](#debug-mode)
@@ -1146,6 +1147,37 @@ async_max_wait_secs = 300
 This notification used to appear when you released the hotkey and Soniox's server-side timer fired before the connection fully closed. Voxtype now suppresses 408s that arrive **after** you've signalled end-of-audio, so this should be silent. If you still see it, your build predates the fix (any release v0.7.5 or later includes it).
 
 ---
+
+## Media Does Not Pause While Recording (Omarchy Quattro)
+
+**Symptom:** `pause_media = true` is set, but music keeps playing while you
+dictate. Common on Omarchy Quattro, whose upgrade removes `playerctl` while the
+shipped Voxtype config still enables media pausing.
+
+**Cause:** Voxtype v0.7.5 and earlier paused players by shelling out to
+`playerctl`. When that binary is absent the pause silently does nothing.
+
+**Fix:** Upgrade to Voxtype v1.0.0 or newer. Media pausing now speaks MPRIS over
+D-Bus directly and needs no external binary, so it works on a playerctl-free
+system.
+
+If you must stay on v0.7.5, either install `playerctl` or turn the feature off:
+
+```toml
+[audio]
+pause_media = false
+```
+
+**Check which players Voxtype can see:**
+
+```bash
+busctl --user list | grep org.mpris.MediaPlayer2
+```
+
+An empty list means no MPRIS-capable player is running, which is a different
+problem from a missing `playerctl`. Some players (notably certain browsers)
+report unreliable MPRIS status; skip those with
+`pause_media_ignored_players`.
 
 ## Quickshell OSD Issues
 


### PR DESCRIPTION
Addresses the Voxtype half of [basecamp/omarchy#7135](https://github.com/basecamp/omarchy/issues/7135).

## What was actually broken

The code was already fine. `src/audio/media.rs` has spoken MPRIS over D-Bus directly since #487, and `src/config/default_config.rs` says so. Nothing in `src/` shells out to `playerctl` any more.

The docs did not get the memo:

- `docs/INSTALL.md` listed `playerctl` as the optional dependency providing "Pause MPRIS players while recording"
- both the apt and dnf install one-liners installed it
- `config/default.toml` never documented `pause_media` at all, mentioning it only as a cross-reference inside the `duck_media` comment

Omarchy Quattro deliberately removes `playerctl` while shipping a Voxtype config with `pause_media = true`. A Quattro user hitting silent media-pause failure and reading our install docs is told to reinstall a binary that v1.0.0 does not use.

## Changes

- `docs/INSTALL.md`: `playerctl` row marked **Not needed**, with the version boundary stated; dropped from both install commands
- `config/default.toml`: `pause_media` documented where users actually look, noting it needs no external binary and is safe on playerctl-free distros
- `docs/TROUBLESHOOTING.md`: new entry for the Quattro symptom, with the v0.7.5 workaround for anyone not upgrading yet, plus a `busctl --user list` check to separate "no playerctl" from "no MPRIS player running" — same symptom, different cause

## Not covered here

Omarchy's own `default/voxtype/config.toml` and its Quattro upgrader live in `basecamp/omarchy`. Their side still pairs `pause_media = true` with a playerctl removal, which stays broken for anyone on `voxtype-bin 0.7.5` until they upgrade. Upgrading to v1.0.0 resolves it without config changes.

Docs only, no code. `config/default.toml` still parses and the 104 config tests pass.