### PR TITLE
Exit the daemon without running static destructors

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4112,7 +4112,32 @@ impl Daemon {
 
         tracing::info!("Daemon stopped");
 
-        Ok(())
+        // Exit without unwinding. Everything this daemon owns is already
+        // released above: profile override, state file, meeting state file,
+        // PID file and the OSD level socket. What remains between here and
+        // `main` returning is tokio teardown plus `_dl_fini` running the
+        // static destructors of ONNX Runtime, ROCm/MIGraphX and PipeWire, and
+        // that stretch is actively hostile:
+        //
+        //   * The ORT/MIGraphX stack releases a shared_ptr it has already
+        //     freed, decrementing a refcount inside a chunk parked in glibc's
+        //     448-byte bin. Nothing faults at the time. glibc aborts on the
+        //     next free landing in that size class, which at exit is
+        //     PipeWire's `pw_log_topic_unregister`. PipeWire is the detector,
+        //     not the cause; any 448-class free would do it. Each abort costs
+        //     a ~1.9 GB core dump, a desktop crash notification, and a unit
+        //     recorded as `Failed with result 'core-dump'`.
+        //   * ROCm's AsyncEventsLoop threads park indefinitely in KFD ioctls
+        //     and MIGraphX's embedded LLVM thread pool never joins, so the
+        //     same teardown can hang instead of aborting.
+        //
+        // ANY CLEANUP THIS DAEMON NEEDS MUST GO ABOVE THIS LINE. Code added
+        // below it will never run.
+        //
+        // `_exit` skips stdio flushing. Rust's stderr is unbuffered so the
+        // tracing output above is already out; anything that starts buffering
+        // daemon output has to flush before reaching here.
+        unsafe { libc::_exit(0) };
     }
 }
 


### PR DESCRIPTION
Stops the intermittent `SIGABRT` on shutdown. Targets `rc/1.0.0`.

## What was happening

glibc prints `free(): chunks in smallbin corrupted` and the stack points at PipeWire:

```
exit -> __run_exit_handlers -> libpipewire destructor -> pw_log_topic_unregister -> free -> abort
```

PipeWire is the detector, not the cause. Diagnosed from the two surviving cores, taken from different builds on different runs:

| Core | Build | Bin | Damage |
|---|---|---|---|
| 3355498 | packaged 0.7.5 | 28 (448-byte class) | `bk` off by −1 |
| 3580125 | local 1.0.0 | 28 (448-byte class) | `bk` off by −1 |

Both carry **exactly one** damaged bin, both off by −1 at `user_pointer + 8` — where `std::_Sp_counted_base::_M_use_count` and Rust's `Arc` weak count live. That is a refcount release on already-freed memory: the stale count reads as huge, the dispose branch never fires, nothing faults.

The block is attributable. Its surviving bytes are byte-identical across both cores despite different processes and different ASLR: MIGraphX provider `.so` path fragments, `vendor:AM`, and a pointer into `libhsa-runtime64.so.1`. Same code path, same victim, twice. Not our code — `src/audio/` has no `unsafe` at all, and safe Rust cannot produce a write-after-free refcount decrement.

Once the tombstone exists the process is **guaranteed** to abort at the next 448-class free, and exit performs many. Short-lived daemons exit cleanly only because the corrupting event has not happened yet.

The same teardown can hang instead of aborting: ROCm's `AsyncEventsLoop` threads park indefinitely in KFD ioctls and MIGraphX's embedded LLVM thread pool never joins.

## The change

`libc::_exit(0)` immediately after `Daemon stopped`. Everything the daemon owns is already released in the lines above: profile override, state file, meeting state file, PID file, OSD level socket. Nothing is gained by unwinding tokio and running `_dl_fini`.

`Daemon::run` has exactly one caller (`Commands::Daemon` in `app/dispatch.rs`) and no test exercises it, so the early exit cannot affect anything else.

The comment carries two warnings that matter more than the code: cleanup added below that line will never run, and `_exit` skips stdio flushing (safe today because Rust's stderr is unbuffered).

## What this does not do

It does not fix the bug. That is upstream in ORT or the MIGraphX EP and worth reporting with the core evidence: ORT 1.24.2 built from source, MIGraphX EP, ROCm 7.2.4, migraphx 7.2.3-4, glibc 2.44. This stops users paying for it on every shutdown — each abort costs a ~1.9 GB core, a desktop crash notification, and a unit recorded as `Failed with result 'core-dump'`.

## Verification

`cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo test` 934 passing.

**Not verified at runtime.** Exercising a real shutdown needs a Docker MIGraphX build, not a host `cargo build --release` (which compiles without the parakeet and migraphx features). Worth confirming during the RC soak that a stop after a long session produces no new core.

## Separate finding, not in this PR

`ORT_MIGRAPHX_MODEL_CACHE_PATH` is set only by the generated `/usr/bin/voxtype` shell wrapper, never by the binary itself (`src/setup/binary.rs:123-125`). Anything that bypasses the wrapper — a unit pointing at the real binary, a debug run, a `gpu_isolation` subprocess — gets `migraphx_save` failures and then **every transcription silently returns empty text with only a WARN**. Worth defaulting the cache path inside the binary.