### PR TITLE
fix(output): keep a clipboard tail in paste mode so guard timeouts don't lose the transcription

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -398,7 +398,14 @@ pub fn create_output_chain_with_override(
             }
         }
         crate::config::OutputMode::Paste => {
-            // Only paste mode (no fallback as requested)
+            // Paste mode (keystroke path). The modifier-release guard skips
+            // keystroke-synthesizing methods — including this paste driver —
+            // when a modifier is still held after the timeout, and its
+            // notification tells the user the transcription was "copied to
+            // clipboard". Keep a clipboard tail in the chain so that promise
+            // holds: if the paste driver is skipped (guard timeout) or fails,
+            // the transcription still lands on the clipboard instead of
+            // failing with AllMethodsFailed and being lost.
             chain.push(Box::new(paste::PasteOutput::new(
                 config.auto_submit,
                 config.append_text.clone(),
@@ -408,6 +415,16 @@ pub fn create_output_chain_with_override(
                 config.restore_clipboard,
                 config.restore_clipboard_delay_ms,
             )));
+            #[cfg(target_os = "macos")]
+            chain.push(Box::new(pbcopy::PbcopyOutput::new(
+                config.notification.on_transcription,
+            )));
+            #[cfg(not(target_os = "macos"))]
+            {
+                chain.push(Box::new(clipboard::ClipboardOutput::new(
+                    config.append_text.clone(),
+                )));
+            }
         }
         crate::config::OutputMode::File => {
             // File output is handled in the daemon before reaching the output chain.
@@ -596,6 +613,32 @@ mod tests {
         let text = "\u{201C}Don\u{2019}t worry,\u{201D} she said.";
         let result = normalize_quotes(text);
         assert_eq!(result, "\"Don't worry,\" she said.");
+    }
+
+    #[test]
+    fn test_paste_mode_chain_keeps_clipboard_tail() {
+        // A modifier-guard timeout skips every keystroke-synthesizing
+        // method; paste mode's only driver is one. Without a non-keystroke
+        // tail the chain becomes empty, output fails with AllMethodsFailed,
+        // and the transcription is lost despite the guard notification
+        // saying it was copied to the clipboard.
+        let mut config = crate::config::OutputConfig::default();
+        config.mode = crate::config::OutputMode::Paste;
+        let chain = create_output_chain(&config);
+
+        assert!(
+            chain.len() >= 2,
+            "paste chain must contain a fallback after the paste driver"
+        );
+        assert!(is_keystroke_method(chain[0].name()));
+        let tail = chain.last().unwrap().name();
+        assert!(
+            !is_keystroke_method(tail),
+            "paste chain must end with a non-keystroke method so a \
+             modifier-guard timeout still delivers the transcription, \
+             got tail {:?}",
+            tail
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In paste mode, when the modifier-release guard times out, the transcription is **lost entirely** — yet the user is told it was copied:

```
INFO  Modifier keys still held after 1500ms (LeftAlt), skipping keystroke methods
INFO  Modifier key held too long, transcription copied to clipboard.
ERROR Output failed: All output methods failed. Ensure wtype, dotool, ydotool, wl-copy, or xclip is available.
```

The notification is false: nothing is on the clipboard.

## Root cause

- `wait_for_modifier_release` timeout sets `skip_keystroke_methods = true` in `output_with_fallback` (`src/output/mod.rs`).
- `is_keystroke_method()` classifies `"paste (clipboard + keystroke)"` as a keystroke method — correct, since paste synthesizes the final keystroke.
- The paste arm of `create_output_chain_with_override` builds a **single-element** chain (`// Only paste mode (no fallback as requested)`).
- Guard timeout → the only chain element is filtered out → empty chain → `Err(AllMethodsFailed)` → `wl-copy` never runs.

So paste mode, uniquely, has no non-keystroke method to fall back to when keystroke output is suppressed. Present in v0.7.5, v1.0.0, and current `main`.

This is easy to hit in practice: the guard window opens right as output begins, and any modifier held a beat too long after the recording toggle (a chorded trigger, a resting finger, or continued typing) skips the paste driver. On my machine (Glove80, Alt+Space toggle), measured natural Alt release after the stop press lands 240–465 ms later — comfortably inside the default 750 ms guard — while deliberate or resting holds exceed 2 s and hit the loss.

## Fix

Append a clipboard driver after the paste driver in the paste chain (`pbcopy` on macOS, `wl-copy`/`xclip` elsewhere):

- The tail only executes when the paste driver is **skipped** (guard timeout) or **fails**, so normal paste output is byte-for-byte unchanged.
- On guard timeout the transcription now actually lands on the clipboard, making the existing notification true.
- Side benefit: a paste driver that copies successfully but fails its keystroke no longer surfaces `AllMethodsFailed`; the tail confirms delivery.

`is_keystroke_method("clipboard (wl-copy)")` is false, so the guard's filter leaves the chain non-empty.

## Test

`test_paste_mode_chain_keeps_clipboard_tail` asserts the paste chain ends with a non-keystroke method — the exact invariant whose absence caused this bug.

## Verification

- Reproduced with journal evidence on v0.7.5 (Linux/Niri/Wayland): deliberate Alt hold at stop → guard timeout → `AllMethodsFailed` → clipboard empty before the fix; transcript present on the clipboard after applying the same chain-level fix.
- Compile across the full release matrix dispatched on my fork: https://github.com/liamwh/voxtype/actions/runs/33304955084
- fmt/clippy/test gates run on this PR.

## Alternatives considered

A timeout-scoped fallback inside `output_with_fallback` (retry clipboard directly when every surviving candidate is keystroke-only) also works, but requires plumbing `append_text` through `OutputOptions` and touching `daemon.rs`. The chain tail achieves the same guarantee with a strictly smaller diff and no public-struct changes, and it composes with the existing `fallback_to_clipboard` machinery rather than bypassing it.
