### PR TITLE
Bump nixpkgs so Nix CI fetches crates from static.crates.io (dev)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Same fix as #615, applied to dev's flake.lock: crates.io now rejects generic curl user agents on the legacy `/api/v1/crates/.../download` endpoint, which fails every Nix CI job with curl 403. The pinned nixpkgs (2026-03-24) `importCargoLock` still fetched crates through that endpoint; the 2026-08-26 rev downloads from the static.crates.io CDN instead ([rust-lang/crates.io#13482](https://github.com/rust-lang/crates.io/issues/13482)).

`nix flake update nixpkgs` only; no other inputs touched. #615 verified the same bump green on rc/1.0.0 (full Nix build passed). Once this merges, rerunning #621's checks should clear its Nix failures. main will need the same bump when it next matters.