### PR TITLE
Keep the --wait-file code span off a line start so Pages builds

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -49,8 +49,9 @@ Without `--json`, an `ok` transcript is printed on stdout and any other outcome
 is reported on stderr. The exit code is the same either way.
 
 `--wait` needs to know which transcript to wait on. It uses the `--file` path
-the recording was started with, so you normally pass nothing; use `--wait-file
-<PATH>` to name it explicitly, and `--timeout <SECS>` to bound the wait.
+the recording was started with, so you normally pass nothing; use
+`--wait-file <PATH>` to name it explicitly, and `--timeout <SECS>` to bound the
+wait.
 
 ### Why not poll the file yourself
 


### PR DESCRIPTION
The GitHub Pages deploy on main is failing, so voxtype.io is not updating. This unblocks it.

## What broke

```
[vite:vue] docs/INTEGRATIONS.md (63:47): Element is missing end tag.
```

An inline code span wrapped across a newline so that `<PATH>` started the next line:

```
... you normally pass nothing; use `--wait-file
<PATH>` to name it explicitly ...
```

The angle bracket at line start was read as raw HTML instead of code-span content, and Vue's template compiler rejected the unclosed `<PATH>` tag.

The reported position is misleading: 63:47 is an offset into the rendered output, not the source. Source line 63 contains `` `<transcript>.done` ``, which looks like the obvious suspect — I confirmed it is not by replacing it and reproducing the identical error.

## Fix

Rewrap so the span sits on one line. Multi-line code spans are fine in general (`CONFIGURATION.md` has two that render correctly); the trigger is specifically an angle bracket at a line start.

## Verified

Reproduced locally, fixed, and rebuilt: `build complete in 3.13s`. The rendered HTML is `<code>--wait-file &lt;PATH&gt;</code>` — same meaning, properly escaped. Prose is unchanged.