### PR TITLE
Ship a real app bundle in the macOS DMG and fix the brew docs

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -23,6 +23,12 @@ on:
 jobs:
   build:
     runs-on: macos-14  # Apple Silicon runner for ARM64 build
+    # Hoisted to job scope on purpose. A step's `if:` cannot read that same
+    # step's own `env:` block, so gating on secrets has to happen against a
+    # job-level env var or the step silently never runs.
+    env:
+      HAS_SIGNING_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT != '' }}
+      HAS_NOTARY_CREDS: ${{ secrets.APPLE_ID != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +84,7 @@ jobs:
           releases/${VERSION}/voxtype-${VERSION}-macos-universal --version
 
       - name: Import certificate
-        if: env.APPLE_DEVELOPER_ID_CERT != ''
+        if: env.HAS_SIGNING_CERT == 'true'
         env:
           APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
           APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
@@ -105,7 +111,7 @@ jobs:
             -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
       - name: Sign binary
-        if: env.APPLE_DEVELOPER_ID_CERT != ''
+        if: env.HAS_SIGNING_CERT == 'true'
         env:
           APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }}
         run: |
@@ -126,7 +132,7 @@ jobs:
           codesign --verify --strict --verbose=2 "$BINARY"
 
       - name: Notarize binary
-        if: env.APPLE_ID != ''
+        if: env.HAS_NOTARY_CREDS == 'true'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
@@ -135,44 +141,92 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           BINARY=releases/${VERSION}/voxtype-${VERSION}-macos-universal
 
-          # Create ZIP for notarization
+          # A standalone Mach-O can be notarized but has nowhere to hold the
+          # ticket, so there is no stapling here. Gatekeeper checks this one
+          # online. The DMG below is what gets stapled.
           ditto -c -k "$BINARY" "${BINARY}.zip"
-
-          # Submit for notarization
           xcrun notarytool submit "${BINARY}.zip" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_ID_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
             --wait
-
-          # Clean up and staple
           rm "${BINARY}.zip"
-          xcrun stapler staple "$BINARY"
 
-      - name: Create DMG
+      - name: Build app bundle
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          BINARY=releases/${VERSION}/voxtype-${VERSION}-macos-universal
+          VOXTYPE_SKIP_DMG=1 ./scripts/build-macos-dmg.sh "$VERSION"
+
+      - name: Sign app bundle
+        if: env.HAS_SIGNING_CERT == 'true'
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          APP=releases/${VERSION}/Voxtype.app
+
+          IDENTITY=$(security find-identity -v -p codesigning | \
+            grep "Developer ID Application" | head -1 | \
+            sed 's/.*"\(.*\)".*/\1/')
+
+          # Inner code first, then the wrapper. build-macos-dmg.sh ad-hoc signs
+          # the inner binary so it runs unsigned locally; re-sign it here with
+          # the real identity before sealing the outer bundle.
+          codesign --force --timestamp --options runtime \
+            --sign "$IDENTITY" \
+            "$APP/Contents/MacOS/VoxtypeMenubar.app" \
+            "$APP/Contents/MacOS/VoxtypeSetup.app"
+
+          codesign --force --deep --timestamp --options runtime \
+            --sign "$IDENTITY" "$APP"
+
+          codesign --verify --strict --deep --verbose=2 "$APP"
+
+      - name: Package DMG
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          VOXTYPE_SKIP_APP=1 ./scripts/build-macos-dmg.sh "$VERSION"
+
+      - name: Sign DMG
+        if: env.HAS_SIGNING_CERT == 'true'
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
           DMG=releases/${VERSION}/voxtype-${VERSION}-macos-universal.dmg
 
-          # Create temp directory with binary
-          TEMP_DIR=$(mktemp -d)
-          cp "$BINARY" "$TEMP_DIR/voxtype"
+          IDENTITY=$(security find-identity -v -p codesigning | \
+            grep "Developer ID Application" | head -1 | \
+            sed 's/.*"\(.*\)".*/\1/')
 
-          # Create simple DMG
-          hdiutil create -volname "Voxtype $VERSION" \
-            -srcfolder "$TEMP_DIR" \
-            -ov -format UDZO \
-            "$DMG"
+          codesign --force --timestamp --sign "$IDENTITY" "$DMG"
 
-          rm -rf "$TEMP_DIR"
+      - name: Notarize and staple DMG
+        if: env.HAS_NOTARY_CREDS == 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          DMG=releases/${VERSION}/voxtype-${VERSION}-macos-universal.dmg
+
+          xcrun notarytool submit "$DMG" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          # A DMG can hold the ticket, so staple it. This is what makes the
+          # download work on a machine with no network path to Apple.
+          xcrun stapler staple "$DMG"
+          xcrun stapler validate "$DMG"
 
       - name: Generate checksums
         run: |
           VERSION=${{ steps.version.outputs.version }}
           cd releases/${VERSION}
-          shasum -a 256 * > SHA256SUMS.txt
-          cat SHA256SUMS.txt
+          # Namespaced per platform. Both this job and build-linux.yml upload
+          # to the same release, and a bare SHA256SUMS.txt from each meant one
+          # silently clobbered the other.
+          shasum -a 256 voxtype-* > SHA256SUMS-macos.txt
+          cat SHA256SUMS-macos.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -180,7 +234,7 @@ jobs:
           name: voxtype-${{ steps.version.outputs.version }}-macos
           path: |
             releases/${{ steps.version.outputs.version }}/voxtype-*
-            releases/${{ steps.version.outputs.version }}/SHA256SUMS.txt
+            releases/${{ steps.version.outputs.version }}/SHA256SUMS-macos.txt
 
       - name: Upload to release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
@@ -188,7 +242,7 @@ jobs:
         with:
           files: |
             releases/${{ steps.version.outputs.version }}/voxtype-*
-            releases/${{ steps.version.outputs.version }}/SHA256SUMS.txt
+            releases/${{ steps.version.outputs.version }}/SHA256SUMS-macos.txt
 
   # Aggregator job — branch protection only needs to require `macos-ci-success`.
   # If we add more macOS jobs (arm64 smoke test, notarization gate, etc.) they

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -87,7 +87,7 @@ Pick your distro from the list below. The fastest path on each:
 - **Arch:** `paru -S voxtype-bin`
 - **Debian/Ubuntu:** `sudo apt install ./voxtype_0.7.5-1_amd64.deb`
 - **Fedora:** `sudo dnf install ./voxtype-0.7.5-1.x86_64.rpm`
-- **macOS:** `brew install --cask voxtype`
+- **macOS:** `brew install --cask peteonrails/voxtype/voxtype`
 - **NixOS:** `nix profile install github:peteonrails/voxtype#vulkan`
 - **AppImage:** download, `chmod +x`, run.
 
@@ -174,13 +174,16 @@ Fedora's ydotool ships as a system service that needs extra setup. See [TROUBLES
 
 ### macOS
 
-Apple Silicon only. Uses Microsoft ONNX Runtime so every engine is available, including Parakeet on the Neural Engine path.
+Universal binary: Apple Silicon and Intel. Uses Microsoft ONNX Runtime so every engine is available, including Parakeet on the Neural Engine path.
 
 ```bash
 brew install --cask peteonrails/voxtype/voxtype
+voxtype configure
 ```
 
-Or download `voxtype-0.7.5-macOS-arm64.dmg` from the [latest release](https://github.com/peteonrails/voxtype/releases/latest). First launch opens a setup wizard that walks you through accessibility permissions, model download, and the FN-key hotkey.
+The cask installs a `voxtype` command-line tool, not an app bundle. The build is
+not signed or notarized yet, so macOS asks you to approve it on first run. Or
+download `voxtype-0.7.5-macos-universal.dmg` from the [latest release](https://github.com/peteonrails/voxtype/releases/latest).
 
 ### NixOS
 

--- a/docs/INSTALL_MACOS.md
+++ b/docs/INSTALL_MACOS.md
@@ -7,7 +7,7 @@ Voxtype is a push-to-talk voice-to-text tool with fast, local speech recognition
 ## Requirements
 
 - macOS 13 (Ventura) or later
-- Apple Silicon (M1/M2/M3/M4)
+- Apple Silicon or Intel (the release binary is universal)
 - Microphone access
 - Input Monitoring permission (for global hotkey)
 
@@ -21,29 +21,32 @@ brew tap peteonrails/voxtype
 brew install --cask peteonrails/voxtype/voxtype
 ```
 
-The Cask automatically:
-- Installs Voxtype.app to /Applications
-- Creates CLI symlink (`voxtype` command)
-- Sets up auto-start at login
-- Starts the daemon
+The Cask installs a single `voxtype` command-line tool into your Homebrew
+prefix and clears the quarantine flag on it. There is no app bundle, no
+`/Applications` entry, and no login item: start the daemon yourself, or install
+the formula instead of the cask if you want a `brew services` job.
+
+The fastest way through the rest of setup is the TUI:
+
+```bash
+voxtype configure
+```
 
 ### First-Time Security Setup
 
-Because the app is unsigned, macOS will block it on first run. This is a one-time setup:
+The binary is not signed or notarized yet, so macOS asks about it on first run.
+This is a one-time setup:
 
-1. **Allow the app to run:**
-   - Open **System Settings** > **Privacy & Security**
-   - Scroll down to find "Voxtype.app was blocked"
-   - Click **Open Anyway**
-
-2. **Grant Input Monitoring permission (required for hotkey):**
+1. **Grant Input Monitoring permission (required for the hotkey):**
    - Open **System Settings** > **Privacy & Security** > **Input Monitoring**
-   - Enable **Voxtype**
+   - Add and enable the terminal you run `voxtype` from
+
+2. **Grant Microphone access** when macOS prompts on the first recording.
 
 3. **Restart the daemon** to pick up permissions:
    ```bash
-   launchctl stop io.voxtype.daemon
-   launchctl start io.voxtype.daemon
+   pkill voxtype
+   voxtype daemon
    ```
 
 ### Download a Speech Model
@@ -167,10 +170,7 @@ launchctl start io.voxtype.daemon
 brew uninstall --cask voxtype
 ```
 
-This removes:
-- Voxtype.app from /Applications
-- LaunchAgent (auto-start)
-- CLI symlink
+This removes the `voxtype` command-line tool and the staged DMG payload.
 
 To also remove data:
 ```bash

--- a/scripts/build-macos-dmg.sh
+++ b/scripts/build-macos-dmg.sh
@@ -14,6 +14,11 @@
 #
 # Usage:
 #   ./scripts/build-macos-dmg.sh 0.6.0-rc1
+#
+# Phases. By default this builds the .app and then packages the DMG from it.
+# CI needs to sign the .app in between, so each phase can run alone:
+#   VOXTYPE_SKIP_DMG=1  build Voxtype.app, stop before the DMG
+#   VOXTYPE_SKIP_APP=1  package the DMG from an already-built Voxtype.app
 
 set -euo pipefail
 
@@ -39,10 +44,10 @@ APP_DIR="${RELEASES_DIR}/Voxtype.app"
 # Find the binary (try arm64 first, then universal)
 if [[ -f "${RELEASES_DIR}/voxtype-${VERSION}-macos-arm64" ]]; then
     BINARY="${RELEASES_DIR}/voxtype-${VERSION}-macos-arm64"
-    DMG_PATH="${RELEASES_DIR}/Voxtype-${VERSION}-macos-arm64.dmg"
+    DMG_PATH="${RELEASES_DIR}/voxtype-${VERSION}-macos-arm64.dmg"
 elif [[ -f "${RELEASES_DIR}/voxtype-${VERSION}-macos-universal" ]]; then
     BINARY="${RELEASES_DIR}/voxtype-${VERSION}-macos-universal"
-    DMG_PATH="${RELEASES_DIR}/Voxtype-${VERSION}-macos-universal.dmg"
+    DMG_PATH="${RELEASES_DIR}/voxtype-${VERSION}-macos-universal.dmg"
 else
     echo -e "${RED}Error: No binary found in ${RELEASES_DIR}${NC}"
     echo "Expected: voxtype-${VERSION}-macos-arm64 or voxtype-${VERSION}-macos-universal"
@@ -54,6 +59,15 @@ fi
 # into the .app/Contents/Frameworks/ and make the binary's rpath point at it.
 ORT_DYLIB="$(ls "${RELEASES_DIR}"/libonnxruntime.*.dylib 2>/dev/null | head -1 || true)"
 
+if [[ "${VOXTYPE_SKIP_APP:-}" == "1" ]]; then
+    if [[ ! -d "$APP_DIR" ]]; then
+        echo -e "${RED}Error: VOXTYPE_SKIP_APP=1 but $APP_DIR does not exist${NC}"
+        exit 1
+    fi
+    echo -e "${YELLOW}Reusing existing bundle: $APP_DIR${NC}"
+fi
+
+if [[ "${VOXTYPE_SKIP_APP:-}" != "1" ]]; then
 echo -e "${GREEN}Building Voxtype.app for ${VERSION}...${NC}"
 echo "Binary: $BINARY"
 echo
@@ -172,6 +186,13 @@ echo -e "${GREEN}App bundle created:${NC}"
 echo "  $APP_DIR"
 du -sh "$APP_DIR"
 echo
+
+fi  # end app-build phase
+
+if [[ "${VOXTYPE_SKIP_DMG:-}" == "1" ]]; then
+    echo "VOXTYPE_SKIP_DMG=1 set, stopping before DMG creation."
+    exit 0
+fi
 
 # Create DMG with Applications symlink for drag-to-install
 echo -e "${YELLOW}Creating DMG...${NC}"

--- a/website/download/index.html
+++ b/website/download/index.html
@@ -515,9 +515,9 @@
                     </svg>
                     macOS
                 </h3>
-                <p>Install via Homebrew Cask. Apple Silicon and Intel both supported. The cask runs <code>voxtype setup</code> on first launch to download the model and request microphone permissions.</p>
+                <p>Install via Homebrew Cask. Apple Silicon and Intel both supported. The cask installs a <code>voxtype</code> command-line tool. Run <code>voxtype configure</code> afterwards to pick a model and grant microphone and Input Monitoring permissions.</p>
                 <div class="code-block">
-                    <code><span class="comment"># Add the tap</span><br/>brew tap peteonrails/voxtype<br/><br/><span class="comment"># Install</span><br/>brew install --cask voxtype<br/><br/><span class="comment"># Launch the menubar app</span><br/>open -a Voxtype</code>
+                    <code><span class="comment"># Add the tap</span><br/>brew tap peteonrails/voxtype<br/><br/><span class="comment"># Install</span><br/>brew install --cask voxtype<br/><br/><span class="comment"># Pick a model, set the hotkey, grant permissions</span><br/>voxtype configure</code>
                 </div>
             </div>
         </div>

--- a/website/index.html
+++ b/website/index.html
@@ -959,19 +959,19 @@ sudo dnf install wtype wl-clipboard libnotify pipewire-alsa playerctl</code></pr
                 </div>
 
                 <div id="macos" class="tab-content">
-                    <p class="install-note">Apple Silicon (arm64) only. Uses Microsoft ONNX Runtime so all engines are available, including Parakeet on the Neural Engine path.</p>
+                    <p class="install-note">Universal binary: Apple Silicon and Intel. Uses Microsoft ONNX Runtime so all engines are available, including Parakeet on the Neural Engine path.</p>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install via Homebrew</span>
-                            <button class="copy-btn" data-copy="brew install --cask voxtype">Copy</button>
+                            <button class="copy-btn" data-copy="brew install --cask peteonrails/voxtype/voxtype">Copy</button>
                         </div>
-                        <pre><code><span class="comment"># Install the signed app bundle</span>
-brew install --cask voxtype
+                        <pre><code><span class="comment"># Voxtype is not in Homebrew core yet, so install from the tap</span>
+brew install --cask peteonrails/voxtype/voxtype
 
-<span class="comment"># First launch opens a setup wizard that walks you through</span>
-<span class="comment"># Accessibility permissions, model download, and the FN-key hotkey.</span></code></pre>
+<span class="comment"># Pick a model, set the hotkey, grant permissions</span>
+voxtype configure</code></pre>
                     </div>
-                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-0.7.5-macOS-arm64.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
+                    <p class="install-note" style="margin-top: 1rem;">This installs a <code>voxtype</code> command-line tool, not an app bundle. The build is not signed or notarized yet, so macOS asks you to approve it the first time. Or download <code>voxtype-0.7.5-macos-universal.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
                 </div>
 
                 <div id="nixos" class="tab-content">


### PR DESCRIPTION
## Description

Two related problems surfaced by #604.

**The cask was broken, not just stale.** Its URL pointed at `Voxtype-<v>-macos-arm64.dmg`, which stopped existing after 0.6.3. Releases now publish `voxtype-<v>-macos-universal.dmg`, and since 0.6.6 its payload has been a single bare CLI binary rather than an app bundle, so `app`, `login_item`, and `appdir` resolved to nothing. Fixed separately in the tap (`peteonrails/homebrew-voxtype@bbe5cf4`, now tracking 0.7.5).

**This PR fixes the pipeline and the docs.**

`scripts/build-macos-dmg.sh` already knew how to assemble `Voxtype.app` with the menubar and setup apps bundled. It just was not wired into the release workflow. Split it into two phases (`VOXTYPE_SKIP_DMG` / `VOXTYPE_SKIP_APP`) so CI can sign the bundle between assembling it and sealing the DMG, and normalized its DMG filename to the lowercase name the releases actually publish.

Three workflow fixes:

- **Gate signing on job-level env vars.** A step's `if:` cannot read that same step's own `env:` block, so the old `if: env.APPLE_DEVELOPER_ID_CERT != ''` gates would have kept skipping even after the Apple secrets were added.
- **Staple the DMG, not the bare binary.** A standalone Mach-O has nowhere to hold a notarization ticket, so `xcrun stapler staple` on it would have failed. The binary is still notarized for online Gatekeeper checks; the DMG gets the stapled ticket.
- **Write `SHA256SUMS-macos.txt`.** This job and `build-linux.yml` both uploaded a bare `SHA256SUMS.txt` to the same release, so the macOS entries were silently clobbered. v0.7.5's published manifest contains no macOS hashes at all.

Docs and website corrected to match reality: universal rather than arm64-only, tap-qualified install command, CLI tool rather than app bundle, and the "signed app bundle" / "setup wizard" claims removed.

## Testing

- `yaml.safe_load` on the workflow, `bash -n` on the script.
- **Not verified on macOS.** I have no Apple hardware, no Xcode, and no Developer ID in this environment, so the signing, notarization, and stapling paths are unexercised. The first tagged build after the Apple secrets land is the real test.
- The Apple secrets do not exist in the repo yet (only `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE`), so on this PR every signing step will skip and the DMG will build unsigned, exactly as before.

## Follow-up

Once a release ships a signed bundle, the cask needs `app "Voxtype.app"` instead of `binary "voxtype"` and can drop its quarantine-strip postflight. `docs/MACOS_ARCHITECTURE.md` and `docs/MACOS_TROUBLESHOOTING.md` still document `/Applications/Voxtype.app/...` paths; I left them alone deliberately rather than rewriting them to CLI-only and back again.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)

Refs #604