### PR TITLE
Add --no-osd for per-recording OSD suppression

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -529,7 +529,17 @@ voxtype record start --auto-submit
 
 # Disable auto-submit just this recording (even if config has auto_submit = true)
 voxtype record toggle --no-auto-submit
+
+# Suppress the on-screen display for just this recording
+voxtype record start --no-osd
 ```
+
+`--no-osd` hides the OSD for that recording only and leaves `osd.enabled` in
+`config.toml` untouched. It exists for programs that drive dictation and draw
+their own UI: without it, the only way to suppress the overlay is to rewrite the
+user's config and restart the daemon. Both OSD frontends honor it, and the
+daemon still reports the real state, so Waybar and `voxtype status` are
+unaffected.
 
 ---
 

--- a/quickshell/OsdSurface.qml
+++ b/quickshell/OsdSurface.qml
@@ -11,7 +11,8 @@
 // `audio` property so the OsdSurface, EnginePicker, and MeetingControls
 // share one sidecar process rather than each spawning their own.
 //
-// Visibility follows `daemonState`: hidden when idle/empty, shown
+// Visibility follows `daemonState` unless `osdSuppressed` is set:
+// hidden when suppressed or idle/empty, shown
 // otherwise. The component is layered as a WlrLayer.Overlay surface so
 // it floats above all other windows without taking input focus.
 
@@ -28,6 +29,12 @@ PanelWindow {
     /// Wired by the parent (typically from VT.StateReader.state).
     property string daemonState: "idle"
 
+    /// Set while the in-flight recording was started with `--no-osd`. Wired by
+    /// the parent from VT.StateReader.osdSuppressed. Keeps the surface hidden
+    /// for tools that draw their own dictation UI, without touching the
+    /// daemon's reported state.
+    property bool osdSuppressed: false
+
     /// The audio bridge instance whose frameReceived signal drives the
     /// waveform. Passed in by the parent so it's shared with sibling
     /// widgets that also want VAD / peak data.
@@ -37,7 +44,7 @@ PanelWindow {
     /// visual recipe layers, and optional custom QML package entry.
     property var style: null
 
-    visible: daemonState !== "idle" && daemonState !== ""
+    visible: !osdSuppressed && daemonState !== "idle" && daemonState !== ""
     anchors {
         top: true
         bottom: true

--- a/quickshell/shell.qml
+++ b/quickshell/shell.qml
@@ -52,6 +52,7 @@ ShellRoot {
     OsdSurface {
         id: osd
         daemonState: stateReader.state
+        osdSuppressed: stateReader.osdSuppressed
         audio: audio
         style: osdStyle
     }

--- a/quickshell/voxtype-shared/StateReader.qml
+++ b/quickshell/voxtype-shared/StateReader.qml
@@ -15,6 +15,12 @@
 //       }
 //   }
 //
+// The component also exposes `osdSuppressed`, set while the daemon is
+// running a recording started with `voxtype record start --no-osd`. OSD
+// surfaces should stay hidden while it is true; the daemon state itself is
+// still reported truthfully, because Waybar and every other status consumer
+// depends on it.
+//
 // The component exposes `state` as a bindable property so consumers
 // don't have to listen for the signal:
 //
@@ -54,6 +60,17 @@ QtObject {
     /// changes; consumers read the current value off the property.
     property string state: "idle"
 
+    /// Sibling marker written by the daemon while a `--no-osd` recording is
+    /// in flight. True means "do not draw the OSD for this one".
+    property string osdSuppressedPath: {
+        const base = root.statePath;
+        const cut = base.lastIndexOf("/");
+        return (cut > 0 ? base.substring(0, cut) : base) + "/osd_suppressed";
+    }
+
+    /// True while the in-flight recording asked for the OSD to stay hidden.
+    property bool osdSuppressed: false
+
     // FileView re-reads on file changes when watchChanges is true. We
     // update the `state` property inside onLoaded; QML's property change
     // signal fires automatically for binding-based and imperative
@@ -73,6 +90,29 @@ QtObject {
         onLoadFailed: {
             if (root.state !== "idle") {
                 root.state = "idle";
+            }
+        }
+
+        onFileChanged: reload()
+    }
+
+    // The marker is created and removed rather than rewritten, so both the
+    // load and the failure path carry meaning: present means suppress, absent
+    // (the common case) means draw normally.
+    property FileView _osdSuppressedView: FileView {
+        path: root.osdSuppressedPath
+        watchChanges: true
+        printErrors: false
+
+        onLoaded: {
+            if (!root.osdSuppressed) {
+                root.osdSuppressed = true;
+            }
+        }
+
+        onLoadFailed: {
+            if (root.osdSuppressed) {
+                root.osdSuppressed = false;
             }
         }
 

--- a/src/app/record.rs
+++ b/src/app/record.rs
@@ -114,6 +114,15 @@ pub(crate) fn send_record_command(
             .map_err(|e| anyhow::anyhow!("Failed to write shift_enter override: {}", e))?;
     }
 
+    // Write the OSD suppression sentinel if --no-osd was passed. Only written,
+    // never cleared here: like the other overrides the daemon consumes and
+    // removes it, so a stale file cannot silence a later recording.
+    if action.suppress_osd() {
+        let override_file = config::Config::runtime_dir().join("no_osd_override");
+        std::fs::write(&override_file, "true")
+            .map_err(|e| anyhow::anyhow!("Failed to write no_osd override: {}", e))?;
+    }
+
     // For toggle, we need to read current state to decide which signal to send
     let signal: libc::c_int = match &action {
         RecordAction::Start { .. } => libc::SIGUSR1,

--- a/src/bin/voxtype_osd_gtk4.rs
+++ b/src/bin/voxtype_osd_gtk4.rs
@@ -77,6 +77,21 @@ const RENDER_TICK_MS: u32 = 16;
 /// hiding the surface. Matches the BRIEF's "Idle: surface destroyed" rule.
 const IDLE_TIMEOUT_SECS: f32 = 0.15;
 
+/// True while the daemon has marked the in-flight recording as OSD-suppressed
+/// (`voxtype record start --no-osd`).
+///
+/// Frames stop flowing for a suppressed recording too, so the idle timeout
+/// alone would hide the surface. This is checked anyway so suppression is
+/// immediate rather than waiting out IDLE_TIMEOUT_SECS, and so the behaviour
+/// matches the Quickshell frontend exactly.
+fn osd_suppressed() -> bool {
+    let base = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| format!("/run/user/{}", unsafe { libc::getuid() }));
+    std::path::Path::new(&base)
+        .join("voxtype/osd_suppressed")
+        .exists()
+}
+
 /// Number of segments in the vertical peak meter.
 const METER_SEGMENTS: usize = 10;
 
@@ -430,7 +445,7 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
             .lock()
             .map(|t| *t)
             .unwrap_or_else(|_| Instant::now() - Duration::from_secs(3600));
-        let idle = last_at.elapsed().as_secs_f32() > IDLE_TIMEOUT_SECS;
+        let idle = last_at.elapsed().as_secs_f32() > IDLE_TIMEOUT_SECS || osd_suppressed();
 
         if idle {
             if visible.get() {

--- a/src/cli/record.rs
+++ b/src/cli/record.rs
@@ -57,6 +57,14 @@ pub enum RecordAction {
         #[arg(long, conflicts_with = "shift_enter_newlines")]
         no_shift_enter_newlines: bool,
 
+        /// Suppress the on-screen display for this recording only
+        ///
+        /// Leaves `osd.enabled` in config.toml untouched. Intended for external
+        /// tools that draw their own dictation UI and do not want voxtype's
+        /// overlay on top of it.
+        #[arg(long)]
+        no_osd: bool,
+
         /// Enable smart auto-submit for this recording (say "submit" to press Enter)
         #[arg(long, conflicts_with = "no_smart_auto_submit")]
         smart_auto_submit: bool,
@@ -146,6 +154,14 @@ pub enum RecordAction {
         /// Disable Shift+Enter newlines for this transcription (overrides config)
         #[arg(long, conflicts_with = "shift_enter_newlines")]
         no_shift_enter_newlines: bool,
+
+        /// Suppress the on-screen display for this recording only
+        ///
+        /// Leaves `osd.enabled` in config.toml untouched. Intended for external
+        /// tools that draw their own dictation UI and do not want voxtype's
+        /// overlay on top of it.
+        #[arg(long)]
+        no_osd: bool,
 
         /// Enable smart auto-submit for this recording (say "submit" to press Enter)
         #[arg(long, conflicts_with = "no_smart_auto_submit")]
@@ -261,6 +277,18 @@ impl RecordAction {
                 ..
             } => override_from_flags(*auto_submit, *no_auto_submit),
             RecordAction::Stop { .. } | RecordAction::Cancel => None,
+        }
+    }
+
+    /// Get the OSD suppression request from --no-osd.
+    ///
+    /// Returns true only when the flag is present; there is deliberately no
+    /// `--osd` counterpart, because "show the OSD" is already the config
+    /// default and a per-recording opt-in has no caller.
+    pub fn suppress_osd(&self) -> bool {
+        match self {
+            RecordAction::Start { no_osd, .. } | RecordAction::Toggle { no_osd, .. } => *no_osd,
+            RecordAction::Stop { .. } | RecordAction::Cancel => false,
         }
     }
 
@@ -752,6 +780,65 @@ mod tests {
         match cli.command {
             Some(Commands::Record { action }) => {
                 assert_eq!(action.auto_submit_override(), Some(true));
+            }
+            _ => panic!("Expected Record command"),
+        }
+    }
+
+    /// #636: --no-osd suppresses the OSD for one recording. Parsed on both
+    /// start and toggle, absent by default, and never claimed by stop/cancel
+    /// (the OSD decision belongs to the recording that opens the surface).
+    #[test]
+    fn test_record_no_osd_flag() {
+        for sub in ["start", "toggle"] {
+            let cli = Cli::parse_from(["voxtype", "record", sub, "--no-osd"]);
+            match cli.command {
+                Some(Commands::Record { action }) => {
+                    assert!(action.suppress_osd(), "--no-osd not honored on {}", sub);
+                }
+                _ => panic!("Expected Record command"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_record_no_osd_defaults_off() {
+        for args in [
+            vec!["voxtype", "record", "start"],
+            vec!["voxtype", "record", "toggle"],
+            vec!["voxtype", "record", "stop"],
+            vec!["voxtype", "record", "cancel"],
+        ] {
+            let cli = Cli::parse_from(args.clone());
+            match cli.command {
+                Some(Commands::Record { action }) => {
+                    assert!(
+                        !action.suppress_osd(),
+                        "unexpected suppression for {:?}",
+                        args
+                    );
+                }
+                _ => panic!("Expected Record command"),
+            }
+        }
+    }
+
+    /// The flag is orthogonal to the other per-recording overrides; combining
+    /// them must not disturb either.
+    #[test]
+    fn test_record_no_osd_composes_with_other_overrides() {
+        let cli = Cli::parse_from([
+            "voxtype",
+            "record",
+            "start",
+            "--no-osd",
+            "--no-auto-submit",
+            "--file",
+        ]);
+        match cli.command {
+            Some(Commands::Record { action }) => {
+                assert!(action.suppress_osd());
+                assert_eq!(action.auto_submit_override(), Some(false));
             }
             _ => panic!("Expected Record command"),
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -24,7 +24,7 @@ use crate::state::{ChunkResult, State};
 use crate::text::TextProcessor;
 use crate::transcribe::{StreamHandle, StreamingEvent, Transcriber};
 use pidlock::Pidlock;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -100,6 +100,36 @@ fn write_state_file(path: &PathBuf, state: &str) {
 }
 
 /// Remove state file on shutdown
+/// Path of the marker that tells OSD frontends to stay hidden for the
+/// recording in flight. Written when a recording starts with `--no-osd`,
+/// removed when the daemon returns to idle.
+///
+/// A marker file rather than a state-file value on purpose: the status JSON
+/// contract went stable in 1.0.0, and Waybar, `status --follow`, and every
+/// other consumer must keep seeing the real state. Only the OSD frontends
+/// read this.
+fn osd_suppressed_path() -> PathBuf {
+    Config::runtime_dir().join("osd_suppressed")
+}
+
+fn set_osd_suppressed(suppressed: bool) {
+    set_osd_suppressed_at(&osd_suppressed_path(), suppressed);
+}
+
+/// Path-taking half of `set_osd_suppressed`, so the marker lifecycle is
+/// testable without mocking `Config::runtime_dir()`.
+fn set_osd_suppressed_at(path: &Path, suppressed: bool) {
+    if suppressed {
+        if let Err(e) = std::fs::write(path, "1") {
+            tracing::warn!("Failed to write OSD suppression marker: {}", e);
+        }
+    } else if path.exists() {
+        if let Err(e) = std::fs::remove_file(path) {
+            tracing::warn!("Failed to clear OSD suppression marker: {}", e);
+        }
+    }
+}
+
 fn cleanup_state_file(path: &PathBuf) {
     if path.exists() {
         if let Err(e) = std::fs::remove_file(path) {
@@ -965,6 +995,21 @@ impl Daemon {
     fn update_state(&self, state_name: &str) {
         if let Some(ref path) = self.state_file_path {
             write_state_file(path, state_name);
+        }
+
+        // OSD suppression marker lifecycle. Consuming the sentinel here rather
+        // than at output time is deliberate: the OSD appears when recording
+        // starts, so the decision has to be made before the surface is drawn.
+        // The marker survives the transcribing state and is cleared on the way
+        // back to idle.
+        match state_name {
+            "recording" | "streaming" => {
+                if read_bool_override("no_osd").unwrap_or(false) {
+                    set_osd_suppressed(true);
+                }
+            }
+            "idle" | "stopped" => set_osd_suppressed(false),
+            _ => {}
         }
     }
 
@@ -4299,6 +4344,31 @@ mod tests {
         // `value_parser` requires touching this test, keeping the daemon
         // and CLI surfaces in sync.
         assert_eq!(ALLOWED_DIARIZATION_OVERRIDES, &["simple", "ml"]);
+    }
+
+    /// #636: the OSD suppression marker is created and removed, never
+    /// rewritten, because both OSD frontends treat "file exists" as the
+    /// signal. Absent is the overwhelmingly common case and must be cheap.
+    #[test]
+    fn test_osd_suppression_marker_lifecycle() {
+        with_test_runtime_dir(|dir| {
+            let marker = dir.join("osd_suppressed");
+            assert!(!marker.exists(), "marker must start absent");
+
+            set_osd_suppressed_at(&marker, true);
+            assert!(marker.exists(), "marker not written");
+
+            // Idempotent: setting it twice is not an error and leaves one file.
+            set_osd_suppressed_at(&marker, true);
+            assert!(marker.exists());
+
+            set_osd_suppressed_at(&marker, false);
+            assert!(!marker.exists(), "marker not cleared");
+
+            // Clearing an already-absent marker must not panic or error.
+            set_osd_suppressed_at(&marker, false);
+            assert!(!marker.exists());
+        });
     }
 
     #[test]


### PR DESCRIPTION
Closes #636. First 1.0.1 item, against `dev`.

## Why

The only way to suppress the OSD was `osd.enabled` in config.toml, which is global and read once at daemon startup. A program that drives dictation and draws its own UI therefore has to rewrite the user's config and restart the daemon. OmaPilot does precisely that in `runtime/src/voxtype-osd.ts`: read config.toml, rewrite `[osd] enabled`, keep a `.omapilot.bak`, write at mode 0600, then `systemctl --user restart voxtype.service` with a 15s timeout. With this flag that file can be deleted upstream. Already promised to the maintainer in [spencerbull/omarchy-omapilot#18](https://github.com/spencerbull/omarchy-omapilot/issues/18).

## How

`--no-osd` on `record start` and `record toggle`, following the existing `--no-auto-submit` shape. The CLI writes a `no_osd_override` sentinel alongside the other per-recording overrides; the daemon consumes it on the transition into recording and publishes an `osd_suppressed` marker, cleared on the way back to idle.

**The marker is a separate file, not a state-file value.** The status JSON contract went stable in 1.0.0 and Waybar, `status --follow`, and every other consumer must keep seeing the true state. Only the OSD frontends read the marker.

**Both frontends honor it**, which turned out to be necessary rather than thorough. They gate visibility differently: the GTK4 frontend is frame-driven (hides after `IDLE_TIMEOUT_SECS` without audio frames) while the Quickshell surface is state-driven (`visible: daemonState !== "idle"`). Withholding frames alone would have fixed GTK4 and left Quickshell showing a waveform-less card — exactly the frontend the OmaPilot users are on. So:

- `quickshell/voxtype-shared/StateReader.qml` watches the marker and exposes `osdSuppressed`
- `quickshell/OsdSurface.qml` gates its `visible` binding on it, wired through `shell.qml`
- `src/bin/voxtype_osd_gtk4.rs` treats the marker like the idle condition, so suppression is immediate rather than waiting out the timeout

## Testing

Four new tests: three on CLI parsing (both subcommands, defaults off across all four record actions, composes with other overrides) and one on the daemon marker lifecycle including idempotent set and clear-when-absent. Full suite passes (954), clippy clean on all targets.

Verified the CLI half against the running daemon: `record start --no-osd` writes the sentinel. The end-to-end path needs a daemon built from this branch, which I did not swap onto the release daemon in use; the daemon logic is covered by the lifecycle test instead.

## Note for reviewers

`set_osd_suppressed` is split into a path-taking `set_osd_suppressed_at` so the lifecycle is testable — `with_test_runtime_dir` does not mock `Config::runtime_dir()`, and the existing tests in that module work around it by duplicating file logic inline rather than exercising the real functions.