### PR TITLE
Consume stale cancel triggers at recording start

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -975,6 +975,15 @@ impl Daemon {
     /// at 100 Hz during recording. The emitter task is tracked so it can
     /// be cleanly aborted when recording stops.
     async fn start_recording_capture(&mut self) -> std::result::Result<Box<dyn AudioCapture>, ()> {
+        // A `record cancel` issued while idle leaves its trigger file behind,
+        // and the idle-time sweep that was meant to consume it never runs:
+        // its 500ms timer sits in a select! loop whose unconditional 100ms
+        // poll arm recreates every timer each iteration, so the 500ms sleep
+        // restarts forever. A stale trigger then kills this recording (and
+        // each one after it) ~100-400ms in. Consume it here, at the single
+        // point every recording path passes through, so a cancel can only
+        // ever apply to a recording that was live when it was issued (#606).
+        cleanup_cancel_file();
         match audio::create_capture(&self.config.audio) {
             Ok(mut capture) => match capture.start().await {
                 Ok(chunk_rx) => {
@@ -1036,6 +1045,10 @@ impl Daemon {
         streaming_chain: &mut Option<Vec<Box<dyn TextOutput>>>,
         model_override: Option<String>,
     ) -> bool {
+        // Same stale-trigger hazard as start_recording_capture: Streaming is
+        // an is_recording() state, so a leftover cancel file would kill the
+        // session moments after it starts. See #606.
+        cleanup_cancel_file();
         let Some(transcriber) = transcriber_preloaded.as_ref() else {
             return false;
         };


### PR DESCRIPTION
Fixes #606 (refiled from #590 by @perfektnacht; original analysis by @Mees-Molenaar).

## Why the 0.7.5 fix didn't work

e6327aa added a 500ms idle-state arm to the daemon's `select!` loop to sweep stale cancel files. But the loop also has an unconditional 100ms poll arm (meeting-command IPC), and `tokio::select!` drops and recreates the un-completed timer futures on every iteration — so the 500ms sleep restarts each time the 100ms arm fires and never completes. Verified empirically on a live rc-era daemon: `record cancel` while idle left the trigger file in place indefinitely.

## Fix

Consume any stale trigger at the two entry points every capture passes through: `start_recording_capture` (batch + eager) and `try_start_streaming` (Streaming is an `is_recording()` state, so it was killable too). A cancel can now only apply to a session that was live when it was issued. Cancel-during-recording behavior is unchanged.

## Notes

- The starved idle arm also never runs its ~60s idle model eviction — pre-existing since 0.7.5, not a regression, left for a follow-up issue rather than widening this change on release day.
- Repro before/after: `voxtype record cancel` while idle, then start a recording. Before: cancelled ~100-400ms in. After: records normally.
- Clippy clean, 949 lib tests pass.