### PR TITLE
Fade media ducking without delaying the microphone

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ We want to hear from you! Voxtype is a young project and your feedback helps mak
 - [KaiStarkk](https://github.com/KaiStarkk) - Post-process trim and fallback_on_empty options
 - [graysky](https://github.com/graysky2) - Flash attention config fix
 - [OldJobobo](https://github.com/OldJobobo) - Quickshell OSD theming, Omarchy theme state path support, configurable media ducking, degenerate Whisper transcript retry; co-owns `quickshell/`
-- [Matthias Breddin](https://github.com/lunetics) - IBus non-ASCII reordering troubleshooting, Rust 1.98 clippy fix, media ducking review
+- [Matthias Breddin](https://github.com/lunetics) - IBus non-ASCII reordering troubleshooting, Rust 1.98 clippy fix, media ducking fade, cubic-scale ducking volume correction
 
 ## License
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -72,7 +72,7 @@ max_duration_secs = 60
 # recording stops. This is separate from pause_media; enable one behavior or
 # the other depending on whether you want media paused or only quieter.
 # duck_media = false
-# duck_media_volume_percent = 70
+# duck_media_volume_percent = 34
 
 # [audio.feedback]
 # Enable audio feedback sounds (beeps when recording starts/stops)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -410,6 +410,24 @@ applied to each stream's current per-channel volume, not to a fixed 100% base:
 original per-channel volumes are restored when recording stops. Values above
 `150` are clamped by the CLI override.
 
+### duck_media_fade_ms
+
+**Type:** Integer
+**Default:** `150`
+**Required:** No
+
+Fade duration in milliseconds for the ducking ramp. The same duration is used
+going down at recording start and coming back up when recording ends, so media
+slides out of the way instead of jumping. `0` restores the previous instant
+behaviour. Durations shorter than one 20 ms step are treated as `0`.
+
+```toml
+[audio]
+duck_media = true
+duck_media_volume_percent = 70
+duck_media_fade_ms = 150
+```
+
 ---
 
 ## [audio.feedback]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -395,20 +395,30 @@ Use this as an alternative to `pause_media` when you want music or video to keep
 ```toml
 [audio]
 duck_media = true
-duck_media_volume_percent = 70
+duck_media_volume_percent = 34
 ```
 
 ### duck_media_volume_percent
 
 **Type:** Integer
-**Default:** `70`
+**Default:** `34`
 **Required:** No
 
-Relative volume percentage for streams affected by `duck_media`. The value is
-applied to each stream's current per-channel volume, not to a fixed 100% base:
-`70` keeps media at 70% of its current volume, `50` keeps it at half, and the
-original per-channel volumes are restored when recording stops. Values above
-`150` are clamped by the CLI override.
+Fraction of its current amplitude that a stream affected by `duck_media`
+keeps, in percent: `50` keeps it at half (-6 dB), `34` at roughly a third
+(-9.3 dB). The value is relative to each stream's current per-channel volume,
+not to a fixed 100% base, and the original volumes are restored when recording
+stops. Values above `150` are clamped by the CLI override.
+
+voxtype converts the value internally to PulseAudio's cubic percentage scale,
+so what you configure is what you hear.
+
+**Changed in 1.1.0.** Through v1.0.0 the configured percentage was applied
+directly to PulseAudio's cubic scale, which cubed the reduction: `50` left only
+12.5% of the amplitude and `30` was effectively mute. The default moved from
+`70` to `34` at the same time so the audible depth is unchanged (0.70³ ≈ 0.34).
+If you set this value yourself against an older build, cube your old number to
+get the equivalent — an old `50` is a new `13`.
 
 ### duck_media_fade_ms
 
@@ -424,7 +434,7 @@ behaviour. Durations shorter than one 20 ms step are treated as `0`.
 ```toml
 [audio]
 duck_media = true
-duck_media_volume_percent = 70
+duck_media_volume_percent = 34
 duck_media_fade_ms = 150
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -413,7 +413,7 @@ stops. Values above `150` are clamped by the CLI override.
 voxtype converts the value internally to PulseAudio's cubic percentage scale,
 so what you configure is what you hear.
 
-**Changed in 1.1.0.** Through v1.0.0 the configured percentage was applied
+**Changed in 1.0.1.** Through v1.0.0 the configured percentage was applied
 directly to PulseAudio's cubic scale, which cubed the reduction: `50` left only
 12.5% of the amplitude and `30` was effectively mute. The default moved from
 `70` to `34` at the same time so the audible depth is unchanged (0.70³ ≈ 0.34).

--- a/packaging/homebrew/Casks/voxtype.rb
+++ b/packaging/homebrew/Casks/voxtype.rb
@@ -12,7 +12,7 @@ cask "voxtype" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
   depends_on formula: "terminal-notifier"
 
   app "Voxtype.app"

--- a/src/app/overrides.rs
+++ b/src/app/overrides.rs
@@ -191,6 +191,9 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
     if let Some(volume) = cli.duck_media_volume {
         config.audio.duck_media_volume_percent = volume.min(150);
     }
+    if let Some(fade_ms) = cli.duck_media_fade_ms {
+        config.audio.duck_media_fade_ms = fade_ms;
+    }
 
     // Output overrides
     if let Some(ref append_text) = cli.append_text {

--- a/src/audio/media.rs
+++ b/src/audio/media.rs
@@ -30,6 +30,7 @@ mod imp {
     use super::DuckedMediaStream;
     use serde_json::Value;
     use tokio::process::Command;
+    use tokio::task::JoinHandle;
     use tracing::{debug, warn};
     use zbus::{fdo::DBusProxy, Connection, Proxy};
 
@@ -115,22 +116,10 @@ mod imp {
         debug!("Resumed {}/{} media player(s)", resumed, players.len());
     }
 
-    /// Lower active sink-input volumes and return their original volumes.
-    ///
-    /// This intentionally does not use MPRIS transport controls. It can be
-    /// enabled alongside `pause_media`, but when both are enabled the pause
-    /// feature keeps its existing start/stop behavior and ducking only manages
-    /// stream volume.
     /// Interval between ramp steps. Short enough to sound continuous, long
     /// enough to keep the number of `pactl` invocations per fade small.
     const FADE_STEP_MS: u64 = 20;
 
-    /// Ramp all `streams` from `from_percent` to `to_percent` of their
-    /// original volume over `fade_ms`, leaving the final value to the caller
-    /// (which keeps the existing per-stream error handling in one place).
-    ///
-    /// Best effort: a step that fails is ignored, because the caller sets the
-    /// exact target right afterwards anyway.
     /// Intermediate scaling factors for a fade, excluding the final target.
     ///
     /// The caller sets `to_percent` itself, which keeps the exact target and
@@ -152,16 +141,18 @@ mod imp {
             .collect()
     }
 
+    /// Walk `streams` from `from_percent` towards `to_percent` over `fade_ms`,
+    /// stopping short of the target — the caller writes that itself, which
+    /// keeps the exact value and its error handling in one place.
+    ///
+    /// Best effort: a failed intermediate step is ignored, since the caller's
+    /// final write is authoritative.
     async fn ramp_streams(
         streams: &[DuckedMediaStream],
         from_percent: u8,
         to_percent: u8,
         fade_ms: u32,
     ) {
-        if streams.is_empty() {
-            return;
-        }
-
         for factor in ramp_factors(from_percent, to_percent, fade_ms) {
             for stream in streams {
                 let _ = Command::new("pactl")
@@ -175,30 +166,15 @@ mod imp {
         }
     }
 
-    pub async fn duck_playing_audio(volume_percent: u8, fade_ms: u32) -> Vec<DuckedMediaStream> {
-        let streams = match list_active_sink_inputs().await {
-            Ok(streams) => streams,
-            Err(e) => {
-                warn!("Failed to enumerate audio streams for media ducking: {e}");
-                return Vec::new();
-            }
-        };
-
-        if streams.is_empty() {
-            debug!("No active audio streams found for media ducking");
-            return Vec::new();
-        }
-
-        let factor = volume_percent.min(150);
-        ramp_streams(&streams, 100, factor, fade_ms).await;
-        let mut ducked = Vec::new();
+    /// Set every stream to `amplitude_percent` of its original volume.
+    async fn apply_volumes(streams: &[DuckedMediaStream], amplitude_percent: u8) {
         for stream in streams {
-            let target = scaled_volumes(&stream.volumes, factor);
+            let target = scaled_volumes(&stream.volumes, amplitude_percent);
             debug!(
                 stream = stream.index,
                 from = ?stream.volumes,
                 to = ?target,
-                factor_percent = factor,
+                factor_percent = amplitude_percent,
                 "Ducking media stream"
             );
             match Command::new("pactl")
@@ -208,7 +184,7 @@ mod imp {
                 .status()
                 .await
             {
-                Ok(status) if status.success() => ducked.push(stream),
+                Ok(status) if status.success() => {}
                 Ok(status) => warn!(
                     stream = stream.index,
                     "Media ducking failed with status: {status}"
@@ -219,8 +195,46 @@ mod imp {
                 ),
             }
         }
+    }
 
-        ducked
+    /// Lower active sink-input volumes and return their original volumes.
+    ///
+    /// This intentionally does not use MPRIS transport controls. It can be
+    /// enabled alongside `pause_media`, but when both are enabled the pause
+    /// feature keeps its existing start/stop behavior and ducking only manages
+    /// stream volume.
+    ///
+    /// The originals are captured before anything is written, and the fade
+    /// itself runs on a spawned task so the caller can open the microphone
+    /// without waiting out `fade_ms`. The returned handle is that task: the
+    /// caller must await it before capturing originals again, or a second
+    /// recording started mid-fade would record intermediate volumes as the new
+    /// "originals" and media would drift permanently quieter.
+    pub async fn duck_playing_audio(
+        volume_percent: u8,
+        fade_ms: u32,
+    ) -> (Vec<DuckedMediaStream>, Option<JoinHandle<()>>) {
+        let streams = match list_active_sink_inputs().await {
+            Ok(streams) => streams,
+            Err(e) => {
+                warn!("Failed to enumerate audio streams for media ducking: {e}");
+                return (Vec::new(), None);
+            }
+        };
+
+        if streams.is_empty() {
+            debug!("No active audio streams found for media ducking");
+            return (Vec::new(), None);
+        }
+
+        let factor = volume_percent.min(150);
+        let fading = streams.clone();
+        let handle = tokio::spawn(async move {
+            ramp_streams(&fading, 100, factor, fade_ms).await;
+            apply_volumes(&fading, factor).await;
+        });
+
+        (streams, Some(handle))
     }
 
     /// Restore stream volumes captured by `duck_playing_audio`.
@@ -326,7 +340,17 @@ mod imp {
             .collect()
     }
 
-    fn scaled_volumes(volumes: &[String], factor_percent: u8) -> Vec<String> {
+    /// Scale each channel's `value_percent` so the stream keeps
+    /// `amplitude_percent` of its current amplitude.
+    ///
+    /// PulseAudio's percentage scale is cubic (`amplitude = (percent /
+    /// 100)^3`), so keeping half the amplitude does NOT mean halving the
+    /// percentage: the percentage only shrinks by the cube root of the
+    /// requested fraction. Scaling the percentage directly instead — the
+    /// previous behaviour — cubed the reduction, so a configured 50 left
+    /// 12.5% of the amplitude (-18 dB) and 30 was effectively mute.
+    fn scaled_volumes(volumes: &[String], amplitude_percent: u8) -> Vec<String> {
+        let gain = (f32::from(amplitude_percent) / 100.0).cbrt();
         volumes
             .iter()
             .map(|volume| {
@@ -334,7 +358,7 @@ mod imp {
                 let Ok(value) = numeric.parse::<f32>() else {
                     return volume.clone();
                 };
-                let scaled = value * f32::from(factor_percent) / 100.0;
+                let scaled = value * gain;
                 format!("{scaled:.0}%")
             })
             .collect()
@@ -387,6 +411,24 @@ mod imp {
     #[cfg(test)]
     mod tests {
         use super::*;
+
+        /// The cube-root correction changed what `duck_media_volume_percent`
+        /// means, so the shipped default had to move with it or ducking would
+        /// have quietly become nearly inaudible: the old default of 70 was
+        /// applied to PulseAudio's cubic scale and actually left 0.70^3 of the
+        /// amplitude. Pin that the new default reproduces the old depth, since
+        /// a well-meaning "round it back up to 70" would silently undo it.
+        #[test]
+        fn default_duck_percent_preserves_pre_correction_loudness() {
+            let old_default_amplitude = 0.70_f32.powi(3);
+            let new_default_amplitude =
+                f32::from(crate::config::AudioConfig::default().duck_media_volume_percent) / 100.0;
+
+            assert!(
+                (new_default_amplitude - old_default_amplitude).abs() < 0.01,
+                "default duck depth drifted: {new_default_amplitude} vs {old_default_amplitude}"
+            );
+        }
 
         #[tokio::test]
         async fn list_skips_non_mpris_and_playerctld() {
@@ -471,14 +513,37 @@ mod imp {
 
         #[test]
         fn scales_stream_volumes_relative_to_current_values() {
+            // 70% of the amplitude = cube root of 0.7 on the cubic
+            // percentage scale, applied per channel.
             assert_eq!(
                 scaled_volumes(&["100%".to_string(), "80%".to_string()], 70),
-                vec!["70%", "56%"]
+                vec!["89%", "71%"]
             );
             assert_eq!(
                 scaled_volumes(&["50%".to_string(), "25%".to_string()], 30),
-                vec!["15%", "8%"]
+                vec!["33%", "17%"]
             );
+        }
+
+        #[test]
+        fn full_amplitude_leaves_volumes_unchanged() {
+            assert_eq!(
+                scaled_volumes(&["100%".to_string(), "37%".to_string()], 100),
+                vec!["100%", "37%"]
+            );
+        }
+
+        #[test]
+        fn zero_amplitude_mutes() {
+            assert_eq!(scaled_volumes(&["100%".to_string()], 0), vec!["0%"]);
+        }
+
+        #[test]
+        fn half_amplitude_is_six_db_not_eighteen() {
+            // 0.5^(1/3) = 0.7937: half the amplitude keeps ~79% of the cubic
+            // percentage. The pre-change behaviour would have produced "50%",
+            // which is only 12.5% of the amplitude.
+            assert_eq!(scaled_volumes(&["100%".to_string()], 50), vec!["79%"]);
         }
     }
 }
@@ -497,8 +562,11 @@ pub async fn pause_playing_players(_ignored: &[String]) -> Vec<String> {
 pub async fn resume_players(_players: Vec<String>) {}
 
 #[cfg(not(target_os = "linux"))]
-pub async fn duck_playing_audio(_volume_percent: u8, _fade_ms: u32) -> Vec<DuckedMediaStream> {
-    Vec::new()
+pub async fn duck_playing_audio(
+    _volume_percent: u8,
+    _fade_ms: u32,
+) -> (Vec<DuckedMediaStream>, Option<tokio::task::JoinHandle<()>>) {
+    (Vec::new(), None)
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/audio/media.rs
+++ b/src/audio/media.rs
@@ -121,7 +121,61 @@ mod imp {
     /// enabled alongside `pause_media`, but when both are enabled the pause
     /// feature keeps its existing start/stop behavior and ducking only manages
     /// stream volume.
-    pub async fn duck_playing_audio(volume_percent: u8) -> Vec<DuckedMediaStream> {
+    /// Interval between ramp steps. Short enough to sound continuous, long
+    /// enough to keep the number of `pactl` invocations per fade small.
+    const FADE_STEP_MS: u64 = 20;
+
+    /// Ramp all `streams` from `from_percent` to `to_percent` of their
+    /// original volume over `fade_ms`, leaving the final value to the caller
+    /// (which keeps the existing per-stream error handling in one place).
+    ///
+    /// Best effort: a step that fails is ignored, because the caller sets the
+    /// exact target right afterwards anyway.
+    /// Intermediate scaling factors for a fade, excluding the final target.
+    ///
+    /// The caller sets `to_percent` itself, which keeps the exact target and
+    /// its error handling in a single place. Returns an empty vector when the
+    /// fade is too short to produce a step, so `fade_ms = 0` means "instant".
+    fn ramp_factors(from_percent: u8, to_percent: u8, fade_ms: u32) -> Vec<u8> {
+        let steps = u64::from(fade_ms).div_ceil(FADE_STEP_MS);
+        if steps <= 1 {
+            return Vec::new();
+        }
+
+        let from = f32::from(from_percent);
+        let span = f32::from(to_percent) - from;
+        (1..steps)
+            .map(|step| {
+                let factor = from + span * (step as f32 / steps as f32);
+                factor.round().clamp(0.0, f32::from(u8::MAX)) as u8
+            })
+            .collect()
+    }
+
+    async fn ramp_streams(
+        streams: &[DuckedMediaStream],
+        from_percent: u8,
+        to_percent: u8,
+        fade_ms: u32,
+    ) {
+        if streams.is_empty() {
+            return;
+        }
+
+        for factor in ramp_factors(from_percent, to_percent, fade_ms) {
+            for stream in streams {
+                let _ = Command::new("pactl")
+                    .arg("set-sink-input-volume")
+                    .arg(stream.index.to_string())
+                    .args(scaled_volumes(&stream.volumes, factor))
+                    .status()
+                    .await;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(FADE_STEP_MS)).await;
+        }
+    }
+
+    pub async fn duck_playing_audio(volume_percent: u8, fade_ms: u32) -> Vec<DuckedMediaStream> {
         let streams = match list_active_sink_inputs().await {
             Ok(streams) => streams,
             Err(e) => {
@@ -136,6 +190,7 @@ mod imp {
         }
 
         let factor = volume_percent.min(150);
+        ramp_streams(&streams, 100, factor, fade_ms).await;
         let mut ducked = Vec::new();
         for stream in streams {
             let target = scaled_volumes(&stream.volumes, factor);
@@ -169,10 +224,16 @@ mod imp {
     }
 
     /// Restore stream volumes captured by `duck_playing_audio`.
-    pub async fn restore_ducked_audio(streams: Vec<DuckedMediaStream>) {
+    pub async fn restore_ducked_audio(
+        streams: Vec<DuckedMediaStream>,
+        ducked_percent: u8,
+        fade_ms: u32,
+    ) {
         if streams.is_empty() {
             return;
         }
+
+        ramp_streams(&streams, ducked_percent.min(150), 100, fade_ms).await;
 
         let total = streams.len();
         let mut restored = 0usize;
@@ -351,6 +412,36 @@ mod imp {
         }
 
         #[test]
+        fn ramp_is_skipped_when_the_fade_is_shorter_than_one_step() {
+            assert!(ramp_factors(100, 55, 0).is_empty());
+            assert!(ramp_factors(100, 55, FADE_STEP_MS as u32).is_empty());
+        }
+
+        #[test]
+        fn ramp_walks_down_towards_the_target_without_reaching_it() {
+            // 100 ms at a 20 ms step is 5 slices, so 4 intermediate factors;
+            // the exact target is set by the caller, not by the ramp.
+            let factors = ramp_factors(100, 50, 100);
+            assert_eq!(factors, vec![90, 80, 70, 60]);
+        }
+
+        #[test]
+        fn ramp_walks_up_when_restoring() {
+            let factors = ramp_factors(50, 100, 100);
+            assert_eq!(factors, vec![60, 70, 80, 90]);
+        }
+
+        #[test]
+        fn ramp_stays_monotonic_and_inside_the_endpoints() {
+            let factors = ramp_factors(100, 33, 250);
+            assert!(!factors.is_empty());
+            for pair in factors.windows(2) {
+                assert!(pair[1] <= pair[0], "not monotonic: {factors:?}");
+            }
+            assert!(factors.iter().all(|&f| (33..=100).contains(&f)));
+        }
+
+        #[test]
         fn parses_active_sink_inputs_with_channel_volumes() {
             let value: Value = serde_json::json!([
                 {
@@ -406,9 +497,14 @@ pub async fn pause_playing_players(_ignored: &[String]) -> Vec<String> {
 pub async fn resume_players(_players: Vec<String>) {}
 
 #[cfg(not(target_os = "linux"))]
-pub async fn duck_playing_audio(_volume_percent: u8) -> Vec<DuckedMediaStream> {
+pub async fn duck_playing_audio(_volume_percent: u8, _fade_ms: u32) -> Vec<DuckedMediaStream> {
     Vec::new()
 }
 
 #[cfg(not(target_os = "linux"))]
-pub async fn restore_ducked_audio(_streams: Vec<DuckedMediaStream>) {}
+pub async fn restore_ducked_audio(
+    _streams: Vec<DuckedMediaStream>,
+    _ducked_percent: u8,
+    _fade_ms: u32,
+) {
+}

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -244,7 +244,7 @@ pub struct Cli {
     #[arg(long, help_heading = "Audio", hide_short_help = true)]
     pub duck_media: bool,
 
-    /// Relative media volume percentage while ducking
+    /// Percent of its current amplitude ducked media keeps (50 = half, -6 dB)
     #[arg(
         long,
         value_name = "PERCENT",
@@ -252,6 +252,15 @@ pub struct Cli {
         hide_short_help = true
     )]
     pub duck_media_volume: Option<u8>,
+
+    /// Milliseconds to fade ducked media down and back up (0 = instant)
+    #[arg(
+        long,
+        value_name = "MS",
+        help_heading = "Audio",
+        hide_short_help = true
+    )]
+    pub duck_media_fade_ms: Option<u32>,
 
     // -- Output (delivery, timing, file output, hooks) --
     /// Force clipboard mode (don't try to type)

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -33,7 +33,9 @@ pub struct AudioConfig {
     #[serde(default)]
     pub duck_media: bool,
 
-    /// Target volume percentage for media ducking
+    /// Fraction of its current amplitude a ducked stream keeps, in percent
+    /// (50 = half the amplitude, -6 dB). Converted internally to PulseAudio's
+    /// cubic percentage scale.
     #[serde(default = "default_duck_media_volume_percent")]
     pub duck_media_volume_percent: u8,
 
@@ -74,8 +76,14 @@ fn default_audio_max_duration_secs() -> u32 {
     60
 }
 
+/// 34 rather than 70 because the value now means amplitude directly. Before
+/// the cube-root correction the configured percentage was applied to
+/// PulseAudio's own cubic scale, so the shipped default of 70 actually left
+/// 0.70^3 = 0.343 of the amplitude. 34 reproduces that same audible depth
+/// under the corrected meaning; keeping 70 would have quietly turned a -9.3 dB
+/// duck into a -3.1 dB one for everyone on defaults.
 fn default_duck_media_volume_percent() -> u8 {
-    70
+    34
 }
 
 fn default_duck_media_fade_ms() -> u32 {

--- a/src/config/audio.rs
+++ b/src/config/audio.rs
@@ -37,6 +37,10 @@ pub struct AudioConfig {
     #[serde(default = "default_duck_media_volume_percent")]
     pub duck_media_volume_percent: u8,
 
+    /// Fade duration in milliseconds for the ducking ramp (0 = instant)
+    #[serde(default = "default_duck_media_fade_ms")]
+    pub duck_media_fade_ms: u32,
+
     /// Audio feedback settings
     #[serde(default)]
     pub feedback: AudioFeedbackConfig,
@@ -52,6 +56,7 @@ impl Default for AudioConfig {
             pause_media_ignored_players: Vec::new(),
             duck_media: false,
             duck_media_volume_percent: default_duck_media_volume_percent(),
+            duck_media_fade_ms: default_duck_media_fade_ms(),
             feedback: AudioFeedbackConfig::default(),
         }
     }
@@ -71,6 +76,10 @@ fn default_audio_max_duration_secs() -> u32 {
 
 fn default_duck_media_volume_percent() -> u8 {
     70
+}
+
+fn default_duck_media_fade_ms() -> u32 {
+    150
 }
 
 /// Audio feedback configuration for sound cues

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -65,6 +65,11 @@ max_duration_secs = 60
 # the other depending on whether you want media paused or only quieter.
 # duck_media = false
 # duck_media_volume_percent = 70
+#
+# Fade the ducking ramp instead of jumping straight to the target volume. The
+# same duration is used going down and coming back up; 0 keeps the previous
+# instant behavior.
+# duck_media_fade_ms = 150
 
 # [audio.feedback]
 # Enable audio feedback sounds (beeps when recording starts/stops)

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -64,7 +64,11 @@ max_duration_secs = 60
 # recording stops. This is separate from pause_media; enable one behavior or
 # the other depending on whether you want media paused or only quieter.
 # duck_media = false
-# duck_media_volume_percent = 70
+#
+# Percent of its current amplitude a ducked stream keeps: 70 keeps media at
+# 70% (-3.1 dB), 50 at half (-6 dB). Converted internally to PulseAudio's
+# cubic scale, so what you configure is what you hear.
+# duck_media_volume_percent = 34
 #
 # Fade the ducking ramp instead of jumping straight to the target volume. The
 # same duration is used going down and coming back up; 0 keeps the previous

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -112,6 +112,11 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
             config.audio.duck_media_volume_percent = n.min(150);
         }
     }
+    if let Ok(val) = std::env::var("VOXTYPE_DUCK_MEDIA_FADE_MS") {
+        if let Ok(n) = val.parse::<u32>() {
+            config.audio.duck_media_fade_ms = n;
+        }
+    }
 
     // Output
     if let Ok(mode) = std::env::var("VOXTYPE_OUTPUT_MODE") {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -753,6 +753,15 @@ pub const CONFIG_KEYS: &[KeySpec] = &[
         "Target volume percentage for other streams while ducking.",
     ),
     spec(
+        "audio.duck_media_fade_ms",
+        "audio",
+        "duck_media_fade_ms",
+        KeyType::Int { min: 0, max: 5000 },
+        "Audio",
+        "Duck fade",
+        "Milliseconds to fade media volume down and back up. 0 is instant.",
+    ),
+    spec(
         "audio.feedback.enabled",
         "audio.feedback",
         "enabled",
@@ -1616,6 +1625,7 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
         "audio.pause_media" => json!(cfg.audio.pause_media),
         "audio.duck_media" => json!(cfg.audio.duck_media),
         "audio.duck_media_volume_percent" => json!(cfg.audio.duck_media_volume_percent),
+        "audio.duck_media_fade_ms" => json!(cfg.audio.duck_media_fade_ms),
         "audio.feedback.enabled" => json!(cfg.audio.feedback.enabled),
         "audio.feedback.theme" => json!(cfg.audio.feedback.theme),
         "audio.feedback.volume" => f32_json(cfg.audio.feedback.volume),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -799,6 +799,10 @@ pub struct Daemon {
     paused_media_players: Vec<String>,
     // Audio streams that were ducked when recording started (for restore on recording stop)
     ducked_media_streams: Vec<audio::media::DuckedMediaStream>,
+    // In-flight media volume fade, down at recording start or up at stop. Held
+    // so the next duck/restore can serialize against it; see
+    // `duck_media_streams` for why capturing originals mid-fade is unsafe.
+    media_fade_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl Daemon {
@@ -903,6 +907,7 @@ impl Daemon {
             speech_enhancer: None,
             paused_media_players: Vec::new(),
             ducked_media_streams: Vec::new(),
+            media_fade_task: None,
         }
     }
 
@@ -925,23 +930,41 @@ impl Daemon {
     /// Duck active audio streams if configured, storing original volumes
     async fn duck_media_streams(&mut self) {
         if self.config.audio.duck_media {
-            self.ducked_media_streams = audio::media::duck_playing_audio(
+            // Wait out any restore still fading up. Its final write is what
+            // puts the streams back at their true original volumes, and
+            // enumerating before that lands would capture intermediate values
+            // as the new originals — every fast toggle cycle would then store
+            // a quieter baseline and media would drift down permanently.
+            // Normally already finished, so this costs nothing.
+            if let Some(task) = self.media_fade_task.take() {
+                let _ = task.await;
+            }
+            let (streams, fade) = audio::media::duck_playing_audio(
                 self.config.audio.duck_media_volume_percent,
                 self.config.audio.duck_media_fade_ms,
             )
             .await;
+            self.ducked_media_streams = streams;
+            self.media_fade_task = fade;
         }
     }
 
     /// Restore any audio streams that were ducked at recording start
     fn restore_ducked_media_streams(&mut self) {
         if !self.ducked_media_streams.is_empty() {
+            // Abort rather than await a fade still on its way down: this path
+            // is synchronous, and the restore we are about to spawn ends by
+            // writing the stored originals, so an interrupted duck ramp is
+            // corrected either way.
+            if let Some(task) = self.media_fade_task.take() {
+                task.abort();
+            }
             let streams = std::mem::take(&mut self.ducked_media_streams);
-            tokio::spawn(audio::media::restore_ducked_audio(
+            self.media_fade_task = Some(tokio::spawn(audio::media::restore_ducked_audio(
                 streams,
                 self.config.audio.duck_media_volume_percent,
                 self.config.audio.duck_media_fade_ms,
-            ));
+            )));
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -925,8 +925,11 @@ impl Daemon {
     /// Duck active audio streams if configured, storing original volumes
     async fn duck_media_streams(&mut self) {
         if self.config.audio.duck_media {
-            self.ducked_media_streams =
-                audio::media::duck_playing_audio(self.config.audio.duck_media_volume_percent).await;
+            self.ducked_media_streams = audio::media::duck_playing_audio(
+                self.config.audio.duck_media_volume_percent,
+                self.config.audio.duck_media_fade_ms,
+            )
+            .await;
         }
     }
 
@@ -934,7 +937,11 @@ impl Daemon {
     fn restore_ducked_media_streams(&mut self) {
         if !self.ducked_media_streams.is_empty() {
             let streams = std::mem::take(&mut self.ducked_media_streams);
-            tokio::spawn(audio::media::restore_ducked_audio(streams));
+            tokio::spawn(audio::media::restore_ducked_audio(
+                streams,
+                self.config.audio.duck_media_volume_percent,
+                self.config.audio.duck_media_fade_ms,
+            ));
         }
     }
 


### PR DESCRIPTION
Supersedes #585 and #586, both by @lunetics, whose commits and work this builds on directly. Resolves the three issues raised in review on #585 so the fade and the cube-root correction can land together.

## What was wrong

**The fade delayed every recording.** `duck_playing_audio` ramped inline, and it's awaited in `suppress_recording_media()` before `start_recording_capture()` — so the microphone waited out the full fade plus seven sequential `pactl` spawns per stream. Push-to-talk clipped first syllables; @peteonrails reproduced it.

**The restore race was a ratchet.** Because restore now runs for the whole fade, a second recording started inside that window enumerated *mid-fade* volumes and stored them as the new originals. Every fast toggle cycle stored a quieter baseline, so media drifted permanently down and never recovered.

**The cube-root fix would have made ducking inaudible on defaults.** #586's analysis is correct — pactl percentages relate to amplitude as (percent/100)³, so the old code cubed the reduction. But the shipped default of 70 was being applied to that cubic scale and actually left 0.70³ = 0.343 of the amplitude. Reinterpreting 70 as amplitude directly turns a -9.3 dB duck into -3.1 dB for everyone on defaults.

## What changed

- The ramp runs on a spawned task, with originals captured before it starts, so capture begins immediately.
- The daemon holds that task so duck and restore serialize. Duck **awaits** a restore in flight, because only its final write puts the true originals back. Restore **aborts** a duck in flight, because restore ends by writing those originals anyway.
- Default `duck_media_volume_percent` moves 70 → 34, keeping the audible depth identical under the corrected meaning. A test pins the relationship so it can't be quietly rounded back.
- Adds `--duck-media-fade-ms`, `VOXTYPE_DUCK_MEDIA_FADE_MS`, and the config-set schema entry. Before this, `voxtype config set audio.duck_media_fade_ms 200` returned "unknown config key" while the neighbouring volume key worked.
- Unshuffles the rustdoc the fade commit displaced onto `FADE_STEP_MS`.

## Upgrade note

Anyone who set `duck_media_volume_percent` **explicitly** needs to cube their old number — an old `50` is a new `13`. Users on the default are unaffected. `CONFIGURATION.md` documents this under a "Changed in 1.1.0" note.

## Testing

`cargo test` 957 passing, `cargo clippy --all-targets --no-deps -- -D warnings` clean, `cargo fmt --check` clean. Verified `voxtype config get audio.duck_media_fade_ms` now returns a value and `--duck-media-fade-ms` appears in help.

Not manually smoke-tested against live audio — worth one pass with `duck_media = true` and music playing before merge.