### PR TITLE
Resolve installed-model detection against the registry dir_name

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -534,13 +534,7 @@ fn detect_missing_model() -> Option<MissingModel> {
         return None;
     }
 
-    let installed = if engine_name == "whisper" {
-        dir.join(format!("ggml-{}.bin", model)).exists()
-    } else {
-        let p = dir.join(&model);
-        p.exists()
-    };
-    if installed {
+    if model_installed_on_disk(&dir, engine_name, &model) {
         None
     } else {
         Some(MissingModel {
@@ -550,6 +544,26 @@ fn detect_missing_model() -> Option<MissingModel> {
         })
     }
 }
+
+/// Is the configured model actually on disk under `dir`?
+///
+/// Whisper stores a single `ggml-{model}.bin` file, so the raw config value
+/// is also the filename. Every other engine downloads into a subdirectory,
+/// and for some engines (sensevoice, moonshine) the config value is a short
+/// name that differs from the directory the downloader wrote to (e.g.
+/// sensevoice's "small" lives in "sensevoice-small"). Resolving through
+/// `model_catalog::model_dir_name` before probing keeps this in sync with
+/// what the daemon and downloader actually use, instead of reporting an
+/// installed model as missing.
+fn model_installed_on_disk(dir: &Path, engine_name: &str, model: &str) -> bool {
+    if engine_name == "whisper" {
+        dir.join(format!("ggml-{}.bin", model)).exists()
+    } else {
+        let dir_name = crate::model_catalog::model_dir_name(engine_name, model);
+        dir.join(&dir_name).exists()
+    }
+}
+
 use crate::daemon_status::is_daemon_running;
 
 /// Modification time of the config file the TUI edits (the same
@@ -628,5 +642,39 @@ mod tests {
         assert_eq!(app.cursor, (0, 0));
         app.move_cursor(10, 10);
         assert_eq!(app.cursor, (ROWS.len() - 1, COLS.len() - 1));
+    }
+
+    /// Regression (#662): the General section reported an installed
+    /// sensevoice model as missing because it probed `models_dir/{config
+    /// value}` directly instead of resolving the config's short name
+    /// ("small") to the directory the downloader actually wrote
+    /// ("sensevoice-small").
+    #[test]
+    fn model_installed_on_disk_resolves_short_names_to_their_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::create_dir_all(dir.join("sensevoice-small")).unwrap();
+
+        assert!(
+            model_installed_on_disk(dir, "sensevoice", "small"),
+            "the short config name must resolve to the on-disk directory"
+        );
+        assert!(
+            model_installed_on_disk(dir, "sensevoice", "sensevoice-small"),
+            "the directory name itself must also be recognized as installed"
+        );
+        assert!(!model_installed_on_disk(dir, "sensevoice", "medium"));
+    }
+
+    /// Whisper's on-disk layout is a single `ggml-{model}.bin` file, not a
+    /// directory, and must keep using the raw config value as the filename.
+    #[test]
+    fn model_installed_on_disk_whisper_uses_ggml_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("ggml-base.en.bin"), b"stub").unwrap();
+
+        assert!(model_installed_on_disk(dir, "whisper", "base.en"));
+        assert!(!model_installed_on_disk(dir, "whisper", "tiny"));
     }
 }

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -590,7 +590,7 @@ impl EngineState {
                 let active_model = active_model_for_engine(&self.engine, &self.fields);
                 let download_needed = active_model
                     .as_deref()
-                    .map(|m| !model_present_on_disk(m))
+                    .map(|m| !model_present_on_disk(&self.engine, m))
                     .unwrap_or(false);
 
                 let next_action = match (pending_switch, download_needed, active_model.clone()) {
@@ -916,16 +916,21 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
 /// Resolve where on disk a model directory lives. Mirrors the daemon's
 /// resolution path so the TUI's "is this downloaded?" check matches what
 /// the daemon will look for at load time.
-fn model_dir_on_disk(name: &str) -> std::path::PathBuf {
-    crate::config::Config::models_dir().join(name)
+///
+/// `name` is the raw config value, which for some engines (moonshine,
+/// sensevoice) is a short name that differs from the directory the
+/// downloader actually wrote to. `model_catalog::model_dir_name` resolves
+/// that mapping; see its docs for why.
+fn model_dir_on_disk(engine: &str, name: &str) -> std::path::PathBuf {
+    crate::config::Config::models_dir().join(crate::model_catalog::model_dir_name(engine, name))
 }
 
 /// True when the model directory exists with at least one file in it. We
 /// don't validate the file list — the daemon will surface specific missing
 /// pieces — but a fully empty or missing directory definitely needs a
 /// download before save.
-fn model_present_on_disk(name: &str) -> bool {
-    let dir = model_dir_on_disk(name);
+fn model_present_on_disk(engine: &str, name: &str) -> bool {
+    let dir = model_dir_on_disk(engine, name);
     match std::fs::read_dir(&dir) {
         Ok(mut iter) => iter.next().is_some(),
         Err(_) => false,


### PR DESCRIPTION
Closes #662.

The General section's missing-model warning (`detect_missing_model()` in
`src/tui/app.rs`) and the Engine section's save-triggered download check
(`model_present_on_disk()` in `src/tui/engine.rs`) both probed
`models_dir/<config value>` directly. For sensevoice, moonshine, and any
engine whose config `model` name differs from its on-disk directory (e.g.
sensevoice `"small"` lives in `"sensevoice-small"`), that always missed,
so a fully installed and working model was reported as not downloaded.

Both checks now route through `model_catalog::model_dir_name`, the
existing helper that already resolves that mapping and is what the
downloader and daemon use. Whisper's `ggml-{model}.bin` file-based lookup
is unchanged.

Two regression tests added: sensevoice short-name resolution to its
on-disk directory, and confirmation the whisper filename path is untouched.

## Testing

- `cargo build` clean
- `cargo test --lib` — 960 passed, 0 failed, 2 pre-existing ignores
- `cargo clippy --lib -- -D warnings` clean
- `cargo fmt --check` clean

## Credit

Thanks to xzedx for #662 — the diagnosis pinpointed the exact file, lines,
and root cause before this was picked up.