### PR TITLE
Ship the aarch64 OSD binaries CI was already building

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -303,13 +303,17 @@ jobs:
           retention-days: 14
 
       # The OSD launcher + frontends + audio bridge are engine-agnostic and
-      # built once by Dockerfile.onnx alongside the onnx-avx2 binary (same
-      # cargo invocation builds voxtype-osd, voxtype-osd-gtk4,
-      # voxtype-osd-quickshell, and voxtype-audio-bridge). The onnx-avx2
-      # job is the only place these binaries end up in /output, so upload
-      # them as their own artifacts here. Other matrix variants skip.
-      - name: Upload OSD binaries + audio bridge (onnx-avx2 only)
-        if: matrix.variant == 'onnx-avx2'
+      # built alongside the ONNX binary in the same image (one cargo
+      # invocation produces voxtype-osd, voxtype-osd-gtk4,
+      # voxtype-osd-quickshell, and voxtype-audio-bridge). Two matrix jobs
+      # put them in /output: x86_64 onnx-avx2 and aarch64 onnx.
+      #
+      # The aarch64 job built them all along and they were dropped on the
+      # floor, because this upload was keyed to onnx-avx2 alone. Asahi users
+      # were told to build the OSD from source for a binary CI had already
+      # produced (#579).
+      - name: Upload OSD binaries + audio bridge (ONNX jobs only)
+        if: matrix.variant == 'onnx-avx2' || (matrix.arch == 'aarch64' && matrix.variant == 'onnx')
         uses: actions/upload-artifact@v4
         with:
           name: voxtype-${{ steps.version.outputs.version }}-linux-${{ matrix.arch }}-osd

--- a/Dockerfile.aarch64-onnx
+++ b/Dockerfile.aarch64-onnx
@@ -91,14 +91,20 @@ RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,do
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-aarch64-onnx
 
-# Build the OSD launcher and gtk4 frontend in a separate cargo invocation
-# so the daemon binary stays clean of GTK4 / layer-shell baggage.
+# Build the OSD launcher and frontends in a separate cargo invocation so the
+# daemon binary stays clean of GTK4 / layer-shell baggage. Matches the binary
+# set Dockerfile.onnx produces for x86_64: the quickshell launcher and the
+# audio bridge are engine- and arch-agnostic, and an Asahi user running the
+# Quickshell OSD needs both (#579).
 RUN cargo build --release --features osd-gtk4 \
     --bin voxtype-osd --bin voxtype-osd-gtk4 \
+    --bin voxtype-osd-quickshell --bin voxtype-audio-bridge \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype-osd /tmp/voxtype-osd \
-    && cp target/release/voxtype-osd-gtk4 /tmp/voxtype-osd-gtk4
+    && cp target/release/voxtype-osd-gtk4 /tmp/voxtype-osd-gtk4 \
+    && cp target/release/voxtype-osd-quickshell /tmp/voxtype-osd-quickshell \
+    && cp target/release/voxtype-audio-bridge /tmp/voxtype-audio-bridge
 
 # Verify binary
 RUN echo "=== Verifying aarch64 ONNX binary ===" \
@@ -111,5 +117,7 @@ CMD mkdir -p /output \
     && cp /tmp/voxtype-aarch64-onnx /output/voxtype-${VERSION}-linux-aarch64-onnx \
     && cp /tmp/voxtype-osd /output/voxtype-${VERSION}-linux-aarch64-osd \
     && cp /tmp/voxtype-osd-gtk4 /output/voxtype-${VERSION}-linux-aarch64-osd-gtk4 \
+    && cp /tmp/voxtype-osd-quickshell /output/voxtype-${VERSION}-linux-aarch64-osd-quickshell \
+    && cp /tmp/voxtype-audio-bridge /output/voxtype-${VERSION}-linux-aarch64-audio-bridge \
     && echo "Binaries copied to /output:" \
     && ls -la /output/voxtype-*


### PR DESCRIPTION
Addresses the concrete gap in #579 (Asahi Linux field report). Fourth 1.0.1 item.

## What was wrong

The report says aarch64 users must build the OSD from source because releases ship only `linux-x86_64-osd*`. It turns out CI **was already building them**: `Dockerfile.aarch64-onnx` compiles `voxtype-osd` and `voxtype-osd-gtk4` and copies both to `/output`.

They were thrown away. The workflow's OSD upload step was keyed to `matrix.variant == 'onnx-avx2'`, which is the x86_64 job, so the aarch64 job's copies were never uploaded and vanished when the job ended. We were asking users to compile binaries we had already compiled for them.

## Changes

- Key the upload on either ONNX job: x86_64 `onnx-avx2` or aarch64 `onnx`
- Add `voxtype-osd-quickshell` and `voxtype-audio-bridge` to the aarch64 image, matching the four binaries `Dockerfile.onnx` produces for x86_64. Both are engine- and arch-agnostic, and the report notes the Quickshell top bar is in use on that machine, which needs the bridge for the waveform.

No plumbing needed downstream: collect, checksum, sign, and upload all glob `voxtype-*`.

## Result

v1.0.1 aarch64 assets go from two binaries to six:

```
voxtype-<ver>-linux-aarch64-cpu
voxtype-<ver>-linux-aarch64-onnx
voxtype-<ver>-linux-aarch64-osd              (new)
voxtype-<ver>-linux-aarch64-osd-gtk4         (new)
voxtype-<ver>-linux-aarch64-osd-quickshell   (new)
voxtype-<ver>-linux-aarch64-audio-bridge     (new)
```

## Not fixed here

The other item in #579 is cosmetic: ONNX Runtime logs `Unknown CPU vendor. cpuinfo_vendor value: 0` on Apple silicon because implementer `0x61` is not in its vendor table. Output is correct and the noise comes from inside ORT, so I left it rather than filter someone else's log line. Worth deciding separately whether #579 stays open for it.

Verified the workflow YAML parses; the build itself is exercised by CI on this PR.