### PR TITLE
Fix clippy useless_format in the Niri stop binding

### DIFF
--- a/src/tui/compositor_bindings.rs
+++ b/src/tui/compositor_bindings.rs
@@ -438,9 +438,9 @@ fn render_role(comp: Compositor, role: Role, key: &str, second_key: Option<&str>
             "{} {{ spawn \"voxtype\" \"record\" \"start\"; }}",
             canonical_to_niri(key)
         )],
-        (Compositor::Niri, Role::Stop) => vec![format!(
-            "// Niri does not bind on key release; consider Role::Toggle instead."
-        )],
+        (Compositor::Niri, Role::Stop) => vec![
+            "// Niri does not bind on key release; consider Role::Toggle instead.".to_string(),
+        ],
         (Compositor::Niri, Role::PttPair) => vec![
             format!(
                 "{} {{ spawn \"voxtype\" \"record\" \"toggle\"; }}",


### PR DESCRIPTION
**Cause:** the Niri `Role::Stop` arm wraps a plain string literal in `format!()` with no interpolation. CI runs `cargo clippy -- -D warnings`, so any pull request that gets a cold clippy run currently fails on this line regardless of its own changes (first seen on the CI run for #586: `src/tui/compositor_bindings.rs:441`, `-D clippy::useless-format`).

**Impact:** unblocks clippy for every open and future PR against `dev`. The literal becomes a `.to_string()` call; the generated binding text is byte-identical.
