### PR TITLE
fix: add remote_send_auto_language for whisper.cpp auto-detect

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1070,6 +1070,28 @@ remote_endpoint = "http://192.168.1.100:8080"
 remote_timeout_secs = 60  # 60 second timeout for long recordings
 ```
 
+### remote_send_auto_language
+
+**Type:** Boolean
+**Default:** `false`
+**Required:** No
+
+Controls what happens to the `language` field of the request when `language = "auto"`.
+
+By default the field is omitted, which OpenAI-compatible endpoints treat as auto-detect (OpenAI rejects non-ISO-639-1 values such as `"auto"`). whisper.cpp's server instead falls back to its own `-l` setting (default `"en"`) when the field is missing, so auto-detection configured in voxtype is silently ignored. Enable this option to send `language=auto` explicitly.
+
+- For **whisper.cpp server**: Set to `true` (it accepts `"auto"`)
+- For **OpenAI API**: Leave `false` (omitting the field means auto-detect)
+
+**Example:**
+```toml
+[whisper]
+mode = "remote"
+remote_endpoint = "http://192.168.1.100:8080"
+language = "auto"
+remote_send_auto_language = true
+```
+
 ### whisper_cli_path
 
 **Type:** String

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -165,6 +165,12 @@ translate = false
 #
 # Timeout for remote requests in seconds (default: 30)
 # remote_timeout_secs = 30
+#
+# Send an explicit "language=auto" field when language = "auto" (default: false)
+# By default the language field is omitted in auto mode, which OpenAI-compatible
+# endpoints treat as auto-detect. whisper.cpp's server instead falls back to its
+# own -l setting (default "en"); enable this so "auto" is sent explicitly.
+# remote_send_auto_language = true
 
 [output]
 # Primary output mode: "type" or "clipboard"

--- a/src/config/whisper.rs
+++ b/src/config/whisper.rs
@@ -144,6 +144,15 @@ pub struct WhisperConfig {
     #[serde(default)]
     pub remote_timeout_secs: Option<u64>,
 
+    /// Send an explicit `language=auto` field when language = "auto" (default: false)
+    /// OpenAI-compatible endpoints treat a missing language field as auto-detect
+    /// (and reject non-ISO-639-1 values like "auto"), but whisper.cpp's server
+    /// falls back to its own `-l` setting (default "en") when the field is
+    /// missing, silently ignoring voxtype's auto-detect configuration.
+    /// Enable this when using a whisper.cpp server so "auto" is sent explicitly.
+    #[serde(default)]
+    pub remote_send_auto_language: bool,
+
     // --- CLI backend settings ---
     /// Path to whisper-cli binary (optional, searches PATH if not set)
     /// Used when mode = "cli"
@@ -206,6 +215,7 @@ impl Default for WhisperConfig {
             remote_model: None,
             remote_api_key: None,
             remote_timeout_secs: None,
+            remote_send_auto_language: false,
             whisper_cli_path: None,
         }
     }

--- a/src/transcribe/remote.rs
+++ b/src/transcribe/remote.rs
@@ -28,6 +28,8 @@ pub struct RemoteTranscriber {
     api_key: Option<String>,
     /// Optional initial prompt for transcription context
     initial_prompt: Option<String>,
+    /// Send an explicit `language=auto` field instead of omitting it
+    send_auto_language: bool,
     /// Request timeout
     timeout: Duration,
 }
@@ -106,6 +108,7 @@ impl RemoteTranscriber {
             translate: config.translate,
             api_key,
             initial_prompt,
+            send_auto_language: config.remote_send_auto_language,
             timeout,
         })
     }
@@ -167,9 +170,11 @@ impl RemoteTranscriber {
         body.extend_from_slice(self.model.as_bytes());
         body.extend_from_slice(b"\r\n");
 
-        // Add language field (if not auto-detect mode)
+        // Add language field (omitted in auto-detect mode unless the server
+        // needs an explicit "auto", e.g. whisper.cpp server which otherwise
+        // falls back to its own -l default)
         // For language arrays, use the primary language since remote APIs don't support arrays
-        if !self.language.is_auto() {
+        if !self.language.is_auto() || self.send_auto_language {
             body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
             body.extend_from_slice(b"Content-Disposition: form-data; name=\"language\"\r\n\r\n");
             body.extend_from_slice(self.language.primary().as_bytes());
@@ -360,6 +365,43 @@ mod tests {
         assert!(body_str.contains("name=\"language\""));
         assert!(body_str.contains("name=\"response_format\""));
         assert!(body_str.contains("json"));
+    }
+
+    #[test]
+    fn test_multipart_body_omits_language_when_auto() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            language: LanguageConfig::Single("auto".to_string()),
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        let wav_data = vec![0u8; 100];
+
+        let (_boundary, body) = transcriber.build_multipart_body(&wav_data);
+        let body_str = String::from_utf8_lossy(&body);
+
+        assert!(!body_str.contains("name=\"language\""));
+    }
+
+    #[test]
+    fn test_multipart_body_sends_auto_language_when_enabled() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            language: LanguageConfig::Single("auto".to_string()),
+            remote_send_auto_language: true,
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        let wav_data = vec![0u8; 100];
+
+        let (_boundary, body) = transcriber.build_multipart_body(&wav_data);
+        let body_str = String::from_utf8_lossy(&body);
+
+        assert!(body_str.contains("name=\"language\"\r\n\r\nauto\r\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

When `language = "auto"`, the remote backend omits the `language` multipart field. OpenAI-compatible endpoints treat that as auto-detect, but whisper.cpp's server falls back to its own `-l` setting (default `en`), silently ignoring voxtype's auto-detect configuration.

This adds an opt-in `[whisper] remote_send_auto_language` option (default `false`) that sends an explicit `language=auto` field instead. The default preserves current behavior, so existing OpenAI setups (which reject non-ISO-639-1 values like `"auto"`) are unaffected.

Verified against whisper.cpp 1.9.1: a field-less request logs `lang = en`, while an explicit `language=auto` logs `lang = auto` followed by `auto-detected language: fr (p = 0.954)`.

## Related Issue

Fixes #619

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

New tests: `test_multipart_body_omits_language_when_auto` (default keeps omitting the field) and `test_multipart_body_sends_auto_language_when_enabled` (opt-in sends `auto`).

Note: `cargo clippy --all-targets -- -D warnings` reports 12 pre-existing errors on macOS targets (daemon.rs, menubar.rs, hotkey_macos.rs, etc.) that are present on a clean `dev` checkout and untouched by this PR; the Linux CI lanes are unaffected.

## Documentation

- [x] I have updated documentation as needed (`docs/CONFIGURATION.md`, commented option in the default config template)
- [ ] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [ ] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

Since there is no single value that means auto-detect on both API families (OpenAI needs the field omitted, whisper.cpp needs an explicit `"auto"`), the option defaults to the current omit behavior and is documented as a whisper.cpp-server switch. If you'd rather flip the default or take a different shape entirely, happy to adjust.
