### PR TITLE
Make voxtype configure honor -c/--config

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -403,7 +403,7 @@ pub(crate) async fn dispatch(
         }
 
         Commands::Configure { force_package_mode } => {
-            voxtype::tui::run(force_package_mode)?;
+            voxtype::tui::run(force_package_mode, cli.config.clone())?;
         }
 
         Commands::Status {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -552,11 +552,14 @@ fn detect_missing_model() -> Option<MissingModel> {
 }
 use crate::daemon_status::is_daemon_running;
 
-/// Modification time of the config file the TUI edits (the same
-/// `Config::default_path()` every section's `ConfigEditor::load()` writes
-/// to). `None` when the path can't be resolved or the file doesn't exist.
+/// Modification time of the config file the TUI edits — the same file every
+/// section's `ConfigEditor::load()` writes to, which is the `-c/--config`
+/// override when one was given. Asking the editor rather than resolving the
+/// default keeps the quit-time restart decision (#614) pointed at the file
+/// actually being edited (#595). `None` when the path can't be resolved or
+/// the file doesn't exist.
 pub fn config_file_mtime() -> Option<std::time::SystemTime> {
-    let path = crate::config::Config::default_path()?;
+    let path = super::config_editor::tui_config_path()?;
     std::fs::metadata(path).ok()?.modified().ok()
 }
 

--- a/src/tui/config_editor.rs
+++ b/src/tui/config_editor.rs
@@ -14,6 +14,7 @@ use crate::config;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use toml_edit::{DocumentMut, Item, Value};
 
 #[derive(Debug, thiserror::Error)]
@@ -45,11 +46,54 @@ pub struct ConfigEditor {
     dirty: bool,
 }
 
+/// Config file the TUI edits, when it is not the default.
+///
+/// The TUI has 24 `ConfigEditor::load()` call sites across 12 section modules.
+/// Threading a path through all of them invites a missed one, and a missed one
+/// silently writes the user's real config instead of the file they named —
+/// which is the bug this exists to prevent (#595). Setting it once at TUI
+/// startup keeps the resolution in a single place that cannot be partially
+/// applied.
+static TUI_CONFIG_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Point `ConfigEditor::load()` at a specific file for the rest of this
+/// process. Called once, from `tui::run`, with the `-c/--config` value.
+///
+/// Ignored when `path` is `None` so the default resolution stays untouched,
+/// and a no-op if called twice: the TUI is a single-purpose process and a
+/// second config file mid-run has no meaning.
+pub fn set_tui_config_path(path: Option<PathBuf>) {
+    if let Some(path) = path {
+        let _ = TUI_CONFIG_PATH.set(path);
+    }
+}
+
+/// The config file the TUI is editing: the `-c/--config` override when one was
+/// given, otherwise the default path.
+///
+/// Anything in the TUI that needs to know which file is in play must ask here
+/// rather than calling `Config::default_path()` directly, or it will disagree
+/// with what the sections actually read and write.
+pub fn tui_config_path() -> Option<PathBuf> {
+    resolve_tui_config_path(TUI_CONFIG_PATH.get())
+}
+
+/// Pure form of `tui_config_path`, taking the override explicitly so the
+/// resolution can be tested without touching the process-global `OnceLock`
+/// (which only sets once, making order-dependent tests unavoidable otherwise).
+fn resolve_tui_config_path(override_path: Option<&PathBuf>) -> Option<PathBuf> {
+    match override_path {
+        Some(path) => Some(path.clone()),
+        None => config::Config::default_path(),
+    }
+}
+
 impl ConfigEditor {
-    /// Load `~/.config/voxtype/config.toml` (creating an empty document if the
-    /// file is missing — `save()` will write it on first edit).
+    /// Load the config the TUI is editing: the `-c/--config` file when one was
+    /// given, otherwise `~/.config/voxtype/config.toml`. Creates an empty
+    /// document if the file is missing — `save()` writes it on first edit.
     pub fn load() -> Result<Self, EditorError> {
-        let path = config::Config::default_path().ok_or(EditorError::NoConfigPath)?;
+        let path = tui_config_path().ok_or(EditorError::NoConfigPath)?;
         Self::load_from(path)
     }
 
@@ -357,6 +401,43 @@ mod tests {
         let mut f = fs::File::create(&path).unwrap();
         f.write_all(contents.as_bytes()).unwrap();
         (dir, path)
+    }
+
+    /// #595: an override is used verbatim, and its absence falls back to the
+    /// default so the common case is unchanged.
+    #[test]
+    fn tui_config_path_prefers_the_override() {
+        let scratch = PathBuf::from("/tmp/scratch.toml");
+        assert_eq!(
+            resolve_tui_config_path(Some(&scratch)).as_deref(),
+            Some(scratch.as_path())
+        );
+        // Without an override the answer is whatever the default resolution
+        // says — including None in an environment with no home directory.
+        assert_eq!(
+            resolve_tui_config_path(None),
+            config::Config::default_path()
+        );
+    }
+
+    /// The override is what `load()` consults, and it is what `save()` then
+    /// writes back to — the two must not diverge, which is exactly how the
+    /// bug wrote the user's real config while reporting the scratch file.
+    #[test]
+    fn editor_saves_to_the_path_it_loaded() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let scratch = dir.path().join("scratch.toml");
+        std::fs::write(&scratch, "engine = \"whisper\"\n").unwrap();
+
+        let mut ed = ConfigEditor::load_from_path(scratch.clone()).unwrap();
+        ed.set_string("whisper", "model", "large-v3");
+        ed.save().unwrap();
+
+        let written = std::fs::read_to_string(&scratch).unwrap();
+        assert!(
+            written.contains("large-v3"),
+            "the file that was loaded must be the file that is written"
+        );
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -53,7 +53,17 @@ use section::Section;
 
 type Tui = Terminal<CrosstermBackend<Stdout>>;
 
-pub fn run(force_package_mode: bool) -> anyhow::Result<()> {
+/// Launch the TUI.
+///
+/// `config_path` is the `-c/--config` value; when set, every section reads and
+/// writes that file instead of the default. Installed before the first section
+/// loads, because a section that has already read the default would save back
+/// to it (#595).
+pub fn run(
+    force_package_mode: bool,
+    config_path: Option<std::path::PathBuf>,
+) -> anyhow::Result<()> {
+    config_editor::set_tui_config_path(config_path);
     let mut terminal = enter_terminal()?;
     let result = event_loop(&mut terminal, force_package_mode);
     leave_terminal(&mut terminal)?;


### PR DESCRIPTION
Fixes #595. Third 1.0.1 item.

## The bug

Every TUI section calls `ConfigEditor::load()`, which resolved `Config::default_path()` directly. So `voxtype -c /tmp/scratch.toml configure` read and wrote `~/.config/voxtype/config.toml` regardless. Someone testing a change against a scratch copy got their real config rewritten, while the TUI reported saving the scratch file. `voxtype config set` already honored the flag, so the two ways of editing config disagreed.

## Approach

There are **24 `ConfigEditor::load()` call sites across 12 section modules**. Threading a path parameter through all of them is the obvious fix and the wrong one here: a single missed site keeps writing the user's real config, which is precisely the failure mode that makes this bug harmful rather than annoying. So the resolution happens once, in the loader, from a value installed at TUI startup — it cannot be partially applied.

- `set_tui_config_path()` is called by `tui::run` before the first section loads
- `tui_config_path()` is the single answer to "which file is the TUI editing"
- `ConfigEditor::load()` consults it

## A second site with the same defect

`config_file_mtime()` also called `Config::default_path()`. That is what the quit-time daemon restart from #614 compares against, so under `-c` it watched the wrong file's timestamp and would restart (or fail to restart) based on a config the user never touched. Now routed through the same resolver.

I checked the rest of `src/tui/` for other direct `default_path()` callers; these were the only two.

## Testing

Two new tests. The resolution logic is split into a pure `resolve_tui_config_path(Option<&PathBuf>)` so it can be tested without the process-global `OnceLock` — that only sets once, so any test asserting on its unset state is order-dependent and would break the moment another test set it. The other test pins that an editor saves to the file it loaded, which is the invariant the bug violated.

Full suite passes (952), clippy clean on all targets.

## Not verified end to end

The TUI needs an interactive terminal, so I did not drive the issue's exact reproduction. The wiring is covered by the unit tests plus a grep confirming no section bypasses the loader.