### PR TITLE
Ask model_catalog whether a model is installed, rather than re-deriving it

### DIFF
--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -523,6 +523,35 @@ mod tests {
         }
     }
 
+    /// Regression (#662): sensevoice's config value is a short name and the
+    /// downloader writes a differently-named directory. A caller asking "is
+    /// the configured model installed?" passes the config value, so the
+    /// lookup has to resolve it. The configure TUI probed the raw value and
+    /// told users a working model was not downloaded.
+    ///
+    /// Pinned end to end rather than on the name mapping alone, because the
+    /// mapping was always correct — it was the lookup that skipped it.
+    #[test]
+    fn an_installed_sensevoice_model_is_found_by_its_short_config_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        install_onnx_model(
+            tmp.path(),
+            "sensevoice",
+            "sensevoice-small",
+            &[("model.onnx", b"weights"), ("tokens.txt", b"tokens")],
+        );
+
+        assert!(
+            model_installed_in(tmp.path(), "sensevoice", "small"),
+            "the short config value must resolve to the directory on disk"
+        );
+        assert!(
+            model_installed_in(tmp.path(), "sensevoice", "sensevoice-small"),
+            "the directory name itself must keep working"
+        );
+        assert!(!model_installed_in(tmp.path(), "sensevoice", "medium"));
+    }
+
     /// The catalog covers every engine `config set engine` accepts, minus
     /// cloud engines that have no downloadable model.
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -468,7 +468,6 @@ fn detect_variant_mismatch(inventory: &Inventory) -> Option<VariantMismatch> {
 fn detect_missing_model() -> Option<MissingModel> {
     use crate::config;
     let cfg = config::load_config(None).ok()?;
-    let dir = config::Config::models_dir();
     let (engine_name, model, setup_command) = match cfg.engine {
         config::TranscriptionEngine::Whisper => (
             "whisper",
@@ -534,7 +533,7 @@ fn detect_missing_model() -> Option<MissingModel> {
         return None;
     }
 
-    if model_installed_on_disk(&dir, engine_name, &model) {
+    if crate::model_catalog::model_installed(engine_name, &model) {
         None
     } else {
         Some(MissingModel {
@@ -542,25 +541,6 @@ fn detect_missing_model() -> Option<MissingModel> {
             model,
             setup_command,
         })
-    }
-}
-
-/// Is the configured model actually on disk under `dir`?
-///
-/// Whisper stores a single `ggml-{model}.bin` file, so the raw config value
-/// is also the filename. Every other engine downloads into a subdirectory,
-/// and for some engines (sensevoice, moonshine) the config value is a short
-/// name that differs from the directory the downloader wrote to (e.g.
-/// sensevoice's "small" lives in "sensevoice-small"). Resolving through
-/// `model_catalog::model_dir_name` before probing keeps this in sync with
-/// what the daemon and downloader actually use, instead of reporting an
-/// installed model as missing.
-fn model_installed_on_disk(dir: &Path, engine_name: &str, model: &str) -> bool {
-    if engine_name == "whisper" {
-        dir.join(format!("ggml-{}.bin", model)).exists()
-    } else {
-        let dir_name = crate::model_catalog::model_dir_name(engine_name, model);
-        dir.join(&dir_name).exists()
     }
 }
 
@@ -642,39 +622,5 @@ mod tests {
         assert_eq!(app.cursor, (0, 0));
         app.move_cursor(10, 10);
         assert_eq!(app.cursor, (ROWS.len() - 1, COLS.len() - 1));
-    }
-
-    /// Regression (#662): the General section reported an installed
-    /// sensevoice model as missing because it probed `models_dir/{config
-    /// value}` directly instead of resolving the config's short name
-    /// ("small") to the directory the downloader actually wrote
-    /// ("sensevoice-small").
-    #[test]
-    fn model_installed_on_disk_resolves_short_names_to_their_directory() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path();
-        std::fs::create_dir_all(dir.join("sensevoice-small")).unwrap();
-
-        assert!(
-            model_installed_on_disk(dir, "sensevoice", "small"),
-            "the short config name must resolve to the on-disk directory"
-        );
-        assert!(
-            model_installed_on_disk(dir, "sensevoice", "sensevoice-small"),
-            "the directory name itself must also be recognized as installed"
-        );
-        assert!(!model_installed_on_disk(dir, "sensevoice", "medium"));
-    }
-
-    /// Whisper's on-disk layout is a single `ggml-{model}.bin` file, not a
-    /// directory, and must keep using the raw config value as the filename.
-    #[test]
-    fn model_installed_on_disk_whisper_uses_ggml_filename() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path();
-        std::fs::write(dir.join("ggml-base.en.bin"), b"stub").unwrap();
-
-        assert!(model_installed_on_disk(dir, "whisper", "base.en"));
-        assert!(!model_installed_on_disk(dir, "whisper", "tiny"));
     }
 }

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -913,28 +913,24 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
     out
 }
 
-/// Resolve where on disk a model directory lives. Mirrors the daemon's
-/// resolution path so the TUI's "is this downloaded?" check matches what
-/// the daemon will look for at load time.
+/// Is the configured model usable, so a save does not need to download it?
 ///
-/// `name` is the raw config value, which for some engines (moonshine,
-/// sensevoice) is a short name that differs from the directory the
-/// downloader actually wrote to. `model_catalog::model_dir_name` resolves
-/// that mapping; see its docs for why.
-fn model_dir_on_disk(engine: &str, name: &str) -> std::path::PathBuf {
-    crate::config::Config::models_dir().join(crate::model_catalog::model_dir_name(engine, name))
-}
-
-/// True when the model directory exists with at least one file in it. We
-/// don't validate the file list — the daemon will surface specific missing
-/// pieces — but a fully empty or missing directory definitely needs a
-/// download before save.
+/// Delegates to `model_catalog::model_installed`, which is what the daemon
+/// and the downloader already resolve through. Asking it rather than probing
+/// the directory ourselves buys two things.
+///
+/// It handles the name mapping: `name` is the raw config value, and for
+/// moonshine and sensevoice that is a short name that differs from the
+/// directory the downloader wrote to. Getting that wrong is what made a
+/// working model report as absent (#662).
+///
+/// It also rejects a model that is present but damaged. The check here used
+/// to be "the directory exists and has at least one file in it", which calls
+/// an interrupted download complete and skips the re-download that would fix
+/// it. `model_installed` verifies against the recorded manifest, so a partial
+/// download is treated as needing a download.
 fn model_present_on_disk(engine: &str, name: &str) -> bool {
-    let dir = model_dir_on_disk(engine, name);
-    match std::fs::read_dir(&dir) {
-        Ok(mut iter) => iter.next().is_some(),
-        Err(_) => false,
-    }
+    crate::model_catalog::model_installed(engine, name)
 }
 
 fn cycle_str(choices: &[&'static str], current: &str, delta: i32) -> String {


### PR DESCRIPTION
Follow-up to #663, which closed #662.

#663 fixed the symptom correctly: the configure TUI reported an installed sensevoice model as missing because it probed `models_dir/<config value>` instead of resolving the short name to the directory the downloader wrote. But it fixed it by adding another copy of the resolution rule, and the bug existed *because* the TUI carried its own copy. The next engine whose config name differs from its directory breaks these call sites the same way.

`model_catalog` already answers this question, and it is what the daemon and the downloader resolve through:

```rust
pub fn model_installed(engine: &str, model: &str) -> bool
pub(crate) fn model_installed_in(models_dir: &Path, engine: &str, model: &str) -> bool
```

## What changed

- `src/tui/app.rs` — `detect_missing_model` calls `model_catalog::model_installed`; the local `model_installed_on_disk` helper and its `models_dir` binding are gone.
- `src/tui/engine.rs` — `model_present_on_disk` delegates; `model_dir_on_disk` is gone.
- `src/model_catalog.rs` — one new regression test.

Net −29 lines.

## This is not only deduplication

The Engine section's check was "the directory exists and has at least one file in it". That reports an **interrupted download as complete** and skips the re-download that would fix it. `model_installed` checks each file against the manifest recorded at download time, and validates the ggml header for whisper, so a partial or damaged model is now correctly treated as needing a download.

For the General section the practical difference is the warning text: a corrupt model now reads as "not downloaded" rather than as fine. Re-downloading is the right remedy in both cases, so the message still points somewhere useful.

## On the removed tests

The two tests from #663 covered a copy of the logic that no longer exists, and both behaviors they asserted are already pinned in `model_catalog`'s own tests — `sensevoice_catalog_uses_short_names_while_the_default_is_a_dir_name` for the mapping, `whisper_health_rests_on_the_ggml_header` for the filename path. They would also have failed as written once routed through the shared helper, because their fixtures (a `b"stub"` file, an empty directory) are exactly what it now rejects.

What was genuinely uncovered is the end-to-end shape of #662 — a *properly installed* model found by its short config name — so that test goes next to `install_onnx_model`, the fixture builder that can set it up the way a real download leaves things.

## Testing

`cargo test` 1013 passed, `cargo clippy --all-targets --no-deps -- -D warnings` clean, `cargo fmt --check` clean.

## Credit

Thanks to xzedx for #662; the diagnosis there is what made both this and #663 straightforward.