### PR TITLE
Sliding-window streaming transcription + OpenVINO NPU/GPU backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3907,8 +3907,7 @@ dependencies = [
 [[package]]
 name = "openvino-finder"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a527e1414732f5bcad520b9febf29fd92ef4bba100588b4591cba8370ab6cbda"
+source = "git+https://github.com/tslove923/openvino-rs?branch=whisper-pipeline-with-properties#8109638cfc78eb16953316627bf194d59ca521ab"
 dependencies = [
  "cfg-if",
  "log",
@@ -3917,8 +3916,7 @@ dependencies = [
 [[package]]
 name = "openvino-genai"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58748dc7c7eb98f2706152eb9e3ce0f4023359e54a9607656d653f8b7af689a8"
+source = "git+https://github.com/tslove923/openvino-rs?branch=whisper-pipeline-with-properties#8109638cfc78eb16953316627bf194d59ca521ab"
 dependencies = [
  "openvino-finder",
  "openvino-genai-sys",
@@ -3927,8 +3925,7 @@ dependencies = [
 [[package]]
 name = "openvino-genai-sys"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce904847ba3b9328e412dd95741e432f75db3177e21742f80b22eb9dcef4cafe"
+source = "git+https://github.com/tslove923/openvino-rs?branch=whisper-pipeline-with-properties#8109638cfc78eb16953316627bf194d59ca521ab"
 dependencies = [
  "env_logger",
  "libloading 0.8.9",
@@ -3939,8 +3936,7 @@ dependencies = [
 [[package]]
 name = "openvino-sys"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637459f74d22a7bb772af9d3a5df61c88608d8daaa6fefe950849c7aabf891c3"
+source = "git+https://github.com/tslove923/openvino-rs?branch=whisper-pipeline-with-properties#8109638cfc78eb16953316627bf194d59ca521ab"
 dependencies = [
  "env_logger",
  "libloading 0.8.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -103,6 +118,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -652,7 +676,7 @@ version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -1105,6 +1129,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,10 +1439,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream 1.0.0",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "epaint"
@@ -2838,6 +2916,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3791,6 +3905,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvino-finder"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a527e1414732f5bcad520b9febf29fd92ef4bba100588b4591cba8370ab6cbda"
+dependencies = [
+ "cfg-if",
+ "log",
+]
+
+[[package]]
+name = "openvino-genai"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58748dc7c7eb98f2706152eb9e3ce0f4023359e54a9607656d653f8b7af689a8"
+dependencies = [
+ "openvino-finder",
+ "openvino-genai-sys",
+]
+
+[[package]]
+name = "openvino-genai-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce904847ba3b9328e412dd95741e432f75db3177e21742f80b22eb9dcef4cafe"
+dependencies = [
+ "env_logger",
+ "libloading 0.8.9",
+ "openvino-finder",
+ "openvino-sys",
+]
+
+[[package]]
+name = "openvino-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637459f74d22a7bb772af9d3a5df61c88608d8daaa6fefe950849c7aabf891c3"
+dependencies = [
+ "env_logger",
+ "libloading 0.8.9",
+ "openvino-finder",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4466,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4478,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4489,9 +4646,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "renderdoc-sys"
@@ -4629,7 +4786,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5987,6 +6144,7 @@ dependencies = [
  "nix 0.29.0",
  "notify",
  "num_cpus",
+ "openvino-genai",
  "ort",
  "parakeet-rs",
  "pidlock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,3 +330,13 @@ path = "src/bin/voxtype_mirror_registry.rs"
 [[example]]
 name = "inspect_cohere_onnx"
 required-features = ["cohere"]
+
+# TEMPORARY: openvino-genai 0.11.0's WhisperPipeline has no way to pass
+# device properties (CACHE_DIR etc.), unlike LlmPipeline/VlmPipeline in
+# the same crate which already expose with_properties(). Pinned to a fork
+# branch that adds the same method for Whisper, pending upstream review:
+# https://github.com/intel/openvino-rs/pull/196
+# Drop this patch (and bump the openvino-genai version requirement below
+# if needed) once that PR merges and ships in a crates.io release.
+[patch.crates-io]
+openvino-genai = { git = "https://github.com/tslove923/openvino-rs", branch = "whisper-pipeline-with-properties" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,10 @@ half = { version = "2", optional = true }
 tokenizers = { version = "0.20", optional = true, default-features = false, features = ["onig"] }
 rustfft = { version = "6", optional = true }
 
+# OpenVINO GenAI (optional, Intel NPU/GPU/CPU via OpenVINO GenAI WhisperPipeline)
+# `runtime-linking` loads libopenvino_genai.so at runtime via openvino-finder.
+openvino-genai = { version = "0.11", optional = true, features = ["runtime-linking"] }
+
 # CPU count for thread detection
 num_cpus = "1.16"
 
@@ -242,6 +246,11 @@ omnilingual-tensorrt = ["omnilingual", "onnx-tensorrt-enabled"]
 cohere = ["onnx-common", "dep:half", "dep:tokenizers"]
 cohere-cuda = ["cohere", "onnx-cuda-enabled"]
 cohere-tensorrt = ["cohere", "onnx-tensorrt-enabled"]
+# OpenVINO GenAI backend (Intel NPU/GPU/CPU). Standalone — does not pull
+# onnx-common. Loads libopenvino_genai.so at runtime via the crate's
+# `runtime-linking` feature. Requires the OpenVINO runtime + NPU plugin
+# (e.g. `openvino-intel-npu-plugin` on Arch) at runtime.
+openvino = ["dep:openvino-genai"]
 # Soniox is unconditional. Its deps (tokio-tungstenite, futures-util, reqwest)
 # add ~1-2 MB after LTO+strip and ride alongside ureq, which every binary
 # already ships for model downloads. Treating it like remote.rs (also always

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -398,6 +398,50 @@ duck_media = true
 duck_media_volume_percent = 70
 ```
 
+### external_trigger_silence_timeout_secs
+
+**Type:** Float
+**Default:** unset (disabled)
+**Required:** No
+
+Auto-stops an external-trigger recording (started via `voxtype record start`
+— SIGUSR1 — the mechanism a wake-word integration uses, since it has no
+physical key to hold or press again) after this many seconds of continuous
+silence following any detected speech. Unset by default: an external-trigger
+recording only ends on an explicit `voxtype record stop`/`record toggle`,
+matching behavior from before this option existed.
+
+This never applies to hotkey-driven push-to-talk or toggle recordings —
+those already have an explicit user-driven stop (release the key, or press
+it again), and don't need a silence timer.
+
+Speech detection uses `external_trigger_speech_threshold_dbfs` (below) on
+the same 10 ms level frames the OSD visualizer already computes — no extra
+audio processing.
+
+```toml
+[audio]
+external_trigger_silence_timeout_secs = 2.0  # stop 2s after the user stops talking
+```
+
+### external_trigger_speech_threshold_dbfs
+
+**Type:** Float
+**Default:** `-40.0`
+**Required:** No
+
+Peak level, in dBFS, at or above which a frame counts as speech for
+`external_trigger_silence_timeout_secs`. Only meaningful when that option is
+set. `-40.0` is a reasonable quiet-room default; raise it (toward `0.0`) on
+a noisy mic that never reads as silent, or lower it (more negative) if soft
+speech isn't resetting the silence timer.
+
+```toml
+[audio]
+external_trigger_silence_timeout_secs = 2.0
+external_trigger_speech_threshold_dbfs = -35.0  # less sensitive, noisier room
+```
+
 ### duck_media_volume_percent
 
 **Type:** Integer

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1431,6 +1431,95 @@ The prebuilt `voxtype-*-onnx-*` release binaries already include `cohere`, so us
 
 ---
 
+## [openvino]
+
+Configuration for the OpenVINO GenAI Whisper speech-to-text engine. This section is only used when `engine = "openvino"`.
+
+Runs Whisper through Intel's OpenVINO GenAI `WhisperPipeline` on the NPU, integrated GPU, or CPU. Automatically falls back to CPU if the requested device fails to initialize. There is no prebuilt binary for this engine — see "Building from Source" below.
+
+### model
+
+**Type:** String
+**Default:** `"base.en"`
+**Required:** No
+
+Model name (looked up under `~/.local/share/voxtype/models/openvino/<name>/`) or an absolute path to an OpenVINO IR directory (`openvino_encoder_model.xml`, `openvino_decoder_model.xml`, ...).
+
+**Available models:** `tiny.en`, `base.en`, `small.en`, `base`, `small`. `.en` variants are English-only, faster, and skip the language/task token setup entirely. Download via `voxtype setup model` or directly:
+
+```bash
+huggingface-cli download OpenVINO/whisper-base.en-int8-ov \
+  --local-dir ~/.local/share/voxtype/models/openvino/base.en
+```
+
+### device
+
+**Type:** String
+**Default:** `"NPU"`
+**Required:** No
+
+Inference device: `"NPU"`, `"GPU"`, or `"CPU"`. Falls back to CPU automatically if the requested device fails to initialize (missing hardware, driver not loaded, etc.) — a bad or unavailable value here degrades rather than crashes.
+
+**Example:**
+```toml
+[openvino]
+device = "GPU"
+```
+
+### language
+
+**Type:** String
+**Default:** `"en"`
+**Required:** No
+
+Language for transcription. Ignored for `.en` model checkpoints, whose vocabulary has no task/language tokens at all.
+
+### on_demand_loading
+
+**Type:** Boolean
+**Default:** `false`
+**Required:** No
+
+Same behavior as `[whisper].on_demand_loading`. Combined with the model-blob caching below, on-demand loading is viable on all three devices — a cached reload is well under a second even on NPU/GPU, not just CPU.
+
+### Compiled model caching
+
+Not a config field — always on. OpenVINO compiles the model graph into a device-specific blob before first inference on NPU (graph compiled to NPU-ISA) and GPU (OpenCL kernel compilation), and both are slow: NPU compiled cold in ~17s, GPU in a few seconds, measured on Meteor Lake with `base.en`. voxtype passes `CACHE_DIR` pointing at `$XDG_CACHE_HOME/voxtype/openvino` (falls back to `$HOME/.cache/voxtype/openvino`) so that compiled blob persists to disk and subsequent pipeline inits skip recompilation entirely — cached reload measured at 0.5-0.6s on both NPU and GPU. CPU has no comparable compile step and sees no meaningful change either way.
+
+Safe to delete (`rm -rf ~/.cache/voxtype/openvino`) if you switch models/devices often and want to reclaim the space; it repopulates on the next cold load.
+
+### Complete Example
+
+```toml
+engine = "openvino"
+
+[openvino]
+model = "base.en"
+device = "NPU"
+language = "en"
+on_demand_loading = false
+```
+
+### Building from Source
+
+There is no prebuilt binary for this engine. Source builds need the `openvino` Cargo feature, plus two runtime dependencies that must be installed separately (Arch example):
+
+```bash
+pacman -S openvino openvino-intel-npu-plugin openvino-intel-gpu-plugin \
+          intel-npu-driver level-zero-loader intel-compute-runtime
+```
+
+Those packages provide the OpenVINO runtime and device plugins, but *not* the C API library the Rust crate links against (`libopenvino_genai_c.so`) — that only ships in Intel's separate GenAI SDK archive (not the AUR `openvino-genai-bin` package or the pip wheel, both Python-bindings-only). Download the matching archive from `storage.openvinotoolkit.org/repositories/openvino_genai/packages/<version>/linux/` (version-matched to the installed core `openvino` package) and point `LD_LIBRARY_PATH` at its `runtime/lib/intel64`:
+
+```bash
+cargo build --release --features openvino
+export LD_LIBRARY_PATH=/path/to/openvino_genai_sdk/runtime/lib/intel64
+```
+
+See PR #592 for the full setup story, including two real bugs found only through NPU hardware testing.
+
+---
+
 ## [soniox]
 
 Configuration for the Soniox cloud streaming WebSocket STT engine. This section is only used when `engine = "soniox"`.

--- a/src/audio/levels.rs
+++ b/src/audio/levels.rs
@@ -55,7 +55,7 @@ use crate::config::Config;
 use std::io;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, Mutex};
@@ -540,6 +540,68 @@ impl Default for LevelBucketer {
     }
 }
 
+/// Shared handle for tracking "time since audio last showed sustained
+/// speech", used to drive silence-based auto-stop for external-trigger
+/// (wake-word) recordings — those have no user-driven stop signal, so
+/// something has to decide the user is done talking.
+///
+/// Cloning is cheap (`Arc` inside); the emitter task holds one clone and
+/// updates it, the daemon's periodic checker holds another and reads it.
+/// Reset on construction so a session with no speech yet reports "elapsed
+/// since the session started", not zero or a stale value from a prior use.
+#[derive(Clone)]
+pub struct SpeechTracker {
+    inner: Arc<Mutex<SpeechTrackerInner>>,
+    threshold_dbfs: f32,
+}
+
+struct SpeechTrackerInner {
+    last_speech_at: Instant,
+    consecutive_loud: u32,
+}
+
+/// A frame's peak at/above the threshold only counts as speech once this
+/// many consecutive 100 Hz frames (30 ms) have reached it. A single frame's
+/// peak is too spike-prone on a noisy mic (fans, HVAC, movement) to reset
+/// the silence timer on its own — without this, any ambient transient keeps
+/// the timer from ever accumulating. Real words sustain well past 30 ms.
+const SPEECH_BURST_FRAMES: u32 = 3;
+
+impl SpeechTracker {
+    pub fn new(threshold_dbfs: f32) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SpeechTrackerInner {
+                last_speech_at: Instant::now(),
+                consecutive_loud: 0,
+            })),
+            threshold_dbfs,
+        }
+    }
+
+    /// Record one bucketed frame's peak level. A run of
+    /// [`SPEECH_BURST_FRAMES`] consecutive frames at or above the speech
+    /// threshold bumps the "last speech" timestamp; a lone loud frame (or
+    /// a quiet frame) doesn't, so a noisy mic can't keep the silence clock
+    /// from ever accumulating.
+    pub async fn observe(&self, peak_dbfs: f32) {
+        let mut inner = self.inner.lock().await;
+        if peak_dbfs >= self.threshold_dbfs {
+            inner.consecutive_loud += 1;
+            if inner.consecutive_loud >= SPEECH_BURST_FRAMES {
+                inner.last_speech_at = Instant::now();
+            }
+        } else {
+            inner.consecutive_loud = 0;
+        }
+    }
+
+    /// Time elapsed since the last speech burst (or since construction, if
+    /// none has arrived yet).
+    pub async fn silence_elapsed(&self) -> Duration {
+        self.inner.lock().await.last_speech_at.elapsed()
+    }
+}
+
 /// Spawn a forwarder task that reads from an `mpsc::Receiver<Vec<f32>>`
 /// (the chunk stream from `AudioCapture::start()`), buckets the samples
 /// into 100 Hz frames, and publishes them to the supplied `FrameSink`.
@@ -550,21 +612,24 @@ pub fn spawn_emitter(
     chunk_rx: mpsc::Receiver<Vec<f32>>,
     sink: FrameSink,
 ) -> tokio::task::JoinHandle<()> {
-    spawn_emitter_with_streaming_tap(chunk_rx, sink, None)
+    spawn_emitter_with_streaming_tap(chunk_rx, sink, None, None)
 }
 
 /// Like [`spawn_emitter`] but also forwards every chunk to an optional
-/// `streaming_tx`, used by the streaming transcription pipeline to feed
-/// audio into a backend without disturbing the OSD level emitter.
+/// `streaming_tx` (used by the streaming transcription pipeline to feed
+/// audio into a backend without disturbing the OSD level emitter) and
+/// updates an optional [`SpeechTracker`] from each bucketed frame's peak
+/// level (used for silence-based auto-stop).
 ///
 /// When `streaming_tx` is `Some`, each chunk is cloned and `try_send`'d to
 /// it. Failure to send (closed receiver, full bounded channel) is logged at
-/// trace and never blocks the level emitter. When `streaming_tx` is `None`,
-/// behavior is identical to [`spawn_emitter`].
+/// trace and never blocks the level emitter. When both optional args are
+/// `None`, behavior is identical to [`spawn_emitter`].
 pub fn spawn_emitter_with_streaming_tap(
     mut chunk_rx: mpsc::Receiver<Vec<f32>>,
     sink: FrameSink,
     streaming_tx: Option<mpsc::Sender<Vec<f32>>>,
+    speech_tracker: Option<SpeechTracker>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut bucketer = LevelBucketer::new();
@@ -576,6 +641,9 @@ pub fn spawn_emitter_with_streaming_tap(
             out.clear();
             bucketer.push(&chunk, &mut out);
             for frame in out.drain(..) {
+                if let Some(tracker) = &speech_tracker {
+                    tracker.observe(frame.peak_dbfs).await;
+                }
                 sink.publish(frame);
             }
 
@@ -586,6 +654,28 @@ pub fn spawn_emitter_with_streaming_tap(
             }
         }
         tracing::trace!("Audio level emitter task ended");
+    })
+}
+
+/// Like [`spawn_emitter_with_streaming_tap`] but with no `FrameSink` to
+/// publish to — for silence tracking on a recording that has no OSD level
+/// hub running (OSD disabled or bind failed). Buckets samples purely to
+/// feed `speech_tracker`; frames are computed and discarded otherwise.
+pub fn spawn_silence_tracker(
+    mut chunk_rx: mpsc::Receiver<Vec<f32>>,
+    speech_tracker: SpeechTracker,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut bucketer = LevelBucketer::new();
+        let mut out: Vec<AudioFrame> = Vec::with_capacity(8);
+        while let Some(chunk) = chunk_rx.recv().await {
+            out.clear();
+            bucketer.push(&chunk, &mut out);
+            for frame in out.drain(..) {
+                speech_tracker.observe(frame.peak_dbfs).await;
+            }
+        }
+        tracing::trace!("Silence-tracking-only emitter task ended");
     })
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,7 @@ pub use setup::{CompositorType, SetupAction};
 /// `src/config/engines/mod.rs` so a new engine variant forces this string
 /// to update or the build breaks.
 pub const ENGINE_NAMES_CSV: &str =
-    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox";
+    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, openvino, soniox";
 
 /// Diarization backends the daemon dispatches on. Used by the CLI's
 /// `value_parser` for `--diarization` so unknown values are rejected at

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -40,6 +40,45 @@ pub struct AudioConfig {
     /// Audio feedback settings
     #[serde(default)]
     pub feedback: AudioFeedbackConfig,
+
+    /// Auto-stop an external-trigger (`voxtype record start`, e.g. from a
+    /// wake-word integration) recording after this many seconds of
+    /// silence. Unset (default) disables it — the recording only ends on
+    /// an explicit `record stop`/`record toggle`, same as before this
+    /// option existed. Never applies to hotkey-driven push-to-talk or
+    /// toggle recordings, which already have an explicit user-driven stop;
+    /// only sessions started via `record start` (SIGUSR1) arm this.
+    #[serde(default)]
+    pub external_trigger_silence_timeout_secs: Option<f32>,
+
+    /// Peak level (dBFS) at or above which a frame counts as speech for
+    /// `external_trigger_silence_timeout_secs`. Only meaningful when that
+    /// option is set. -20 dBFS sits clearly above the ambient noise floor
+    /// of typical laptop mics (measured here at ~-30 dBFS median) while
+    /// still catching normal dictation speech; raise it (toward 0) on a
+    /// noisier mic, lower it (more negative) if soft speech isn't resetting
+    /// the silence timer. A single frame only counts as speech once a short
+    /// burst sustains it (see `SPEECH_BURST_FRAMES`), so the exact value is
+    /// not spike-sensitive.
+    #[serde(default = "default_external_trigger_speech_threshold_dbfs")]
+    pub external_trigger_speech_threshold_dbfs: f32,
+
+    /// Shell command run whenever an external-trigger (`record start` /
+    /// SIGUSR1) recording ends, for *any* reason: an explicit `record
+    /// stop`/`record toggle`, `external_trigger_silence_timeout_secs`
+    /// firing, or the `max_duration_secs` hard cap. Never fires for
+    /// hotkey-driven push-to-talk/toggle recordings.
+    ///
+    /// External-trigger integrations (a wake-word daemon, a voice
+    /// assistant plugin) typically start recording and then wait for
+    /// *themselves* to be told to stop it — but silence-timeout means
+    /// voxtype can now end the session on its own, with no way for the
+    /// caller to know unless something tells it. Point this at whatever
+    /// re-signals your integration (for OmaPilot's wake-word plugin:
+    /// `omarchy-shell -q io.github.spencerbull.omapilot voiceToggle`,
+    /// the same command a second wake word would send).
+    #[serde(default)]
+    pub external_trigger_stop_command: Option<String>,
 }
 
 impl Default for AudioConfig {
@@ -53,6 +92,10 @@ impl Default for AudioConfig {
             duck_media: false,
             duck_media_volume_percent: default_duck_media_volume_percent(),
             feedback: AudioFeedbackConfig::default(),
+            external_trigger_silence_timeout_secs: None,
+            external_trigger_speech_threshold_dbfs: default_external_trigger_speech_threshold_dbfs(
+            ),
+            external_trigger_stop_command: None,
         }
     }
 }
@@ -71,6 +114,10 @@ fn default_audio_max_duration_secs() -> u32 {
 
 fn default_duck_media_volume_percent() -> u8 {
     70
+}
+
+fn default_external_trigger_speech_threshold_dbfs() -> f32 {
+    -20.0
 }
 
 /// Audio feedback configuration for sound cues

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -66,6 +66,20 @@ max_duration_secs = 60
 # duck_media = false
 # duck_media_volume_percent = 70
 
+# Auto-stop an external-trigger recording (`voxtype record start`, e.g. from
+# a wake-word integration) after this many seconds of silence. Unset by
+# default: the recording only ends on an explicit `record stop`/`record
+# toggle`. Never applies to hotkey-driven push-to-talk/toggle recordings,
+# which already have an explicit user-driven stop.
+# external_trigger_silence_timeout_secs = 2.0
+
+# Peak level (dBFS) at or above which a frame counts as speech for
+# external_trigger_silence_timeout_secs above. -20 sits above typical
+# laptop-mic noise (~-30 dBFS); raise it (toward 0) on a noisier mic,
+# lower it if soft speech isn't resetting the silence timer. A frame only
+# counts once a short burst sustains it, so stray noise spikes don't count.
+# external_trigger_speech_threshold_dbfs = -20.0
+
 # [audio.feedback]
 # Enable audio feedback sounds (beeps when recording starts/stops)
 # enabled = true

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -6,6 +6,7 @@ mod cohere;
 mod dolphin;
 mod moonshine;
 mod omnilingual;
+mod openvino;
 mod paraformer;
 mod parakeet;
 mod sensevoice;
@@ -15,6 +16,7 @@ pub use cohere::CohereConfig;
 pub use dolphin::DolphinConfig;
 pub use moonshine::MoonshineConfig;
 pub use omnilingual::OmnilingualConfig;
+pub use openvino::OpenVinoConfig;
 pub use paraformer::ParaformerConfig;
 pub use parakeet::{ParakeetConfig, ParakeetModelType};
 pub use sensevoice::SenseVoiceConfig;
@@ -63,6 +65,9 @@ pub enum TranscriptionEngine {
     /// task tokens). Top of the Open ASR Leaderboard.
     /// Requires: cargo build --features cohere
     Cohere,
+    /// Use OpenVINO GenAI Whisper (Intel NPU/GPU/CPU).
+    /// Requires: cargo build --features openvino
+    OpenVino,
     /// Use Soniox (cloud streaming WebSocket STT).
     Soniox,
 }

--- a/src/config/engines/openvino.rs
+++ b/src/config/engines/openvino.rs
@@ -1,0 +1,118 @@
+//! OpenVINO engine configuration (Intel NPU / GPU / CPU via OpenVINO GenAI).
+//!
+//! Requires: cargo build --features openvino
+
+use serde::{Deserialize, Serialize};
+
+use super::super::default_on_demand_loading;
+
+/// OpenVINO GenAI Whisper configuration.
+///
+/// Runs Whisper through OpenVINO GenAI's `WhisperPipeline` on the Intel NPU
+/// (or GPU/CPU). The model is an OpenVINO IR directory (`.xml` + `.bin`),
+/// e.g. `OpenVINO/whisper-base.en-int8-ov` from HuggingFace.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OpenVinoConfig {
+    /// Model name or path to a directory containing OpenVINO IR files
+    /// (openvino_encoder_model.xml, openvino_decoder_model.xml, ...).
+    /// Short names: "tiny.en", "base.en", "small.en", "base", "small"
+    pub model: String,
+
+    /// Inference device: "NPU", "GPU", or "CPU" (default: "NPU").
+    /// Falls back to CPU if the requested device fails to initialize.
+    #[serde(default = "default_openvino_device")]
+    pub device: String,
+
+    /// Language for transcription (default: "en")
+    #[serde(default = "default_openvino_language")]
+    pub language: String,
+
+    /// Number of CPU threads for OpenVINO inference
+    #[serde(default)]
+    pub threads: Option<usize>,
+
+    /// Load model on-demand when recording starts (true) or keep loaded (false)
+    #[serde(default = "default_on_demand_loading")]
+    pub on_demand_loading: bool,
+
+    // --- Sliding-window streaming settings (same knobs as [whisper]) ---
+    /// Enable live streaming transcription via the shared sliding-window engine.
+    #[serde(default)]
+    pub streaming: bool,
+
+    /// Seconds between re-transcriptions of the rolling buffer.
+    #[serde(default = "default_streaming_interval_secs")]
+    pub streaming_interval_secs: f32,
+
+    /// Maximum buffered audio (seconds) before the window slides.
+    #[serde(default = "default_streaming_max_buffer_secs")]
+    pub streaming_max_buffer_secs: f32,
+
+    /// Skip transcription while whole-buffer RMS is below this.
+    #[serde(default = "default_streaming_min_speech_rms")]
+    pub streaming_min_speech_rms: f32,
+
+    /// Minimum buffered audio (seconds) before the first partial is attempted.
+    #[serde(default = "default_streaming_min_audio_secs")]
+    pub streaming_min_audio_secs: f32,
+
+    /// Minimum number of new stable words before a delta is committed/typed.
+    #[serde(default = "default_streaming_partial_min_words")]
+    pub streaming_partial_min_words: usize,
+
+    /// Type committed deltas live at the cursor (`true`) or commit whole
+    /// segments at once (`false`).
+    #[serde(default = "default_streaming_type_partials")]
+    pub streaming_type_partials: bool,
+}
+
+fn default_openvino_device() -> String {
+    "NPU".to_string()
+}
+
+fn default_openvino_language() -> String {
+    "en".to_string()
+}
+
+fn default_streaming_interval_secs() -> f32 {
+    0.8
+}
+
+fn default_streaming_max_buffer_secs() -> f32 {
+    29.0
+}
+
+fn default_streaming_min_speech_rms() -> f32 {
+    0.005
+}
+
+fn default_streaming_min_audio_secs() -> f32 {
+    1.0
+}
+
+fn default_streaming_partial_min_words() -> usize {
+    1
+}
+
+fn default_streaming_type_partials() -> bool {
+    true
+}
+
+impl Default for OpenVinoConfig {
+    fn default() -> Self {
+        Self {
+            model: "base.en".to_string(),
+            device: "NPU".to_string(),
+            language: "en".to_string(),
+            threads: None,
+            on_demand_loading: false,
+            streaming: false,
+            streaming_interval_secs: default_streaming_interval_secs(),
+            streaming_max_buffer_secs: default_streaming_max_buffer_secs(),
+            streaming_min_speech_rms: default_streaming_min_speech_rms(),
+            streaming_min_audio_secs: default_streaming_min_audio_secs(),
+            streaming_partial_min_words: default_streaming_partial_min_words(),
+            streaming_type_partials: default_streaming_type_partials(),
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,8 +26,9 @@ mod whisper;
 pub use audio::{AudioConfig, AudioFeedbackConfig};
 pub use default_config::{default_config_content, DEFAULT_CONFIG};
 pub use engines::{
-    CohereConfig, DolphinConfig, MoonshineConfig, OmnilingualConfig, ParaformerConfig,
-    ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig, TranscriptionEngine,
+    CohereConfig, DolphinConfig, MoonshineConfig, OmnilingualConfig, OpenVinoConfig,
+    ParaformerConfig, ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig,
+    TranscriptionEngine,
 };
 pub use hotkey::{ActivationMode, HotkeyConfig};
 pub use language::LanguageConfig;

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -1,7 +1,8 @@
 use super::{
     AudioConfig, CohereConfig, DolphinConfig, HotkeyConfig, MeetingConfig, MoonshineConfig,
-    OmnilingualConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile, SenseVoiceConfig,
-    SonioxConfig, StatusConfig, TextConfig, TranscriptionEngine, VadConfig, WhisperConfig,
+    OmnilingualConfig, OpenVinoConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile,
+    SenseVoiceConfig, SonioxConfig, StatusConfig, TextConfig, TranscriptionEngine, VadConfig,
+    WhisperConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -55,6 +56,10 @@ pub struct Config {
     /// Cohere Transcribe configuration (optional, only used when engine = "cohere")
     #[serde(default)]
     pub cohere: Option<CohereConfig>,
+
+    /// OpenVINO GenAI configuration (optional, only used when engine = "openvino")
+    #[serde(default)]
+    pub openvino: Option<OpenVinoConfig>,
 
     /// Soniox cloud streaming WebSocket STT configuration
     /// (optional, only used when engine = "soniox")
@@ -112,6 +117,7 @@ impl Default for Config {
             dolphin: None,
             omnilingual: None,
             cohere: None,
+            openvino: None,
             soniox: None,
             text: TextConfig::default(),
             vad: VadConfig::default(),
@@ -146,6 +152,7 @@ impl Config {
                 .as_ref()
                 .map(|s| s.streaming && !s.async_api)
                 .unwrap_or(false),
+            TranscriptionEngine::Whisper => self.whisper.streaming,
             _ => false,
         }
     }
@@ -338,6 +345,11 @@ impl Config {
                 .as_ref()
                 .map(|c| c.on_demand_loading)
                 .unwrap_or(false),
+            TranscriptionEngine::OpenVino => self
+                .openvino
+                .as_ref()
+                .map(|o| o.on_demand_loading)
+                .unwrap_or(false),
             // Soniox is a cloud backend; nothing to load on demand.
             TranscriptionEngine::Soniox => false,
         }
@@ -382,6 +394,11 @@ impl Config {
                 .as_ref()
                 .map(|c| c.model.as_str())
                 .unwrap_or("cohere (not configured)"),
+            TranscriptionEngine::OpenVino => self
+                .openvino
+                .as_ref()
+                .map(|o| o.model.as_str())
+                .unwrap_or("openvino (not configured)"),
             TranscriptionEngine::Soniox => self
                 .soniox
                 .as_ref()

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -153,6 +153,9 @@ impl Config {
                 .map(|s| s.streaming && !s.async_api)
                 .unwrap_or(false),
             TranscriptionEngine::Whisper => self.whisper.streaming,
+            TranscriptionEngine::OpenVino => {
+                self.openvino.as_ref().map(|o| o.streaming).unwrap_or(false)
+            }
             _ => false,
         }
     }

--- a/src/config/whisper.rs
+++ b/src/config/whisper.rs
@@ -97,6 +97,41 @@ pub struct WhisperConfig {
     #[serde(default = "default_eager_overlap_secs")]
     pub eager_overlap_secs: f32,
 
+    // --- Sliding-window streaming settings ---
+    /// Enable live streaming transcription (sliding-window re-transcription,
+    /// ported from nova-npu). When true, text lands at the cursor incrementally
+    /// as you speak (via the streaming pipeline) instead of only after the
+    /// hotkey is released. Only applies to `mode = "local"`.
+    #[serde(default)]
+    pub streaming: bool,
+
+    /// Seconds between re-transcriptions of the rolling buffer.
+    /// Lower = more responsive partials, higher CPU/NPU cost.
+    #[serde(default = "default_streaming_interval_secs")]
+    pub streaming_interval_secs: f32,
+
+    /// Maximum buffered audio (seconds) before the window slides (drops old
+    /// samples to respect the Whisper context limit).
+    #[serde(default = "default_streaming_max_buffer_secs")]
+    pub streaming_max_buffer_secs: f32,
+
+    /// Skip transcription while whole-buffer RMS is below this.
+    #[serde(default = "default_streaming_min_speech_rms")]
+    pub streaming_min_speech_rms: f32,
+
+    /// Minimum buffered audio (seconds) before the first partial is attempted.
+    #[serde(default = "default_streaming_min_audio_secs")]
+    pub streaming_min_audio_secs: f32,
+
+    /// Minimum number of new stable words before a delta is committed/typed.
+    #[serde(default = "default_streaming_partial_min_words")]
+    pub streaming_partial_min_words: usize,
+
+    /// Type committed deltas live at the cursor (`true`) or only commit whole
+    /// segments at once (`false`). Live typing is the faithful nova behavior.
+    #[serde(default = "default_streaming_type_partials")]
+    pub streaming_type_partials: bool,
+
     /// Initial prompt to provide context for transcription
     /// Use this to hint at terminology, proper nouns, or formatting conventions.
     /// Example: "Technical discussion about Rust, TypeScript, and Kubernetes."
@@ -197,6 +232,13 @@ impl Default for WhisperConfig {
             eager_processing: false,
             eager_chunk_secs: default_eager_chunk_secs(),
             eager_overlap_secs: default_eager_overlap_secs(),
+            streaming: false,
+            streaming_interval_secs: default_streaming_interval_secs(),
+            streaming_max_buffer_secs: default_streaming_max_buffer_secs(),
+            streaming_min_speech_rms: default_streaming_min_speech_rms(),
+            streaming_min_audio_secs: default_streaming_min_audio_secs(),
+            streaming_partial_min_words: default_streaming_partial_min_words(),
+            streaming_type_partials: default_streaming_type_partials(),
             initial_prompt: None,
             secondary_model: None,
             available_models: vec![],
@@ -229,6 +271,30 @@ fn default_eager_chunk_secs() -> f32 {
 
 fn default_eager_overlap_secs() -> f32 {
     0.5
+}
+
+fn default_streaming_interval_secs() -> f32 {
+    0.8
+}
+
+fn default_streaming_max_buffer_secs() -> f32 {
+    29.0
+}
+
+fn default_streaming_min_speech_rms() -> f32 {
+    0.005
+}
+
+fn default_streaming_min_audio_secs() -> f32 {
+    1.0
+}
+
+fn default_streaming_partial_min_words() -> usize {
+    1
+}
+
+fn default_streaming_type_partials() -> bool {
+    true
 }
 
 fn default_whisper_model() -> String {

--- a/src/config_set.rs
+++ b/src/config_set.rs
@@ -80,6 +80,7 @@ pub fn engine_feature_compiled(name: &str) -> bool {
         TranscriptionEngine::Dolphin => cfg!(feature = "dolphin"),
         TranscriptionEngine::Omnilingual => cfg!(feature = "omnilingual"),
         TranscriptionEngine::Cohere => cfg!(feature = "cohere"),
+        TranscriptionEngine::OpenVino => cfg!(feature = "openvino"),
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -611,6 +611,17 @@ pub struct Daemon {
     level_hub: Option<audio::levels::LevelHub>,
     /// Active per-recording level emitter task; aborted when recording stops
     level_emitter_task: Option<tokio::task::JoinHandle<()>>,
+    /// Tracks time-since-last-speech for the active recording, when
+    /// silence-based auto-stop is armed (external-trigger sessions only —
+    /// see `new_speech_tracker`). `None` when idle or not armed for this
+    /// session. Read by the periodic silence check in the main loop.
+    silence_tracker: Option<audio::levels::SpeechTracker>,
+    /// Whether the currently-active recording was started via an external
+    /// trigger (SIGUSR1 / `record start`) rather than the hotkey. Set in
+    /// `start_recording_capture`/`start_streaming_capture`, read (and
+    /// cleared) by `stop_active_recording` to decide whether to run
+    /// `external_trigger_stop_command`.
+    is_external_trigger: bool,
     /// Synthetic zero-level publisher that keeps the OSD visible while a
     /// streaming session is draining server-side after the mic stopped.
     /// Aborted in `end_streaming`.
@@ -747,6 +758,8 @@ impl Daemon {
             last_dictation: None,
             level_hub: None,
             level_emitter_task: None,
+            silence_tracker: None,
+            is_external_trigger: false,
             streaming_drain_pump: None,
             osd_supervisor_task: None,
             model_manager: None,
@@ -837,20 +850,67 @@ impl Daemon {
     /// capture is plumbed into the level hub so the OSD sees audio frames
     /// at 100 Hz during recording. The emitter task is tracked so it can
     /// be cleanly aborted when recording stops.
-    async fn start_recording_capture(&mut self) -> std::result::Result<Box<dyn AudioCapture>, ()> {
+    /// Build a `SpeechTracker` for silence-based auto-stop, if `armed` and
+    /// the feature is configured. `armed` should be `true` only for
+    /// external-trigger (wake-word) sessions — see the doc comment on
+    /// `silence_tracker` — never for hotkey-driven push-to-talk/toggle
+    /// recordings, which already have an explicit user-driven stop.
+    fn new_speech_tracker(&self, armed: bool) -> Option<audio::levels::SpeechTracker> {
+        if !armed {
+            return None;
+        }
+        self.config
+            .audio
+            .external_trigger_silence_timeout_secs
+            .map(|timeout| {
+                tracing::info!(
+                    "Silence auto-stop armed for this session (timeout={:.1}s, threshold={:.1}dBFS)",
+                    timeout,
+                    self.config.audio.external_trigger_speech_threshold_dbfs,
+                );
+                audio::levels::SpeechTracker::new(
+                    self.config.audio.external_trigger_speech_threshold_dbfs,
+                )
+            })
+    }
+
+    /// Start a batch (non-streaming) audio capture. `track_silence` arms
+    /// silence-based auto-stop when the session is external-trigger and the
+    /// feature is configured (see `new_speech_tracker`) — pass `false` for
+    /// hotkey-driven recordings.
+    async fn start_recording_capture(
+        &mut self,
+        track_silence: bool,
+    ) -> std::result::Result<Box<dyn AudioCapture>, ()> {
         match audio::create_capture(&self.config.audio) {
             Ok(mut capture) => match capture.start().await {
                 Ok(chunk_rx) => {
-                    if let Some(hub) = &self.level_hub {
-                        // Cancel any prior emitter (defensive; should be idle).
-                        if let Some(handle) = self.level_emitter_task.take() {
-                            handle.abort();
-                        }
-                        let handle = audio::levels::spawn_emitter(chunk_rx, hub.frame_sink());
+                    self.is_external_trigger = track_silence;
+                    let speech_tracker = self.new_speech_tracker(track_silence);
+                    self.silence_tracker = speech_tracker.clone();
+
+                    // Cancel any prior emitter (defensive; should be idle).
+                    if let Some(handle) = self.level_emitter_task.take() {
+                        handle.abort();
+                    }
+                    let handle = if let Some(hub) = &self.level_hub {
+                        Some(audio::levels::spawn_emitter_with_streaming_tap(
+                            chunk_rx,
+                            hub.frame_sink(),
+                            None,
+                            speech_tracker,
+                        ))
+                    } else {
+                        // No OSD sink. If silence tracking is armed it still
+                        // needs a consumer for chunk_rx — otherwise it'd
+                        // just be dropped, matching the pre-tracking
+                        // behaviour when tracking isn't armed either.
+                        speech_tracker
+                            .map(|tracker| audio::levels::spawn_silence_tracker(chunk_rx, tracker))
+                    };
+                    if let Some(handle) = handle {
                         self.level_emitter_task = Some(handle);
                     }
-                    // If level_hub is None we still return Ok; the chunk_rx
-                    // is dropped here, matching previous behaviour.
                     Ok(capture)
                 }
                 Err(e) => {
@@ -930,6 +990,7 @@ impl Daemon {
         streaming_session: &mut Option<StreamingSession>,
         streaming_chain: &mut Option<Vec<Box<dyn TextOutput>>>,
         model_override: Option<String>,
+        track_silence: bool,
     ) -> bool {
         let Some(transcriber) = transcriber_preloaded.as_ref() else {
             return false;
@@ -938,7 +999,7 @@ impl Daemon {
             return false;
         }
 
-        let (capture, samples_rx) = match self.start_streaming_capture().await {
+        let (capture, samples_rx) = match self.start_streaming_capture(track_silence).await {
             Ok(v) => v,
             Err(()) => return false,
         };
@@ -997,6 +1058,158 @@ impl Daemon {
         }
 
         true
+    }
+
+    /// End an external-trigger (SIGUSR1 / `record start`) session that is
+    /// being stopped on *any* path — the caller's own `record stop`, the
+    /// silence timeout, the hard `max_duration_secs` cap, or a cancel — so
+    /// the integration that started the recording is told it ended (it may
+    /// not be the one that decided to stop it). Disarms the silence tracker
+    /// and clears `is_external_trigger` unconditionally.
+    ///
+    /// `was_recording` gates whether the hook fires: pass `state.is_recording()`
+    /// captured *before* mutating state. A stale `is_external_trigger` from an
+    /// already-ended session (e.g. one cancelled outside
+    /// `stop_active_recording`) must not fire the hook for an unrelated later
+    /// SIGUSR2 that arrives while idle.
+    async fn end_external_session(&mut self, was_recording: bool) {
+        self.silence_tracker = None;
+        let was_external = self.is_external_trigger && was_recording;
+        self.is_external_trigger = false;
+        if was_external {
+            if let Some(cmd) = self.config.audio.external_trigger_stop_command.clone() {
+                if let Err(e) = output::run_hook(&cmd, "external_trigger_stop").await {
+                    tracing::warn!("{}", e);
+                }
+            }
+        }
+    }
+
+    /// Stop whatever recording is currently active — streaming, batch
+    /// (`State::Recording`), or eager — and hand it off to transcription.
+    /// Shared by the SIGUSR2 handler (explicit `record stop` / compositor
+    /// keybinding) and the silence-timeout auto-stop, which need identical
+    /// per-state-variant stop behavior; the only difference between them is
+    /// *why* the stop fired, not what happens next.
+    #[allow(clippy::too_many_arguments)]
+    async fn stop_active_recording(
+        &mut self,
+        state: &mut State,
+        audio_capture: &mut Option<Box<dyn AudioCapture>>,
+        streaming_session: &mut Option<StreamingSession>,
+        streaming_chain: &mut Option<Vec<Box<dyn TextOutput>>>,
+        eager_transcriber: &mut Option<Arc<dyn Transcriber>>,
+        transcriber_preloaded: &Option<Arc<dyn Transcriber>>,
+    ) {
+        // Notify an external-trigger caller that this session is ending,
+        // regardless of why (stop, silence timeout, hard timeout) — it may
+        // not be the one that decided to stop it — and disarm silence
+        // tracking for the next session. Gated on the recording actually
+        // being active: SIGUSR2 can arrive while idle, and a stale
+        // `is_external_trigger` from an earlier session must not fire the
+        // hook for an unrelated later signal.
+        self.end_external_session(state.is_recording()).await;
+
+        if state.is_streaming() {
+            // File-output sessions (`--file=path`) have nowhere to leak
+            // into — they accumulate text instead of typing it (see the
+            // event pump) — so the disown-on-stop protection below
+            // doesn't apply; disowning here would just silently drop
+            // whatever the backend was still draining, and end_streaming
+            // would then write an empty file. Let it drain normally so
+            // end_streaming can write the real text.
+            let file_output = matches!(
+                &*state,
+                State::Streaming {
+                    file_output_path: Some(_),
+                    ..
+                }
+            );
+            if file_output {
+                tracing::info!("Stopping streaming session (file output); closing capture");
+            } else {
+                tracing::info!("Stopping streaming session; closing capture and disowning session");
+            }
+            self.stop_streaming_capture(audio_capture).await;
+            if !file_output {
+                // Drop the typing surface synchronously so any
+                // Final/Partial events the backend emits while
+                // draining its internal buffer reach the event-pump
+                // arm with `streaming_session = None` and get
+                // discarded instead of typed into whatever window
+                // has focus by then.
+                *streaming_session = None;
+                *streaming_chain = None;
+            }
+        } else if let State::Recording { model_override, .. } = &*state {
+            let model_override = model_override.clone();
+
+            self.start_transcription_task(
+                state,
+                audio_capture,
+                model_override,
+                transcriber_preloaded,
+            )
+            .await;
+        } else if state.is_eager_recording() {
+            // Handle eager recording stop via external trigger - extract model_override first
+            let model_override = match &*state {
+                State::EagerRecording { model_override, .. } => model_override.clone(),
+                _ => None,
+            };
+
+            let duration = state.recording_duration().unwrap_or_default();
+            tracing::info!("Eager recording stopped ({:.1}s)", duration.as_secs_f32());
+
+            // Stop audio capture and get remaining samples
+            if let Some(mut capture) = audio_capture.take() {
+                if let Ok(final_samples) = capture.stop().await {
+                    if let State::EagerRecording {
+                        accumulated_audio, ..
+                    } = state
+                    {
+                        accumulated_audio.extend(final_samples);
+                    }
+                }
+            }
+            self.restore_recording_media();
+
+            self.play_feedback(SoundEvent::RecordingStop);
+
+            if self.config.output.notification.on_recording_stop {
+                send_notification(
+                    "Recording Stopped",
+                    "Transcribing...",
+                    self.config.output.notification.show_engine_icon,
+                    self.config.engine,
+                    &self.config.output.notification.urgency,
+                )
+                .await;
+            }
+
+            let transcriber = match self
+                .get_transcriber_for_recording(model_override.as_deref(), transcriber_preloaded)
+                .await
+            {
+                Ok(t) => t,
+                Err(()) => {
+                    *state = State::Idle;
+                    self.update_state("idle");
+                    return;
+                }
+            };
+
+            self.update_state("transcribing");
+
+            if let Some(text) = self.finish_eager_recording(state, transcriber).await {
+                *state = State::Transcribing { audio: Vec::new() };
+                self.handle_transcription_result(state, Ok(Ok(text))).await;
+            } else {
+                tracing::debug!("Eager recording produced empty result");
+                self.reset_to_idle(state).await;
+            }
+            *eager_transcriber = None;
+        }
     }
 
     /// End a streaming session gracefully (called when the backend emits
@@ -1201,6 +1414,7 @@ impl Daemon {
     /// Returns `(capture, streaming_samples_rx)` on success.
     async fn start_streaming_capture(
         &mut self,
+        track_silence: bool,
     ) -> std::result::Result<(Box<dyn AudioCapture>, tokio::sync::mpsc::Receiver<Vec<f32>>), ()>
     {
         match audio::create_capture(&self.config.audio) {
@@ -1213,17 +1427,31 @@ impl Daemon {
                     if let Some(handle) = self.level_emitter_task.take() {
                         handle.abort();
                     }
+                    self.is_external_trigger = track_silence;
+                    let speech_tracker = self.new_speech_tracker(track_silence);
+                    self.silence_tracker = speech_tracker.clone();
                     let handle = if let Some(hub) = &self.level_hub {
                         audio::levels::spawn_emitter_with_streaming_tap(
                             chunk_rx,
                             hub.frame_sink(),
                             Some(streaming_tx),
+                            speech_tracker,
                         )
                     } else {
-                        // No OSD: still need to drive chunk_rx → streaming_tx.
+                        // No OSD: still need to drive chunk_rx → streaming_tx,
+                        // and optionally bucket for silence tracking too.
                         tokio::spawn(async move {
                             let mut rx = chunk_rx;
+                            let mut bucketer = audio::levels::LevelBucketer::new();
+                            let mut out = Vec::with_capacity(8);
                             while let Some(chunk) = rx.recv().await {
+                                if let Some(tracker) = &speech_tracker {
+                                    out.clear();
+                                    bucketer.push(&chunk, &mut out);
+                                    for frame in out.drain(..) {
+                                        tracker.observe(frame.peak_dbfs).await;
+                                    }
+                                }
                                 if streaming_tx.try_send(chunk).is_err() {
                                     // Backend slow or gone; drop and keep going.
                                 }
@@ -2863,12 +3091,13 @@ impl Daemon {
                                     &mut streaming_session,
                                     &mut streaming_chain,
                                     model_override.clone(),
+                                    false,
                                 ).await {
                                     tracing::info!("Streaming session started (push-to-talk)");
                                 } else {
                                     // Create and start audio capture
                                     tracing::debug!("Creating audio capture with device: {}", self.config.audio.device);
-                                    match self.start_recording_capture().await {
+                                    match self.start_recording_capture(false).await {
                                         Ok(capture) => {
                                             tracing::debug!("Audio capture started successfully");
                                             audio_capture = Some(capture);
@@ -3074,10 +3303,11 @@ impl Daemon {
                                     &mut streaming_session,
                                     &mut streaming_chain,
                                     model_override.clone(),
+                                    false,
                                 ).await {
                                     tracing::info!("Streaming session started (toggle)");
                                 } else {
-                                    match self.start_recording_capture().await {
+                                    match self.start_recording_capture(false).await {
                                         Ok(capture) => {
                                             audio_capture = Some(capture);
 
@@ -3201,6 +3431,11 @@ impl Daemon {
                             } else if state.is_recording() {
                                 tracing::info!("Recording cancelled via hotkey");
 
+                                // A cancelled external-trigger session is
+                                // still an ended session — tell the caller
+                                // and disarm tracking.
+                                self.end_external_session(state.is_recording()).await;
+
                                 // Stop recording and discard audio
                                 if let Some(mut capture) = audio_capture.take() {
                                     let _ = capture.stop().await;
@@ -3311,6 +3546,9 @@ impl Daemon {
                         cleanup_model_override();
                         cleanup_profile_override();
                         cleanup_bool_override("smart_auto_submit");
+                        // A cancelled external-trigger session is still an
+                        // ended session — tell the caller and disarm tracking.
+                        self.end_external_session(state.is_recording()).await;
                         state = State::Idle;
                         eager_transcriber = None;
                         self.update_state("idle");
@@ -3385,6 +3623,40 @@ impl Daemon {
                         }
                     }
 
+                    // Silence-based auto-stop for external-trigger
+                    // (wake-word) sessions. Checked from this tick rather
+                    // than a standalone sleep arm: `loop { select! }` rebuilds
+                    // every arm future each iteration, so a 300 ms sleep arm
+                    // here was permanently starved by this same 100 ms tick
+                    // and never fired. 100 ms granularity is plenty for a
+                    // multi-second threshold.
+                    if self.is_external_trigger && state.is_recording() {
+                        if let Some(tracker) = &self.silence_tracker {
+                            if let Some(timeout_secs) =
+                                self.config.audio.external_trigger_silence_timeout_secs
+                            {
+                                let elapsed = tracker.silence_elapsed().await;
+                                if elapsed.as_secs_f32() >= timeout_secs {
+                                    tracing::info!(
+                                        "Silence timeout ({:.1}s >= {:.1}s), auto-stopping",
+                                        elapsed.as_secs_f32(),
+                                        timeout_secs
+                                    );
+                                    self.stop_active_recording(
+                                        &mut state,
+                                        &mut audio_capture,
+                                        &mut streaming_session,
+                                        &mut streaming_chain,
+                                        &mut eager_transcriber,
+                                        &transcriber_preloaded,
+                                    )
+                                    .await;
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+
                     // Check for recording timeout. Skip when audio_capture is
                     // already gone so we don't re-fire cleanup on every 100ms
                     // tick while the streaming session drains server-side
@@ -3392,6 +3664,12 @@ impl Daemon {
                     let timeout_fired = audio_capture.is_some()
                         && state.recording_duration().is_some_and(|d| d > max_duration);
                     if timeout_fired {
+                        // A hard-capped session is ending on voxtype's own
+                        // initiative (not the caller's `record stop`) — end
+                        // it as an external-trigger session so the caller is
+                        // told, and the silence tracker is disarmed.
+                        self.end_external_session(state.is_recording()).await;
+
                         // Streaming has its own clean stop path: skip the
                         // batch_transcribe branch below to avoid opening a
                         // second WS session for audio already being processed
@@ -3551,10 +3829,11 @@ impl Daemon {
                             &mut streaming_session,
                             &mut streaming_chain,
                             model_override.clone(),
+                            true,
                         ).await {
                             tracing::info!("Streaming session started (SIGUSR1)");
                         } else {
-                            match self.start_recording_capture().await {
+                            match self.start_recording_capture(true).await {
                                 Ok(capture) => {
                                     audio_capture = Some(capture);
 
@@ -3597,93 +3876,14 @@ impl Daemon {
                 // Handle SIGUSR2 - stop recording (for compositor keybindings)
                 _ = sigusr2.recv() => {
                     tracing::debug!("Received SIGUSR2 (stop recording)");
-                    if state.is_streaming() {
-                        // File-output sessions (`--file=path`) have nowhere
-                        // to leak into — they accumulate text instead of
-                        // typing it (see the event pump) — so the
-                        // disown-on-SIGUSR2 protection below doesn't apply;
-                        // disowning here would just silently drop whatever
-                        // the backend was still draining, and end_streaming
-                        // would then write an empty file. Let it drain
-                        // normally so end_streaming can write the real text.
-                        let file_output = matches!(
-                            &state,
-                            State::Streaming { file_output_path: Some(_), .. }
-                        );
-                        if file_output {
-                            tracing::info!("SIGUSR2 stop while streaming (file output); closing capture");
-                        } else {
-                            tracing::info!("SIGUSR2 stop while streaming; closing capture and disowning session");
-                        }
-                        self.stop_streaming_capture(&mut audio_capture).await;
-                        if !file_output {
-                            // Drop the typing surface synchronously so any
-                            // Final/Partial events the backend emits while
-                            // draining its internal buffer reach the event-pump
-                            // arm with `streaming_session = None` and get
-                            // discarded instead of typed into whatever window
-                            // has focus by then.
-                            streaming_session = None;
-                            streaming_chain = None;
-                        }
-                    } else if let State::Recording { model_override, .. } = &state {
-                        let model_override = model_override.clone();
-
-                        self.start_transcription_task(
-                            &mut state,
-                            &mut audio_capture,
-                            model_override,
-                            &transcriber_preloaded,
-                        ).await;
-                    } else if state.is_eager_recording() {
-                        // Handle eager recording stop via external trigger - extract model_override first
-                        let model_override = match &state {
-                            State::EagerRecording { model_override, .. } => model_override.clone(),
-                            _ => None,
-                        };
-
-                        let duration = state.recording_duration().unwrap_or_default();
-                        tracing::info!("Eager recording stopped ({:.1}s)", duration.as_secs_f32());
-
-                        // Stop audio capture and get remaining samples
-                        if let Some(mut capture) = audio_capture.take() {
-                            if let Ok(final_samples) = capture.stop().await {
-                                if let State::EagerRecording { accumulated_audio, .. } = &mut state {
-                                    accumulated_audio.extend(final_samples);
-                                }
-                            }
-                        }
-                        self.restore_recording_media();
-
-                        self.play_feedback(SoundEvent::RecordingStop);
-
-                        if self.config.output.notification.on_recording_stop {
-                            send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
-                        }
-
-                        let transcriber = match self.get_transcriber_for_recording(
-                            model_override.as_deref(),
-                            &transcriber_preloaded,
-                        ).await {
-                            Ok(t) => t,
-                            Err(()) => {
-                                state = State::Idle;
-                                self.update_state("idle");
-                                continue;
-                            }
-                        };
-
-                        self.update_state("transcribing");
-
-                        if let Some(text) = self.finish_eager_recording(&mut state, transcriber).await {
-                            state = State::Transcribing { audio: Vec::new() };
-                            self.handle_transcription_result(&mut state, Ok(Ok(text))).await;
-                        } else {
-                            tracing::debug!("Eager recording produced empty result");
-                            self.reset_to_idle(&mut state).await;
-                        }
-                        eager_transcriber = None;
-                    }
+                    self.stop_active_recording(
+                        &mut state,
+                        &mut audio_capture,
+                        &mut streaming_session,
+                        &mut streaming_chain,
+                        &mut eager_transcriber,
+                        &transcriber_preloaded,
+                    ).await;
                 }
 
                 // Handle transcription task completion

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -877,6 +877,38 @@ impl Daemon {
         }
     }
 
+    /// Resolve the file-output target path for a recording, if any.
+    ///
+    /// Priority: 1. CLI `--file=path`, 2. CLI `--file` (config's
+    /// `file_path`), 3. profile `output_mode = "file"`, 4. config
+    /// `mode = "file"`. Shared by the classic (batch) transcription path
+    /// and the streaming path so a `--file=` override behaves the same
+    /// regardless of which one `[whisper] streaming` selects — before
+    /// this was factored out, only the classic path consulted it, so a
+    /// streaming session silently ignored `--file=` and typed at the
+    /// cursor instead.
+    fn resolve_file_output_path(
+        &self,
+        output_override: &Option<OutputOverride>,
+        profile_output_mode: Option<OutputMode>,
+    ) -> Option<PathBuf> {
+        match output_override {
+            // CLI --file=path.txt
+            Some(OutputOverride::FileWithPath(path)) => Some(path.clone()),
+            // CLI --file (no path) - use config's file_path
+            Some(OutputOverride::Mode(OutputMode::File)) => self.config.output.file_path.clone(),
+            // Profile specifies file mode
+            None if profile_output_mode == Some(OutputMode::File) => {
+                self.config.output.file_path.clone()
+            }
+            // Config mode = "file" (no CLI override)
+            None if self.config.output.mode == OutputMode::File => {
+                self.config.output.file_path.clone()
+            }
+            _ => None,
+        }
+    }
+
     /// Attempt to start a streaming transcription session.
     ///
     /// Returns `true` and populates the streaming locals on success. Returns
@@ -924,6 +956,14 @@ impl Daemon {
             }
         };
 
+        // A `--file=path` (or config/`mode = "file"`) override means this
+        // session accumulates into `finalized_text` instead of typing —
+        // see the Partial/Final/Replace arms in the event pump, gated on
+        // `file_output_path`. The chain is still built normally; it's
+        // simply unused for a file-output session.
+        let output_override = read_output_mode_override();
+        let file_output_path = self.resolve_file_output_path(&output_override, None);
+
         *audio_capture = Some(capture);
         *streaming_handle = Some(handle);
         *streaming_session = Some(StreamingSession::new());
@@ -934,6 +974,7 @@ impl Daemon {
             partial_buffer: String::new(),
             finalized_text: String::new(),
             typed_chars: 0,
+            file_output_path,
         };
         self.update_state("streaming");
         self.play_feedback(SoundEvent::RecordingStart);
@@ -1026,6 +1067,52 @@ impl Daemon {
             let _ = h.task.await;
         }
         self.stop_streaming_drain_pump();
+
+        // File-output sessions (`--file=path`) never typed anything as
+        // they went — see the event pump's `file_output` branch — so the
+        // accumulated text only exists in the session. Write it out now,
+        // before the session is dropped below. Mirrors the classic
+        // (non-streaming) path's file handling, including skipping
+        // post_output_command: file mode is a batch dump, not a
+        // live-typing operation the hook is meant to wrap around.
+        let file_output_path = match &state {
+            State::Streaming {
+                file_output_path, ..
+            } => file_output_path.clone(),
+            _ => None,
+        };
+        if let Some(output_path) = file_output_path {
+            let final_text = streaming_session
+                .as_ref()
+                .map(|s| s.finalized_text().to_string())
+                .unwrap_or_default();
+            *streaming_session = None;
+            *streaming_chain = None;
+
+            let file_mode = &self.config.output.file_mode;
+            match write_transcription_to_file(&output_path, &final_text, file_mode).await {
+                Ok(()) => {
+                    let mode_str = match file_mode {
+                        FileMode::Overwrite => "wrote",
+                        FileMode::Append => "appended",
+                    };
+                    tracing::info!("{} streamed transcription to {:?}", mode_str, output_path);
+                    self.play_feedback(SoundEvent::TranscriptionComplete);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to write streamed transcription to {:?}: {}",
+                        output_path,
+                        e
+                    );
+                }
+            }
+
+            *state = State::Idle;
+            self.update_state("idle");
+            return;
+        }
+
         *streaming_session = None;
         *streaming_chain = None;
 
@@ -2123,26 +2210,8 @@ impl Daemon {
                     let profile_output_mode = active_profile.and_then(|p| p.output_mode.clone());
 
                     // Determine file output path (if file mode)
-                    // Priority: 1. CLI --file=path, 2. CLI --file (config path), 3. profile output_mode, 4. config mode=file
-                    let file_output_path: Option<PathBuf> = match &output_override {
-                        Some(OutputOverride::FileWithPath(path)) => {
-                            // CLI --file=path.txt
-                            Some(path.clone())
-                        }
-                        Some(OutputOverride::Mode(OutputMode::File)) => {
-                            // CLI --file (no path) - use config's file_path
-                            self.config.output.file_path.clone()
-                        }
-                        None if profile_output_mode == Some(OutputMode::File) => {
-                            // Profile specifies file mode
-                            self.config.output.file_path.clone()
-                        }
-                        None if self.config.output.mode == OutputMode::File => {
-                            // Config mode = "file" (no CLI override)
-                            self.config.output.file_path.clone()
-                        }
-                        _ => None,
-                    };
+                    let file_output_path = self
+                        .resolve_file_output_path(&output_override, profile_output_mode.clone());
 
                     if let Some(output_path) = file_output_path {
                         *state = State::Outputting {
@@ -3529,16 +3598,34 @@ impl Daemon {
                 _ = sigusr2.recv() => {
                     tracing::debug!("Received SIGUSR2 (stop recording)");
                     if state.is_streaming() {
-                        tracing::info!("SIGUSR2 stop while streaming; closing capture and disowning session");
+                        // File-output sessions (`--file=path`) have nowhere
+                        // to leak into — they accumulate text instead of
+                        // typing it (see the event pump) — so the
+                        // disown-on-SIGUSR2 protection below doesn't apply;
+                        // disowning here would just silently drop whatever
+                        // the backend was still draining, and end_streaming
+                        // would then write an empty file. Let it drain
+                        // normally so end_streaming can write the real text.
+                        let file_output = matches!(
+                            &state,
+                            State::Streaming { file_output_path: Some(_), .. }
+                        );
+                        if file_output {
+                            tracing::info!("SIGUSR2 stop while streaming (file output); closing capture");
+                        } else {
+                            tracing::info!("SIGUSR2 stop while streaming; closing capture and disowning session");
+                        }
                         self.stop_streaming_capture(&mut audio_capture).await;
-                        // Drop the typing surface synchronously so any
-                        // Final/Partial events the backend emits while
-                        // draining its internal buffer reach the event-pump
-                        // arm with `streaming_session = None` and get
-                        // discarded instead of typed into whatever window
-                        // has focus by then.
-                        streaming_session = None;
-                        streaming_chain = None;
+                        if !file_output {
+                            // Drop the typing surface synchronously so any
+                            // Final/Partial events the backend emits while
+                            // draining its internal buffer reach the event-pump
+                            // arm with `streaming_session = None` and get
+                            // discarded instead of typed into whatever window
+                            // has focus by then.
+                            streaming_session = None;
+                            streaming_chain = None;
+                        }
                     } else if let State::Recording { model_override, .. } = &state {
                         let model_override = model_override.clone();
 
@@ -3617,18 +3704,30 @@ impl Daemon {
                         None => std::future::pending().await,
                     }
                 }, if state.is_streaming() && streaming_handle.is_some() => {
+                    // File-output sessions (`--file=path`) accumulate into
+                    // finalized_text via the `_silent` session methods
+                    // instead of typing through `chain` — there's no
+                    // cursor/focused window to type into, and doing so
+                    // anyway is exactly the leak this branch exists to
+                    // avoid (see the SIGUSR2 handler below).
+                    let file_output = matches!(
+                        &state,
+                        State::Streaming { file_output_path: Some(_), .. }
+                    );
                     match event {
                         Some(StreamingEvent::Partial { text, .. }) => {
-                            if let (Some(s), Some(chain)) =
-                                (streaming_session.as_mut(), streaming_chain.as_ref())
-                            {
-                                if let Err(e) = s.type_partial_delta(
-                                    chain,
-                                    text,
-                                    self.config.output.pre_output_command.as_deref(),
-                                    self.config.output.post_output_command.as_deref(),
-                                ).await {
-                                    tracing::warn!("Streaming partial delta type failed: {}", e);
+                            if let Some(s) = streaming_session.as_mut() {
+                                if file_output {
+                                    s.observe_partial_delta(&text);
+                                } else if let Some(chain) = streaming_chain.as_ref() {
+                                    if let Err(e) = s.type_partial_delta(
+                                        chain,
+                                        text,
+                                        self.config.output.pre_output_command.as_deref(),
+                                        self.config.output.post_output_command.as_deref(),
+                                    ).await {
+                                        tracing::warn!("Streaming partial delta type failed: {}", e);
+                                    }
                                 }
                                 if let State::Streaming { typed_chars, .. } = &mut state {
                                     *typed_chars = s.typed_chars();
@@ -3636,18 +3735,20 @@ impl Daemon {
                             }
                         }
                         Some(StreamingEvent::Final { text, .. }) => {
-                            if let (Some(s), Some(chain)) =
-                                (streaming_session.as_mut(), streaming_chain.as_ref())
-                            {
-                                let pp = self.post_processor.as_ref();
-                                if let Err(e) = s.commit_segment(
-                                    chain,
-                                    &text,
-                                    pp,
-                                    self.config.output.pre_output_command.as_deref(),
-                                    self.config.output.post_output_command.as_deref(),
-                                ).await {
-                                    tracing::error!("Streaming commit_segment failed: {}", e);
+                            if let Some(s) = streaming_session.as_mut() {
+                                if file_output {
+                                    s.commit_segment_silent(&text);
+                                } else if let Some(chain) = streaming_chain.as_ref() {
+                                    let pp = self.post_processor.as_ref();
+                                    if let Err(e) = s.commit_segment(
+                                        chain,
+                                        &text,
+                                        pp,
+                                        self.config.output.pre_output_command.as_deref(),
+                                        self.config.output.post_output_command.as_deref(),
+                                    ).await {
+                                        tracing::error!("Streaming commit_segment failed: {}", e);
+                                    }
                                 }
                                 // Mirror typed_chars onto the state for cancel-rewind.
                                 if let State::Streaming { typed_chars, finalized_text, .. } = &mut state {
@@ -3658,17 +3759,19 @@ impl Daemon {
                             }
                         }
                         Some(StreamingEvent::Replace { backspace, text, .. }) => {
-                            if let (Some(s), Some(chain)) =
-                                (streaming_session.as_mut(), streaming_chain.as_ref())
-                            {
-                                if let Err(e) = s.replace_and_commit(
-                                    chain,
-                                    backspace,
-                                    &text,
-                                    self.config.output.pre_output_command.as_deref(),
-                                    self.config.output.post_output_command.as_deref(),
-                                ).await {
-                                    tracing::error!("Streaming replace_and_commit failed: {}", e);
+                            if let Some(s) = streaming_session.as_mut() {
+                                if file_output {
+                                    s.replace_and_commit_silent(&text);
+                                } else if let Some(chain) = streaming_chain.as_ref() {
+                                    if let Err(e) = s.replace_and_commit(
+                                        chain,
+                                        backspace,
+                                        &text,
+                                        self.config.output.pre_output_command.as_deref(),
+                                        self.config.output.post_output_command.as_deref(),
+                                    ).await {
+                                        tracing::error!("Streaming replace_and_commit failed: {}", e);
+                                    }
                                 }
                                 if let State::Streaming { typed_chars, finalized_text, .. } = &mut state {
                                     *typed_chars = s.typed_chars();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1295,6 +1295,15 @@ impl Daemon {
             _ => None,
         };
         if let Some(output_path) = file_output_path {
+            // Fold any leftover `partial` in first: the sliding-window
+            // engine can confirm a whole short utterance as a single
+            // Partial mid-session and leave nothing for `final_flush` to
+            // send as Final, which would otherwise strand that text in
+            // `partial` and write an empty file despite a correct
+            // transcription. See `finalize_pending_partial`.
+            if let Some(s) = streaming_session.as_mut() {
+                s.finalize_pending_partial();
+            }
             let final_text = streaming_session
                 .as_ref()
                 .map(|s| s.finalized_text().to_string())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1205,6 +1205,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::OpenVino
                 | crate::config::TranscriptionEngine::Soniox => {
                     if let Some(ref t) = transcriber_preloaded {
                         Ok(t.clone())
@@ -2587,10 +2588,25 @@ impl Daemon {
             tracing::info!("Loading transcription model: {}", self.config.model_name());
             match self.config.engine {
                 crate::config::TranscriptionEngine::Whisper => {
-                    // Use model manager for Whisper
-                    if let Err(e) = model_manager.preload_primary() {
-                        tracing::error!("Failed to preload model: {}", e);
-                        return Err(crate::error::VoxtypeError::Transcribe(e));
+                    if self.config.whisper.streaming {
+                        // Streaming needs the transcriber in `transcriber_preloaded`
+                        // so try_start_streaming can find it. The factory returns
+                        // the sliding-window wrapper when [whisper] streaming = true.
+                        if self.config.whisper.on_demand_loading {
+                            tracing::warn!(
+                                "[whisper] streaming requires on_demand_loading = false; \
+                                 streaming will be unavailable"
+                            );
+                        }
+                        transcriber_preloaded = Some(Arc::from(
+                            crate::transcribe::create_transcriber(&self.config)?,
+                        ));
+                    } else {
+                        // Use model manager for Whisper
+                        if let Err(e) = model_manager.preload_primary() {
+                            tracing::error!("Failed to preload model: {}", e);
+                            return Err(crate::error::VoxtypeError::Transcribe(e));
+                        }
                     }
                 }
                 crate::config::TranscriptionEngine::Parakeet
@@ -2600,6 +2616,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::OpenVino
                 | crate::config::TranscriptionEngine::Soniox => {
                     // Non-Whisper engines do their own setup; Soniox just validates
                     // API key + endpoint at construction (no model to download).
@@ -2720,6 +2737,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::OpenVino
                 | crate::config::TranscriptionEngine::Soniox => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
@@ -2750,6 +2768,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::OpenVino
                 | crate::config::TranscriptionEngine::Soniox => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
@@ -2933,6 +2952,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::OpenVino
                 | crate::config::TranscriptionEngine::Soniox => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
@@ -2963,6 +2983,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::OpenVino
                 | crate::config::TranscriptionEngine::Soniox => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
@@ -3409,6 +3430,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::OpenVino
                 | crate::config::TranscriptionEngine::Soniox => {
                                     let config = self.config.clone();
                                     self.model_load_task = Some(tokio::task::spawn_blocking(move || {
@@ -3438,6 +3460,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::OpenVino
                 | crate::config::TranscriptionEngine::Soniox => {
                                     if let Some(ref t) = transcriber_preloaded {
                                         let transcriber = t.clone();

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -92,6 +92,7 @@ fn send_macos_native(title: &str, body: &str, engine: Option<TranscriptionEngine
         | TranscriptionEngine::Dolphin
         | TranscriptionEngine::Omnilingual
         | TranscriptionEngine::Cohere
+        | TranscriptionEngine::OpenVino
         | TranscriptionEngine::Soniox => None,
     });
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -178,6 +178,7 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
         crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",  // 🐬
         crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
         crate::config::TranscriptionEngine::Cohere => "\u{1F4DD}",   // 📝
+        crate::config::TranscriptionEngine::OpenVino => "\u{1F9E0}", // 🧠
         crate::config::TranscriptionEngine::Soniox => "\u{2601}\u{FE0F}", // ☁️
     }
 }

--- a/src/output/streaming.rs
+++ b/src/output/streaming.rs
@@ -132,6 +132,17 @@ impl StreamingSession {
         self.partial.clear();
     }
 
+    /// File-output counterpart to `type_partial_delta`: accumulate the
+    /// delta into the partial buffer without typing anything. File-mode
+    /// sessions have no cursor to type into, but the delta still has to
+    /// be held until the next commit — partials are deltas, not a
+    /// cumulative transcript (see `type_partial_delta`), so dropping
+    /// this would silently lose whatever text was only ever seen as an
+    /// unfinalized partial.
+    pub fn observe_partial_delta(&mut self, new_partial: &str) {
+        self.partial.push_str(new_partial);
+    }
+
     /// Current partial buffer.
     pub fn partial(&self) -> &str {
         &self.partial
@@ -199,6 +210,20 @@ impl StreamingSession {
         Ok(())
     }
 
+    /// File-output counterpart to `commit_segment`: same finalized_text
+    /// bookkeeping, but skips `output_with_fallback` entirely — there's
+    /// no cursor/focused window to type into when the session's target
+    /// is a file.
+    pub fn commit_segment_silent(&mut self, text: &str) {
+        if text.is_empty() {
+            self.clear_partial();
+            return;
+        }
+        let finalized_tail = format!("{}{}", self.partial, text);
+        self.finalized_text.push_str(&finalized_tail);
+        self.clear_partial();
+    }
+
     /// Backspace `backspace` chars then commit `text`. Used by streaming
     /// backends that revise the previously-typed partial tail when
     /// finalizing (e.g. Soniox punctuation flips).
@@ -255,6 +280,18 @@ impl StreamingSession {
         }
         self.clear_partial();
         Ok(())
+    }
+
+    /// File-output counterpart to `replace_and_commit`: no backspaces —
+    /// there's nothing typed to revise — just fold the (now-superseded)
+    /// partial tail plus `text` into `finalized_text`, matching what the
+    /// typed path's accounting would produce.
+    pub fn replace_and_commit_silent(&mut self, text: &str) {
+        if !text.is_empty() {
+            let finalized_tail = format!("{}{}", self.partial, text);
+            self.finalized_text.push_str(&finalized_tail);
+        }
+        self.clear_partial();
     }
 
     /// Best-effort rewind: emit `typed_chars` BackSpace key events via

--- a/src/output/streaming.rs
+++ b/src/output/streaming.rs
@@ -210,6 +210,23 @@ impl StreamingSession {
         Ok(())
     }
 
+    /// Fold any still-pending `partial` into `finalized_text` without a
+    /// trailing Final segment. For file-output sessions, `commit_segment_silent`
+    /// only runs when the engine happens to emit a `Final` event — but the
+    /// sliding-window engine can legitimately confirm an entire utterance as
+    /// a single `Partial` mid-session (e.g. a short phrase transcribed
+    /// identically on back-to-back ticks) and then have nothing left for
+    /// `final_flush` to send as `Final` at end-of-stream. Without this, that
+    /// text sits in `partial` forever and the session ends with an empty
+    /// `finalized_text`, silently discarding a correct transcription. Call
+    /// this once, at stream end, before reading `finalized_text()`.
+    pub fn finalize_pending_partial(&mut self) {
+        if !self.partial.is_empty() {
+            self.finalized_text.push_str(&self.partial);
+            self.partial.clear();
+        }
+    }
+
     /// File-output counterpart to `commit_segment`: same finalized_text
     /// bookkeeping, but skips `output_with_fallback` entirely — there's
     /// no cursor/focused window to type into when the session's target
@@ -534,6 +551,33 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(session.partial(), "");
+    }
+
+    #[test]
+    fn finalize_pending_partial_folds_leftover_partial() {
+        // Reproduces the empty-transcript bug: the sliding-window engine
+        // can confirm an entire short utterance as a single Partial
+        // mid-session (see `on_tick`'s growing-mode branch) and then have
+        // nothing left for `final_flush` to send as a terminal Final. A
+        // file-output session that only ever calls `commit_segment_silent`
+        // on a Final event would strand that text in `partial` forever and
+        // write an empty file despite a correct transcription.
+        let mut session = StreamingSession::new();
+        session.observe_partial_delta("turn on Sophie's room.");
+        assert_eq!(session.finalized_text(), "");
+
+        session.finalize_pending_partial();
+
+        assert_eq!(session.finalized_text(), "turn on Sophie's room.");
+        assert_eq!(session.partial(), "");
+    }
+
+    #[test]
+    fn finalize_pending_partial_is_noop_when_already_final() {
+        let mut session = StreamingSession::new();
+        session.commit_segment_silent("hello");
+        session.finalize_pending_partial();
+        assert_eq!(session.finalized_text(), "hello");
     }
 
     #[tokio::test]

--- a/src/setup/binary.rs
+++ b/src/setup/binary.rs
@@ -717,6 +717,12 @@ pub fn compiled_features() -> Vec<&'static str> {
     if cfg!(feature = "cohere") {
         f.push("cohere");
     }
+    // OpenVINO isn't ONNX-based (no execution provider; a separate Intel
+    // runtime) and has no prebuilt binary variant, but it's still a Cargo
+    // feature source builds can compile in, so it belongs in this list.
+    if cfg!(feature = "openvino") {
+        f.push("openvino");
+    }
     // Meeting-mode capability: ML-based speaker diarization (ECAPA-TDNN).
     // When absent, meeting mode falls back to source-based attribution.
     if cfg!(feature = "ml-diarization") {
@@ -1053,6 +1059,7 @@ mod tests {
         require_feature_listed!("dolphin");
         require_feature_listed!("omnilingual");
         require_feature_listed!("cohere");
+        require_feature_listed!("openvino");
         require_feature_listed!("ml-diarization");
         require_feature_listed!("gpu-vulkan");
         require_feature_listed!("gpu-cuda");

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -544,21 +544,25 @@ pub async fn run_setup(
 
     let models_dir = Config::models_dir();
 
-    // Check if model_override is a Parakeet or SenseVoice model
+    // Check if model_override is a Parakeet, SenseVoice, or OpenVINO model
     let is_parakeet = model_override
         .map(model::is_parakeet_model)
         .unwrap_or(false);
     let is_sensevoice = model_override
         .map(model::is_sensevoice_model)
         .unwrap_or(false);
+    let is_openvino = model_override
+        .map(model::is_openvino_model)
+        .unwrap_or(false);
 
     // Validate model_override if provided (variable unused after this, each branch re-defines)
     let _model_name: &str = match model_override {
         Some(name) => {
-            // Validate the model name (check Whisper, Parakeet, and SenseVoice)
+            // Validate the model name (check Whisper, Parakeet, SenseVoice, and OpenVINO)
             if !model::is_valid_model(name)
                 && !model::is_parakeet_model(name)
                 && !model::is_sensevoice_model(name)
+                && !model::is_openvino_model(name)
             {
                 let valid = model::valid_model_names().join(", ");
                 anyhow::bail!("Unknown model '{}'. Valid models are: {}", name, valid);
@@ -674,6 +678,44 @@ pub async fn run_setup(
                         model_name
                     ));
                 }
+            } else if !quiet {
+                print_info(&format!("Model '{}' not downloaded yet", model_name));
+                println!(
+                    "       Run: voxtype setup --download --model {}",
+                    model_name
+                );
+            }
+        }
+    } else if is_openvino {
+        // Handle OpenVINO model
+        #[allow(unused_variables)]
+        let model_name = model_override.unwrap(); // Safe: is_openvino implies Some
+
+        if !quiet {
+            println!("\nOpenVINO model...");
+        }
+
+        #[cfg(not(feature = "openvino"))]
+        {
+            print_failure(&format!(
+                "OpenVINO model '{}' requires the 'openvino' feature",
+                model_name
+            ));
+            println!("       Rebuild with: cargo build --features openvino");
+            anyhow::bail!("OpenVINO feature not enabled");
+        }
+
+        #[cfg(feature = "openvino")]
+        {
+            let model_path = models_dir.join("openvino").join(model_name);
+            let model_valid = model_path.join("openvino_encoder_model.xml").exists();
+
+            if model_valid {
+                if !quiet {
+                    print_success(&format!("Model ready: {}", model_name));
+                }
+            } else if download {
+                model::download_openvino_model(model_name)?;
             } else if !quiet {
                 print_info(&format!("Model '{}' not downloaded yet", model_name));
                 println!(

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -668,6 +668,54 @@ const COHERE_MODELS: &[CohereModelInfo] = &[
     },
 ];
 
+/// OpenVINO IR whisper model variants (Intel NPU/GPU/CPU via OpenVINO GenAI).
+///
+/// These are the OpenVINO org's pre-converted whisper models on HuggingFace
+/// (`OpenVINO/whisper-*-int8-ov`). Unlike the ONNX engines, they are NOT yet
+/// mirrored to the voxtype R2 CDN, so `download_openvino_model` shells out
+/// to `huggingface-cli` (snapshot download) rather than `download_artifact`.
+/// The on-disk layout is `<models_dir>/openvino/<name>/` with the standard
+/// OpenVINO GenAI files (`openvino_encoder_model.xml`, ...).
+struct OpenVinoModelInfo {
+    name: &'static str,
+    size_mb: u32,
+    description: &'static str,
+    huggingface_repo: &'static str,
+}
+
+const OPENVINO_MODELS: &[OpenVinoModelInfo] = &[
+    OpenVinoModelInfo {
+        name: "tiny.en",
+        size_mb: 40,
+        description: "English-only, smallest and fastest",
+        huggingface_repo: "OpenVINO/whisper-tiny.en-int8-ov",
+    },
+    OpenVinoModelInfo {
+        name: "base.en",
+        size_mb: 75,
+        description: "English-only, balanced (default)",
+        huggingface_repo: "OpenVINO/whisper-base.en-int8-ov",
+    },
+    OpenVinoModelInfo {
+        name: "small.en",
+        size_mb: 240,
+        description: "English-only, higher accuracy",
+        huggingface_repo: "OpenVINO/whisper-small.en-int8-ov",
+    },
+    OpenVinoModelInfo {
+        name: "base",
+        size_mb: 75,
+        description: "Multilingual",
+        huggingface_repo: "OpenVINO/whisper-base-int8-ov",
+    },
+    OpenVinoModelInfo {
+        name: "small",
+        size_mb: 240,
+        description: "Multilingual, higher accuracy",
+        huggingface_repo: "OpenVINO/whisper-small-int8-ov",
+    },
+];
+
 // =============================================================================
 // ModelArtifact implementations
 // =============================================================================
@@ -1203,6 +1251,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let is_dolphin_engine = matches!(config.engine, TranscriptionEngine::Dolphin);
     let is_omnilingual_engine = matches!(config.engine, TranscriptionEngine::Omnilingual);
     let is_cohere_engine = matches!(config.engine, TranscriptionEngine::Cohere);
+    let is_openvino_engine = matches!(config.engine, TranscriptionEngine::OpenVino);
     let current_whisper_model = &config.whisper.model;
     let current_parakeet_model = config.parakeet.as_ref().map(|p| p.model.as_str());
     let current_moonshine_model = config.moonshine.as_ref().map(|m| m.model.as_str());
@@ -1211,6 +1260,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let current_dolphin_model = config.dolphin.as_ref().map(|d| d.model.as_str());
     let current_omnilingual_model = config.omnilingual.as_ref().map(|o| o.model.as_str());
     let current_cohere_model = config.cohere.as_ref().map(|c| c.model.as_str());
+    let current_openvino_model = config.openvino.as_ref().map(|o| o.model.as_str());
     let parakeet_available = cfg!(feature = "parakeet");
     let moonshine_available = cfg!(feature = "moonshine");
     let sensevoice_available = cfg!(feature = "sensevoice");
@@ -1218,6 +1268,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let dolphin_available = cfg!(feature = "dolphin");
     let omnilingual_available = cfg!(feature = "omnilingual");
     let cohere_available = cfg!(feature = "cohere");
+    let openvino_available = cfg!(feature = "openvino");
     let whisper_count = MODELS.len();
     let parakeet_count = PARAKEET_MODELS.len();
     let moonshine_count = MOONSHINE_MODELS.len();
@@ -1226,6 +1277,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let dolphin_count = DOLPHIN_MODELS.len();
     let omnilingual_count = OMNILINGUAL_MODELS.len();
     let cohere_count = COHERE_MODELS.len();
+    let openvino_count = OPENVINO_MODELS.len();
 
     let available_count = |available: bool, count: usize| if available { count } else { 0 };
     let total_count = whisper_count
@@ -1235,7 +1287,8 @@ pub async fn interactive_select() -> anyhow::Result<()> {
         + available_count(paraformer_available, paraformer_count)
         + available_count(dolphin_available, dolphin_count)
         + available_count(omnilingual_available, omnilingual_count)
-        + available_count(cohere_available, cohere_count);
+        + available_count(cohere_available, cohere_count)
+        + available_count(openvino_available, openvino_count);
 
     // --- Whisper Section ---
     println!("--- Whisper (OpenAI, 99+ languages) ---\n");
@@ -1535,6 +1588,41 @@ pub async fn interactive_select() -> anyhow::Result<()> {
         println!("  \x1b[90m(not available - rebuild with --features cohere)\x1b[0m");
     }
 
+    // --- OpenVINO Section ---
+    let openvino_offset = cohere_offset + available_count(cohere_available, cohere_count);
+    println!(
+        "\n--- OpenVINO GenAI Whisper (Intel NPU/GPU/CPU){} ---\n",
+        AMD_CPU_ONLY_TAG
+    );
+
+    if openvino_available {
+        for (i, model) in OPENVINO_MODELS.iter().enumerate() {
+            let model_path = models_dir.join("openvino").join(model.name);
+            let installed = model_path.join("openvino_encoder_model.xml").exists();
+
+            let is_current = is_openvino_engine && current_openvino_model == Some(model.name);
+            let star = if is_current { "*" } else { " " };
+
+            let status = if installed {
+                "\x1b[32m[installed]\x1b[0m"
+            } else {
+                ""
+            };
+
+            println!(
+                " {}[{:>2}] {:<28} ({:>4} MB) - {} {}",
+                star,
+                openvino_offset + i + 1,
+                model.name,
+                model.size_mb,
+                model.description,
+                status
+            );
+        }
+    } else {
+        println!("  \x1b[90m(not available - rebuild with --features openvino)\x1b[0m");
+    }
+
     println!("\n  [ 0] Cancel\n");
 
     // Get user selection
@@ -1581,6 +1669,9 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     } else if cohere_available && selection <= cohere_offset + cohere_count {
         let idx = selection - cohere_offset;
         handle_cohere_selection(idx).await
+    } else if openvino_available && selection <= openvino_offset + openvino_count {
+        let idx = selection - openvino_offset;
+        handle_openvino_selection(idx).await
     } else {
         println!("\nInvalid selection.");
         Ok(())
@@ -2457,6 +2548,143 @@ pub fn download_cohere_model(model_name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Validate that an OpenVINO IR model directory has the files the GenAI
+/// WhisperPipeline needs.
+pub fn validate_openvino_model(path: &Path) -> anyhow::Result<()> {
+    if !path.exists() {
+        anyhow::bail!("Model directory does not exist: {:?}", path);
+    }
+    let required = [
+        "openvino_encoder_model.xml",
+        "openvino_decoder_model.xml",
+        "tokenizer.json",
+    ];
+    let missing: Vec<&str> = required
+        .iter()
+        .copied()
+        .filter(|f| !path.join(f).exists())
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!("Incomplete OpenVINO model, missing: {}", missing.join(", "))
+    }
+}
+
+/// True if `name` is a known OpenVINO model short name.
+pub fn is_openvino_model(name: &str) -> bool {
+    OPENVINO_MODELS.iter().any(|m| m.name == name)
+}
+
+/// Download an OpenVINO IR whisper model from HuggingFace into
+/// `<models_dir>/openvino/<name>/`.
+///
+/// OpenVINO models are not yet on the voxtype R2 CDN, so this shells out to
+/// `huggingface-cli` (snapshot download). A local directory path can always
+/// be used instead by setting `[openvino] model` to an absolute path.
+pub fn download_openvino_model(model_name: &str) -> anyhow::Result<()> {
+    let model = OPENVINO_MODELS
+        .iter()
+        .find(|m| m.name == model_name)
+        .ok_or_else(|| anyhow::anyhow!("Unknown OpenVINO model: {}", model_name))?;
+    let models_dir = Config::models_dir();
+    let model_path = models_dir.join("openvino").join(model.name);
+
+    if model_path.join("openvino_encoder_model.xml").exists() {
+        println!(
+            "OpenVINO model '{}' already installed at {:?}",
+            model.name,
+            model_path.display()
+        );
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&model_path)?;
+    println!(
+        "\nDownloading OpenVINO model '{}' ({} MB) from {} ...",
+        model.name, model.size_mb, model.huggingface_repo
+    );
+
+    let status = std::process::Command::new("huggingface-cli")
+        .args(["download", model.huggingface_repo, "--local-dir"])
+        .arg(&model_path)
+        .status()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Could not run huggingface-cli ({}). Install it with:\n  \
+                 pip install huggingface_hub\n\n\
+                 or download manually:\n  \
+                 huggingface-cli download {} --local-dir {}",
+                e,
+                model.huggingface_repo,
+                model_path.display()
+            )
+        })?;
+
+    if !status.success() {
+        anyhow::bail!(
+            "huggingface-cli download failed. Try again, or download manually:\n  \
+             huggingface-cli download {} --local-dir {}",
+            model.huggingface_repo,
+            model_path.display()
+        );
+    }
+
+    validate_openvino_model(&model_path)?;
+    println!(
+        "OpenVINO model '{}' installed at {:?}",
+        model.name,
+        model_path.display()
+    );
+    Ok(())
+}
+
+/// Handle OpenVINO model selection (download + config update).
+async fn handle_openvino_selection(selection: usize) -> anyhow::Result<()> {
+    let models_dir = Config::models_dir();
+
+    if selection == 0 || selection > OPENVINO_MODELS.len() {
+        println!("\nCancelled.");
+        return Ok(());
+    }
+
+    let model = &OPENVINO_MODELS[selection - 1];
+    let model_path = models_dir.join("openvino").join(model.name);
+
+    if model_path.join("openvino_encoder_model.xml").exists() {
+        println!("\nOpenVINO model '{}' is already installed.\n", model.name);
+        println!("  [1] Set as default model (update config)");
+        println!("  [2] Re-download");
+        println!("  [0] Cancel\n");
+
+        print!("Select option [1]: ");
+        io::stdout().flush()?;
+
+        let mut choice = String::new();
+        io::stdin().read_line(&mut choice)?;
+        let choice = choice.trim().parse::<usize>().unwrap_or(1);
+
+        match choice {
+            1 => {
+                update_config_openvino(model.name)?;
+                restart_daemon_if_running().await;
+                println!("\nOpenVINO model '{}' set as default.\n", model.name);
+            }
+            2 => {
+                download_openvino_model(model.name)?;
+            }
+            _ => println!("\nCancelled."),
+        }
+    } else {
+        download_openvino_model(model.name)?;
+        update_config_openvino(model.name)?;
+        restart_daemon_if_running().await;
+        println!("\nOpenVINO model '{}' set as default.\n", model.name);
+    }
+
+    Ok(())
+}
+
 /// Handle Cohere model selection (download + config update).
 async fn handle_cohere_selection(selection: usize) -> anyhow::Result<()> {
     let models_dir = Config::models_dir();
@@ -2610,6 +2838,106 @@ fn update_cohere_in_config(config: &str, model_name: &str) -> String {
             result.push('\n');
         }
         result.push_str(&format!("\n[cohere]\nmodel = \"{}\"\n", model_name));
+    }
+
+    result
+}
+
+/// Update the config to use the OpenVINO engine with a specific model.
+fn update_config_openvino(model_name: &str) -> anyhow::Result<()> {
+    if let Some(config_path) = Config::default_path() {
+        if config_path.exists() {
+            let content = std::fs::read_to_string(&config_path)?;
+            let updated = update_engine_in_config(&content, "openvino", "openvino", model_name);
+            std::fs::write(&config_path, updated)?;
+            print_success(&format!(
+                "Config updated: engine = \"openvino\", model = \"{}\"",
+                model_name
+            ));
+            Ok(())
+        } else {
+            print_info("No config file found. Run 'voxtype setup' first.");
+            Ok(())
+        }
+    } else {
+        anyhow::bail!("Could not determine config path")
+    }
+}
+
+/// Generic engine/model config updater. Mirrors `update_cohere_in_config`
+/// with the engine name and section name parameterized.
+fn update_engine_in_config(
+    config: &str,
+    engine_name: &str,
+    section_name: &str,
+    model_name: &str,
+) -> String {
+    let mut result = String::new();
+    let mut has_engine_line = false;
+    let mut has_section = false;
+    let mut in_section = false;
+    let mut model_updated = false;
+
+    for line in config.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('[') {
+            if in_section && !model_updated {
+                result.push_str(&format!("model = \"{}\"\n", model_name));
+                model_updated = true;
+            }
+            in_section = trimmed == format!("[{}]", section_name);
+            if in_section {
+                has_section = true;
+            }
+        }
+
+        if trimmed.starts_with("engine") && !trimmed.starts_with('[') {
+            result.push_str(&format!("engine = \"{}\"\n", engine_name));
+            has_engine_line = true;
+        } else if in_section && trimmed.starts_with("model") {
+            result.push_str(&format!("model = \"{}\"\n", model_name));
+            model_updated = true;
+        } else {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    if in_section && !model_updated {
+        result.push_str(&format!("model = \"{}\"\n", model_name));
+    }
+
+    if !has_engine_line {
+        let mut new_result = String::new();
+        let mut engine_added = false;
+        for line in result.lines() {
+            let trimmed = line.trim();
+            if !engine_added
+                && !trimmed.is_empty()
+                && !trimmed.starts_with('#')
+                && !trimmed.starts_with("engine")
+            {
+                new_result.push_str(&format!("engine = \"{}\"\n", engine_name));
+                engine_added = true;
+            }
+            new_result.push_str(line);
+            new_result.push('\n');
+        }
+        if !engine_added {
+            new_result.push_str(&format!("engine = \"{}\"\n", engine_name));
+        }
+        result = new_result;
+    }
+
+    if !has_section {
+        if !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(&format!(
+            "\n[{}]\nmodel = \"{}\"\n",
+            section_name, model_name
+        ));
     }
 
     result
@@ -3116,7 +3444,7 @@ fn update_config_engine(engine_name: &str, model_name: &str) -> anyhow::Result<(
     if let Some(config_path) = Config::default_path() {
         if config_path.exists() {
             let content = std::fs::read_to_string(&config_path)?;
-            let updated = update_engine_in_config(&content, engine_name, model_name);
+            let updated = update_engine_in_config(&content, engine_name, engine_name, model_name);
             std::fs::write(&config_path, updated)?;
             print_success(&format!(
                 "Config updated: engine = \"{}\", model = \"{}\"",
@@ -3130,78 +3458,6 @@ fn update_config_engine(engine_name: &str, model_name: &str) -> anyhow::Result<(
     } else {
         anyhow::bail!("Could not determine config path")
     }
-}
-
-/// Update a config string to use a specific engine and model
-fn update_engine_in_config(config: &str, engine_name: &str, model_name: &str) -> String {
-    let section_name = format!("[{}]", engine_name);
-    let mut result = String::new();
-    let mut has_engine_line = false;
-    let mut has_section = false;
-    let mut in_section = false;
-    let mut model_updated = false;
-
-    for line in config.lines() {
-        let trimmed = line.trim();
-
-        if trimmed.starts_with('[') {
-            if in_section && !model_updated {
-                result.push_str(&format!("model = \"{}\"\n", model_name));
-                model_updated = true;
-            }
-            in_section = trimmed == section_name;
-            if in_section {
-                has_section = true;
-            }
-        }
-
-        if trimmed.starts_with("engine") && !trimmed.starts_with('[') {
-            result.push_str(&format!("engine = \"{}\"\n", engine_name));
-            has_engine_line = true;
-        } else if in_section && trimmed.starts_with("model") {
-            result.push_str(&format!("model = \"{}\"\n", model_name));
-            model_updated = true;
-        } else {
-            result.push_str(line);
-            result.push('\n');
-        }
-    }
-
-    if in_section && !model_updated {
-        result.push_str(&format!("model = \"{}\"\n", model_name));
-    }
-
-    if !has_engine_line {
-        let mut new_result = String::new();
-        let mut engine_added = false;
-        for line in result.lines() {
-            let trimmed = line.trim();
-            if !engine_added
-                && !trimmed.is_empty()
-                && !trimmed.starts_with('#')
-                && !trimmed.starts_with("engine")
-            {
-                new_result.push_str(&format!("engine = \"{}\"\n\n", engine_name));
-                engine_added = true;
-            }
-            new_result.push_str(line);
-            new_result.push('\n');
-        }
-        result = new_result;
-    }
-
-    if !has_section {
-        result.push_str(&format!(
-            "\n[{}]\nmodel = \"{}\"\n",
-            engine_name, model_name
-        ));
-    }
-
-    if !config.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
-    }
-
-    result
 }
 
 #[cfg(test)]

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -1589,11 +1589,11 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     }
 
     // --- OpenVINO Section ---
+    // No AMD_CPU_ONLY_TAG here: that tag flags ONNX graphs the MIGraphX EP
+    // can't compile on AMD GPUs. OpenVINO is an Intel-only backend (NPU/GPU/
+    // CPU via Intel's own runtime, not ONNX/MIGraphX) and is unaffected.
     let openvino_offset = cohere_offset + available_count(cohere_available, cohere_count);
-    println!(
-        "\n--- OpenVINO GenAI Whisper (Intel NPU/GPU/CPU){} ---\n",
-        AMD_CPU_ONLY_TAG
-    );
+    println!("\n--- OpenVINO GenAI Whisper (Intel NPU/GPU/CPU) ---\n");
 
     if openvino_available {
         for (i, model) in OPENVINO_MODELS.iter().enumerate() {
@@ -2574,6 +2574,11 @@ pub fn validate_openvino_model(path: &Path) -> anyhow::Result<()> {
 /// True if `name` is a known OpenVINO model short name.
 pub fn is_openvino_model(name: &str) -> bool {
     OPENVINO_MODELS.iter().any(|m| m.name == name)
+}
+
+/// Get list of valid OpenVINO model names
+pub fn valid_openvino_model_names() -> Vec<&'static str> {
+    OPENVINO_MODELS.iter().map(|m| m.name).collect()
 }
 
 /// Download an OpenVINO IR whisper model from HuggingFace into

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,7 @@
 //! Defines the states for the push-to-talk workflow:
 //! Idle → Recording → Transcribing → Outputting → Idle
 
+use std::path::PathBuf;
 use std::time::Instant;
 
 /// Audio samples collected during recording (f32, mono, 16kHz)
@@ -75,6 +76,13 @@ pub enum State {
         /// daemon's cancel path to send N backspaces and rewind text
         /// that was already delivered to the user.
         typed_chars: usize,
+        /// When set, this session targets file output (`--file=path` or
+        /// a `mode = "file"` config/profile), not the live cursor.
+        /// Segments accumulate into `finalized_text` without typing —
+        /// see `StreamingSession::commit_segment_silent` — and the
+        /// daemon writes the accumulated text to this path once the
+        /// backend reports `Ended`.
+        file_output_path: Option<PathBuf>,
     },
 }
 
@@ -274,6 +282,7 @@ mod tests {
             partial_buffer: String::new(),
             finalized_text: String::new(),
             typed_chars: 0,
+            file_output_path: None,
         };
         assert!(state.is_recording());
         assert!(state.is_streaming());
@@ -290,6 +299,7 @@ mod tests {
             partial_buffer: "hel".into(),
             finalized_text: "hello".into(),
             typed_chars: 5,
+            file_output_path: None,
         };
         let display = format!("{}", state);
         assert!(display.starts_with("Streaming"));

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -16,12 +16,14 @@ pub mod cli;
 #[cfg(feature = "parakeet")]
 pub mod parakeet_streaming;
 pub mod remote;
+pub mod sliding_window;
 pub mod soniox;
 pub mod streaming;
 pub mod subprocess;
 pub mod whisper;
 pub mod worker;
 
+pub use sliding_window::{SlidingWindowConfig, SlidingWindowStreamingTranscriber};
 pub use streaming::{SegmentId, StreamHandle, StreamingEvent, StreamingTranscriber};
 
 /// Shared log-mel filterbank feature extraction for ONNX-based ASR engines
@@ -71,13 +73,20 @@ pub mod omnilingual;
 #[cfg(feature = "cohere")]
 pub mod cohere;
 
+/// OpenVINO GenAI Whisper backend (Intel NPU/GPU/CPU).
+#[cfg(feature = "openvino")]
+pub mod openvino;
+
 /// Cohere-specific log-mel feature extractor (NeMo conventions, 128 mels).
 #[cfg(feature = "cohere")]
 pub mod cohere_fbank;
 
+#[cfg(feature = "openvino")]
+use crate::config::OpenVinoConfig;
 use crate::config::{Config, TranscriptionEngine, WhisperConfig, WhisperMode};
 use crate::error::TranscribeError;
 use crate::setup::gpu;
+use std::sync::Arc;
 
 /// A timed segment from transcription (word or sentence level)
 #[derive(Debug, Clone)]
@@ -153,7 +162,24 @@ pub trait Transcriber: Send + Sync {
 /// Factory function to create transcriber based on configured engine
 pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, TranscribeError> {
     match config.engine {
-        TranscriptionEngine::Whisper => create_whisper_transcriber(&config.whisper),
+        TranscriptionEngine::Whisper => {
+            let transcriber = create_whisper_transcriber(&config.whisper)?;
+            if config.whisper.streaming {
+                if config.whisper.effective_mode() != WhisperMode::Local {
+                    tracing::warn!(
+                        "[whisper] streaming requires mode = \"local\"; ignoring streaming"
+                    );
+                    Ok(transcriber)
+                } else {
+                    Ok(Box::new(SlidingWindowStreamingTranscriber::new(
+                        Arc::from(transcriber),
+                        sliding_window_config_from_whisper(config),
+                    )))
+                }
+            } else {
+                Ok(transcriber)
+            }
+        }
         #[cfg(feature = "parakeet")]
         TranscriptionEngine::Parakeet => {
             let parakeet_config = config.parakeet.as_ref().ok_or_else(|| {
@@ -268,6 +294,28 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
             "Cohere engine requested but voxtype was not compiled with --features cohere"
                 .to_string(),
         )),
+        #[cfg(feature = "openvino")]
+        TranscriptionEngine::OpenVino => {
+            let cfg = config.openvino.as_ref().ok_or_else(|| {
+                TranscribeError::InitFailed(
+                    "OpenVINO engine selected but [openvino] config section is missing".to_string(),
+                )
+            })?;
+            let transcriber = openvino::OpenVinoTranscriber::new(cfg)?;
+            if cfg.streaming {
+                Ok(Box::new(SlidingWindowStreamingTranscriber::new(
+                    Arc::from(Box::new(transcriber) as Box<dyn Transcriber>),
+                    sliding_window_config_from_openvino(config, cfg),
+                )))
+            } else {
+                Ok(Box::new(transcriber))
+            }
+        }
+        #[cfg(not(feature = "openvino"))]
+        TranscriptionEngine::OpenVino => Err(TranscribeError::InitFailed(
+            "OpenVINO engine requested but voxtype was not compiled with --features openvino"
+                .to_string(),
+        )),
         TranscriptionEngine::Soniox => {
             let cfg = config.soniox.as_ref().ok_or_else(|| {
                 TranscribeError::InitFailed(
@@ -284,6 +332,37 @@ pub fn create_whisper_transcriber(
     config: &WhisperConfig,
 ) -> Result<Box<dyn Transcriber>, TranscribeError> {
     create_transcriber_with_config_path(config, None)
+}
+
+/// Build the sliding-window engine config from `[whisper]` streaming settings.
+fn sliding_window_config_from_whisper(config: &Config) -> SlidingWindowConfig {
+    SlidingWindowConfig {
+        interval_s: config.whisper.streaming_interval_secs as f64,
+        max_buffer_s: config.whisper.streaming_max_buffer_secs,
+        // Streaming audio arrives at the configured [audio] sample rate.
+        sample_rate: config.audio.sample_rate,
+        min_speech_rms: config.whisper.streaming_min_speech_rms,
+        min_audio_s: config.whisper.streaming_min_audio_secs,
+        partial_min_words: config.whisper.streaming_partial_min_words,
+        type_partials: config.whisper.streaming_type_partials,
+    }
+}
+
+/// Build the sliding-window engine config from `[openvino]` streaming settings.
+#[cfg(feature = "openvino")]
+fn sliding_window_config_from_openvino(
+    config: &Config,
+    openvino: &OpenVinoConfig,
+) -> SlidingWindowConfig {
+    SlidingWindowConfig {
+        interval_s: openvino.streaming_interval_secs as f64,
+        max_buffer_s: openvino.streaming_max_buffer_secs,
+        sample_rate: config.audio.sample_rate,
+        min_speech_rms: openvino.streaming_min_speech_rms,
+        min_audio_s: openvino.streaming_min_audio_secs,
+        partial_min_words: openvino.streaming_partial_min_words,
+        type_partials: openvino.streaming_type_partials,
+    }
 }
 
 /// Factory function to create transcriber with optional config path

--- a/src/transcribe/openvino.rs
+++ b/src/transcribe/openvino.rs
@@ -12,7 +12,7 @@
 use super::Transcriber;
 use crate::config::OpenVinoConfig;
 use crate::error::TranscribeError;
-use openvino_genai::{WhisperGenerationConfig, WhisperPipeline};
+use openvino_genai::WhisperPipeline;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -25,6 +25,14 @@ pub struct OpenVinoTranscriber {
     device: String,
     /// Language passed to the generation config.
     language: String,
+    /// True for English-only checkpoints (tiny.en/base.en/small.en/...).
+    /// Their vocabulary has no task/language special tokens at all, so
+    /// calling `set_language`/`set_task` on them looks up a token that
+    /// doesn't exist. CPU/GPU tolerate this (silently ignored); the NPU
+    /// backend throws (surfaces as a bare "unknown exception" through the
+    /// C API — this is what nova-npu's OpenVINOTranscriber works around
+    /// by skipping both calls for `.en` models; ported the same rule).
+    english_only: bool,
 }
 
 impl OpenVinoTranscriber {
@@ -73,6 +81,7 @@ impl OpenVinoTranscriber {
             pipeline: Mutex::new(pipeline),
             device: config.device.clone(),
             language: config.language.clone(),
+            english_only: config.model.ends_with(".en"),
         })
     }
 }
@@ -83,15 +92,25 @@ impl Transcriber for OpenVinoTranscriber {
             TranscribeError::InferenceFailed("OpenVINO pipeline lock poisoned".to_string())
         })?;
 
-        let mut gen_cfg = WhisperGenerationConfig::new().map_err(|e| {
+        // Start from the pipeline's OWN generation config (derived from the
+        // loaded model's generation_config.json: EOS/decoder-start token
+        // ids, is_multilingual, etc.), not a bare `::new()` default — a
+        // disconnected default config is missing that model-specific state
+        // entirely, which is what the official C sample's
+        // `ov_genai_whisper_pipeline_get_generation_config` pattern avoids.
+        let mut gen_cfg = pipeline.get_generation_config().map_err(|e| {
             TranscribeError::InferenceFailed(format!("OpenVINO generation config: {}", e))
         })?;
-        gen_cfg.set_language(&self.language).map_err(|e| {
-            TranscribeError::InferenceFailed(format!("OpenVINO set_language: {}", e))
-        })?;
-        gen_cfg
-            .set_task("transcribe")
-            .map_err(|e| TranscribeError::InferenceFailed(format!("OpenVINO set_task: {}", e)))?;
+        // English-only checkpoints have no task/language tokens in their
+        // vocabulary at all — see the `english_only` field doc.
+        if !self.english_only {
+            gen_cfg.set_language(&self.language).map_err(|e| {
+                TranscribeError::InferenceFailed(format!("OpenVINO set_language: {}", e))
+            })?;
+            gen_cfg.set_task("transcribe").map_err(|e| {
+                TranscribeError::InferenceFailed(format!("OpenVINO set_task: {}", e))
+            })?;
+        }
 
         let results = pipeline.generate(samples, Some(&gen_cfg)).map_err(|e| {
             TranscribeError::InferenceFailed(format!("OpenVINO generate failed: {}", e))

--- a/src/transcribe/openvino.rs
+++ b/src/transcribe/openvino.rs
@@ -16,6 +16,17 @@ use openvino_genai::WhisperPipeline;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
+/// Directory OpenVINO persists compiled device blobs to (`CACHE_DIR`
+/// property), so NPU/GPU graph compilation isn't repeated on every
+/// pipeline init. Same `$XDG_CACHE_HOME/voxtype/<name>` convention as the
+/// MIGraphX model cache in `setup/binary.rs`.
+fn openvino_cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("voxtype")
+        .join("openvino")
+}
+
 /// OpenVINO GenAI Whisper transcriber.
 pub struct OpenVinoTranscriber {
     /// The GenAI pipeline. `!Sync`, hence the mutex.
@@ -49,7 +60,17 @@ impl OpenVinoTranscriber {
         );
         let start = std::time::Instant::now();
 
-        let pipeline = match WhisperPipeline::new(model_str, &config.device) {
+        // CACHE_DIR persists the device's compiled model blob to disk so
+        // subsequent pipeline inits skip recompilation. This matters most
+        // on NPU (compiling the graph to NPU-ISA) and GPU (OpenCL kernel
+        // compilation) — both are expensive on cold start and otherwise
+        // pay that cost on every daemon restart. CPU accepts the property
+        // too but has little to gain from it (its compile step is cheap).
+        let cache_dir = openvino_cache_dir();
+        let cache_dir_str = cache_dir.to_string_lossy();
+        let props: &[(&str, &str)] = &[("CACHE_DIR", &cache_dir_str)];
+
+        let pipeline = match WhisperPipeline::with_properties(model_str, &config.device, props) {
             Ok(p) => p,
             Err(e) if config.device != "CPU" => {
                 tracing::warn!(
@@ -57,7 +78,7 @@ impl OpenVinoTranscriber {
                     config.device,
                     e
                 );
-                WhisperPipeline::new(model_str, "CPU").map_err(|e2| {
+                WhisperPipeline::with_properties(model_str, "CPU", props).map_err(|e2| {
                     TranscribeError::InitFailed(format!(
                         "OpenVINO pipeline init failed on CPU: {}",
                         e2

--- a/src/transcribe/openvino.rs
+++ b/src/transcribe/openvino.rs
@@ -1,0 +1,139 @@
+//! OpenVINO GenAI Whisper transcription (Intel NPU / GPU / CPU).
+//!
+//! Uses OpenVINO GenAI's `WhisperPipeline` via the `openvino-genai` crate.
+//! The model is an OpenVINO IR directory (`openvino_encoder_model.xml`,
+//! `openvino_decoder_model.xml`, `tokenizer.json`, ...), e.g. the
+//! `OpenVINO/whisper-*-ov` repos on HuggingFace.
+//!
+//! Selected when `engine = "openvino"` and built with `--features openvino`.
+//! The pipeline object is `!Sync`, so it is wrapped in a `Mutex` (same pattern
+//! as the ONNX engines wrapping `ort::Session`).
+
+use super::Transcriber;
+use crate::config::OpenVinoConfig;
+use crate::error::TranscribeError;
+use openvino_genai::{WhisperGenerationConfig, WhisperPipeline};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// OpenVINO GenAI Whisper transcriber.
+pub struct OpenVinoTranscriber {
+    /// The GenAI pipeline. `!Sync`, hence the mutex.
+    pipeline: Mutex<WhisperPipeline>,
+    /// Device actually in use ("NPU", "GPU", or "CPU").
+    #[allow(dead_code)]
+    device: String,
+    /// Language passed to the generation config.
+    language: String,
+}
+
+impl OpenVinoTranscriber {
+    pub fn new(config: &OpenVinoConfig) -> Result<Self, TranscribeError> {
+        let model_dir = resolve_model_path(&config.model)?;
+        let model_str = model_dir
+            .to_str()
+            .ok_or_else(|| TranscribeError::InitFailed("Invalid model path".to_string()))?;
+
+        tracing::info!(
+            "Loading OpenVINO Whisper model from {:?} on {}",
+            model_dir,
+            config.device
+        );
+        let start = std::time::Instant::now();
+
+        let pipeline = match WhisperPipeline::new(model_str, &config.device) {
+            Ok(p) => p,
+            Err(e) if config.device != "CPU" => {
+                tracing::warn!(
+                    "OpenVINO device '{}' failed to initialize ({}); falling back to CPU",
+                    config.device,
+                    e
+                );
+                WhisperPipeline::new(model_str, "CPU").map_err(|e2| {
+                    TranscribeError::InitFailed(format!(
+                        "OpenVINO pipeline init failed on CPU: {}",
+                        e2
+                    ))
+                })?
+            }
+            Err(e) => {
+                return Err(TranscribeError::InitFailed(format!(
+                    "OpenVINO pipeline init failed on {}: {}",
+                    config.device, e
+                )))
+            }
+        };
+
+        tracing::info!(
+            "OpenVINO model loaded in {:.2}s",
+            start.elapsed().as_secs_f32()
+        );
+
+        Ok(Self {
+            pipeline: Mutex::new(pipeline),
+            device: config.device.clone(),
+            language: config.language.clone(),
+        })
+    }
+}
+
+impl Transcriber for OpenVinoTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        let mut pipeline = self.pipeline.lock().map_err(|_| {
+            TranscribeError::InferenceFailed("OpenVINO pipeline lock poisoned".to_string())
+        })?;
+
+        let mut gen_cfg = WhisperGenerationConfig::new().map_err(|e| {
+            TranscribeError::InferenceFailed(format!("OpenVINO generation config: {}", e))
+        })?;
+        gen_cfg.set_language(&self.language).map_err(|e| {
+            TranscribeError::InferenceFailed(format!("OpenVINO set_language: {}", e))
+        })?;
+        gen_cfg
+            .set_task("transcribe")
+            .map_err(|e| TranscribeError::InferenceFailed(format!("OpenVINO set_task: {}", e)))?;
+
+        let results = pipeline.generate(samples, Some(&gen_cfg)).map_err(|e| {
+            TranscribeError::InferenceFailed(format!("OpenVINO generate failed: {}", e))
+        })?;
+
+        results.get_string().map_err(|e| {
+            TranscribeError::InferenceFailed(format!("OpenVINO get_string failed: {}", e))
+        })
+    }
+
+    fn last_detected_language(&self) -> Option<String> {
+        Some(self.language.clone())
+    }
+}
+
+/// Resolve the model argument to an OpenVINO IR directory.
+///
+/// Accepts a path to an existing IR directory, or a short name
+/// (`tiny.en`, `base.en`, `small.en`, `base`, `small`) resolved under
+/// `<models_dir>/openvino/<name>`.
+fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
+    let path = PathBuf::from(model);
+    if path.join("openvino_encoder_model.xml").exists() {
+        return Ok(path);
+    }
+
+    let models_dir = crate::config::Config::models_dir();
+    let model_path = models_dir.join("openvino").join(model);
+    if model_path.join("openvino_encoder_model.xml").exists() {
+        return Ok(model_path);
+    }
+
+    Err(TranscribeError::ModelNotFound(format!(
+        "OpenVINO model '{}' not found. Looked in:\n  \
+         - {}\n  \
+         - {}\n\n\
+         Download an OpenVINO IR whisper model, e.g.:\n  \
+         huggingface-cli download OpenVINO/whisper-base.en-int8-ov --local-dir {}\n\n\
+         or run 'voxtype setup model' to pick one.",
+        model,
+        path.display(),
+        model_path.display(),
+        model_path.display()
+    )))
+}

--- a/src/transcribe/sliding_window.rs
+++ b/src/transcribe/sliding_window.rs
@@ -1,0 +1,739 @@
+//! Sliding-window streaming transcription.
+//!
+//! Ported from nova-npu's `SlidingWindowTranscriber` (MIT) and adapted to
+//! voxtype's [`StreamingTranscriber`] trait. Instead of segmenting audio
+//! into small VAD-delimited chunks (which degrades Whisper accuracy), this
+//! keeps a rolling buffer of the full recording and re-transcribes the
+//! whole window every `interval_s` seconds. Because whisper.cpp / OpenVINO
+//! inference is fast relative to speech, this gives the model full acoustic
+//! context on every pass.
+//!
+//! New text is extracted by diffing successive transcriptions against the
+//! already-committed text, and only the stable tail delta is emitted. The
+//! daemon appends each emitted delta at the cursor, so **events must always
+//! be deltas** — never cumulative transcripts (or the cursor receives
+//! duplicates). The stable-prefix commit policy below guarantees this.
+//!
+//! ## Commit policy
+//!
+//! - **Growing mode** (buffer shorter than `max_buffer_seconds`): commit
+//!   the common-prefix words between the previous and current Whisper
+//!   outputs, gated by `partial_min_words`, advancing `confirmed_words` so
+//!   each emission is strictly-new stable text.
+//! - **Sliding mode** (buffer trimmed once it wraps): diff the whole
+//!   Whisper output against the already-emitted text and commit only the
+//!   common prefix of the current delta vs. the previous delta — a tail
+//!   word is only committed once stable across two consecutive passes.
+//!
+//! The engine wraps any batch [`Transcriber`] (whisper.cpp, OpenVINO GenAI,
+//! …), so the same code powers every streaming backend.
+//!
+//! ## Event mapping
+//!
+//! Each committed delta is emitted as a [`StreamingEvent::Partial`] (typed
+//! live at the cursor) when `type_partials` is true, or a
+//! [`StreamingEvent::Final`] (commit-only) when false. On graceful EOF the
+//! remaining tail delta is emitted as a `Final`, then [`StreamingEvent::Ended`].
+//! Cancellation ends the stream with `Ended` and no flush.
+
+use super::streaming::{StreamHandle, StreamingEvent, StreamingTranscriber};
+use super::Transcriber;
+use crate::error::TranscribeError;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{interval, MissedTickBehavior};
+
+/// Whisper silence-hallucination phrases. When Whisper is fed silence or
+/// noise it frequently emits one of these; drop the result entirely.
+const HALLUCINATION_PATTERNS: &[&str] = &[
+    "you",
+    "the",
+    "i",
+    "a",
+    "it",
+    "is",
+    "and",
+    "to",
+    "thank you",
+    "thanks",
+    "bye",
+    "okay",
+    "thank you for watching",
+    "thanks for watching",
+    "please subscribe",
+    "subscribe",
+    "thank you very much",
+    "you're welcome",
+    "good night",
+    "good bye",
+    "see you next time",
+    "subtitles by the amara.org community",
+];
+
+/// Minimum RMS energy for the whole buffer to be treated as speech.
+/// Below this we skip transcription entirely (prevents hallucination).
+const MIN_SPEECH_RMS: f32 = 0.005;
+
+/// Tuning knobs for the sliding-window engine. Defaults mirror nova-npu.
+#[derive(Debug, Clone, Copy)]
+pub struct SlidingWindowConfig {
+    /// Re-transcribe the whole buffer every `interval_s` seconds.
+    pub interval_s: f64,
+    /// Maximum buffered audio before the window starts sliding (drops old
+    /// samples). Hard-coded to 29.0 s in nova (Whisper context limit).
+    pub max_buffer_s: f32,
+    /// Assumed sample rate (16 kHz mono for whisper).
+    pub sample_rate: u32,
+    /// Skip transcription while whole-buffer RMS is below this.
+    pub min_speech_rms: f32,
+    /// Minimum buffered audio (seconds) before first transcription.
+    pub min_audio_s: f32,
+    /// Minimum number of new stable words before committing a delta.
+    pub partial_min_words: usize,
+    /// Emit committed deltas as `Partial` (typed live at the cursor) when
+    /// true; emit them as commit-only `Final` segments when false.
+    pub type_partials: bool,
+}
+
+impl Default for SlidingWindowConfig {
+    fn default() -> Self {
+        Self {
+            interval_s: 0.8,
+            max_buffer_s: 29.0,
+            sample_rate: 16_000,
+            min_speech_rms: MIN_SPEECH_RMS,
+            min_audio_s: 1.0,
+            partial_min_words: 2,
+            type_partials: true,
+        }
+    }
+}
+
+/// Sliding-window streaming transcriber that wraps any batch [`Transcriber`].
+///
+/// Implements both [`Transcriber`] (delegating to the wrapped backend) and
+/// [`StreamingTranscriber`] (the live-delta engine). The factory constructs
+/// this wrapper when the engine's `streaming` config flag is set.
+pub struct SlidingWindowStreamingTranscriber {
+    base: Arc<dyn Transcriber>,
+    config: SlidingWindowConfig,
+}
+
+impl SlidingWindowStreamingTranscriber {
+    /// Wrap `base` in the sliding-window streaming engine.
+    pub fn new(base: Arc<dyn Transcriber>, config: SlidingWindowConfig) -> Self {
+        Self { base, config }
+    }
+}
+
+impl Transcriber for SlidingWindowStreamingTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        self.base.transcribe(samples)
+    }
+
+    fn as_streaming(&self) -> Option<&dyn StreamingTranscriber> {
+        Some(self)
+    }
+}
+
+impl StreamingTranscriber for SlidingWindowStreamingTranscriber {
+    fn start_stream(
+        &self,
+        mut samples_rx: mpsc::Receiver<Vec<f32>>,
+    ) -> Result<StreamHandle, TranscribeError> {
+        let (events_tx, events_rx) = mpsc::channel::<StreamingEvent>(64);
+        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+
+        let base = Arc::clone(&self.base);
+        let config = self.config;
+
+        let task = tokio::task::spawn_blocking(move || -> Result<(), TranscribeError> {
+            let runtime = tokio::runtime::Handle::current();
+            let mut session = Session::new(base, config);
+
+            // Skip the interval's immediate first tick so we don't
+            // re-transcribe an empty buffer.
+            let mut ticker = interval(Duration::from_secs_f64(config.interval_s));
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            runtime.block_on(ticker.tick());
+
+            enum Outcome {
+                Chunk(Vec<f32>),
+                Eof,
+                Tick,
+                Cancelled,
+            }
+
+            loop {
+                let outcome = runtime.block_on(async {
+                    tokio::select! {
+                        chunk = samples_rx.recv() => match chunk {
+                            Some(c) => Outcome::Chunk(c),
+                            None => Outcome::Eof,
+                        },
+                        _ = ticker.tick() => Outcome::Tick,
+                        _ = &mut cancel_rx => Outcome::Cancelled,
+                    }
+                });
+
+                match outcome {
+                    Outcome::Chunk(chunk) => session.feed(&chunk),
+                    Outcome::Cancelled => {
+                        // Abort promptly; contract allows ending without flush.
+                        let _ = runtime.block_on(events_tx.send(StreamingEvent::Ended));
+                        return Ok(());
+                    }
+                    Outcome::Eof => {
+                        // Graceful end: one last flush so no audio is lost.
+                        if let Some(tail) = session.final_flush() {
+                            let _ = runtime.block_on(events_tx.send(StreamingEvent::Final {
+                                text: tail,
+                                segment_id: 0,
+                            }));
+                        }
+                        let _ = runtime.block_on(events_tx.send(StreamingEvent::Ended));
+                        return Ok(());
+                    }
+                    Outcome::Tick => match session.on_tick() {
+                        Ok(deltas) => {
+                            for delta in deltas {
+                                let event = if config.type_partials {
+                                    StreamingEvent::Partial {
+                                        text: delta,
+                                        segment_id: 0,
+                                    }
+                                } else {
+                                    StreamingEvent::Final {
+                                        text: delta,
+                                        segment_id: 0,
+                                    }
+                                };
+                                let _ = runtime.block_on(events_tx.send(event));
+                            }
+                        }
+                        Err(err) => {
+                            let _ = runtime.block_on(events_tx.send(StreamingEvent::Error(err)));
+                            let _ = runtime.block_on(events_tx.send(StreamingEvent::Ended));
+                            return Ok(());
+                        }
+                    },
+                }
+            }
+        });
+
+        // Map the spawn_blocking JoinHandle to the trait's expected shape.
+        let task = tokio::spawn(async move {
+            match task.await {
+                Ok(r) => r,
+                Err(join_err) => Err(TranscribeError::InferenceFailed(format!(
+                    "Sliding-window streaming task panicked: {}",
+                    join_err
+                ))),
+            }
+        });
+
+        Ok(StreamHandle {
+            events: events_rx,
+            cancel: cancel_tx,
+            task,
+        })
+    }
+}
+
+/// Mutable per-session state for one `start_stream` call.
+struct Session {
+    base: Arc<dyn Transcriber>,
+    config: SlidingWindowConfig,
+
+    // Audio accumulator.
+    buffer: Vec<f32>,
+    /// True once the buffer wrapped (audio was dropped). Switches diffing
+    /// from prefix-stable (growing) to tail-delta (sliding).
+    sliding: bool,
+
+    // Diff state.
+    /// Committed deltas (text already emitted).
+    full_text_parts: Vec<String>,
+    /// Last raw Whisper output.
+    #[allow(dead_code)]
+    prev_whisper: String,
+    /// Words of the previous transcription (growing mode).
+    last_words: Vec<String>,
+    /// Words already confirmed & emitted (growing mode).
+    confirmed_words: Vec<String>,
+    /// Delta words from the previous pass (sliding mode).
+    last_delta_words: Vec<String>,
+}
+
+impl Session {
+    fn new(base: Arc<dyn Transcriber>, config: SlidingWindowConfig) -> Self {
+        Self {
+            base,
+            config,
+            buffer: Vec::new(),
+            sliding: false,
+            full_text_parts: Vec::new(),
+            prev_whisper: String::new(),
+            last_words: Vec::new(),
+            confirmed_words: Vec::new(),
+            last_delta_words: Vec::new(),
+        }
+    }
+
+    /// Append audio and trim once past `max_buffer_s` (enters sliding mode).
+    fn feed(&mut self, samples: &[f32]) {
+        self.buffer.extend_from_slice(samples);
+
+        let max_samples = (self.config.max_buffer_s * self.config.sample_rate as f32) as usize;
+        let mut dropped = 0usize;
+        if self.buffer.len() > max_samples {
+            dropped = self.buffer.len() - max_samples;
+            self.buffer.drain(..dropped);
+        }
+        if dropped > 0 && !self.sliding {
+            tracing::debug!("[sliding] Buffer full — entering sliding mode");
+            self.sliding = true;
+        }
+    }
+
+    /// Transcribe the whole buffer, applying the silence + hallucination
+    /// gates. Returns `None` when there is nothing worth committing.
+    fn transcribe_buffer(&self) -> Result<Option<String>, TranscribeError> {
+        if (self.buffer.len() as f32) < self.config.min_audio_s * self.config.sample_rate as f32 {
+            return Ok(None);
+        }
+        if rms(&self.buffer) < self.config.min_speech_rms {
+            return Ok(None);
+        }
+        let text = self.base.transcribe(&self.buffer)?;
+        let text = text.trim().to_string();
+        if text.is_empty() || is_hallucination(&text) {
+            return Ok(None);
+        }
+        Ok(Some(text))
+    }
+
+    /// One interval tick: re-transcribe, diff, and return the newly-committed
+    /// stable deltas (at most one per tick).
+    fn on_tick(&mut self) -> Result<Vec<String>, TranscribeError> {
+        let Some(curr) = self.transcribe_buffer()? else {
+            return Ok(Vec::new());
+        };
+        let curr_words: Vec<String> = curr.split_whitespace().map(str::to_owned).collect();
+        if curr_words.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut deltas = Vec::new();
+
+        if self.sliding {
+            // Sliding mode: diff the whole output against what's already
+            // been emitted, then only commit the portion of the delta that
+            // was also present in the previous delta (stable across two
+            // consecutive passes).
+            let already_emitted = self.full_text_parts.join(" ");
+            let mut delta = extract_new_text(&already_emitted, &curr);
+            let mut delta_words: Vec<String> =
+                delta.split_whitespace().map(str::to_owned).collect();
+
+            if !self.last_delta_words.is_empty() && !delta_words.is_empty() {
+                let stable_n = common_prefix_len(&self.last_delta_words, &delta_words);
+                if stable_n >= self.config.partial_min_words {
+                    let new = delta_words[..stable_n].join(" ");
+                    let last_emitted = self.full_text_parts.last();
+                    let not_repeat = last_emitted.map(|s| s != &new).unwrap_or(true);
+                    if !new.is_empty() && not_repeat {
+                        self.full_text_parts.push(new.clone());
+                        deltas.push(new);
+                        // Re-diff so last_delta_words reflects the remaining
+                        // unconfirmed words only.
+                        let already_emitted = self.full_text_parts.join(" ");
+                        delta = extract_new_text(&already_emitted, &curr);
+                        delta_words = delta.split_whitespace().map(str::to_owned).collect();
+                    }
+                }
+            }
+            self.last_delta_words = delta_words;
+        } else {
+            // Growing buffer: commit the common-prefix words between the
+            // previous and current transcriptions, advancing confirmed_words.
+            if !self.last_words.is_empty() {
+                let stable_n = common_prefix_len(&self.last_words, &curr_words);
+                if stable_n > self.confirmed_words.len() {
+                    let confirmed_new = &curr_words[self.confirmed_words.len()..stable_n];
+                    if confirmed_new.len() >= self.config.partial_min_words {
+                        let new = confirmed_new.join(" ");
+                        let last_emitted = self.full_text_parts.last();
+                        let not_repeat = last_emitted.map(|s| s != &new).unwrap_or(true);
+                        if !new.is_empty() && not_repeat {
+                            self.full_text_parts.push(new.clone());
+                            self.confirmed_words.extend(confirmed_new.iter().cloned());
+                            deltas.push(new);
+                        }
+                    }
+                }
+            }
+        }
+
+        self.prev_whisper = curr;
+        self.last_words = curr_words;
+        Ok(deltas)
+    }
+
+    /// One last transcription at end-of-recording. Returns the remaining tail
+    /// delta (never cumulative text — the daemon already typed the partials).
+    fn final_flush(&mut self) -> Option<String> {
+        let final_text = match self.transcribe_buffer() {
+            Ok(Some(t)) => t,
+            _ => return None,
+        };
+        let already_emitted = self.full_text_parts.join(" ");
+        let delta = extract_new_text(&already_emitted, &final_text);
+        let delta = delta.trim().to_string();
+        if delta.is_empty() {
+            None
+        } else {
+            self.full_text_parts.push(delta.clone());
+            Some(delta)
+        }
+    }
+}
+
+// ── Diff helpers (ported 1:1 from nova's sliding_window.py) ──────────────
+
+/// Whisper-tolerant word equality: case-insensitive, ignoring trailing
+/// punctuation.
+fn word_eq(a: &str, b: &str) -> bool {
+    let norm = |s: &str| {
+        s.trim_end_matches(['.', ',', '!', '?', ';', ':'])
+            .to_lowercase()
+    };
+    norm(a) == norm(b)
+}
+
+fn words_match<T: AsRef<str>>(a: &[T], b: &[T]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .all(|(x, y)| word_eq(x.as_ref(), y.as_ref()))
+}
+
+fn common_prefix_len<T: AsRef<str>>(a: &[T], b: &[T]) -> usize {
+    let n = a.len().min(b.len());
+    let mut i = 0;
+    while i < n && word_eq(a[i].as_ref(), b[i].as_ref()) {
+        i += 1;
+    }
+    i
+}
+
+/// Return the portion of `curr` that is new compared to `prev`.
+///
+/// Strategies, in order:
+/// 1. Longest suffix→prefix word overlap (the common case).
+/// 2. Verbatim string-prefix check.
+/// 3. Greedy forward scan — how far into `curr` the `prev` words reach,
+///    trusting the position when ≥50% matched (handles Whisper punctuation
+///    / casing rewrites).
+/// 4. Safety: if `curr` is not substantially longer, Whisper is refining —
+///    no new text; otherwise emit only the tail beyond `prev`'s length.
+fn extract_new_text(prev: &str, curr: &str) -> String {
+    if prev.is_empty() {
+        return curr.to_string();
+    }
+    if curr.is_empty() {
+        return String::new();
+    }
+
+    let prev_words: Vec<&str> = prev.split_whitespace().collect();
+    let curr_words: Vec<&str> = curr.split_whitespace().collect();
+
+    if prev_words.is_empty() || curr_words.is_empty() {
+        return curr.to_string();
+    }
+
+    // 1. Exact suffix→prefix overlap (longest wins).
+    let mut best_overlap = 0;
+    let max_check = prev_words.len().min(curr_words.len());
+    for length in 1..=max_check {
+        let suffix = &prev_words[prev_words.len() - length..];
+        let prefix = &curr_words[..length];
+        if words_match(suffix, prefix) {
+            best_overlap = length;
+        }
+    }
+    if best_overlap > 0 {
+        return curr_words[best_overlap..].join(" ");
+    }
+
+    // 2. Verbatim prefix check.
+    if let Some(rest) = curr.strip_prefix(prev) {
+        return rest.trim().to_string();
+    }
+
+    // 3. Greedy forward scan.
+    let mut pi = 0;
+    let mut best_ci = 0;
+    for (ci, cw) in curr_words.iter().enumerate() {
+        if pi >= prev_words.len() {
+            break;
+        }
+        if word_eq(prev_words[pi], cw) {
+            pi += 1;
+            best_ci = ci + 1;
+        }
+        // else: skip — Whisper rewrote this word, keep scanning.
+    }
+    if pi as f32 >= prev_words.len() as f32 * 0.5 {
+        return curr_words[best_ci..].join(" ");
+    }
+
+    // 4. Safety: Whisper may have fully rewritten the window.
+    if curr_words.len() <= prev_words.len() + 1 {
+        return String::new();
+    }
+    curr_words[prev_words.len()..].join(" ")
+}
+
+/// Whole-buffer RMS (sqrt of mean of squares), float32.
+fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum: f64 = samples.iter().map(|s| f64::from(*s) * f64::from(*s)).sum();
+    (sum / samples.len() as f64).sqrt() as f32
+}
+
+/// Whisper hallucination check: lowercase, strip trailing `.,!?`, membership.
+fn is_hallucination(text: &str) -> bool {
+    let norm = text.trim().to_lowercase();
+    let norm = norm.trim_end_matches(['.', ',', '!', '?']);
+    HALLUCINATION_PATTERNS.contains(&norm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    // ── Pure diff helpers ────────────────────────────────────────────
+
+    #[test]
+    fn word_eq_ignores_case_and_trailing_punct() {
+        assert!(word_eq("Hello,", "hello"));
+        assert!(word_eq("WORLD.", "world"));
+        assert!(word_eq("you?", "you"));
+        assert!(!word_eq("there", "their"));
+    }
+
+    #[test]
+    fn common_prefix_len_stops_at_first_divergence() {
+        let a = ["hello", "world", "foo"];
+        let b = ["hello", "WORLD", "bar"];
+        assert_eq!(common_prefix_len(&a, &b), 2);
+        let c = ["hello"];
+        assert_eq!(common_prefix_len(&a, &c), 1);
+    }
+
+    #[test]
+    fn extract_new_text_empty_prev_returns_curr() {
+        assert_eq!(extract_new_text("", "hello world"), "hello world");
+    }
+
+    #[test]
+    fn extract_new_text_empty_curr_returns_empty() {
+        assert_eq!(extract_new_text("hello", ""), "");
+    }
+
+    #[test]
+    fn extract_new_text_suffix_prefix_overlap() {
+        // "you" overlaps: suffix of prev == prefix of curr.
+        assert_eq!(extract_new_text("hello world", "world foo bar"), "foo bar");
+        // Longest overlap wins: 2 words overlap.
+        assert_eq!(
+            extract_new_text("we should deploy now", "deploy now please"),
+            "please"
+        );
+    }
+
+    #[test]
+    fn extract_new_text_verbatim_prefix() {
+        assert_eq!(extract_new_text("hello", "hello world foo"), "world foo");
+    }
+
+    #[test]
+    fn extract_new_text_fuzzy_scan() {
+        // Whisper rewrote punctuation: prev matches 2/3 words fuzzily.
+        assert_eq!(extract_new_text("hello, world", "hello world foo"), "foo");
+    }
+
+    #[test]
+    fn extract_new_text_refining_emits_nothing() {
+        // curr no longer than prev → Whisper is refining; no new text.
+        assert_eq!(extract_new_text("hello world foo", "hello world"), "");
+        assert_eq!(extract_new_text("a b c", "a b"), "");
+    }
+
+    #[test]
+    fn extract_new_text_safety_tail() {
+        // No overlap, prev unreachable via fuzzy scan, curr much longer.
+        assert_eq!(extract_new_text("x y", "a b c d"), "c d");
+    }
+
+    #[test]
+    fn is_hallucination_matches_and_strips_punct() {
+        assert!(is_hallucination("thank you."));
+        assert!(is_hallucination("  YOU  "));
+        assert!(!is_hallucination("hello world"));
+        assert!(!is_hallucination("the quick brown fox"));
+    }
+
+    #[test]
+    fn rms_measures_energy() {
+        assert_eq!(rms(&[]), 0.0);
+        let silence = vec![0.0; 100];
+        assert_eq!(rms(&silence), 0.0);
+        let loud = vec![0.5; 100];
+        assert!((rms(&loud) - 0.5).abs() < 1e-6);
+    }
+
+    /// Deterministic fake backend: transcript grows with buffer length.
+    struct FakeTranscriber;
+
+    impl Transcriber for FakeTranscriber {
+        fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+            let secs = samples.len() as f32 / 16_000.0;
+            let text = if secs < 1.0 {
+                ""
+            } else if secs < 2.0 {
+                "alpha beta"
+            } else if secs < 3.0 {
+                "alpha beta gamma"
+            } else {
+                "alpha beta gamma delta"
+            };
+            Ok(text.to_string())
+        }
+    }
+
+    fn loud_samples(secs: f32) -> Vec<f32> {
+        let n = (secs * 16_000.0) as usize;
+        // 0.05 amplitude tone-ish samples — above MIN_SPEECH_RMS.
+        (0..n)
+            .map(|i| if i % 2 == 0 { 0.05 } else { -0.05 })
+            .collect()
+    }
+
+    fn streaming_config() -> SlidingWindowConfig {
+        SlidingWindowConfig {
+            interval_s: 0.02,
+            max_buffer_s: 29.0,
+            sample_rate: 16_000,
+            min_speech_rms: 0.004,
+            min_audio_s: 1.0,
+            partial_min_words: 1,
+            type_partials: true,
+        }
+    }
+
+    /// Drive a session: feed ~3s of audio, then EOF, and collect events.
+    async fn run_session(config: SlidingWindowConfig) -> Vec<StreamingEvent> {
+        let transcriber: Arc<dyn Transcriber> = Arc::new(FakeTranscriber);
+        let engine = SlidingWindowStreamingTranscriber::new(transcriber, config);
+
+        let (tx, rx) = mpsc::channel::<Vec<f32>>(32);
+        let mut handle = engine.start_stream(rx).expect("start stream");
+
+        // Feed three seconds in 0.5s chunks with small gaps between ticks.
+        for _ in 0..6 {
+            tx.send(loud_samples(0.5)).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(60)).await;
+        }
+        drop(tx); // graceful EOF
+
+        let mut events = Vec::new();
+        while let Some(ev) = handle.events.recv().await {
+            events.push(ev);
+            if matches!(events.last(), Some(StreamingEvent::Ended)) {
+                break;
+            }
+        }
+        handle.task.await.unwrap().expect("task ok");
+        events
+    }
+
+    fn emitted_text(events: &[StreamingEvent]) -> Vec<&str> {
+        events
+            .iter()
+            .filter_map(|ev| match ev {
+                StreamingEvent::Partial { text, .. } | StreamingEvent::Final { text, .. } => {
+                    Some(text.as_str())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn session_emits_stable_deltas_then_final_flush_and_ended() {
+        let events = run_session(streaming_config()).await;
+
+        // Must end cleanly.
+        assert!(matches!(events.last(), Some(StreamingEvent::Ended)));
+        assert!(events.len() >= 3, "expected partials + final + ended");
+
+        let parts = emitted_text(&events);
+        // Concatenated deltas reproduce the full transcript.
+        assert_eq!(parts.join(" "), "alpha beta gamma delta");
+        // Each delta is strictly new text — no duplicates at boundaries.
+        for i in 1..parts.len() {
+            let tail = parts[..i].join(" ");
+            assert!(!tail.contains(parts[i]), "repeated text: {parts:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn commit_only_mode_emits_final_deltas() {
+        let mut cfg = streaming_config();
+        cfg.type_partials = false;
+        let events = run_session(cfg).await;
+
+        let parts = emitted_text(&events);
+        assert_eq!(parts.join(" "), "alpha beta gamma delta");
+        assert!(events
+            .iter()
+            .all(|ev| !matches!(ev, StreamingEvent::Partial { .. })));
+    }
+
+    #[tokio::test]
+    async fn silence_only_buffer_emits_no_events() {
+        let (tx, rx) = mpsc::channel::<Vec<f32>>(32);
+        let engine =
+            SlidingWindowStreamingTranscriber::new(Arc::new(FakeTranscriber), streaming_config());
+        let mut handle = engine.start_stream(rx).expect("start stream");
+
+        // 3s of near-silence — below the RMS gate.
+        tx.send(vec![0.0; 16000]).await.unwrap();
+        tx.send(vec![0.0; 16000]).await.unwrap();
+        tx.send(vec![0.0; 16000]).await.unwrap();
+        drop(tx);
+
+        let mut events = Vec::new();
+        while let Some(ev) = handle.events.recv().await {
+            events.push(ev);
+            if matches!(events.last(), Some(StreamingEvent::Ended)) {
+                break;
+            }
+        }
+        assert!(matches!(events.last(), Some(StreamingEvent::Ended)));
+        assert_eq!(
+            emitted_text(&events).len(),
+            0,
+            "silence should not transcribe"
+        );
+        handle.task.await.unwrap().unwrap();
+    }
+}

--- a/src/transcribe/sliding_window.rs
+++ b/src/transcribe/sliding_window.rs
@@ -308,6 +308,10 @@ impl Session {
         }
         let text = self.base.transcribe(&self.buffer)?;
         let text = text.trim().to_string();
+        tracing::trace!(
+            "[sliding] tick transcribe -> {text:?} ({} samples)",
+            self.buffer.len()
+        );
         if text.is_empty() || is_hallucination(&text) {
             return Ok(None);
         }

--- a/src/transcribe/sliding_window.rs
+++ b/src/transcribe/sliding_window.rs
@@ -344,8 +344,16 @@ impl Session {
                     let last_emitted = self.full_text_parts.last();
                     let not_repeat = last_emitted.map(|s| s != &new).unwrap_or(true);
                     if !new.is_empty() && not_repeat {
-                        self.full_text_parts.push(new.clone());
-                        deltas.push(new);
+                        // `new` is a bare word-join with no leading space.
+                        // The daemon types deltas verbatim at the cursor, so
+                        // separate it from whatever was already committed.
+                        let typed = if self.full_text_parts.is_empty() {
+                            new.clone()
+                        } else {
+                            format!(" {new}")
+                        };
+                        self.full_text_parts.push(new);
+                        deltas.push(typed);
                         // Re-diff so last_delta_words reflects the remaining
                         // unconfirmed words only.
                         let already_emitted = self.full_text_parts.join(" ");
@@ -367,9 +375,17 @@ impl Session {
                         let last_emitted = self.full_text_parts.last();
                         let not_repeat = last_emitted.map(|s| s != &new).unwrap_or(true);
                         if !new.is_empty() && not_repeat {
-                            self.full_text_parts.push(new.clone());
+                            // `new` is a bare word-join with no leading space.
+                            // The daemon types deltas verbatim at the cursor,
+                            // so separate it from whatever was already committed.
+                            let typed = if self.full_text_parts.is_empty() {
+                                new.clone()
+                            } else {
+                                format!(" {new}")
+                            };
+                            self.full_text_parts.push(new);
                             self.confirmed_words.extend(confirmed_new.iter().cloned());
-                            deltas.push(new);
+                            deltas.push(typed);
                         }
                     }
                 }
@@ -394,8 +410,15 @@ impl Session {
         if delta.is_empty() {
             None
         } else {
-            self.full_text_parts.push(delta.clone());
-            Some(delta)
+            // `delta` has no leading space (see `on_tick`); separate it from
+            // whatever was already committed before typing it at the cursor.
+            let typed = if self.full_text_parts.is_empty() {
+                delta.clone()
+            } else {
+                format!(" {delta}")
+            };
+            self.full_text_parts.push(delta);
+            Some(typed)
         }
     }
 }
@@ -686,12 +709,15 @@ mod tests {
         assert!(events.len() >= 3, "expected partials + final + ended");
 
         let parts = emitted_text(&events);
-        // Concatenated deltas reproduce the full transcript.
-        assert_eq!(parts.join(" "), "alpha beta gamma delta");
+        // Deltas are typed verbatim at the cursor (see `on_tick`), each
+        // carrying its own separating leading space — so plain
+        // concatenation, not `join(" ")`, is what the daemon actually
+        // produces and what must reproduce the full transcript.
+        assert_eq!(parts.concat(), "alpha beta gamma delta");
         // Each delta is strictly new text — no duplicates at boundaries.
         for i in 1..parts.len() {
-            let tail = parts[..i].join(" ");
-            assert!(!tail.contains(parts[i]), "repeated text: {parts:?}");
+            let tail = parts[..i].concat();
+            assert!(!tail.contains(parts[i].trim()), "repeated text: {parts:?}");
         }
     }
 
@@ -702,7 +728,7 @@ mod tests {
         let events = run_session(cfg).await;
 
         let parts = emitted_text(&events);
-        assert_eq!(parts.join(" "), "alpha beta gamma delta");
+        assert_eq!(parts.concat(), "alpha beta gamma delta");
         assert!(events
             .iter()
             .all(|ev| !matches!(ev, StreamingEvent::Partial { .. })));

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -513,6 +513,8 @@ fn detect_missing_model() -> Option<MissingModel> {
         // Cohere — checked but model layout differs by rc/0.7.0; skip the
         // disk probe rather than emit a false-positive missing warning.
         config::TranscriptionEngine::Cohere => return None,
+        // OpenVINO — model is an IR directory; the setup flow handles it.
+        config::TranscriptionEngine::OpenVino => return None,
         // Soniox is cloud-only, no local model to probe.
         config::TranscriptionEngine::Soniox => return None,
     };

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -116,6 +116,14 @@ pub struct AllFields {
     pub co_threads: Option<i64>,
     pub co_on_demand_loading: bool,
     pub co_section_existed: bool,
+
+    // OpenVINO GenAI Whisper (Intel NPU/GPU/CPU)
+    pub ov_model: String,
+    pub ov_device: String,
+    pub ov_language: String,
+    pub ov_threads: Option<i64>,
+    pub ov_on_demand_loading: bool,
+    pub ov_section_existed: bool,
 }
 
 /// Model catalogs per engine. Whisper/Parakeet/Moonshine/SenseVoice come from
@@ -136,6 +144,7 @@ fn model_catalog(engine: &str) -> Vec<&'static str> {
             "cohere-transcribe-int8",
             "cohere-transcribe-fp16",
         ],
+        "openvino" => model::valid_openvino_model_names(),
         _ => Vec::new(),
     }
 }
@@ -153,6 +162,7 @@ const fn default_model(engine: &str) -> &'static str {
         b"dolphin" => "dolphin-base",
         b"omnilingual" => "omnilingual-300m",
         b"cohere" => "cohere-transcribe-q4f16",
+        b"openvino" => "base.en",
         _ => "",
     }
 }
@@ -224,6 +234,13 @@ pub enum FieldId {
     CoLanguage,
     CoThreads,
     CoOnDemandLoading,
+
+    // OpenVINO
+    OvModel,
+    OvDevice,
+    OvLanguage,
+    OvThreads,
+    OvOnDemandLoading,
 }
 
 /// Cohere Transcribe officially supports these 14 languages. Token IDs are
@@ -239,6 +256,9 @@ const LANG_CHOICES: &[&str] = &[
 ];
 const SV_LANG_CHOICES: &[&str] = &["auto", "zh", "en", "ja", "ko", "yue"];
 const PARAKEET_MODEL_TYPES: &[Option<&str>] = &[None, Some("tdt"), Some("ctc")];
+/// Inference device OpenVINO GenAI tries first; falls back to CPU if the
+/// requested device fails to initialize (see `OpenVinoTranscriber::new`).
+const OV_DEVICE_CHOICES: &[&str] = &["NPU", "GPU", "CPU"];
 
 fn rows_for_engine_with_mode(engine: &str, whisper_mode: &str) -> Vec<FieldId> {
     let mut rows = vec![FieldId::Engine];
@@ -301,6 +321,13 @@ fn rows_for_engine_with_mode(engine: &str, whisper_mode: &str) -> Vec<FieldId> {
             FieldId::CoLanguage,
             FieldId::CoThreads,
             FieldId::CoOnDemandLoading,
+        ]),
+        "openvino" => rows.extend_from_slice(&[
+            FieldId::OvModel,
+            FieldId::OvDevice,
+            FieldId::OvLanguage,
+            FieldId::OvThreads,
+            FieldId::OvOnDemandLoading,
         ]),
         _ => {}
     }
@@ -407,6 +434,22 @@ impl EngineState {
             co_threads: ed.get_int("cohere", "threads"),
             co_on_demand_loading: ed.get_bool("cohere", "on_demand_loading").unwrap_or(false),
             co_section_existed: ed.get_string("cohere", "model").is_some(),
+
+            // OpenVINO
+            ov_model: ed
+                .get_string("openvino", "model")
+                .unwrap_or_else(|| default_model("openvino").to_string()),
+            ov_device: ed
+                .get_string("openvino", "device")
+                .unwrap_or_else(|| "NPU".to_string()),
+            ov_language: ed
+                .get_string("openvino", "language")
+                .unwrap_or_else(|| "en".to_string()),
+            ov_threads: ed.get_int("openvino", "threads"),
+            ov_on_demand_loading: ed
+                .get_bool("openvino", "on_demand_loading")
+                .unwrap_or(false),
+            ov_section_existed: ed.get_string("openvino", "model").is_some(),
         };
         let mut state = Self {
             engine,
@@ -439,6 +482,22 @@ impl EngineState {
         self.binary_switch_blocked = None;
 
         let inv = binary::inventory();
+
+        // OpenVINO isn't part of the prebuilt binary distribution: no
+        // Whisper or ONNX variant links against openvino-genai (it's an
+        // entirely separate Intel runtime, not an ONNX execution provider),
+        // so there's no variant to switch to. It's purely a source-build
+        // Cargo feature; just check whether the running binary has it.
+        if self.engine == "openvino" {
+            if !inv.compiled_features.contains(&"openvino") {
+                self.binary_switch_blocked = Some(
+                    "OpenVINO isn't available in prebuilt voxtype binaries. \
+                     Build from source with --features openvino.",
+                );
+            }
+            return;
+        }
+
         if inv.install_kind == InstallKind::Source {
             // Source builds can't be hot-swapped; whether the running binary
             // supports the chosen engine depends on its compiled features.
@@ -621,6 +680,18 @@ impl EngineState {
             ed.set_bool("cohere", "on_demand_loading", f.co_on_demand_loading);
         }
 
+        // OpenVINO
+        if self.engine == "openvino" || f.ov_section_existed {
+            ed.set_string("openvino", "model", &f.ov_model);
+            ed.set_string("openvino", "device", &f.ov_device);
+            ed.set_string("openvino", "language", &f.ov_language);
+            match f.ov_threads {
+                Some(n) => ed.set_int("openvino", "threads", n),
+                None => ed.unset("openvino", "threads"),
+            }
+            ed.set_bool("openvino", "on_demand_loading", f.ov_on_demand_loading);
+        }
+
         match ed.save() {
             Ok(()) => {
                 self.dirty_since_load = false;
@@ -628,7 +699,7 @@ impl EngineState {
                 let active_model = active_model_for_engine(&self.engine, &self.fields);
                 let download_needed = active_model
                     .as_deref()
-                    .map(|m| !model_present_on_disk(m))
+                    .map(|m| !model_present_on_disk(&self.engine, m))
                     .unwrap_or(false);
 
                 let next_action = match (pending_switch, download_needed, active_model.clone()) {
@@ -862,6 +933,12 @@ impl EngineState {
             }
             FieldId::CoThreads => f.co_threads = cycle_threads(f.co_threads, delta),
             FieldId::CoOnDemandLoading => f.co_on_demand_loading = !f.co_on_demand_loading,
+
+            FieldId::OvModel => f.ov_model = cycle_model("openvino", &f.ov_model, delta),
+            FieldId::OvDevice => f.ov_device = cycle_str(OV_DEVICE_CHOICES, &f.ov_device, delta),
+            FieldId::OvLanguage => f.ov_language = cycle_str(LANG_CHOICES, &f.ov_language, delta),
+            FieldId::OvThreads => f.ov_threads = cycle_threads(f.ov_threads, delta),
+            FieldId::OvOnDemandLoading => f.ov_on_demand_loading = !f.ov_on_demand_loading,
         }
         self.dirty_since_load = true;
         self.feedback = None;
@@ -884,6 +961,7 @@ fn active_model_for_engine(engine: &str, f: &AllFields) -> Option<String> {
         "dolphin" => Some(f.dol_model.clone()),
         "omnilingual" => Some(f.om_model.clone()),
         "cohere" => Some(f.co_model.clone()),
+        "openvino" => Some(f.ov_model.clone()),
         _ => None,
     }
 }
@@ -941,6 +1019,11 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
             "dolphin",
             "omnilingual",
             "cohere",
+            // OpenVINO isn't checked against `variant.supports_engine()`
+            // above — it has no prebuilt binary variant at all (Intel-only
+            // runtime, unrelated to the Whisper/ONNX distribution). Source
+            // builds with the feature compiled in are the only way it runs.
+            "openvino",
         ] {
             if *f == engine {
                 out.insert(engine);
@@ -953,17 +1036,25 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
 
 /// Resolve where on disk a model directory lives. Mirrors the daemon's
 /// resolution path so the TUI's "is this downloaded?" check matches what
-/// the daemon will look for at load time.
-fn model_dir_on_disk(name: &str) -> std::path::PathBuf {
-    crate::config::Config::models_dir().join(name)
+/// the daemon will look for at load time. Every ONNX engine stores models
+/// flat under `models_dir/<name>`; OpenVINO is the exception, nesting under
+/// `models_dir/openvino/<name>` (see `transcribe::openvino::resolve_model_path`
+/// and `setup::model::download_openvino_model`).
+fn model_dir_on_disk(engine: &str, name: &str) -> std::path::PathBuf {
+    let dir = crate::config::Config::models_dir();
+    if engine == "openvino" {
+        dir.join("openvino").join(name)
+    } else {
+        dir.join(name)
+    }
 }
 
 /// True when the model directory exists with at least one file in it. We
 /// don't validate the file list — the daemon will surface specific missing
 /// pieces — but a fully empty or missing directory definitely needs a
 /// download before save.
-fn model_present_on_disk(name: &str) -> bool {
-    let dir = model_dir_on_disk(name);
+fn model_present_on_disk(engine: &str, name: &str) -> bool {
+    let dir = model_dir_on_disk(engine, name);
     match std::fs::read_dir(&dir) {
         Ok(mut iter) => iter.next().is_some(),
         Err(_) => false,
@@ -1249,6 +1340,20 @@ fn field_label_value(state: &EngineState, fid: FieldId) -> (&'static str, String
             "Cohere · on-demand model load",
             yesno(f.co_on_demand_loading),
         ),
+
+        FieldId::OvModel => ("OpenVINO · model", f.ov_model.clone()),
+        FieldId::OvDevice => ("OpenVINO · device", f.ov_device.clone()),
+        FieldId::OvLanguage => ("OpenVINO · language", f.ov_language.clone()),
+        FieldId::OvThreads => (
+            "OpenVINO · threads",
+            f.ov_threads
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "auto".to_string()),
+        ),
+        FieldId::OvOnDemandLoading => (
+            "OpenVINO · on-demand model load",
+            yesno(f.ov_on_demand_loading),
+        ),
     }
 }
 
@@ -1344,6 +1449,13 @@ fn engine_guidance(state: &EngineState) -> Vec<Line<'static>> {
             "Cohere Transcribe (Cohere Labs). #1 on the Open ASR Leaderboard \
              for English (5.42 WER). 14 languages. ~3 GB on disk.",
         ),
+        (
+            "openvino",
+            "OpenVINO GenAI Whisper (Intel). Runs on Intel NPU/GPU/CPU via \
+             Intel's own runtime — separate from the ONNX/MIGraphX pipeline \
+             above, so it needs its own binary switch story. Not part of \
+             the prebuilt binaries yet; requires --features openvino.",
+        ),
     ] {
         lines.push(Line::from(Span::styled(
             format!("{}: ", name),
@@ -1380,6 +1492,7 @@ fn guidance(state: &EngineState) -> Vec<Line<'_>> {
         FieldId::DolModel => model_guidance("dolphin", &f.dol_model),
         FieldId::OmModel => model_guidance("omnilingual", &f.om_model),
         FieldId::CoModel => model_guidance("cohere", &f.co_model),
+        FieldId::OvModel => model_guidance("openvino", &f.ov_model),
 
         FieldId::WMode => vec![
             heading("Whisper · execution mode"),
@@ -1673,6 +1786,60 @@ fn guidance(state: &EngineState) -> Vec<Line<'_>> {
         FieldId::CoThreads => threads_guidance("Cohere"),
         FieldId::CoOnDemandLoading => on_demand_guidance("Cohere"),
 
+        FieldId::OvDevice => vec![
+            heading("OpenVINO · device"),
+            Line::from(""),
+            Line::from(
+                "Inference device OpenVINO GenAI tries first. Falls back to \
+                 CPU automatically if the requested device fails to \
+                 initialize (missing driver, no NPU on this chip, ...).",
+            ),
+            Line::from(""),
+            Line::from(Span::styled(
+                "NPU: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            )),
+            Line::from(
+                "Intel's dedicated AI accelerator (Meteor Lake and newer). Lowest power draw.",
+            ),
+            Line::from(Span::styled(
+                "GPU: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            )),
+            Line::from("Intel integrated or discrete GPU via oneAPI."),
+            Line::from(Span::styled(
+                "CPU: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            )),
+            Line::from("Always available; the automatic fallback target."),
+        ],
+        FieldId::OvLanguage => vec![
+            heading("OpenVINO · language"),
+            Line::from(""),
+            Line::from(
+                "Two-letter language code passed to the Whisper generation \
+                 config.",
+            ),
+            Line::from(""),
+            Line::from(Span::styled(
+                "\".en\" models (tiny.en, base.en, small.en) are \
+                 English-only regardless of this setting; pick the \
+                 multilingual \"base\" or \"small\" model for other \
+                 languages.",
+                Style::default().fg(Color::Gray),
+            )),
+        ],
+        FieldId::OvThreads => vec![
+            heading("OpenVINO · threads"),
+            Line::from(""),
+            Line::from(
+                "Number of CPU threads OpenVINO's runtime uses for \
+                 inference. `auto` lets it pick. Only matters when device \
+                 is CPU, or as a fallback if NPU/GPU init fails.",
+            ),
+        ],
+        FieldId::OvOnDemandLoading => on_demand_guidance("OpenVINO"),
+
         FieldId::WRemoteEndpoint => vec![
             heading("Whisper · remote endpoint"),
             Line::from(""),
@@ -1796,7 +1963,7 @@ fn installed_models_for(engine: &str) -> Vec<String> {
             if engine == "whisper" {
                 dir.join(format!("ggml-{}.bin", name)).exists()
             } else {
-                let p = dir.join(name);
+                let p = model_dir_on_disk(engine, name);
                 p.exists() || p.is_dir()
             }
         })
@@ -1814,6 +1981,7 @@ fn display_engine(engine: &str) -> &'static str {
         "dolphin" => "Dolphin",
         "omnilingual" => "Omnilingual",
         "cohere" => "Cohere",
+        "openvino" => "OpenVINO",
         _ => "Engine",
     }
 }

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -64,6 +64,7 @@ pub fn create_vad(config: &Config) -> Result<Option<Box<dyn VoiceActivityDetecto
                 | TranscriptionEngine::Dolphin
                 | TranscriptionEngine::Omnilingual
                 | TranscriptionEngine::Cohere
+                | TranscriptionEngine::OpenVino
                 | TranscriptionEngine::Soniox => VadBackend::Energy,
             }
         }


### PR DESCRIPTION
## Description

Two things, sharing one engine:

1. **Sliding-window streaming transcription** for `[whisper] streaming = true` — ported from a companion project's `SlidingWindowTranscriber` (MIT), adapted to voxtype's `StreamingTranscriber` trait. Instead of segmenting on VAD boundaries, it re-transcribes a rolling audio buffer on an interval and emits only the stable-prefix delta, so text lands at the cursor incrementally as you speak instead of only after the hotkey releases.
2. **OpenVINO GenAI backend** (`engine = "openvino"`, feature-gated behind `--features openvino`) — runs Whisper via Intel's OpenVINO GenAI `WhisperPipeline` on NPU/GPU/CPU, falling back to CPU automatically if the requested device fails to initialize. The streaming engine above is backend-agnostic, so `[openvino] streaming = true` gets the same live-typing behavior on NPU hardware.

Full wiring: setup/model download flow (`voxtype setup model`), the `voxtype configure` TUI, daemon preload/streaming paths, VAD/notification/output-icon dispatch — the usual set of exhaustive `TranscriptionEngine` matches.

### Why NPU

The point isn't raw wall-clock speed — on `base.en`, NPU came out ~2.5x faster than CPU here (0.075s vs 0.185s mean per 4.75s clip, both already well past realtime since OpenVINO's CPU path is INT8-quantized, not a naive baseline). The real value is that inference moves off the P/E cores entirely and onto the NPU: a separate, always-on, low-power IP block on the SoC.

Measured with `getrusage` (process CPU-time, summed across all threads) around 10 back-to-back `transcribe()` calls on the same 4.75s clip:

| | CPU-seconds per call | Avg cores kept busy |
|---|---|---|
| CPU | 0.710s | 3.82 |
| NPU | 0.020s | 0.28 |

**~36x less CPU-core-time consumed on NPU.** CPU inference genuinely occupies ~3.8 cores for its duration; NPU inference barely touches the CPU (just data marshalling/queuing to the accelerator) while the actual compute runs on the separate IP block. That's the number that matters for laptop battery life and for not starving whatever else is running while you dictate — not the wall-clock latency, which undersells it since CPU inference is already fast in absolute terms by parallelizing across those 3.8 cores.

### GPU as a fallback on non-NPU hardware

For anyone without an NPU but with an Intel iGPU, the natural question is whether GPU is worth it over CPU. On `base.en`, GPU is only ~1.5x faster wall-clock than CPU — a much smaller win than NPU's, and it initially looked like a bad trade because of model-load time (see next section). With that fixed, GPU still pulls CPU-core-time down ~4x versus CPU (0.673s vs 2.915s per call, `getrusage`-measured the same way as the NPU table above), so it's a real if smaller offload win, and now viable with `on_demand_loading = true` as well since reload is fast (see below).

### Compiled model caching (NPU and GPU load time)

Both NPU and GPU pay a real cost before first inference: OpenVINO compiles the model graph into a device-specific blob (NPU: to NPU-ISA; GPU: OpenCL kernel compilation), and neither is fast — NPU measured 6-17s cold, GPU a few seconds, both on Meteor Lake with `base.en`. That's paid on *every* pipeline init, which for a long-running daemon means every restart.

`openvino-genai`'s `WhisperPipeline::new()` had no way to pass device properties to avoid this — unlike `LlmPipeline`/`VlmPipeline` in the same crate, which already expose `with_properties()` for exactly this reason. Opened [intel/openvino-rs#196](https://github.com/intel/openvino-rs/pull/196) upstream adding the same method for Whisper, and this PR pins a fork branch via `[patch.crates-io]` (with a comment pointing at the upstream PR, to drop once it lands) so `CACHE_DIR` gets wired through to a `$XDG_CACHE_HOME/voxtype/openvino` cache dir.

Measured on real hardware, cold vs. cached reload:

| Device | Cold | Cached | Speedup |
|---|---|---|---|
| NPU | 16.82s | 0.58-0.62s | ~28x |
| GPU | ~8s (true cold, no cache anywhere) | 0.50-0.58s | ~14x |
| CPU | 1.07s | 0.84-0.86s | ~1x (no meaningful compile step to cache) |

Practical effect: `on_demand_loading = true` (load only when recording starts, unload after) is now viable on NPU and GPU too, not just CPU — a cached reload is sub-second on either.

### Related work

I found these after starting, both still open/draft and tackling the same problem independently:
- #282 (`TsaiGaggery`) — landed on essentially the same design (direct Rust FFI to `libopenvino_genai_c.so`, no Python/subprocess). Good independent confirmation the approach is sound.
- #547 (`jacob-vincent-mink`) — broader scope, also adds HF download pathways for OpenVINO models.

Flagging in case a maintainer wants to consolidate. Two bugs below (in "Verified on hardware") were found through actual NPU testing and may be worth checking against either of those PRs if they hit the same failure.

## Verified on hardware

Tested end-to-end on real Intel NPU (Meteor Lake, `/dev/accel0`) — a real recording → transcribe → type cycle, then daily-driven through my own `voxtype.service` with `[openvino] streaming = true`. Screen recording of live streaming dictation attached below.

https://github.com/user-attachments/assets/d1aac3d3-b2f6-4349-b57a-149335d55c7d



Two real bugs surfaced during that testing and are fixed in this PR:

1. **`generate()` threw "unknown exception" on NPU** (worked on CPU/GPU). Root cause: we built the Whisper generation config via `WhisperGenerationConfig::new()` — a bare config disconnected from the loaded model, missing EOS/decoder-start token ids and the `is_multilingual` flag. The official `openvino_genai` C sample instead starts from `pipeline.get_generation_config()` (populated from the model's own `generation_config.json`) and only adjusts task/timestamps on top. Switched to that pattern. Also skip `set_language`/`set_task` entirely for English-only (`.en`) checkpoints — their vocabulary has no task/language tokens at all, so setting them looks up tokens that don't exist. This matches the failure shape of [openvinotoolkit/openvino.genai#4222](https://github.com/openvinotoolkit/openvino.genai/issues/4222).
2. **`Config::streaming_active()`** (which auto-promotes push-to-talk to toggle activation, because typing at the cursor while a key is physically held clobbers libinput's held-key tracking on Hyprland/Sway/River) had no `OpenVino` arm and silently fell through to `false`. Enabling `[openvino] streaming` with push-to-talk would have left recording permanently stuck open on the first real session. Fixed.

## Related Issue

Relates to #283 (streaming transcription request, closed) and the OpenVINO NPU interest in #282 / #547.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I have tested these changes locally (including on real NPU hardware, daily-driven through my own systemd service)
- [x] I have run `cargo test` and all tests pass (855+, with and without `--features openvino`)
- [x] I have run `cargo clippy -- -D warnings` with no warnings (both feature sets)
- [x] I have run `cargo fmt`

## Documentation

- [x] I have updated documentation as needed *(added a full `[openvino]` section to `docs/CONFIGURATION.md`, matching the existing per-engine sections)*

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [ ] Wait for `ci-success` to pass before marking Ready for Review

## Additional Notes

`OpenVinoModelInfo`/model catalog covers `tiny.en`, `base.en`, `small.en`, `base`, `small` — downloaded via `huggingface-cli` from the `OpenVINO/whisper-*-int8-ov` org (not yet mirrored to the voxtype R2 CDN, same caveat as Cohere).

### Arch Linux setup (what it actually took to get NPU inference running)

Pacman `extra` gets you the core toolkit and device plugins:

```
pacman -S openvino openvino-intel-npu-plugin openvino-intel-gpu-plugin \
          intel-npu-driver level-zero-loader intel-compute-runtime
```

That's necessary but not sufficient. The Rust crate (`openvino-genai` / `openvino-genai-sys`, runtime-linked via `openvino-finder`) needs a separate **C API** library, `libopenvino_genai_c.so` — and neither the AUR `openvino-genai-bin` package nor the `openvino-genai` pip wheel ship it. Both only bundle the Python-binding `.so` (pybind11, a different linking mechanism entirely), which is a dead end for FFI from Rust/C/C++.

The actual fix: download Intel's official GenAI C++/C SDK archive directly —
`openvino_genai_ubuntu24_<version>_x86_64.tar.gz` from `storage.openvinotoolkit.org/repositories/openvino_genai/packages/<version>/linux/`, **version-matched to the installed core `openvino` package** (e.g. core `openvino` 2026.3.0 → SDK `openvino_genai_ubuntu24_2026.3.0.0_x86_64.tar.gz`) — extract it anywhere, and point `LD_LIBRARY_PATH` at `<extracted>/runtime/lib/intel64` (where `libopenvino_genai_c.so` actually lives) when running voxtype.

That same SDK archive's `samples/c/whisper_speech_recognition/whisper_speech_recognition.c` is what led to the `generate()` fix above — it's the canonical example of correct `WhisperPipeline` C API usage (`get_generation_config()` off the pipeline, not a bare `create()`), and there's no equivalent reference for this pattern in the Rust crate's own docs.

Worth a packaging note somewhere (`docs/INSTALL.md`, PKGBUILD `optdepends`) if this engine moves toward a real release story — as it stands, `openvino-genai-bin` on AUR being insufficient is a real trap for anyone trying this from the pacman package alone.



