### PR TITLE
fix: Eager processing transcribes chunks with whisper when a non-whisper engi...

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3409,7 +3409,10 @@ impl Daemon {
                             _ => None,
                         };
                         eager_transcriber = transcriber_preloaded.clone();
-                        if eager_transcriber.is_none() {
+                        if eager_transcriber.is_none()
+                            && self.config.engine
+                                == crate::config::TranscriptionEngine::Whisper
+                        {
                             // Whisper engine: get from model manager
                             if let Some(ref mut mm) = self.model_manager {
                                 match mm.get_prepared_transcriber(model_override) {


### PR DESCRIPTION
Fixes #618.

## Summary

Eager processing transcribes chunks with whisper when a non-whisper engine uses on-demand loading

## Validation

- Mechanical gate: +4/-1, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->