### PR TITLE
Credit Matthias Breddin in the contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ We want to hear from you! Voxtype is a young project and your feedback helps mak
 - [KaiStarkk](https://github.com/KaiStarkk) - Post-process trim and fallback_on_empty options
 - [graysky](https://github.com/graysky2) - Flash attention config fix
 - [OldJobobo](https://github.com/OldJobobo) - Quickshell OSD theming, Omarchy theme state path support, configurable media ducking, degenerate Whisper transcript retry; co-owns `quickshell/`
+- [Matthias Breddin](https://github.com/lunetics) - IBus non-ASCII reordering troubleshooting, Rust 1.98 clippy fix, media ducking review
 
 ## License
 


### PR DESCRIPTION
@lunetics merged #569 on 2026-08-17 and has had three PRs open since 2026-08-20, with no entry in the contributors list.

#587 was opened **2026-08-20 17:37 UTC**. The two fixes that landed for the same lint went in on 2026-08-21 at 23:24 and 23:54 UTC, both roughly a day later. We duplicated their work while their PR sat open

Docs only, one line.