### PR TITLE
Cherry-pick the eager engine fix onto rc/1.0.0

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3409,7 +3409,10 @@ impl Daemon {
                             _ => None,
                         };
                         eager_transcriber = transcriber_preloaded.clone();
-                        if eager_transcriber.is_none() {
+                        if eager_transcriber.is_none()
+                            && self.config.engine
+                                == crate::config::TranscriptionEngine::Whisper
+                        {
                             // Whisper engine: get from model manager
                             if let Some(ref mut mm) = self.model_manager {
                                 match mm.get_prepared_transcriber(model_override) {


### PR DESCRIPTION
Cherry-pick of 74e2b0e from #621 (dev) onto rc/1.0.0, for 1.0.0. Fixes #618 on the release branch: eager processing no longer transcribes chunks with whisper when a non-whisper engine uses on-demand loading. Applied clean with `-x`; authorship remains @yhay81's. Clippy and the lib test suite pass locally.