### PR TITLE
Fix macOS install instructions on the website and INSTALL.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -87,7 +87,7 @@ Pick your distro from the list below. The fastest path on each:
 - **Arch:** `paru -S voxtype-bin`
 - **Debian/Ubuntu:** `sudo apt install ./voxtype_0.7.5-1_amd64.deb`
 - **Fedora:** `sudo dnf install ./voxtype-0.7.5-1.x86_64.rpm`
-- **macOS:** `brew install --cask voxtype`
+- **macOS:** `brew install --cask peteonrails/voxtype/voxtype`
 - **NixOS:** `nix profile install github:peteonrails/voxtype#vulkan`
 - **AppImage:** download, `chmod +x`, run.
 
@@ -174,13 +174,13 @@ Fedora's ydotool ships as a system service that needs extra setup. See [TROUBLES
 
 ### macOS
 
-Apple Silicon only. Uses Microsoft ONNX Runtime so every engine is available, including Parakeet on the Neural Engine path.
+Universal binary: Apple Silicon and Intel. Uses Microsoft ONNX Runtime so every engine is available, including Parakeet on the Neural Engine path.
 
 ```bash
 brew install --cask peteonrails/voxtype/voxtype
 ```
 
-Or download `voxtype-0.7.5-macOS-arm64.dmg` from the [latest release](https://github.com/peteonrails/voxtype/releases/latest). First launch opens a setup wizard that walks you through accessibility permissions, model download, and the FN-key hotkey.
+Or download `voxtype-1.0.0-macos-universal.dmg` from the [latest release](https://github.com/peteonrails/voxtype/releases/latest). First launch opens a setup wizard that walks you through accessibility permissions, model download, and the FN-key hotkey.
 
 ### NixOS
 

--- a/website/index.html
+++ b/website/index.html
@@ -959,19 +959,19 @@ sudo dnf install wtype wl-clipboard libnotify pipewire-alsa playerctl</code></pr
                 </div>
 
                 <div id="macos" class="tab-content">
-                    <p class="install-note">Apple Silicon (arm64) only. Uses Microsoft ONNX Runtime so all engines are available, including Parakeet on the Neural Engine path.</p>
+                    <p class="install-note">Universal binary: Apple Silicon and Intel. Uses Microsoft ONNX Runtime so all engines are available, including Parakeet on the Neural Engine path.</p>
                     <div class="code-block">
                         <div class="code-header">
                             <span>Install via Homebrew</span>
-                            <button class="copy-btn" data-copy="brew install --cask voxtype">Copy</button>
+                            <button class="copy-btn" data-copy="brew install --cask peteonrails/voxtype/voxtype">Copy</button>
                         </div>
-                        <pre><code><span class="comment"># Install the signed app bundle</span>
-brew install --cask voxtype
+                        <pre><code><span class="comment"># Voxtype is not in Homebrew core yet, so install from the tap</span>
+brew install --cask peteonrails/voxtype/voxtype
 
 <span class="comment"># First launch opens a setup wizard that walks you through</span>
 <span class="comment"># Accessibility permissions, model download, and the FN-key hotkey.</span></code></pre>
                     </div>
-                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-0.7.5-macOS-arm64.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
+                    <p class="install-note" style="margin-top: 1rem;">Or download <code>voxtype-1.0.0-macos-universal.dmg</code> from the <a href="https://github.com/peteonrails/voxtype/releases/latest">latest release</a>.</p>
                 </div>
 
                 <div id="nixos" class="tab-content">


### PR DESCRIPTION
Closes #604.

## Why this targets `main`

The website deploys from `main`, so this is live-wrong right now: voxtype.io tells macOS users to run `brew install --cask voxtype`, which fails because voxtype is not in homebrew-core. It has to be tap-qualified as `peteonrails/voxtype/voxtype`.

## What changed

- `website/index.html` — tap-qualified brew command (both the code block and the copy button), and the comment above it now says why.
- `docs/INSTALL.md` — the Quick Install summary list had the broken form. The macOS section further down already had it right, which is why this went unnoticed.
- Two facts that changed with 1.0.0: the macOS build is a **universal binary**, not Apple Silicon only, and the DMG asset is `voxtype-1.0.0-macos-universal.dmg` (verified against the v1.0.0 release assets), not the 0.7.5 arm64 name.

## Deliberately not a cherry-pick

`dev` has this fix inside `f8d67ad`, but that commit also carries the macOS DMG app-bundle rework and a 102-line `build-macos.yml` change. Cherry-picking it whole would have brought build changes `main` doesn't have, and its doc text describes dev's build shape and still says 0.7.5. This is the surgical equivalent.

## Two things left alone

- `website/download/index.html` adds the tap first, so its bare `brew install --cask voxtype` works.
- `website/docs/` is generated VitePress output and still contains the old string. It regenerates from `docs/INSTALL.md`, so it needs a docs build rather than a hand edit — flagging rather than touching it.