### PR TITLE
Report the variant the daemon is running, not the one the symlink names

### DIFF
--- a/src/app/info.rs
+++ b/src/app/info.rs
@@ -387,14 +387,46 @@ fn print_variants_text(inv: &setup::binary::Inventory) {
     }
 
     println!("Variants");
-    if let Some(active) = inv.active_variant {
-        println!(
-            "  Active:        {} ({})",
-            active.display(),
-            active.binary_name()
-        );
-    } else {
-        println!("  Active:        unknown (symlink missing or unrecognized)");
+    // Two different facts, previously conflated under "Active": what the
+    // daemon is executing right now, and what /usr/bin/voxtype would launch
+    // next. They diverge after a variant switch with no restart, or when
+    // something other than the symlink started the daemon.
+    match (inv.running_variant, inv.daemon_pid) {
+        (Some(running), Some(pid)) => {
+            println!(
+                "  Running:       {} ({})  — daemon pid {}",
+                running.display(),
+                running.binary_name(),
+                pid
+            );
+        }
+        (None, Some(pid)) => {
+            println!(
+                "  Running:       not a packaged variant  — daemon pid {}",
+                pid
+            );
+        }
+        _ => {
+            println!("  Running:       no daemon");
+        }
+    }
+
+    match inv.active_variant {
+        Some(next) => println!(
+            "  Next launch:   {} ({})",
+            next.display(),
+            next.binary_name()
+        ),
+        None => println!("  Next launch:   unknown (symlink missing or unrecognized)"),
+    }
+
+    if let (Some(running), Some(next)) = (inv.running_variant, inv.active_variant) {
+        if running != next {
+            println!();
+            println!("  The running daemon and the symlink disagree.");
+            println!("  Restart voxtype to pick up {}:", next.display());
+            println!("    systemctl --user restart voxtype");
+        }
     }
 
     println!();

--- a/src/setup/accel.rs
+++ b/src/setup/accel.rs
@@ -416,7 +416,7 @@ pub(crate) fn parse_nvidia_smi_apps(out: &str, pid: i32) -> Option<u64> {
 /// a variant switch (or from a systemd drop-in pointing elsewhere) keeps
 /// running the old binary.
 fn running_variant(pid: i32) -> (Option<Variant>, Option<String>) {
-    let exe = std::fs::read_link(format!("/proc/{}/exe", pid)).ok();
+    let exe = binary::running_binary_path(pid);
     match exe {
         Some(path) => {
             let name = path

--- a/src/setup/binary.rs
+++ b/src/setup/binary.rs
@@ -478,7 +478,16 @@ pub struct Inventory {
     pub install_kind: InstallKind,
     pub binary_path: PathBuf,
     pub package_lib_dir: Option<PathBuf>,
+    /// What `/usr/bin/voxtype` would launch next. Not necessarily what is
+    /// running: see `running_variant`.
     pub active_variant: Option<Variant>,
+    /// What the live daemon is actually executing, when one is running and
+    /// `/proc` is readable. Differs from `active_variant` after a variant
+    /// switch that has not been followed by a restart, or when something other
+    /// than `/usr/bin/voxtype` launched the daemon.
+    pub running_variant: Option<Variant>,
+    /// PID of the live daemon `running_variant` was read from.
+    pub daemon_pid: Option<i32>,
     /// Empty for `InstallKind::Source`.
     pub variants: Vec<VariantStatus>,
     pub cpu: Cpu,
@@ -638,6 +647,31 @@ pub fn detect_install_kind(binary_path: &Path) -> InstallKind {
 /// Read the `/usr/bin/voxtype` symlink to learn which packaged variant is
 /// active. Returns `None` for source installs, missing symlinks, or unknown
 /// targets.
+/// Path of the binary a live process is actually executing.
+///
+/// `None` when `/proc/<pid>/exe` cannot be read: another user's process, or a
+/// platform without `/proc`.
+pub fn running_binary_path(pid: i32) -> Option<PathBuf> {
+    fs::read_link(format!("/proc/{}/exe", pid)).ok()
+}
+
+/// The packaged variant a live process is actually executing.
+///
+/// This is the honest answer to "which backend is in use". `active_variant`
+/// resolves `/usr/bin/voxtype`, which describes the *next* process to start:
+/// a daemon launched before a variant switch keeps running the old binary, and
+/// a systemd drop-in or a `/usr/local/bin` shadow can point somewhere else
+/// entirely. Reporting the symlink as "active" in either case states the
+/// opposite of what is running.
+///
+/// `None` when `/proc` is unreadable, or when the running binary is not a
+/// packaged variant (a source build, for instance).
+pub fn running_variant(pid: i32) -> Option<Variant> {
+    let path = running_binary_path(pid)?;
+    let name = path.file_name()?.to_str()?;
+    Variant::from_binary_name(name)
+}
+
 pub fn active_variant() -> Option<Variant> {
     // Handle both shapes /usr/bin/voxtype can take: a symlink (CPU
     // variants) or a wrapper script (GPU/ONNX variants whose binary
@@ -753,6 +787,8 @@ pub fn inventory() -> Inventory {
     let binary_path = current_binary_path();
     let install_kind = detect_install_kind(&binary_path);
     let active = active_variant();
+    let daemon_pid = crate::daemon_status::read_pid_if_alive();
+    let running = daemon_pid.and_then(running_variant);
 
     let variants = if install_kind == InstallKind::Package {
         Variant::ALL
@@ -783,6 +819,8 @@ pub fn inventory() -> Inventory {
         binary_path,
         package_lib_dir,
         active_variant: active,
+        running_variant: running,
+        daemon_pid,
         variants,
         cpu,
         gpus,
@@ -1144,5 +1182,40 @@ mod tests {
         assert_eq!(variant_subdir("voxtype-avx2"), None);
         assert_eq!(variant_subdir("voxtype-vulkan"), None);
         assert_eq!(variant_subdir(""), None);
+    }
+
+    #[test]
+    fn running_variant_reads_the_live_process_not_the_symlink() {
+        // Our own pid: /proc/self/exe is the test harness, which is not a
+        // packaged variant, so this must be None rather than falling back to
+        // whatever /usr/bin/voxtype happens to point at.
+        let me = std::process::id() as i32;
+        assert!(
+            running_binary_path(me).is_some(),
+            "/proc should be readable"
+        );
+        assert_eq!(running_variant(me), None);
+    }
+
+    #[test]
+    fn running_variant_is_none_for_a_dead_pid() {
+        // Reserved-but-unused pid space: no /proc entry, so no answer. The
+        // point is that it declines rather than guessing from the symlink.
+        assert_eq!(running_binary_path(-1), None);
+        assert_eq!(running_variant(-1), None);
+    }
+
+    #[test]
+    fn variant_names_round_trip_through_from_binary_name() {
+        // running_variant maps a /proc basename back to a Variant, so every
+        // variant's own binary name has to resolve.
+        for v in Variant::ALL {
+            assert_eq!(
+                Variant::from_binary_name(v.binary_name()),
+                Some(*v),
+                "{} did not round-trip",
+                v.binary_name()
+            );
+        }
     }
 }

--- a/src/setup/gpu.rs
+++ b/src/setup/gpu.rs
@@ -146,6 +146,20 @@ fn warn_if_provider_unloadable(binary_name: &str) {
     }
 }
 
+/// Human label for an ONNX variant's binary name.
+fn describe_onnx_variant(name: &str) -> &'static str {
+    match name {
+        "voxtype-onnx-avx2" | "voxtype-parakeet-avx2" => "ONNX CPU (AVX2)",
+        "voxtype-onnx-avx512" | "voxtype-parakeet-avx512" => "ONNX CPU (AVX-512)",
+        "voxtype-onnx-cuda-12" => "ONNX GPU (CUDA 12)",
+        "voxtype-onnx-cuda-13" => "ONNX GPU (CUDA 13)",
+        "voxtype-onnx-cuda" | "voxtype-parakeet-cuda" => "ONNX GPU (CUDA, unversioned)",
+        "voxtype-onnx-migraphx" => "ONNX GPU (MIGraphX)",
+        "voxtype-onnx-rocm" | "voxtype-parakeet-rocm" => "ONNX GPU (MIGraphX, legacy name)",
+        _ => "ONNX (unknown variant)",
+    }
+}
+
 /// Available backend variants
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Backend {
@@ -569,22 +583,44 @@ pub fn show_status() {
     if is_parakeet {
         // Detect active Parakeet backend from symlink
         if let Some(target) = detect_active_parakeet_backend() {
-            let display_name = match target.as_str() {
-                "voxtype-onnx-avx2" | "voxtype-parakeet-avx2" => "ONNX CPU (AVX2)",
-                "voxtype-onnx-avx512" | "voxtype-parakeet-avx512" => "ONNX CPU (AVX-512)",
-                "voxtype-onnx-cuda-12" => "ONNX GPU (CUDA 12)",
-                "voxtype-onnx-cuda-13" => "ONNX GPU (CUDA 13)",
-                "voxtype-onnx-cuda" | "voxtype-parakeet-cuda" => "ONNX GPU (CUDA, unversioned)",
-                "voxtype-onnx-migraphx" => "ONNX GPU (MIGraphX)",
-                "voxtype-onnx-rocm" | "voxtype-parakeet-rocm" => "ONNX GPU (MIGraphX, legacy name)",
-                _ => "ONNX (unknown variant)",
-            };
-            println!("Active backend: {}", display_name);
-            println!(
-                "  Binary: {}",
-                Path::new(VOXTYPE_LIB_DIR).join(&target).display()
-            );
-            warn_if_provider_unloadable(&target);
+            let display_name = describe_onnx_variant(&target);
+            // `target` comes from /usr/bin/voxtype, which describes the next
+            // process to start. Report what the daemon is actually executing
+            // when there is one, and say so when the two disagree; a variant
+            // switch does not take effect until a restart.
+            let daemon = crate::daemon_status::read_pid_if_alive();
+            let running_path = daemon.and_then(super::binary::running_binary_path);
+
+            match (&running_path, daemon) {
+                (Some(path), Some(pid)) => {
+                    let running_name = path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("unknown");
+                    println!(
+                        "Active backend: {} (daemon pid {})",
+                        describe_onnx_variant(running_name),
+                        pid
+                    );
+                    println!("  Binary: {}", path.display());
+                    if running_name != target {
+                        println!();
+                        println!("  Next launch:  {}", display_name);
+                        println!("    {}", Path::new(VOXTYPE_LIB_DIR).join(&target).display());
+                        println!("  Restart voxtype to pick it up:");
+                        println!("    systemctl --user restart voxtype");
+                    }
+                    warn_if_provider_unloadable(running_name);
+                }
+                _ => {
+                    println!("Next launch: {} (no daemon running)", display_name);
+                    println!(
+                        "  Binary: {}",
+                        Path::new(VOXTYPE_LIB_DIR).join(&target).display()
+                    );
+                    warn_if_provider_unloadable(&target);
+                }
+            }
         } else {
             println!("Active backend: Parakeet (unknown variant)");
         }

--- a/src/setup/variant_check.rs
+++ b/src/setup/variant_check.rs
@@ -124,6 +124,10 @@ mod tests {
             binary_path: "/usr/bin/voxtype".into(),
             package_lib_dir: Some("/usr/lib/voxtype".into()),
             active_variant: Some(active_variant),
+            // This fixture drives the variant-mismatch banner, which reads the
+            // symlink's variant; the running-daemon fields are not part of it.
+            running_variant: None,
+            daemon_pid: None,
             variants: vec![],
             cpu: Cpu {
                 avx2: true,


### PR DESCRIPTION
Fixes the status lie we were about to release-note instead. Targets `rc/1.0.0`.

## The bug

`setup gpu --status` and `info variants` both answered "which backend is active" by resolving `/usr/bin/voxtype`. That describes the **next** process to start, not the running one.

Demonstrated on a live machine, before and after, with the daemon running a binary the symlink does not name:

```
before:  Active backend: ONNX GPU (MIGraphX)
           Binary: /usr/lib/voxtype/voxtype-onnx-migraphx          <- wrong

after:   Active backend: ONNX GPU (MIGraphX) (daemon pid 3684407)
           Binary: /usr/local/lib/voxtype/migraphx/voxtype-onnx-migraphx
```

The second matches `readlink /proc/<pid>/exe` exactly.

It diverges in three realistic ways: after `setup gpu --enable` with no restart, under a systemd drop-in overriding `ExecStart`, and with a `/usr/local/bin` build shadowing the packaged path (which `CLAUDE.local.md` prescribes for test builds, so maintainers hit it first).

## Approach

`info accel` already got this right, reading `/proc/<pid>/exe` with a doc comment explaining exactly why. Rather than write a second resolver, that read moves to `binary::running_binary_path` and `accel.rs` now shares it, with `binary::running_variant` mapping the basename to a `Variant`. Same shape as #568, which shared `resolve_active_binary` instead of keeping a wrapper-blind copy.

Both surfaces now report two separate facts instead of conflating them:

```
Variants
  Running:       ONNX GPU (MIGraphX) (voxtype-onnx-migraphx)  — daemon pid 3684407
  Next launch:   ONNX CPU (AVX-512) (voxtype-onnx-avx512)

  The running daemon and the symlink disagree.
  Restart voxtype to pick up ONNX CPU (AVX-512):
    systemctl --user restart voxtype
```

That divergence line is new information, not just a corrected label. A variant switch previously looked like it had taken effect immediately; now the pending restart is visible.

`Inventory` carries `running_variant` and `daemon_pid`, so `info variants --json` exposes the distinction to the Omarchy panel and other consumers. The variant-label match in `gpu.rs` is factored into `describe_onnx_variant` so the running and next-launch paths share one mapping.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- `cargo test` 937 passing, 2 ignored
- 3 new tests: `/proc/self/exe` resolves but is not a packaged variant (so it declines rather than falling back to the symlink), a dead pid yields `None`, and every `Variant`'s binary name round-trips through `from_binary_name`, which is the mapping `running_variant` depends on
- Verified live against a real divergence, output above

**Not exercised at runtime:** the divergence branch itself. On the test machine the daemon and symlink now agree, so the "disagree" path is covered by reading and by the unit tests but has not been seen live. Producing it deliberately means pointing the wrapper at a second variant, which I did not want to do on a working install.