### PR TITLE
Replace the previous notification instead of stacking beside it

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -41,29 +41,108 @@ pub async fn send_with_engine(title: &str, body: &str, engine: Option<Transcript
     }
 }
 
+/// The freedesktop notification ID of the last notification we posted, so the
+/// next one can replace it instead of stacking beside it. 0 means "none yet".
+///
+/// The hints below (`x-canonical-private-synchronous`) only suppress stacking
+/// on GNOME and Canonical's notify-osd. KDE's notification daemon ignores them
+/// entirely, which is why notifications kept stacking on Plasma long after
+/// #345 (see #532). `--replace-id` is the mechanism in the freedesktop
+/// specification, and every conforming server honours it.
+#[cfg(target_os = "linux")]
+static LAST_NOTIFICATION_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Set once `notify-send` has told us it does not understand `--print-id`, so
+/// we stop paying for a failed invocation on every notification. libnotify
+/// gained `--print-id` in 0.7.9; older builds still get notifications, they
+/// just stack.
+#[cfg(target_os = "linux")]
+static REPLACE_UNSUPPORTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Arguments shared by both Linux paths: identity, lifetime, and the GNOME
+/// hints, which stay because they are still what suppresses stacking there.
+#[cfg(target_os = "linux")]
+fn linux_common_args(expire_ms: &str) -> Vec<String> {
+    vec![
+        "--app-name=Voxtype".to_string(),
+        format!("--expire-time={}", expire_ms),
+        "-h".to_string(),
+        "string:x-canonical-private-synchronous:voxtype".to_string(),
+        "-h".to_string(),
+        "int:transient:1".to_string(),
+    ]
+}
+
+/// `--replace-id <n>` for the notification we last posted, or nothing if we
+/// have not posted one yet. A stale ID is harmless: the specification has the
+/// server create a new notification when the ID is unknown.
+#[cfg(target_os = "linux")]
+fn replace_args() -> Vec<String> {
+    use std::sync::atomic::Ordering;
+    match LAST_NOTIFICATION_ID.load(Ordering::Relaxed) {
+        0 => Vec::new(),
+        id => vec!["--replace-id".to_string(), id.to_string()],
+    }
+}
+
+/// Remember the ID `notify-send -p` printed so the next notification can
+/// replace this one.
+#[cfg(target_os = "linux")]
+fn remember_notification_id(stdout: &[u8]) {
+    use std::sync::atomic::Ordering;
+    if let Ok(id) = String::from_utf8_lossy(stdout).trim().parse::<u32>() {
+        LAST_NOTIFICATION_ID.store(id, Ordering::Relaxed);
+    }
+}
+
 /// Send a notification on Linux using notify-send
 #[cfg(target_os = "linux")]
 async fn send_linux(title: &str, body: &str) {
     // Synchronous + transient hints ([#345]) keep this in the same
     // overwrite slot as the daemon's recording/transcribing notifications
     // and prevent stacking in the GNOME/Ubuntu notification history.
-    let result = Command::new("notify-send")
-        .args([
-            "--app-name=Voxtype",
-            "--expire-time=2000",
-            "-h",
-            "string:x-canonical-private-synchronous:voxtype",
-            "-h",
-            "int:transient:1",
-            title,
-            body,
-        ])
+    use std::sync::atomic::Ordering;
+
+    if !REPLACE_UNSUPPORTED.load(Ordering::Relaxed) {
+        let mut args = linux_common_args("2000");
+        args.push("--print-id".to_string());
+        args.extend(replace_args());
+        args.push(title.to_string());
+        args.push(body.to_string());
+
+        match Command::new("notify-send")
+            .args(&args)
+            .stderr(Stdio::null())
+            .output()
+            .await
+        {
+            Ok(out) if out.status.success() => {
+                remember_notification_id(&out.stdout);
+                return;
+            }
+            Ok(_) => {
+                // Almost certainly a libnotify too old for --print-id. Fall
+                // through once, then stop trying.
+                REPLACE_UNSUPPORTED.store(true, Ordering::Relaxed);
+            }
+            Err(e) => {
+                tracing::debug!("Failed to send notification: {}", e);
+                return;
+            }
+        }
+    }
+
+    let mut args = linux_common_args("2000");
+    args.push(title.to_string());
+    args.push(body.to_string());
+    if let Err(e) = Command::new("notify-send")
+        .args(&args)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .await;
-
-    if let Err(e) = result {
+        .await
+    {
         tracing::debug!("Failed to send notification: {}", e);
     }
 }
@@ -175,20 +254,90 @@ pub fn send_sync_with_engine(title: &str, body: &str, engine: Option<Transcripti
 #[cfg(target_os = "linux")]
 fn send_linux_sync(title: &str, body: &str) {
     // Same overwrite-and-transient hints as the async path ([#345]).
+    use std::sync::atomic::Ordering;
+
+    if !REPLACE_UNSUPPORTED.load(Ordering::Relaxed) {
+        let mut args = linux_common_args("5000");
+        args.push("--print-id".to_string());
+        args.extend(replace_args());
+        args.push(title.to_string());
+        args.push(body.to_string());
+
+        // Waits for the child, unlike the old spawn-and-forget, because the
+        // printed ID is the whole point. notify-send returns immediately once
+        // the server has accepted the notification.
+        match std::process::Command::new("notify-send")
+            .args(&args)
+            .stderr(Stdio::null())
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                remember_notification_id(&out.stdout);
+                return;
+            }
+            Ok(_) => REPLACE_UNSUPPORTED.store(true, Ordering::Relaxed),
+            Err(_) => return,
+        }
+    }
+
+    let mut args = linux_common_args("5000");
+    args.push(title.to_string());
+    args.push(body.to_string());
     let _ = std::process::Command::new("notify-send")
-        .args([
-            "--app-name=Voxtype",
-            "--expire-time=5000",
-            "-h",
-            "string:x-canonical-private-synchronous:voxtype",
-            "-h",
-            "int:transient:1",
-            title,
-            body,
-        ])
+        .args(&args)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn();
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod linux_tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    /// One test for the whole round trip: LAST_NOTIFICATION_ID is a process
+    /// global, so splitting these would let them race each other.
+    #[test]
+    fn replace_id_round_trip() {
+        LAST_NOTIFICATION_ID.store(0, Ordering::Relaxed);
+
+        // Nothing posted yet: no --replace-id, so the server assigns a fresh
+        // notification rather than being handed an ID it never issued.
+        assert!(replace_args().is_empty());
+
+        remember_notification_id(b"778\n");
+        assert_eq!(
+            replace_args(),
+            vec!["--replace-id".to_string(), "778".to_string()]
+        );
+
+        // A later notification replaces the newer ID, not the first one.
+        remember_notification_id(b"779");
+        assert_eq!(
+            replace_args(),
+            vec!["--replace-id".to_string(), "779".to_string()]
+        );
+
+        // Garbage on stdout must not clobber a good ID: better to replace the
+        // previous notification than to start stacking again.
+        remember_notification_id(b"not an id");
+        assert_eq!(
+            replace_args(),
+            vec!["--replace-id".to_string(), "779".to_string()]
+        );
+
+        LAST_NOTIFICATION_ID.store(0, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn common_args_carry_identity_and_gnome_hints() {
+        let args = linux_common_args("2000");
+        assert!(args.contains(&"--app-name=Voxtype".to_string()));
+        assert!(args.contains(&"--expire-time=2000".to_string()));
+        // The GNOME hint stays: it is what suppresses stacking there, while
+        // --replace-id is what does it on KDE.
+        assert!(args.contains(&"string:x-canonical-private-synchronous:voxtype".to_string()));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #532. Targets `rc/1.0.0`.

## Why #345 did not fix this

The anti-stacking work used two hints:

```
-h string:x-canonical-private-synchronous:voxtype
-h int:transient:1
```

GNOME and Canonical's notify-osd honour those. **KDE's notification daemon ignores them.** So Plasma users kept getting a fresh notification on every state change, which is exactly what @Hoeze reported on Plasma 6.7 running v0.7.5. The hints were never wrong, they were just never portable.

`--replace-id` is the mechanism in the freedesktop specification, and every conforming server implements it. Capture the ID `notify-send --print-id` writes to stdout, hand it back on the next notification.

## Measured, not assumed

On this machine, the old invocation:

```
775
776
777
```

Three IDs, three notifications. With `--replace-id`:

```
posted as id=778
posted as id=778
posted as id=778
posted as id=778
```

One notification, updated in place.

## Compatibility

libnotify gained `--print-id` in 0.7.9 (Debian 11, Ubuntu 20.04). If `notify-send` rejects it we fall back to the old invocation and latch an atomic so the failed call is not repeated on every notification. Those users keep working notifications and keep the stacking, which is what they have today.

The GNOME hints stay. They are still what suppresses stacking there, and a stale `--replace-id` is harmless: the specification has the server create a new notification when it does not recognise the ID.

The synchronous path now waits for the child rather than spawn-and-forget, since the printed ID is the whole point. `notify-send` returns as soon as the server accepts the notification, so this is not a meaningful delay on the output path.

## Verification

`cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo test` 939 passing.

Two new tests. The round trip lives in a single test on purpose: `LAST_NOTIFICATION_ID` is a process global, so splitting it would let the cases race. It covers no-ID-yet, storing an ID, superseding it, and garbage on stdout not clobbering a good ID.

**Not verified on KDE.** I confirmed the mechanism works against this machine's notification daemon and that the freedesktop spec mandates `replaces_id`, but I have no Plasma 6.7 to test on. Worth asking @Hoeze to confirm against a 1.0.0 build before the issue is closed for good.