### PR TITLE
Bump nixpkgs so Nix CI fetches crates from static.crates.io

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

All three Nix CI jobs (build cpu, build onnx, nix-success) started failing on every PR with curl 403 on each crate download. crates.io now rejects generic curl user agents on the legacy `/api/v1/crates/.../download` endpoint (verified: plain curl GET gets 403, a descriptive UA gets 200, and static.crates.io serves the same file fine). Not transient: reruns fail identically, and the crates.io status page shows no incident.

Our pinned nixpkgs (2026-03-24) `importCargoLock` still fetched crates through that endpoint. nixpkgs has since switched it to the static.crates.io CDN, citing [rust-lang/crates.io#13482](https://github.com/rust-lang/crates.io/issues/13482).

## Change

`nix flake update nixpkgs`: 46db2e0 (2026-03-24) → 9fbb54b (2026-08-26), which carries the static.crates.io mapping in `import-cargo-lock.nix`. No other inputs touched.

## Notes

- The cargo-based clippy/test jobs were never affected: cargo downloads via the sparse index, which already points at static.crates.io.
- This bumps nixpkgs by five months, so the Nix toolchain moves with it. The CI run on this PR is the verification.
- #613 and #614 fail on exactly this; once this merges, rerunning their checks should clear them.
- main and dev pin the same era of nixpkgs and will need the same bump.