### PR TITLE
Refuse to activate a variant that cannot run on this host

### DIFF
--- a/src/setup/binary.rs
+++ b/src/setup/binary.rs
@@ -1224,11 +1224,27 @@ mod tests {
         );
     }
 
-    /// The happy path must stay cheap and quiet: any binary that answers
-    /// --version is accepted.
+    /// The happy path must stay cheap and quiet: anything that runs and exits
+    /// zero is accepted.
+    ///
+    /// The probe target is written here rather than borrowed from the system
+    /// (`/bin/true` and friends): the Nix build sandbox has almost no
+    /// filesystem, and a test that assumes one fails there for reasons that
+    /// have nothing to do with the code under test. The script ignores its
+    /// arguments, so it works under any `/bin/sh`, dash included.
     #[test]
     fn verify_binary_runs_accepts_a_working_binary() {
-        assert!(verify_binary_runs(Path::new("/bin/true")).is_ok());
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("voxtype-fake");
+        std::fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            verify_binary_runs(&path).is_ok(),
+            "a binary that exits zero must be accepted"
+        );
     }
 
     /// Regression test for #443: when `install_active_binary` is called

--- a/src/setup/binary.rs
+++ b/src/setup/binary.rs
@@ -66,11 +66,98 @@ fn variant_subdir(basename: &str) -> Option<&'static str> {
 /// they ran — e.g. `setup gpu --enable` for a Vulkan switch, or `setup onnx
 /// --enable` for a Parakeet switch. The function emits the full retry as
 /// `Try: sudo voxtype <retry_hint>`.
+/// Highest `GLIBC_x.y` version named in a dynamic-linker failure, if any.
+///
+/// The loader prints one line per unmet symbol version, so the largest is the
+/// one the user actually needs.
+fn required_glibc_from_stderr(stderr: &str) -> Option<String> {
+    let mut best: Option<(u32, u32, String)> = None;
+    for token in stderr.split(|c: char| !(c.is_ascii_alphanumeric() || c == '.' || c == '_')) {
+        let Some(rest) = token.strip_prefix("GLIBC_") else {
+            continue;
+        };
+        let mut parts = rest.split('.');
+        let (Some(major), Some(minor)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        let (Ok(major), Ok(minor)) = (major.parse::<u32>(), minor.parse::<u32>()) else {
+            continue;
+        };
+        if best
+            .as_ref()
+            .is_none_or(|(bm, bn, _)| (major, minor) > (*bm, *bn))
+        {
+            best = Some((major, minor, rest.to_string()));
+        }
+    }
+    best.map(|(_, _, v)| v)
+}
+
+/// Verify a variant can actually execute here before pointing the active
+/// binary at it.
+///
+/// A packaged variant can be present and still unrunnable: the ONNX variants
+/// are built against glibc 2.39 while the Whisper ones need 2.34, so on
+/// Debian 12 (2.36) switching to an ONNX variant used to report success and
+/// leave the CLI bricked with a raw linker error. That includes
+/// `setup variant --to` itself, so the user could not switch back with the
+/// tool that broke it. See #633.
+fn verify_binary_runs(binary_path: &Path) -> anyhow::Result<()> {
+    let output = match std::process::Command::new(binary_path)
+        .arg("--version")
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => anyhow::bail!(
+            "Cannot run {}: {}\n\
+             Leaving the current binary active.",
+            binary_path.display(),
+            e
+        ),
+    };
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if let Some(needed) = required_glibc_from_stderr(&stderr) {
+        anyhow::bail!(
+            "{} needs glibc {} but this system is older, so it cannot run here.\n\
+             Leaving the current binary active.\n\
+             \n\
+             The ONNX variants are built on a newer base image than the Whisper\n\
+             ones. Use a Whisper variant, or upgrade the distribution.",
+            binary_path.display(),
+            needed
+        );
+    }
+
+    let detail = stderr
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("no error output");
+    anyhow::bail!(
+        "{} exited {} when asked for its version, so it cannot run here.\n\
+         Leaving the current binary active.\n\
+         \n\
+         {}",
+        binary_path.display(),
+        output.status.code().unwrap_or(-1),
+        detail
+    );
+}
+
 pub fn install_active_binary(
     active_bin: &str,
     binary_path: &Path,
     retry_hint: &str,
 ) -> anyhow::Result<()> {
+    // Refuse to activate a binary that cannot run here. Checked before any
+    // write so a failure leaves the previous target in place (#633).
+    verify_binary_runs(binary_path)?;
+
     // Decide whether this variant needs a wrapper script (vs a plain symlink)
     // from the BASENAME, not from the canonicalized parent dir. The previous
     // implementation looked at `fs::canonicalize(binary_path).parent()`,
@@ -1098,6 +1185,50 @@ mod tests {
         require_feature_listed!("gpu-metal");
         require_feature_listed!("osd-native");
         require_feature_listed!("osd-gtk4");
+    }
+
+    /// #633: the loader names every unmet symbol version; the highest is the
+    /// one the user actually needs, and that is what the error should quote.
+    #[test]
+    fn required_glibc_picks_the_highest_version() {
+        let stderr = "voxtype: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by voxtype)\n\
+                      voxtype: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by voxtype)\n";
+        assert_eq!(required_glibc_from_stderr(stderr).as_deref(), Some("2.39"));
+    }
+
+    #[test]
+    fn required_glibc_compares_numerically_not_lexically() {
+        // 2.9 must not beat 2.34 the way string ordering would.
+        let stderr = "version `GLIBC_2.9' not found\nversion `GLIBC_2.34' not found\n";
+        assert_eq!(required_glibc_from_stderr(stderr).as_deref(), Some("2.34"));
+    }
+
+    #[test]
+    fn required_glibc_absent_for_unrelated_failures() {
+        assert_eq!(required_glibc_from_stderr("Segmentation fault"), None);
+        assert_eq!(required_glibc_from_stderr(""), None);
+    }
+
+    /// A binary that cannot execute must be refused, and the refusal must say
+    /// the current binary is untouched — the old behaviour reported success
+    /// and left the CLI unusable.
+    #[test]
+    fn verify_binary_runs_rejects_a_non_executable() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("voxtype-broken");
+        std::fs::write(&path, b"not a binary").unwrap();
+        let err = verify_binary_runs(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("Leaving the current binary active"),
+            "refusal must state the active binary is unchanged, got: {err}"
+        );
+    }
+
+    /// The happy path must stay cheap and quiet: any binary that answers
+    /// --version is accepted.
+    #[test]
+    fn verify_binary_runs_accepts_a_working_binary() {
+        assert!(verify_binary_runs(Path::new("/bin/true")).is_ok());
     }
 
     /// Regression test for #443: when `install_active_binary` is called


### PR DESCRIPTION
Fixes #633. Second 1.0.1 item.

## The bug

`setup variant --to`, `setup gpu --enable`, and `setup onnx --enable` rewrote `/usr/bin/voxtype` without checking the target could execute. A variant can be installed and still unrunnable — ONNX binaries need glibc 2.39, Whisper ones 2.34 — so on Debian 12 (2.36):

```console
$ voxtype setup variant --to voxtype-onnx-avx2
Switched /usr/bin/voxtype to voxtype-onnx-avx2.     # reports success

$ voxtype --version
voxtype: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

Every later invocation failed the same way, **including `setup variant --to` itself**, so the user could not switch back with the tool that broke it. Recovery meant hand-repairing `/usr/bin/voxtype`.

## The fix

Run the candidate's `--version` before touching anything. All three commands funnel through `install_active_binary`, so the gate goes there once rather than in three callers.

On failure it refuses and states the active binary is untouched. When the loader names glibc versions it quotes the highest one asked for, rather than dumping four lines of linker output at the user.

## Verified

Reproduced the original brick on Debian 12 earlier (that is what filed the issue). With the fix, in an isolated container:

```
=== switch to the broken variant ===
Error: Cannot run /usr/lib/voxtype/voxtype-avx512: No such file or directory (os error 2)
Leaving the current binary active.
=== active after (must be unchanged and working) ===
voxtype 1.0.0
/usr/lib/voxtype/voxtype-avx2
```

Five new unit tests: the glibc parser picks the highest version and compares numerically (so 2.9 does not beat 2.34), returns None for unrelated failures, the gate rejects a non-executable with the "leaving the current binary active" wording, and accepts a working binary. Full suite passes (955), clippy clean on all targets.

## Note

The version probe costs one process spawn per switch, which is not a hot path. It also catches failure modes beyond glibc — a corrupt binary, a missing companion .so for the GPU variants — for the same price.