### PR TITLE
fix(output): clipboard fallback when paste is skipped by modifier guard

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -398,7 +398,7 @@ pub fn create_output_chain_with_override(
             }
         }
         crate::config::OutputMode::Paste => {
-            // Only paste mode (no fallback as requested)
+            // Paste mode: clipboard + simulated paste keystroke.
             chain.push(Box::new(paste::PasteOutput::new(
                 config.auto_submit,
                 config.append_text.clone(),
@@ -408,6 +408,28 @@ pub fn create_output_chain_with_override(
                 config.restore_clipboard,
                 config.restore_clipboard_delay_ms,
             )));
+
+            // The modifier-release guard (wait_for_modifier_release) skips
+            // keystroke-synthesizing methods -- including paste -- when a
+            // modifier is still held after the timeout, falling through to
+            // clipboard-only methods. Without a clipboard fallback here the
+            // transcription would be dropped entirely even though the user is
+            // notified that it was "copied to clipboard". Mirror Type mode's
+            // fallback_to_clipboard behavior so the text still reaches the
+            // user's clipboard.
+            #[cfg(target_os = "macos")]
+            if config.fallback_to_clipboard {
+                chain.push(Box::new(pbcopy::PbcopyOutput::new(false)));
+            }
+            #[cfg(not(target_os = "macos"))]
+            if config.fallback_to_clipboard {
+                chain.push(Box::new(clipboard::ClipboardOutput::new(
+                    config.append_text.clone(),
+                )));
+                chain.push(Box::new(xclip::XclipOutput::new(
+                    config.append_text.clone(),
+                )));
+            }
         }
         crate::config::OutputMode::File => {
             // File output is handled in the daemon before reaching the output chain.
@@ -650,6 +672,39 @@ mod tests {
         std::env::remove_var("YDOTOOL_SOCKET");
 
         assert_eq!(result, Some(sock_path));
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn test_paste_chain_includes_clipboard_fallback_when_enabled() {
+        let mut config = OutputConfig::default();
+        config.mode = crate::config::OutputMode::Paste;
+        config.fallback_to_clipboard = true;
+        let names: Vec<&str> = create_output_chain(&config)
+            .iter()
+            .map(|o| o.name())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "paste (clipboard + keystroke)",
+                "clipboard (wl-copy)",
+                "clipboard (xclip/xsel)",
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn test_paste_chain_no_clipboard_fallback_when_disabled() {
+        let mut config = OutputConfig::default();
+        config.mode = crate::config::OutputMode::Paste;
+        config.fallback_to_clipboard = false;
+        let names: Vec<&str> = create_output_chain(&config)
+            .iter()
+            .map(|o| o.name())
+            .collect();
+        assert_eq!(names, vec!["paste (clipboard + keystroke)"]);
     }
 
     #[test]


### PR DESCRIPTION
**Bug:** In paste mode, when the modifier-release guard times out (a modifier like Super still held past `modifier_release_timeout_ms`), the output chain ends up empty: `PasteOutput` is classified as keystroke-synthesizing and skipped, and paste mode's chain contains no other method. The user is notified "transcription copied to clipboard" but the clipboard is empty — the text is dropped.

**Root cause:** `create_output_chain` builds paste mode as a single-method chain, while `output_with_fallback` skips every keystroke method (`is_keystroke_method` matches `paste*`) on guard timeout.

**Fix:** Mirror Type mode's `fallback_to_clipboard`: append the clipboard methods after `PasteOutput` — wl-copy on Wayland, xclip/xsel on X11, pbcopy on macOS. On guard timeout (or any paste failure), the transcription now lands on the clipboard, making the notification truthful.

**Tests:** Added `test_paste_chain_includes_clipboard_fallback_when_enabled` and `test_paste_chain_no_clipboard_fallback_when_disabled`; full `output::` suite passes (105 tests).

**Repro:** push-to-talk with `mode = "paste"`, keep the modifier held past 750 ms after release.
