### PR TITLE
Fade media ducking in and out instead of jumping

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -410,6 +410,24 @@ applied to each stream's current per-channel volume, not to a fixed 100% base:
 original per-channel volumes are restored when recording stops. Values above
 `150` are clamped by the CLI override.
 
+### duck_media_fade_ms
+
+**Type:** Integer
+**Default:** `150`
+**Required:** No
+
+Fade duration in milliseconds for the ducking ramp. The same duration is used
+going down at recording start and coming back up when recording ends, so media
+slides out of the way instead of jumping. `0` restores the previous instant
+behaviour. Durations shorter than one 20 ms step are treated as `0`.
+
+```toml
+[audio]
+duck_media = true
+duck_media_volume_percent = 70
+duck_media_fade_ms = 150
+```
+
 ---
 
 ## [audio.feedback]

--- a/src/audio/media.rs
+++ b/src/audio/media.rs
@@ -120,7 +120,61 @@ mod imp {
     /// enabled alongside `pause_media`, but when both are enabled the pause
     /// feature keeps its existing start/stop behavior and ducking only manages
     /// stream volume.
-    pub async fn duck_playing_audio(volume_percent: u8) -> Vec<DuckedMediaStream> {
+    /// Interval between ramp steps. Short enough to sound continuous, long
+    /// enough to keep the number of `pactl` invocations per fade small.
+    const FADE_STEP_MS: u64 = 20;
+
+    /// Ramp all `streams` from `from_percent` to `to_percent` of their
+    /// original volume over `fade_ms`, leaving the final value to the caller
+    /// (which keeps the existing per-stream error handling in one place).
+    ///
+    /// Best effort: a step that fails is ignored, because the caller sets the
+    /// exact target right afterwards anyway.
+    /// Intermediate scaling factors for a fade, excluding the final target.
+    ///
+    /// The caller sets `to_percent` itself, which keeps the exact target and
+    /// its error handling in a single place. Returns an empty vector when the
+    /// fade is too short to produce a step, so `fade_ms = 0` means "instant".
+    fn ramp_factors(from_percent: u8, to_percent: u8, fade_ms: u32) -> Vec<u8> {
+        let steps = u64::from(fade_ms).div_ceil(FADE_STEP_MS);
+        if steps <= 1 {
+            return Vec::new();
+        }
+
+        let from = f32::from(from_percent);
+        let span = f32::from(to_percent) - from;
+        (1..steps)
+            .map(|step| {
+                let factor = from + span * (step as f32 / steps as f32);
+                factor.round().clamp(0.0, f32::from(u8::MAX)) as u8
+            })
+            .collect()
+    }
+
+    async fn ramp_streams(
+        streams: &[DuckedMediaStream],
+        from_percent: u8,
+        to_percent: u8,
+        fade_ms: u32,
+    ) {
+        if streams.is_empty() {
+            return;
+        }
+
+        for factor in ramp_factors(from_percent, to_percent, fade_ms) {
+            for stream in streams {
+                let _ = Command::new("pactl")
+                    .arg("set-sink-input-volume")
+                    .arg(stream.index.to_string())
+                    .args(scaled_volumes(&stream.volumes, factor))
+                    .status()
+                    .await;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(FADE_STEP_MS)).await;
+        }
+    }
+
+    pub async fn duck_playing_audio(volume_percent: u8, fade_ms: u32) -> Vec<DuckedMediaStream> {
         let streams = match list_active_sink_inputs().await {
             Ok(streams) => streams,
             Err(e) => {
@@ -135,6 +189,7 @@ mod imp {
         }
 
         let factor = volume_percent.min(150);
+        ramp_streams(&streams, 100, factor, fade_ms).await;
         let mut ducked = Vec::new();
         for stream in streams {
             let target = scaled_volumes(&stream.volumes, factor);
@@ -168,10 +223,16 @@ mod imp {
     }
 
     /// Restore stream volumes captured by `duck_playing_audio`.
-    pub async fn restore_ducked_audio(streams: Vec<DuckedMediaStream>) {
+    pub async fn restore_ducked_audio(
+        streams: Vec<DuckedMediaStream>,
+        ducked_percent: u8,
+        fade_ms: u32,
+    ) {
         if streams.is_empty() {
             return;
         }
+
+        ramp_streams(&streams, ducked_percent.min(150), 100, fade_ms).await;
 
         let total = streams.len();
         let mut restored = 0usize;
@@ -350,6 +411,36 @@ mod imp {
         }
 
         #[test]
+        fn ramp_is_skipped_when_the_fade_is_shorter_than_one_step() {
+            assert!(ramp_factors(100, 55, 0).is_empty());
+            assert!(ramp_factors(100, 55, FADE_STEP_MS as u32).is_empty());
+        }
+
+        #[test]
+        fn ramp_walks_down_towards_the_target_without_reaching_it() {
+            // 100 ms at a 20 ms step is 5 slices, so 4 intermediate factors;
+            // the exact target is set by the caller, not by the ramp.
+            let factors = ramp_factors(100, 50, 100);
+            assert_eq!(factors, vec![90, 80, 70, 60]);
+        }
+
+        #[test]
+        fn ramp_walks_up_when_restoring() {
+            let factors = ramp_factors(50, 100, 100);
+            assert_eq!(factors, vec![60, 70, 80, 90]);
+        }
+
+        #[test]
+        fn ramp_stays_monotonic_and_inside_the_endpoints() {
+            let factors = ramp_factors(100, 33, 250);
+            assert!(!factors.is_empty());
+            for pair in factors.windows(2) {
+                assert!(pair[1] <= pair[0], "not monotonic: {factors:?}");
+            }
+            assert!(factors.iter().all(|&f| (33..=100).contains(&f)));
+        }
+
+        #[test]
         fn parses_active_sink_inputs_with_channel_volumes() {
             let value: Value = serde_json::json!([
                 {
@@ -405,9 +496,14 @@ pub async fn pause_playing_players(_ignored: &[String]) -> Vec<String> {
 pub async fn resume_players(_players: Vec<String>) {}
 
 #[cfg(not(target_os = "linux"))]
-pub async fn duck_playing_audio(_volume_percent: u8) -> Vec<DuckedMediaStream> {
+pub async fn duck_playing_audio(_volume_percent: u8, _fade_ms: u32) -> Vec<DuckedMediaStream> {
     Vec::new()
 }
 
 #[cfg(not(target_os = "linux"))]
-pub async fn restore_ducked_audio(_streams: Vec<DuckedMediaStream>) {}
+pub async fn restore_ducked_audio(
+    _streams: Vec<DuckedMediaStream>,
+    _ducked_percent: u8,
+    _fade_ms: u32,
+) {
+}

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -37,6 +37,10 @@ pub struct AudioConfig {
     #[serde(default = "default_duck_media_volume_percent")]
     pub duck_media_volume_percent: u8,
 
+    /// Fade duration in milliseconds for the ducking ramp (0 = instant)
+    #[serde(default = "default_duck_media_fade_ms")]
+    pub duck_media_fade_ms: u32,
+
     /// Audio feedback settings
     #[serde(default)]
     pub feedback: AudioFeedbackConfig,
@@ -52,6 +56,7 @@ impl Default for AudioConfig {
             pause_media_ignored_players: Vec::new(),
             duck_media: false,
             duck_media_volume_percent: default_duck_media_volume_percent(),
+            duck_media_fade_ms: default_duck_media_fade_ms(),
             feedback: AudioFeedbackConfig::default(),
         }
     }
@@ -71,6 +76,10 @@ fn default_audio_max_duration_secs() -> u32 {
 
 fn default_duck_media_volume_percent() -> u8 {
     70
+}
+
+fn default_duck_media_fade_ms() -> u32 {
+    150
 }
 
 /// Audio feedback configuration for sound cues

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -65,6 +65,11 @@ max_duration_secs = 60
 # the other depending on whether you want media paused or only quieter.
 # duck_media = false
 # duck_media_volume_percent = 70
+#
+# Fade the ducking ramp instead of jumping straight to the target volume. The
+# same duration is used going down and coming back up; 0 keeps the previous
+# instant behavior.
+# duck_media_fade_ms = 150
 
 # [audio.feedback]
 # Enable audio feedback sounds (beeps when recording starts/stops)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -788,8 +788,11 @@ impl Daemon {
     /// Duck active audio streams if configured, storing original volumes
     async fn duck_media_streams(&mut self) {
         if self.config.audio.duck_media {
-            self.ducked_media_streams =
-                audio::media::duck_playing_audio(self.config.audio.duck_media_volume_percent).await;
+            self.ducked_media_streams = audio::media::duck_playing_audio(
+                self.config.audio.duck_media_volume_percent,
+                self.config.audio.duck_media_fade_ms,
+            )
+            .await;
         }
     }
 
@@ -797,7 +800,11 @@ impl Daemon {
     fn restore_ducked_media_streams(&mut self) {
         if !self.ducked_media_streams.is_empty() {
             let streams = std::mem::take(&mut self.ducked_media_streams);
-            tokio::spawn(audio::media::restore_ducked_audio(streams));
+            tokio::spawn(audio::media::restore_ducked_audio(
+                streams,
+                self.config.audio.duck_media_volume_percent,
+                self.config.audio.duck_media_fade_ms,
+            ));
         }
     }
 


### PR DESCRIPTION
**Why:** ducking sets the volume in a single `pactl` call, so music snaps down at recording start and snaps back at the end. The jump is audible — exactly the attention grab ducking is meant to avoid.

**Changes:** a ramp walks the volume to the target in 20 ms steps, same duration down and up. `duck_media_fade_ms` defaults to 150 ms; `0` keeps the old instant behaviour. Only intermediate steps are ramped — the exact target and restore values are still set by the existing calls, so their error handling and the stored originals are untouched.

**Verification:** `cargo test --lib audio::media` → 7 passed (4 new: fade shorter than a step is a no-op, ramp down, ramp up, monotonic and inside the endpoints). `cargo clippy --lib` clean. Built and run locally as the vulkan variant on GNOME/Wayland; ducking fades audibly in both directions.
