### PR TITLE
Resume paused media when a dictation is cancelled

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3131,6 +3131,8 @@ impl Daemon {
                                 cleanup_model_override();
                                 cleanup_profile_override();
                                 cleanup_bool_override("smart_auto_submit");
+                                self.restore_ducked_media_streams();
+                                self.resume_media_players();
                                 state = State::Idle;
                                 self.update_state("idle");
                                 self.play_feedback(SoundEvent::Cancelled);
@@ -3160,6 +3162,8 @@ impl Daemon {
                                 cleanup_model_override();
                                 cleanup_profile_override();
                                 cleanup_bool_override("smart_auto_submit");
+                                self.restore_ducked_media_streams();
+                                self.resume_media_players();
                                 state = State::Idle;
                                 self.update_state("idle");
                                 self.play_feedback(SoundEvent::Cancelled);
@@ -3221,6 +3225,8 @@ impl Daemon {
                         cleanup_model_override();
                         cleanup_profile_override();
                         cleanup_bool_override("smart_auto_submit");
+                        self.restore_ducked_media_streams();
+                        self.resume_media_players();
                         state = State::Idle;
                         eager_transcriber = None;
                         self.update_state("idle");


### PR DESCRIPTION
**Cause:** Three of the four cancel paths in `Daemon::run()` return to `Idle` without undoing what recording start applied to playback: paused MPRIS players stay paused, ducked streams stay quiet. Only `cancel_streaming_to_idle()` restores both.

**Impact:** With `pause_media = true`, cancelling a dictation leaves music silent until some later completed dictation happens to resume it. The fix adds the two existing restore calls to each path, in the order the streaming path already uses.

No test (the cancel arms sit inside the `tokio::select!` loop, no seam); not compiled locally.
