### PR TITLE
Make duck_media_volume_percent mean what it says

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -410,6 +410,24 @@ applied to each stream's current per-channel volume, not to a fixed 100% base:
 original per-channel volumes are restored when recording stops. Values above
 `150` are clamped by the CLI override.
 
+### duck_media_fade_ms
+
+**Type:** Integer
+**Default:** `150`
+**Required:** No
+
+Fade duration in milliseconds for the ducking ramp. The same duration is used
+going down at recording start and coming back up when recording ends, so media
+slides out of the way instead of jumping. `0` restores the previous instant
+behaviour. Durations shorter than one 20 ms step are treated as `0`.
+
+```toml
+[audio]
+duck_media = true
+duck_media_volume_percent = 70
+duck_media_fade_ms = 150
+```
+
 ---
 
 ## [audio.feedback]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -404,11 +404,18 @@ duck_media_volume_percent = 70
 **Default:** `70`
 **Required:** No
 
-Relative volume percentage for streams affected by `duck_media`. The value is
-applied to each stream's current per-channel volume, not to a fixed 100% base:
-`70` keeps media at 70% of its current volume, `50` keeps it at half, and the
-original per-channel volumes are restored when recording stops. Values above
-`150` are clamped by the CLI override.
+Fraction of its current amplitude that a stream affected by `duck_media`
+keeps, in percent: `70` keeps media at 70% of its current amplitude (-3.1 dB),
+`50` keeps it at half (-6 dB). The value is relative to each stream's current
+per-channel volume, not to a fixed 100% base, and the original volumes are
+restored when recording stops. Values above `150` are clamped by the CLI
+override.
+
+voxtype converts the value internally to PulseAudio's cubic percentage scale,
+so what you configure is what you hear. (Earlier development builds scaled the
+cubic percentage directly, which cubed the reduction — `50` left only 12.5% of
+the amplitude and `30` was effectively mute. If you tuned the value against
+such a build, expect ducking to be noticeably louder now.)
 
 ### duck_media_fade_ms
 

--- a/src/audio/media.rs
+++ b/src/audio/media.rs
@@ -120,7 +120,61 @@ mod imp {
     /// enabled alongside `pause_media`, but when both are enabled the pause
     /// feature keeps its existing start/stop behavior and ducking only manages
     /// stream volume.
-    pub async fn duck_playing_audio(volume_percent: u8) -> Vec<DuckedMediaStream> {
+    /// Interval between ramp steps. Short enough to sound continuous, long
+    /// enough to keep the number of `pactl` invocations per fade small.
+    const FADE_STEP_MS: u64 = 20;
+
+    /// Ramp all `streams` from `from_percent` to `to_percent` of their
+    /// original volume over `fade_ms`, leaving the final value to the caller
+    /// (which keeps the existing per-stream error handling in one place).
+    ///
+    /// Best effort: a step that fails is ignored, because the caller sets the
+    /// exact target right afterwards anyway.
+    /// Intermediate scaling factors for a fade, excluding the final target.
+    ///
+    /// The caller sets `to_percent` itself, which keeps the exact target and
+    /// its error handling in a single place. Returns an empty vector when the
+    /// fade is too short to produce a step, so `fade_ms = 0` means "instant".
+    fn ramp_factors(from_percent: u8, to_percent: u8, fade_ms: u32) -> Vec<u8> {
+        let steps = u64::from(fade_ms).div_ceil(FADE_STEP_MS);
+        if steps <= 1 {
+            return Vec::new();
+        }
+
+        let from = f32::from(from_percent);
+        let span = f32::from(to_percent) - from;
+        (1..steps)
+            .map(|step| {
+                let factor = from + span * (step as f32 / steps as f32);
+                factor.round().clamp(0.0, f32::from(u8::MAX)) as u8
+            })
+            .collect()
+    }
+
+    async fn ramp_streams(
+        streams: &[DuckedMediaStream],
+        from_percent: u8,
+        to_percent: u8,
+        fade_ms: u32,
+    ) {
+        if streams.is_empty() {
+            return;
+        }
+
+        for factor in ramp_factors(from_percent, to_percent, fade_ms) {
+            for stream in streams {
+                let _ = Command::new("pactl")
+                    .arg("set-sink-input-volume")
+                    .arg(stream.index.to_string())
+                    .args(scaled_volumes(&stream.volumes, factor))
+                    .status()
+                    .await;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(FADE_STEP_MS)).await;
+        }
+    }
+
+    pub async fn duck_playing_audio(volume_percent: u8, fade_ms: u32) -> Vec<DuckedMediaStream> {
         let streams = match list_active_sink_inputs().await {
             Ok(streams) => streams,
             Err(e) => {
@@ -135,6 +189,7 @@ mod imp {
         }
 
         let factor = volume_percent.min(150);
+        ramp_streams(&streams, 100, factor, fade_ms).await;
         let mut ducked = Vec::new();
         for stream in streams {
             let target = scaled_volumes(&stream.volumes, factor);
@@ -168,10 +223,16 @@ mod imp {
     }
 
     /// Restore stream volumes captured by `duck_playing_audio`.
-    pub async fn restore_ducked_audio(streams: Vec<DuckedMediaStream>) {
+    pub async fn restore_ducked_audio(
+        streams: Vec<DuckedMediaStream>,
+        ducked_percent: u8,
+        fade_ms: u32,
+    ) {
         if streams.is_empty() {
             return;
         }
+
+        ramp_streams(&streams, ducked_percent.min(150), 100, fade_ms).await;
 
         let total = streams.len();
         let mut restored = 0usize;
@@ -350,6 +411,36 @@ mod imp {
         }
 
         #[test]
+        fn ramp_is_skipped_when_the_fade_is_shorter_than_one_step() {
+            assert!(ramp_factors(100, 55, 0).is_empty());
+            assert!(ramp_factors(100, 55, FADE_STEP_MS as u32).is_empty());
+        }
+
+        #[test]
+        fn ramp_walks_down_towards_the_target_without_reaching_it() {
+            // 100 ms at a 20 ms step is 5 slices, so 4 intermediate factors;
+            // the exact target is set by the caller, not by the ramp.
+            let factors = ramp_factors(100, 50, 100);
+            assert_eq!(factors, vec![90, 80, 70, 60]);
+        }
+
+        #[test]
+        fn ramp_walks_up_when_restoring() {
+            let factors = ramp_factors(50, 100, 100);
+            assert_eq!(factors, vec![60, 70, 80, 90]);
+        }
+
+        #[test]
+        fn ramp_stays_monotonic_and_inside_the_endpoints() {
+            let factors = ramp_factors(100, 33, 250);
+            assert!(!factors.is_empty());
+            for pair in factors.windows(2) {
+                assert!(pair[1] <= pair[0], "not monotonic: {factors:?}");
+            }
+            assert!(factors.iter().all(|&f| (33..=100).contains(&f)));
+        }
+
+        #[test]
         fn parses_active_sink_inputs_with_channel_volumes() {
             let value: Value = serde_json::json!([
                 {
@@ -405,9 +496,14 @@ pub async fn pause_playing_players(_ignored: &[String]) -> Vec<String> {
 pub async fn resume_players(_players: Vec<String>) {}
 
 #[cfg(not(target_os = "linux"))]
-pub async fn duck_playing_audio(_volume_percent: u8) -> Vec<DuckedMediaStream> {
+pub async fn duck_playing_audio(_volume_percent: u8, _fade_ms: u32) -> Vec<DuckedMediaStream> {
     Vec::new()
 }
 
 #[cfg(not(target_os = "linux"))]
-pub async fn restore_ducked_audio(_streams: Vec<DuckedMediaStream>) {}
+pub async fn restore_ducked_audio(
+    _streams: Vec<DuckedMediaStream>,
+    _ducked_percent: u8,
+    _fade_ms: u32,
+) {
+}

--- a/src/audio/media.rs
+++ b/src/audio/media.rs
@@ -325,7 +325,17 @@ mod imp {
             .collect()
     }
 
-    fn scaled_volumes(volumes: &[String], factor_percent: u8) -> Vec<String> {
+    /// Scale each channel's `value_percent` so the stream keeps
+    /// `amplitude_percent` of its current amplitude.
+    ///
+    /// PulseAudio's percentage scale is cubic (`amplitude = (percent /
+    /// 100)^3`), so keeping half the amplitude does NOT mean halving the
+    /// percentage: the percentage only shrinks by the cube root of the
+    /// requested fraction. Scaling the percentage directly instead — the
+    /// previous behaviour — cubed the reduction, so a configured 50 left
+    /// 12.5% of the amplitude (-18 dB) and 30 was effectively mute.
+    fn scaled_volumes(volumes: &[String], amplitude_percent: u8) -> Vec<String> {
+        let gain = (f32::from(amplitude_percent) / 100.0).cbrt();
         volumes
             .iter()
             .map(|volume| {
@@ -333,7 +343,7 @@ mod imp {
                 let Ok(value) = numeric.parse::<f32>() else {
                     return volume.clone();
                 };
-                let scaled = value * f32::from(factor_percent) / 100.0;
+                let scaled = value * gain;
                 format!("{scaled:.0}%")
             })
             .collect()
@@ -470,14 +480,37 @@ mod imp {
 
         #[test]
         fn scales_stream_volumes_relative_to_current_values() {
+            // 70% of the amplitude = cube root of 0.7 on the cubic
+            // percentage scale, applied per channel.
             assert_eq!(
                 scaled_volumes(&["100%".to_string(), "80%".to_string()], 70),
-                vec!["70%", "56%"]
+                vec!["89%", "71%"]
             );
             assert_eq!(
                 scaled_volumes(&["50%".to_string(), "25%".to_string()], 30),
-                vec!["15%", "8%"]
+                vec!["33%", "17%"]
             );
+        }
+
+        #[test]
+        fn full_amplitude_leaves_volumes_unchanged() {
+            assert_eq!(
+                scaled_volumes(&["100%".to_string(), "37%".to_string()], 100),
+                vec!["100%", "37%"]
+            );
+        }
+
+        #[test]
+        fn zero_amplitude_mutes() {
+            assert_eq!(scaled_volumes(&["100%".to_string()], 0), vec!["0%"]);
+        }
+
+        #[test]
+        fn half_amplitude_is_six_db_not_eighteen() {
+            // 0.5^(1/3) = 0.7937: half the amplitude keeps ~79% of the cubic
+            // percentage. The pre-change behaviour would have produced "50%",
+            // which is only 12.5% of the amplitude.
+            assert_eq!(scaled_volumes(&["100%".to_string()], 50), vec!["79%"]);
         }
     }
 }

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -244,7 +244,7 @@ pub struct Cli {
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub duck_media: bool,
 
-    /// Relative media volume percentage while ducking
+    /// Percent of its current amplitude ducked media keeps (50 = half, -6 dB)
     #[arg(
         long,
         value_name = "PERCENT",

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -37,6 +37,10 @@ pub struct AudioConfig {
     #[serde(default = "default_duck_media_volume_percent")]
     pub duck_media_volume_percent: u8,
 
+    /// Fade duration in milliseconds for the ducking ramp (0 = instant)
+    #[serde(default = "default_duck_media_fade_ms")]
+    pub duck_media_fade_ms: u32,
+
     /// Audio feedback settings
     #[serde(default)]
     pub feedback: AudioFeedbackConfig,
@@ -52,6 +56,7 @@ impl Default for AudioConfig {
             pause_media_ignored_players: Vec::new(),
             duck_media: false,
             duck_media_volume_percent: default_duck_media_volume_percent(),
+            duck_media_fade_ms: default_duck_media_fade_ms(),
             feedback: AudioFeedbackConfig::default(),
         }
     }
@@ -71,6 +76,10 @@ fn default_audio_max_duration_secs() -> u32 {
 
 fn default_duck_media_volume_percent() -> u8 {
     70
+}
+
+fn default_duck_media_fade_ms() -> u32 {
+    150
 }
 
 /// Audio feedback configuration for sound cues

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -33,7 +33,9 @@ pub struct AudioConfig {
     #[serde(default)]
     pub duck_media: bool,
 
-    /// Target volume percentage for media ducking
+    /// Fraction of its current amplitude a ducked stream keeps, in percent
+    /// (50 = half the amplitude, -6 dB). Converted internally to PulseAudio's
+    /// cubic percentage scale.
     #[serde(default = "default_duck_media_volume_percent")]
     pub duck_media_volume_percent: u8,
 

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -65,6 +65,11 @@ max_duration_secs = 60
 # the other depending on whether you want media paused or only quieter.
 # duck_media = false
 # duck_media_volume_percent = 70
+#
+# Fade the ducking ramp instead of jumping straight to the target volume. The
+# same duration is used going down and coming back up; 0 keeps the previous
+# instant behavior.
+# duck_media_fade_ms = 150
 
 # [audio.feedback]
 # Enable audio feedback sounds (beeps when recording starts/stops)

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -64,6 +64,10 @@ max_duration_secs = 60
 # recording stops. This is separate from pause_media; enable one behavior or
 # the other depending on whether you want media paused or only quieter.
 # duck_media = false
+#
+# Percent of its current amplitude a ducked stream keeps: 70 keeps media at
+# 70% (-3.1 dB), 50 at half (-6 dB). Converted internally to PulseAudio's
+# cubic scale, so what you configure is what you hear.
 # duck_media_volume_percent = 70
 #
 # Fade the ducking ramp instead of jumping straight to the target volume. The

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -788,8 +788,11 @@ impl Daemon {
     /// Duck active audio streams if configured, storing original volumes
     async fn duck_media_streams(&mut self) {
         if self.config.audio.duck_media {
-            self.ducked_media_streams =
-                audio::media::duck_playing_audio(self.config.audio.duck_media_volume_percent).await;
+            self.ducked_media_streams = audio::media::duck_playing_audio(
+                self.config.audio.duck_media_volume_percent,
+                self.config.audio.duck_media_fade_ms,
+            )
+            .await;
         }
     }
 
@@ -797,7 +800,11 @@ impl Daemon {
     fn restore_ducked_media_streams(&mut self) {
         if !self.ducked_media_streams.is_empty() {
             let streams = std::mem::take(&mut self.ducked_media_streams);
-            tokio::spawn(audio::media::restore_ducked_audio(streams));
+            tokio::spawn(audio::media::restore_ducked_audio(
+                streams,
+                self.config.audio.duck_media_volume_percent,
+                self.config.audio.duck_media_fade_ms,
+            ));
         }
     }
 


### PR DESCRIPTION
Builds on #585 (its commit is included in this branch; merging that first shrinks this diff to one commit).

**Root Cause:** the ducking target scales PulseAudio's volume percentage directly, but that scale is cubic — the amplitude is `(percent/100)^3`. The configured reduction is therefore cubed: `50` leaves 12.5% of the amplitude (-18 dB) instead of half, `30` is effectively mute, and `CONFIGURATION.md`'s own example ("`50` keeps it at half") doesn't match the behaviour.

**The Fix:** the value now means the fraction of its current amplitude a stream keeps. `scaled_volumes()` compensates the cubic scale with a cube root, so `50` halves the amplitude (-6 dB); docs, config template and CLI help all describe that. The fade ramp (#585) interpolates in the amplitude domain and gets perceptually smoother as a side effect.

**BC note:** behaviour changes for configs tuned against v1.0.0-rc builds — the same number now ducks audibly less. The option has never shipped in a stable release, so pre-1.0 seemed like the right moment to fix the meaning rather than document the surprise; the docs carry a migration note. Happy to convert this to a new field with a deprecation path instead if you'd rather keep rc-to-rc compatibility.

**Validation:** `cargo test --lib audio::media` → 10 passed, including `half_amplitude_is_six_db_not_eighteen` (fails without the fix: the old code returns `50%` where half the amplitude requires `79%`). `cargo clippy --lib` clean.
