### PR TITLE
Bring the waiting interface into 1.0.0

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -1,0 +1,110 @@
+# Integrating with Voxtype
+
+This document is the contract for programs that drive Voxtype: desktop shells,
+bar widgets, and AI agent harnesses. Anything described here is intended to stay
+stable; anything not described here is an implementation detail, including the
+sentinel files under `$XDG_RUNTIME_DIR/voxtype/`.
+
+## Checking that Voxtype is available
+
+```sh
+voxtype status --format json
+```
+
+Exit code `0` means a daemon is running and reachable. The JSON is shaped for
+status bars (`text`, `alt`, `class`, `tooltip`) and reports one of `idle`,
+`recording`, `streaming`, `transcribing`, or `stopped` in `alt`/`class`.
+
+## Dictating into your own program
+
+Voxtype normally types or pastes into whatever window has focus. A program that
+wants the text for itself asks for file output instead, and waits for it.
+
+```sh
+transcript="${XDG_RUNTIME_DIR:-/tmp}/myapp/dictation.txt"
+rm -f "$transcript"
+
+voxtype record start --file="$transcript" --no-auto-submit --no-smart-auto-submit
+
+# … the user speaks; your UI shows its own indicator …
+
+voxtype record stop --wait --json
+```
+
+`record stop --wait` blocks until the transcription is final and prints one JSON
+object:
+
+```json
+{"status": "ok", "text": "the quick brown fox", "chars": 19, "message": null}
+```
+
+| `status`  | Exit | Meaning |
+|-----------|------|---------|
+| `ok`      | 0    | `text` holds the transcript |
+| `empty`   | 3    | Nothing to transcribe: no speech detected, or the recording was too short |
+| `timeout` | 4    | No outcome within `--timeout` seconds (default 120) |
+| `error`   | 1    | Transcription or the file write failed; see `message` |
+
+Without `--json`, an `ok` transcript is printed on stdout and any other outcome
+is reported on stderr. The exit code is the same either way.
+
+`--wait` needs to know which transcript to wait on. It uses the `--file` path
+the recording was started with, so you normally pass nothing; use `--wait-file
+<PATH>` to name it explicitly, and `--timeout <SECS>` to bound the wait.
+
+### Why not poll the file yourself
+
+Because two cases have no file to poll for. If voice-activity detection finds no
+speech, Voxtype deliberately transcribes nothing and writes nothing; if the write
+fails, likewise. A poller cannot tell either apart from "still working", so it
+waits out its own deadline and reports a timeout that never happened. `--wait`
+returns `empty` or `error` in milliseconds instead.
+
+Programs that must poll should watch for `<transcript>.done`, a JSON completion
+record written after the transcript itself is complete, and only then. It is
+written exactly once per file-mode recording and is consumed by `--wait`.
+
+### Cancelling
+
+```sh
+voxtype record cancel
+```
+
+Discards the recording. No transcript and no completion record are written, so a
+concurrent `--wait` ends at its timeout; cancel your own wait alongside it.
+
+## Per-recording overrides
+
+These apply to a single recording and are consumed by it. They are the supported
+way to keep your integration from disturbing the user's own dictation settings.
+
+| Flag | Effect |
+|------|--------|
+| `--file[=PATH]` | Write the transcript to a file instead of typing it |
+| `--no-auto-submit` | Do not press Enter after the transcript |
+| `--no-smart-auto-submit` | Ignore a spoken "submit" |
+| `--profile NAME` | Apply a `[profiles.NAME]` post-processing command |
+| `--model NAME` | Use a specific model for this recording |
+
+Agent harnesses generally want the first three: the agent composes a message and
+decides for itself when to send it.
+
+A `[profiles.agent]` block with a `post_process_command` is a good place to
+normalise dictation before an agent sees it, stripping filler words for instance.
+
+## What Voxtype will not do for you
+
+Voxtype does not edit your configuration, and asks that you not edit its own:
+`~/.config/voxtype/config.toml` belongs to the user. If you need behaviour that
+is only reachable by editing it, that is a missing flag. Please open an issue.
+
+## Note for existing integrations
+
+Not every Voxtype has `record stop --wait`. Probe for it rather than pinning a
+version, since the release lines do not carry it at the same time:
+
+```sh
+voxtype record stop --help | grep -q -- --wait
+```
+
+Older versions need the polling fallback described above.

--- a/src/app/record.rs
+++ b/src/app/record.rs
@@ -5,6 +5,10 @@
 //! would invent write-race surface that doesn't exist today (see
 //! `docs/REFACTORING.md`).
 
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use voxtype::daemon::result_sidecar_path;
 use voxtype::{config, daemon_status, RecordAction};
 
 /// Send a record command to the running daemon via Unix signals or file triggers
@@ -152,6 +156,26 @@ pub(crate) fn send_record_command(
         RecordAction::Cancel => unreachable!(), // Handled above
     };
 
+    // With --wait, clear a previous run's completion sidecar before signalling,
+    // so the wait below cannot mistake it for this recording's outcome.
+    let wait_target = match &action {
+        RecordAction::Stop {
+            wait: true,
+            wait_file,
+            ..
+        } => {
+            let path = resolve_wait_target(config, wait_file.as_deref()).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--wait needs a transcript file: start the recording with --file, \
+                     set output.mode = \"file\", or pass --wait-file <PATH>"
+                )
+            })?;
+            let _ = std::fs::remove_file(result_sidecar_path(&path));
+            Some(path)
+        }
+        _ => None,
+    };
+
     let result = unsafe { libc::kill(pid, signal) };
     if result != 0 {
         return Err(anyhow::anyhow!(
@@ -160,5 +184,179 @@ pub(crate) fn send_record_command(
         ));
     }
 
+    if let Some(transcript) = wait_target {
+        let (as_json, timeout) = match &action {
+            RecordAction::Stop { json, timeout, .. } => (*json, *timeout),
+            _ => (false, 120),
+        };
+        let outcome = await_transcription(&transcript, Duration::from_secs(timeout));
+        report_outcome(&outcome, as_json);
+        std::process::exit(outcome.exit_code());
+    }
+
     Ok(())
+}
+
+/// Which transcript `--wait` should block on.
+///
+/// An explicit `--wait-file` wins. Otherwise the pending `--file` override this
+/// recording was started with is used, so the common case needs no repetition;
+/// failing that, a configured file-output path.
+fn resolve_wait_target(config: &config::Config, explicit: Option<&str>) -> Option<PathBuf> {
+    if let Some(path) = explicit {
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
+        }
+    }
+
+    let pending =
+        std::fs::read_to_string(config::Config::runtime_dir().join("output_mode_override")).ok();
+    if let Some(value) = pending.as_deref().map(str::trim) {
+        if let Some(path) = value.strip_prefix("file:") {
+            let path = path.trim();
+            if !path.is_empty() {
+                return Some(PathBuf::from(path));
+            }
+        }
+    }
+
+    config.output.file_path.clone()
+}
+
+/// Outcome of a `--wait` stop, as reported to the caller.
+struct WaitOutcome {
+    status: String,
+    text: String,
+    message: Option<String>,
+}
+
+impl WaitOutcome {
+    fn exit_code(&self) -> i32 {
+        match self.status.as_str() {
+            "ok" => 0,
+            "empty" => 3,
+            "timeout" => 4,
+            _ => 1,
+        }
+    }
+}
+
+/// Block until the daemon publishes this recording's outcome.
+///
+/// The daemon writes the completion sidecar after the transcript itself, so
+/// seeing the sidecar means the transcript is complete. A state file that
+/// returns to idle without one is the backstop: that means the recording ended
+/// down a path that produced no transcript.
+fn await_transcription(transcript: &Path, timeout: Duration) -> WaitOutcome {
+    const POLL: Duration = Duration::from_millis(50);
+    // How long to keep looking for a sidecar after the daemon reports idle.
+    const SETTLE: Duration = Duration::from_millis(750);
+
+    let sidecar = result_sidecar_path(transcript);
+    let state_file = config::Config::runtime_dir().join("state");
+    let deadline = Instant::now() + timeout;
+    let mut idle_since: Option<Instant> = None;
+
+    loop {
+        if let Ok(body) = std::fs::read_to_string(&sidecar) {
+            let _ = std::fs::remove_file(&sidecar);
+            return finish(transcript, &body);
+        }
+
+        let state = std::fs::read_to_string(&state_file)
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        if state == "idle" {
+            match idle_since {
+                Some(since) if since.elapsed() >= SETTLE => {
+                    return WaitOutcome {
+                        status: "empty".to_string(),
+                        text: String::new(),
+                        message: Some(
+                            "the daemon returned to idle without producing a transcript"
+                                .to_string(),
+                        ),
+                    };
+                }
+                Some(_) => {}
+                None => idle_since = Some(Instant::now()),
+            }
+        } else {
+            idle_since = None;
+        }
+
+        if Instant::now() >= deadline {
+            return WaitOutcome {
+                status: "timeout".to_string(),
+                text: String::new(),
+                message: Some(format!(
+                    "no outcome within {}s (daemon state: {})",
+                    timeout.as_secs(),
+                    if state.is_empty() { "unknown" } else { &state }
+                )),
+            };
+        }
+
+        std::thread::sleep(POLL);
+    }
+}
+
+/// Turn a sidecar body into an outcome, reading the transcript when there is one.
+fn finish(transcript: &Path, sidecar_body: &str) -> WaitOutcome {
+    let parsed: serde_json::Value = match serde_json::from_str(sidecar_body.trim()) {
+        Ok(value) => value,
+        Err(e) => {
+            return WaitOutcome {
+                status: "error".to_string(),
+                text: String::new(),
+                message: Some(format!("unreadable completion record: {}", e)),
+            }
+        }
+    };
+
+    let status = parsed
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("error")
+        .to_string();
+    let message = parsed
+        .get("message")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let text = if status == "ok" {
+        std::fs::read_to_string(transcript)
+            .map(|t| t.trim_end_matches('\n').to_string())
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    WaitOutcome {
+        status,
+        text,
+        message,
+    }
+}
+
+/// Print the outcome: one JSON object, or the transcript on stdout.
+fn report_outcome(outcome: &WaitOutcome, as_json: bool) {
+    if as_json {
+        let body = serde_json::json!({
+            "status": outcome.status,
+            "text": outcome.text,
+            "chars": outcome.text.chars().count(),
+            "message": outcome.message,
+        });
+        println!("{}", body);
+        return;
+    }
+
+    if outcome.status == "ok" {
+        println!("{}", outcome.text);
+    } else if let Some(message) = &outcome.message {
+        eprintln!("{}: {}", outcome.status, message);
+    } else {
+        eprintln!("{}", outcome.status);
+    }
 }

--- a/src/cli/record.rs
+++ b/src/cli/record.rs
@@ -78,6 +78,30 @@ pub enum RecordAction {
         /// Override output mode to paste (clipboard + Ctrl+V)
         #[arg(long, group = "output_mode")]
         paste: bool,
+
+        /// Block until the transcription is final instead of returning as soon
+        /// as the daemon has been signalled
+        ///
+        /// Requires the recording to be writing to a file (started with
+        /// --file, or output.mode = "file"). Exit code reports the outcome:
+        /// 0 transcribed, 3 nothing to transcribe, 4 timed out, 1 failed.
+        #[arg(long)]
+        wait: bool,
+
+        /// With --wait, print one JSON object describing the outcome
+        #[arg(long, requires = "wait")]
+        json: bool,
+
+        /// With --wait, give up after this many seconds
+        #[arg(long, value_name = "SECS", default_value_t = 120, requires = "wait")]
+        timeout: u64,
+
+        /// With --wait, the transcript path to wait on
+        ///
+        /// Defaults to the path the pending recording is already writing to,
+        /// so a caller that passed --file to `record start` need not repeat it.
+        #[arg(long, value_name = "FILE", requires = "wait")]
+        wait_file: Option<String>,
     },
     /// Toggle recording state
     Toggle {
@@ -171,6 +195,7 @@ impl RecordAction {
                 type_mode,
                 clipboard,
                 paste,
+                ..
             } => (*type_mode, *clipboard, *paste, None),
             RecordAction::Cancel => return None,
         };
@@ -342,6 +367,93 @@ mod tests {
                 assert_eq!(
                     action.output_mode_override(),
                     Some(OutputModeOverride::Type)
+                );
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    #[test]
+    fn stop_defaults_to_not_waiting() {
+        let cli = Cli::parse_from(["voxtype", "record", "stop"]);
+        match cli.command {
+            Some(Commands::Record {
+                action:
+                    RecordAction::Stop {
+                        wait,
+                        json,
+                        wait_file,
+                        ..
+                    },
+            }) => {
+                assert!(!wait, "waiting must stay opt-in");
+                assert!(!json);
+                assert_eq!(wait_file, None);
+            }
+            _ => panic!("Expected Record Stop command"),
+        }
+    }
+
+    #[test]
+    fn stop_accepts_the_waiting_interface() {
+        let cli = Cli::parse_from([
+            "voxtype",
+            "record",
+            "stop",
+            "--wait",
+            "--json",
+            "--timeout",
+            "30",
+            "--wait-file",
+            "/tmp/dictation.txt",
+        ]);
+        match cli.command {
+            Some(Commands::Record {
+                action:
+                    RecordAction::Stop {
+                        wait,
+                        json,
+                        timeout,
+                        wait_file,
+                        ..
+                    },
+            }) => {
+                assert!(wait);
+                assert!(json);
+                assert_eq!(timeout, 30);
+                assert_eq!(wait_file.as_deref(), Some("/tmp/dictation.txt"));
+            }
+            _ => panic!("Expected Record Stop command"),
+        }
+    }
+
+    #[test]
+    fn waiting_flags_require_wait() {
+        // --json and friends are meaningless without --wait, and clap should
+        // say so rather than silently ignoring them.
+        for extra in [
+            vec!["--json"],
+            vec!["--timeout", "5"],
+            vec!["--wait-file", "/tmp/x"],
+        ] {
+            let mut argv = vec!["voxtype", "record", "stop"];
+            argv.extend(extra.iter().copied());
+            assert!(
+                Cli::try_parse_from(&argv).is_err(),
+                "{:?} should require --wait",
+                extra
+            );
+        }
+    }
+
+    #[test]
+    fn stop_wait_still_takes_an_output_mode() {
+        let cli = Cli::parse_from(["voxtype", "record", "stop", "--wait", "--paste"]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert_eq!(
+                    action.output_mode_override(),
+                    Some(OutputModeOverride::Paste)
                 );
             }
             _ => panic!("Expected Record command"),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -192,6 +192,38 @@ enum OutputOverride {
     FileWithPath(PathBuf),
 }
 
+/// Where this recording's transcript would land, without consuming anything.
+///
+/// The output override is only read once transcription succeeds, so the paths
+/// that bail out earlier (too short, no speech) do not know the transcript
+/// path and cannot report an outcome. This peeks the pending override so those
+/// paths can still publish a completion sidecar, leaving the sentinel for the
+/// normal consuming read.
+fn peek_file_output_path(config: &Config) -> Option<PathBuf> {
+    let override_file = Config::runtime_dir().join("output_mode_override");
+    let pending = std::fs::read_to_string(&override_file).ok();
+    match pending.as_deref().map(str::trim) {
+        Some(value) => {
+            if let Some(path) = value.strip_prefix("file:") {
+                let path = path.trim();
+                if !path.is_empty() {
+                    return Some(PathBuf::from(path));
+                }
+                return config.output.file_path.clone();
+            }
+            // A non-file override wins over the configured mode.
+            None
+        }
+        None => {
+            if config.output.mode == OutputMode::File {
+                config.output.file_path.clone()
+            } else {
+                None
+            }
+        }
+    }
+}
+
 /// Read and consume the output mode override file
 /// Format: "type", "clipboard", "paste", "file", or "file:/path/to/file.txt"
 fn read_output_mode_override() -> Option<OutputOverride> {
@@ -518,6 +550,101 @@ fn write_meeting_state_file(path: &PathBuf, state: &str, meeting_id: Option<&str
     }
 }
 
+/// Terminal outcome of a file-mode transcription, published beside the
+/// transcript as `<transcript>.done`.
+///
+/// The daemon's control surface is fire-and-forget: a client that asked for
+/// file output has no way to learn that the recording finished, so it has to
+/// poll the transcript until its own deadline expires. When no speech is
+/// detected nothing is ever written and that deadline is the only thing that
+/// ends the wait, reported to the user as a timeout, which it is not. This
+/// sidecar is the missing completion signal: exactly one is written per
+/// file-mode recording, and `voxtype record stop --wait` blocks on it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct TranscriptOutcome {
+    /// `ok`, `empty`, or `error`.
+    pub status: String,
+    /// Characters written. Zero for `empty` and `error`.
+    pub chars: usize,
+    /// Present only for `error`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl TranscriptOutcome {
+    pub fn ok(chars: usize) -> Self {
+        Self {
+            status: "ok".to_string(),
+            chars,
+            message: None,
+        }
+    }
+
+    /// No speech survived voice-activity detection, so nothing was transcribed.
+    pub fn empty() -> Self {
+        Self {
+            status: "empty".to_string(),
+            chars: 0,
+            message: None,
+        }
+    }
+
+    pub fn error(message: &str) -> Self {
+        Self {
+            status: "error".to_string(),
+            chars: 0,
+            message: Some(message.to_string()),
+        }
+    }
+}
+
+/// Path of the completion sidecar for a transcript.
+pub fn result_sidecar_path(transcript: &std::path::Path) -> std::path::PathBuf {
+    let mut sidecar = transcript.as_os_str().to_os_string();
+    sidecar.push(".done");
+    std::path::PathBuf::from(sidecar)
+}
+
+/// Publish `outcome` beside `transcript`, atomically and last.
+///
+/// Written after the transcript itself so a client that sees the sidecar can
+/// read a complete transcript. Failure to write it is logged and otherwise
+/// ignored: the transcription already succeeded, and a client that misses the
+/// signal falls back to its own timeout.
+fn write_result_sidecar(transcript: &std::path::Path, outcome: &TranscriptOutcome) {
+    let sidecar = result_sidecar_path(transcript);
+    let body = match serde_json::to_string(outcome) {
+        Ok(json) => json,
+        Err(e) => {
+            tracing::warn!("Failed to encode transcript outcome: {}", e);
+            return;
+        }
+    };
+    let staged = temp_sibling(&sidecar);
+    if let Err(e) = std::fs::write(&staged, format!("{}\n", body)) {
+        tracing::warn!("Failed to stage transcript outcome {:?}: {}", staged, e);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&staged, &sidecar) {
+        tracing::warn!("Failed to publish transcript outcome {:?}: {}", sidecar, e);
+        let _ = std::fs::remove_file(&staged);
+    }
+}
+
+/// Sibling temporary path used to stage an atomic transcript write.
+///
+/// Kept in the same directory as the target so the rename stays within one
+/// filesystem. The pid keeps two daemons from colliding on it.
+fn temp_sibling(path: &std::path::Path) -> std::path::PathBuf {
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "transcription".to_string());
+    let mut staged = path.to_path_buf();
+    staged.set_file_name(format!(".{}.{}.tmp", name, std::process::id()));
+    staged
+}
+
 /// Write transcription to a file, respecting file_mode (overwrite or append)
 async fn write_transcription_to_file(
     path: &std::path::Path,
@@ -542,7 +669,17 @@ async fn write_transcription_to_file(
 
     match file_mode {
         FileMode::Overwrite => {
-            tokio::fs::write(path, output_text).await?;
+            // Write through a sibling temporary file and rename, so a reader
+            // polling for a non-empty transcript can never observe a partial
+            // one. Programmatic consumers (OmaPilot, agent harnesses) return
+            // the first non-empty read they get; a truncate-then-write would
+            // hand them a half-written transcript.
+            let temporary = temp_sibling(path);
+            tokio::fs::write(&temporary, output_text).await?;
+            if let Err(e) = tokio::fs::rename(&temporary, path).await {
+                let _ = tokio::fs::remove_file(&temporary).await;
+                return Err(e);
+            }
         }
         FileMode::Append => {
             let mut file = tokio::fs::OpenOptions::new()
@@ -1622,6 +1759,16 @@ impl Daemon {
         }
     }
 
+    /// Tell a waiting file-mode client that this recording produced nothing.
+    ///
+    /// Only fires when the transcript would have gone to a file; interactive
+    /// output modes have the OSD and sounds to say the same thing.
+    fn publish_empty_outcome(&self) {
+        if let Some(path) = peek_file_output_path(&self.config) {
+            write_result_sidecar(&path, &TranscriptOutcome::empty());
+        }
+    }
+
     /// Reset state to idle and run post_output_command to reset compositor submap
     /// Call this when exiting from recording/transcribing without normal output flow
     async fn reset_to_idle(&mut self, state: &mut State) {
@@ -1883,6 +2030,7 @@ impl Daemon {
                     // Skip if too short (likely accidental press)
                     if audio_duration < 0.3 {
                         tracing::debug!("Recording too short ({:.2}s), ignoring", audio_duration);
+                        self.publish_empty_outcome();
                         self.reset_to_idle(state).await;
                         return false;
                     }
@@ -1897,6 +2045,7 @@ impl Daemon {
                                     result.rms_energy
                                 );
                                 self.play_feedback(SoundEvent::Cancelled);
+                                self.publish_empty_outcome();
                                 self.reset_to_idle(state).await;
                                 return false;
                             }
@@ -2119,6 +2268,15 @@ impl Daemon {
                         _ => None,
                     };
 
+                    // Consume the per-recording boolean overrides before any
+                    // early return below. File output returns without building
+                    // an output chain, and these sentinels used to survive it:
+                    // the next recording (typically the user's own hotkey, in
+                    // type mode) then picked them up. Any client that passes
+                    // --no-auto-submit with --file hit this on every dictation.
+                    let auto_submit_override = read_bool_override("auto_submit");
+                    let shift_enter_override = read_bool_override("shift_enter");
+
                     if let Some(output_path) = file_output_path {
                         *state = State::Outputting {
                             text: final_text.clone(),
@@ -2134,6 +2292,10 @@ impl Daemon {
                                     FileMode::Append => "appended",
                                 };
                                 tracing::info!("{} transcription to {:?}", mode_str, output_path);
+                                write_result_sidecar(
+                                    &output_path,
+                                    &TranscriptOutcome::ok(final_text.chars().count()),
+                                );
                                 self.play_feedback(SoundEvent::TranscriptionComplete);
                             }
                             Err(e) => {
@@ -2141,6 +2303,10 @@ impl Daemon {
                                     "Failed to write transcription to {:?}: {}",
                                     output_path,
                                     e
+                                );
+                                write_result_sidecar(
+                                    &output_path,
+                                    &TranscriptOutcome::error(&e.to_string()),
                                 );
                             }
                         }
@@ -2150,10 +2316,6 @@ impl Daemon {
                         self.update_state("idle");
                         return;
                     }
-
-                    // Check for per-recording boolean overrides from CLI flags
-                    let auto_submit_override = read_bool_override("auto_submit");
-                    let shift_enter_override = read_bool_override("shift_enter");
 
                     // Create output chain with potential mode override (for non-file modes)
                     // Priority: 1. CLI override, 2. profile output_mode, 3. config default
@@ -3974,6 +4136,83 @@ mod tests {
         // We can't easily mock Config::runtime_dir(), so we test the file operations
         // directly using the same logic as the functions under test
         f(runtime_dir)
+    }
+
+    #[test]
+    fn overwrite_is_atomic_from_a_readers_point_of_view() {
+        // A reader that polls for a non-empty transcript must never observe a
+        // partial one, so the staged file must not be the target path and the
+        // target must appear complete in one step.
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("dictation.txt");
+        let staged = temp_sibling(&target);
+        assert_ne!(staged, target);
+        assert_eq!(staged.parent(), target.parent());
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime
+            .block_on(write_transcription_to_file(
+                &target,
+                "the quick brown fox",
+                &FileMode::Overwrite,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&target).unwrap().trim_end(),
+            "the quick brown fox"
+        );
+        assert!(!staged.exists(), "staging file must not survive the write");
+    }
+
+    #[test]
+    fn overwrite_replaces_previous_transcript() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("dictation.txt");
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        for text in ["first pass", "second"] {
+            runtime
+                .block_on(write_transcription_to_file(
+                    &target,
+                    text,
+                    &FileMode::Overwrite,
+                ))
+                .unwrap();
+        }
+        assert_eq!(fs::read_to_string(&target).unwrap().trim_end(), "second");
+    }
+
+    #[test]
+    fn sidecar_sits_beside_the_transcript() {
+        assert_eq!(
+            result_sidecar_path(std::path::Path::new("/run/user/1000/x/dictation.txt")),
+            std::path::PathBuf::from("/run/user/1000/x/dictation.txt.done")
+        );
+    }
+
+    #[test]
+    fn sidecar_reports_a_terminal_outcome() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("dictation.txt");
+
+        write_result_sidecar(&target, &TranscriptOutcome::ok(19));
+        let body = fs::read_to_string(result_sidecar_path(&target)).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(body.trim()).unwrap();
+        assert_eq!(parsed["status"], "ok");
+        assert_eq!(parsed["chars"], 19);
+        assert!(parsed.get("message").is_none(), "ok carries no message");
+
+        write_result_sidecar(&target, &TranscriptOutcome::empty());
+        let body = fs::read_to_string(result_sidecar_path(&target)).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(body.trim()).unwrap();
+        assert_eq!(parsed["status"], "empty");
+        assert_eq!(parsed["chars"], 0);
+
+        write_result_sidecar(&target, &TranscriptOutcome::error("disk went away"));
+        let body = fs::read_to_string(result_sidecar_path(&target)).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(body.trim()).unwrap();
+        assert_eq!(parsed["status"], "error");
+        assert_eq!(parsed["message"], "disk went away");
     }
 
     #[test]

--- a/src/tui/compositor_bindings.rs
+++ b/src/tui/compositor_bindings.rs
@@ -438,9 +438,9 @@ fn render_role(comp: Compositor, role: Role, key: &str, second_key: Option<&str>
             "{} {{ spawn \"voxtype\" \"record\" \"start\"; }}",
             canonical_to_niri(key)
         )],
-        (Compositor::Niri, Role::Stop) => vec![format!(
-            "// Niri does not bind on key release; consider Role::Toggle instead."
-        )],
+        (Compositor::Niri, Role::Stop) => {
+            vec!["// Niri does not bind on key release; consider Role::Toggle instead.".to_string()]
+        }
         (Compositor::Niri, Role::PttPair) => vec![
             format!(
                 "{} {{ spawn \"voxtype\" \"record\" \"toggle\"; }}",


### PR DESCRIPTION
Cherry-pick of #594 onto the release candidate, so the interface ships in 1.0.0 rather than waiting for the next release off `dev`.

The reason to take it now: OmaPilot drives voxtype as its dictation engine, and its integration is about to get a lot more visible. Today it polls the transcript file with a 60 second deadline. When voice-activity detection hears no speech, voxtype writes nothing, the poll cannot tell that from "still working", and the user is told the transcription timed out a minute after they stopped talking. That is the behaviour 1.0.0 would ship with.

What is in it:

- `record stop --wait [--json] [--timeout SECS] [--wait-file PATH]` blocks until the transcript is final and reports `ok`, `empty`, `timeout` or `error`, as JSON and as an exit code (0/3/4/1).
- A completion record at `<transcript>.done`, written after the transcript on every terminal outcome of a file-mode recording.
- The transcript write is now atomic. It was truncate-then-write while readers return the first non-empty read, so a long transcript could be read back truncated.
- File output no longer leaks the per-recording `auto_submit` and `shift_enter` sentinels into the next recording. Any caller combining `--no-auto-submit` with `--file` hit that on every dictation.
- `docs/INTEGRATIONS.md` documents the contract and states that the sentinel files are not part of it.

Also folded in: a bare `format!` in `compositor_bindings.rs` that the current Rust stable's clippy rejects. CI pins `dtolnay/rust-toolchain@stable`, so that line fails the clippy gate on every pull request against this branch too, on code untouched since April.

The signal and sentinel path is untouched, so keybindings behave exactly as before.

Verified on this base: fmt clean, `cargo clippy -- -D warnings` clean, 934 tests passing. The interface was also exercised end to end against a stand-in daemon: `ok` returns the transcript in about 500ms, a recording that produced nothing reports `empty` in about 750ms instead of hanging, `--timeout 2` gives up in two seconds, and a stale completion record from a previous run is cleared before signalling.
