### PR TITLE
Restart the daemon on TUI exit when saves left it stale

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -98,6 +98,15 @@ pub struct App {
     /// content pointing the user at the recovery path. Computed at load
     /// time and on `refresh_inventory()`. See #450.
     pub variant_mismatch: Option<VariantMismatch>,
+    /// Modification time of config.toml as of the last moment the daemon
+    /// was known to be in sync with it: TUI startup, or the most recent
+    /// `restart_voxtype_daemon` call. Compared on quit — a newer mtime
+    /// means a save landed that the running daemon has not loaded, so the
+    /// TUI restarts it on the way out. Without this, a config-only change
+    /// (e.g. switching engine on a binary that supports both) saved and
+    /// quit cleanly but never took effect, while variant switches and
+    /// model downloads restarted immediately.
+    pub config_synced_mtime: Option<std::time::SystemTime>,
     /// Lazily loaded Hotkey section state. None until the user opens Hotkey
     /// for the first time (or load fails).
     pub hotkey: Option<HotkeyState>,
@@ -183,6 +192,7 @@ impl App {
             quit_pending: false,
             missing_model: detect_missing_model(),
             variant_mismatch,
+            config_synced_mtime: config_file_mtime(),
             hotkey: None,
             audio: None,
             engine: None,
@@ -542,9 +552,55 @@ fn detect_missing_model() -> Option<MissingModel> {
 }
 use crate::daemon_status::is_daemon_running;
 
+/// Modification time of the config file the TUI edits (the same
+/// `Config::default_path()` every section's `ConfigEditor::load()` writes
+/// to). `None` when the path can't be resolved or the file doesn't exist.
+pub fn config_file_mtime() -> Option<std::time::SystemTime> {
+    let path = crate::config::Config::default_path()?;
+    std::fs::metadata(path).ok()?.modified().ok()
+}
+
+/// Should quitting the TUI restart the daemon?
+///
+/// Yes exactly when a daemon is alive and the config file changed after the
+/// last known daemon (re)start — the running process is stale with respect
+/// to what the user saved. A stopped daemon needs no restart (the next start
+/// reads the new config, and `systemctl restart` on a stopped service would
+/// start it, which the user didn't ask for). `current` being `None` means
+/// the config file doesn't exist, so there is nothing new to load.
+pub fn should_restart_on_quit(
+    daemon_running: bool,
+    synced: Option<std::time::SystemTime>,
+    current: Option<std::time::SystemTime>,
+) -> bool {
+    daemon_running && current.is_some() && current != synced
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: an engine change saved through the TUI never took effect
+    /// because quitting didn't restart the daemon. Quit must restart exactly
+    /// when a daemon is alive and the config was saved after the daemon's
+    /// last known (re)start.
+    #[test]
+    fn quit_restarts_only_a_running_daemon_with_a_newer_config() {
+        use std::time::{Duration, SystemTime};
+        let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        let t1 = t0 + Duration::from_secs(60);
+
+        // Saved after startup, daemon running: restart.
+        assert!(should_restart_on_quit(true, Some(t0), Some(t1)));
+        // Config file created during the session (didn't exist at startup).
+        assert!(should_restart_on_quit(true, None, Some(t1)));
+        // Untouched config: no restart.
+        assert!(!should_restart_on_quit(true, Some(t0), Some(t0)));
+        // Daemon not running: never restart (it would *start* the service).
+        assert!(!should_restart_on_quit(false, Some(t0), Some(t1)));
+        // No config file at all: nothing new for a daemon to load.
+        assert!(!should_restart_on_quit(true, Some(t0), None));
+    }
 
     #[test]
     fn variant_at_finds_known_pairs() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -57,7 +57,12 @@ pub fn run(force_package_mode: bool) -> anyhow::Result<()> {
     let mut terminal = enter_terminal()?;
     let result = event_loop(&mut terminal, force_package_mode);
     leave_terminal(&mut terminal)?;
-    result
+    if result? {
+        // Printed after the alternate screen is torn down so it lands in
+        // the user's shell, not the vanished TUI.
+        println!("Restarted the voxtype daemon to apply saved config changes.");
+    }
+    Ok(())
 }
 
 fn enter_terminal() -> anyhow::Result<Tui> {
@@ -78,7 +83,9 @@ fn leave_terminal(terminal: &mut Tui) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn event_loop(terminal: &mut Tui, force_package_mode: bool) -> anyhow::Result<()> {
+/// Returns `true` when the daemon was restarted on the way out so `run()`
+/// can tell the user once the terminal is back to normal.
+fn event_loop(terminal: &mut Tui, force_package_mode: bool) -> anyhow::Result<bool> {
     let mut app = App::new(force_package_mode);
     let mut last_general_refresh = std::time::Instant::now();
     let general_refresh_interval = Duration::from_secs(2);
@@ -111,7 +118,7 @@ fn event_loop(terminal: &mut Tui, force_package_mode: bool) -> anyhow::Result<()
                 if let Some(action) = handle_global_key(&mut app, key) {
                     match dispatch_action(terminal, &mut app, action)? {
                         LoopControl::Continue => continue,
-                        LoopControl::Quit => return Ok(()),
+                        LoopControl::Quit => return Ok(restart_if_config_newer(&app)),
                     }
                 }
 
@@ -123,7 +130,7 @@ fn event_loop(terminal: &mut Tui, force_package_mode: bool) -> anyhow::Result<()
 
                 match dispatch_action(terminal, &mut app, action)? {
                     LoopControl::Continue => {}
-                    LoopControl::Quit => return Ok(()),
+                    LoopControl::Quit => return Ok(restart_if_config_newer(&app)),
                 }
             }
             Event::Mouse(mouse) => {
@@ -230,7 +237,29 @@ fn restart_voxtype_daemon(app: &mut App) {
     let _ = std::process::Command::new("systemctl")
         .args(["--user", "restart", "voxtype"])
         .status();
+    // The freshly (re)started daemon has read the config as it stands now,
+    // so quitting doesn't need another restart unless a later save lands.
+    app.config_synced_mtime = app::config_file_mtime();
     app.refresh_inventory();
+}
+
+/// Restart the daemon on the way out of the TUI when a save landed after
+/// the daemon's last known (re)start, so config-only changes (an engine
+/// switch on a binary that supports both, a hotkey edit, ...) take effect
+/// without a manual `systemctl --user restart voxtype`. The decision logic
+/// lives in `app::should_restart_on_quit`; see its doc for the cases.
+fn restart_if_config_newer(app: &App) -> bool {
+    let restart = app::should_restart_on_quit(
+        crate::daemon_status::is_daemon_running(),
+        app.config_synced_mtime,
+        app::config_file_mtime(),
+    );
+    if restart {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "restart", "voxtype"])
+            .status();
+    }
+    restart
 }
 
 /// Routes keypresses while the save-on-exit prompt is showing.


### PR DESCRIPTION
## Summary

The TUI restarts the daemon after a binary variant switch or a model download, but a config-only change (switching engine on a binary that supports both, a hotkey edit, ...) saved through a section's `s` key or the save-on-exit prompt just wrote the file and exited. The change looked applied and silently wasn't: the daemon only reads config at startup. Found in the field today — engine switched to Parakeet in the TUI, daemon kept transcribing with Whisper.

## Approach

Track `config.toml`'s mtime from TUI startup, refreshed whenever the TUI itself restarts the daemon (variant switch, model download, the `D` key). On quit, if a daemon is alive and the config is newer than that watermark, restart it and print "Restarted the voxtype daemon to apply saved config changes." after the alternate screen is torn down.

Details:

- One restart at exit rather than per save, so a long editing session doesn't bounce the daemon repeatedly.
- Discard at the quit prompt still restarts if an earlier in-session `s` save hit disk — discard only drops unsaved field edits, the earlier save is already in the file.
- A stopped daemon is left alone: `systemctl restart` on a stopped service would start it, which the user didn't ask for. The next start reads the new config anyway.
- Watching mtime rather than plumbing a dirty flag through every section keeps the change contained and also covers a config edited by a subprocess the TUI spawned.

## Testing

- New unit test on the quit-restart decision covering all five cases (newer config + running daemon, config created mid-session, untouched config, stopped daemon, no config file)
- Full suite passes, clippy clean