### PR TITLE
Build and publish AppImages from CI

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,169 @@
+name: Build AppImage
+
+# AppImages are assembled from the release binaries rather than compiled here:
+# `scripts/build-appimage.sh` bundles the already-built variants behind the
+# dispatch wrapper in `packaging/appimage/`, so this workflow only needs the
+# artifacts that Build Linux produced.
+#
+# History worth knowing: the AppImage tooling landed in April 2026 but was
+# never wired into any release process, so no release has ever carried an
+# AppImage asset even though INSTALL.md and the website advertised one (#622).
+# The .deb/.rpm steps had the same failure mode until v0.7.5 moved them into
+# CI. This workflow closes the same gap for AppImages.
+#
+# Triggers:
+#   - workflow_run: fires after "Build Linux" succeeds, so the release assets
+#     this job downloads already exist.
+#   - workflow_dispatch: build for any published tag on demand, which is how
+#     an existing release gets backfilled.
+#
+# Signing uses the same dedicated CI release primary as every other artifact
+# (9CCF7915...), via the GPG_PRIVATE_KEY / GPG_PASSPHRASE secrets.
+
+on:
+  workflow_run:
+    workflows: ["Build Linux"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build AppImages for, without the leading v (e.g. 1.0.0)"
+        required: true
+        type: string
+
+# Required to upload assets onto an existing release.
+permissions:
+  contents: write
+
+jobs:
+  appimage:
+    name: build-appimage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # On workflow_run, only proceed when the upstream build actually succeeded
+    # and it was a tag build; a branch build has no release to upload to.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version and tag
+        id: version
+        run: |
+          set -euo pipefail
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
+            VERSION='${{ inputs.version }}'
+          else
+            # head_branch is the tag name for a tag-triggered run (e.g. v1.0.0).
+            VERSION='${{ github.event.workflow_run.head_branch }}'
+            VERSION="${VERSION#v}"
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+            echo "::error::Unexpected version '$VERSION'"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building AppImages for v${VERSION}"
+
+      # AppImages need FUSE to run, but appimagetool only needs to write the
+      # squashfs image; --appimage-extract-and-run avoids requiring FUSE on
+      # the runner.
+      - name: Install appimagetool dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y desktop-file-utils zsync
+
+      # Pull the binaries this release already published. The build script
+      # expects them under releases/<version>/ with their published names.
+      - name: Download release binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.version.outputs.version }}'
+          TAG='${{ steps.version.outputs.tag }}'
+          mkdir -p "releases/${VERSION}"
+          cd "releases/${VERSION}"
+          # Only the x86_64 engine binaries feed the AppImages; skip
+          # signatures, packages, and the OSD/bridge companions.
+          for v in avx2 avx512 vulkan onnx-avx2 onnx-avx512 onnx-cuda-12 onnx-cuda-13; do
+            name="voxtype-${VERSION}-linux-x86_64-${v}"
+            if gh release download "${TAG}" --repo '${{ github.repository }}' \
+                 --pattern "${name}" --clobber 2>/dev/null; then
+              chmod +x "${name}"
+              echo "fetched ${name}"
+            else
+              echo "::warning::${name} not present on ${TAG}; its AppImage will be skipped"
+            fi
+          done
+          ls -1
+
+      - name: Build AppImages
+        run: |
+          set -euo pipefail
+          ./scripts/build-appimage.sh '${{ steps.version.outputs.version }}'
+          echo "Produced:"
+          ls -lh "releases/${{ steps.version.outputs.version }}"/*.AppImage
+
+      # Same ephemeral-keyring plumbing as the binary signing step in
+      # build-linux.yml. Skipped with a warning when secrets are unavailable
+      # (e.g. a fork), so the build itself still validates.
+      - name: Sign AppImages
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GPG_PRIVATE_KEY:-}" || -z "${GPG_PASSPHRASE:-}" ]]; then
+            echo "::warning::GPG secrets not set; skipping AppImage signing."
+            exit 0
+          fi
+          VERSION='${{ steps.version.outputs.version }}'
+          SIGNING_KEY="9CCF7915B750CAE8B095ED1AA3FC9F33FD209279"
+          WORK=$(mktemp -d)
+          trap 'rm -rf "${WORK}"' EXIT
+          export GNUPGHOME="${WORK}/gpg"
+          mkdir -p "${GNUPGHOME}"
+          chmod 700 "${GNUPGHOME}"
+          printf 'allow-loopback-pinentry\n' > "${GNUPGHOME}/gpg-agent.conf"
+          printf 'pinentry-mode loopback\n' > "${GNUPGHOME}/gpg.conf"
+          gpgconf --kill gpg-agent || true
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+          cd "releases/${VERSION}"
+          shopt -s nullglob
+          for f in *.AppImage; do
+            printf '%s' "${GPG_PASSPHRASE}" | gpg --batch --yes \
+                --pinentry-mode loopback --passphrase-fd 0 \
+                --local-user "${SIGNING_KEY}!" \
+                --detach-sign --armor --output "${f}.asc" "${f}"
+            echo "Signed ${f}"
+          done
+
+      - name: Upload AppImages to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.version.outputs.version }}'
+          TAG='${{ steps.version.outputs.tag }}'
+          cd "releases/${VERSION}"
+          shopt -s nullglob
+          files=(*.AppImage *.AppImage.asc)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "::error::No AppImages were produced"
+            exit 1
+          fi
+          gh release upload "${TAG}" "${files[@]}" \
+            --repo '${{ github.repository }}' --clobber
+          echo "Uploaded: ${files[*]}"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: voxtype-${{ steps.version.outputs.version }}-appimages
+          path: releases/${{ steps.version.outputs.version }}/*.AppImage*
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -2,10 +2,11 @@
 # Build AppImage packages for voxtype
 # Uses pre-built release binaries from releases/{version}/
 #
-# Produces 3 AppImages:
-#   voxtype-{ver}-x86_64.AppImage          Whisper (avx2 + avx512 + vulkan)
-#   voxtype-{ver}-onnx-x86_64.AppImage     ONNX engines (onnx-avx2 + onnx-avx512 + vulkan)
-#   voxtype-{ver}-onnx-cuda-x86_64.AppImage  ONNX CUDA (onnx-cuda + vulkan)
+# Produces 4 AppImages:
+#   voxtype-{ver}-x86_64.AppImage               Whisper (avx2 + avx512 + vulkan)
+#   voxtype-{ver}-onnx-x86_64.AppImage          ONNX engines (onnx-avx2 + onnx-avx512 + vulkan)
+#   voxtype-{ver}-onnx-cuda-12-x86_64.AppImage  ONNX CUDA 12 (onnx-cuda-12 + vulkan)
+#   voxtype-{ver}-onnx-cuda-13-x86_64.AppImage  ONNX CUDA 13 (onnx-cuda-13 + vulkan)
 #
 # Usage:
 #   ./scripts/build-appimage.sh [options] VERSION
@@ -222,12 +223,18 @@ build_onnx() {
     build_appimage "$appdir" "voxtype-${VERSION}-onnx-x86_64.AppImage"
 }
 
-# ONNX CUDA AppImage: onnx-cuda + vulkan
+# ONNX CUDA AppImage: onnx-cuda-<major> + vulkan
+#
+# v0.7.0 split the single `onnx-cuda` binary into `onnx-cuda-12` and
+# `onnx-cuda-13` (ort picks its CUDA major at build time). This function takes
+# the CUDA major as its first argument and emits one AppImage per major, so a
+# user on either driver generation has something that runs.
 build_onnx_cuda() {
+    local cuda_major="$1"
     echo ""
-    echo "Building ONNX CUDA AppImage (onnx-cuda + vulkan)..."
+    echo "Building ONNX CUDA ${cuda_major} AppImage (onnx-cuda-${cuda_major} + vulkan)..."
 
-    local onnx_cuda="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-cuda"
+    local onnx_cuda="$RELEASE_DIR/voxtype-${VERSION}-linux-x86_64-onnx-cuda-${cuda_major}"
     if [[ ! -f "$onnx_cuda" ]]; then
         echo "  Skipping: $onnx_cuda not found" >&2
         return 1
@@ -254,7 +261,7 @@ build_onnx_cuda() {
     chmod 755 "$appdir/AppRun"
 
     populate_shared_files "$appdir"
-    build_appimage "$appdir" "voxtype-${VERSION}-onnx-cuda-x86_64.AppImage"
+    build_appimage "$appdir" "voxtype-${VERSION}-onnx-cuda-${cuda_major}-x86_64.AppImage"
 }
 
 # Main
@@ -271,12 +278,14 @@ case "$VARIANT" in
         build_onnx || failed=1
         ;;
     onnx-cuda)
-        build_onnx_cuda || failed=1
+        build_onnx_cuda 12 || failed=1
+        build_onnx_cuda 13 || failed=1
         ;;
     all)
         build_whisper || failed=1
         build_onnx || failed=1
-        build_onnx_cuda || failed=1
+        build_onnx_cuda 12 || failed=1
+        build_onnx_cuda 13 || failed=1
         ;;
     *)
         echo "Error: Unknown variant '$VARIANT'" >&2


### PR DESCRIPTION
Fixes #622.

## What was actually wrong

The AppImage tooling (`scripts/build-appimage.sh` + `packaging/appimage/`) landed on 2026-04-18, but it was never wired into any release process. I checked all 67 releases: **none has ever carried an AppImage asset**, including every release since the script landed. Meanwhile `docs/INSTALL.md` and the website advertised a download link, which is the 404 @jfml reported.

This is the same failure mode the .deb and .rpm had until v0.7.5 moved them into CI — a manual step that quietly stopped happening.

## Changes

**New workflow `.github/workflows/build-appimage.yml`:**
- Runs on `workflow_run` after Build Linux succeeds on a tag, so the release assets it consumes already exist
- Also takes a `version` input via `workflow_dispatch`, so an already-published release can be backfilled (v1.0.0 included)
- Downloads the published x86_64 engine binaries, runs the build script, signs each AppImage with the same CI release primary (`9CCF7915...`) using the same ephemeral-keyring plumbing as build-linux.yml, and uploads them to the release

**Fix in `scripts/build-appimage.sh`:** it still looked for `voxtype-$VER-linux-x86_64-onnx-cuda`, a name that stopped existing when v0.7.0 split CUDA into `onnx-cuda-12` and `onnx-cuda-13`. That AppImage had been hitting its "Skipping: not found" branch ever since. `build_onnx_cuda` now takes the CUDA major and emits one AppImage per generation.

## Verified locally against the published 1.0.0 binaries

All four AppImages build and run:

| AppImage | Size | `--version` | transcribe |
|---|---|---|---|
| voxtype-1.0.0-x86_64 (Whisper) | 30M | 1.0.0 | correct |
| voxtype-1.0.0-onnx-x86_64 | 46M | 1.0.0 | correct |
| voxtype-1.0.0-onnx-cuda-12-x86_64 | 32M | 1.0.0 | — |
| voxtype-1.0.0-onnx-cuda-13-x86_64 | 26M | 1.0.0 | — |

(The CUDA pair transcribes through its CPU fallback here; no NVIDIA GPU on this machine.)

Once merged, `gh workflow run build-appimage.yml -f version=1.0.0` backfills the current release.