### PR TITLE
feat: add GigaAM v3 RNN-T as an ONNX transcription engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,6 +242,11 @@ omnilingual-tensorrt = ["omnilingual", "onnx-tensorrt-enabled"]
 cohere = ["onnx-common", "dep:half", "dep:tokenizers"]
 cohere-cuda = ["cohere", "onnx-cuda-enabled"]
 cohere-tensorrt = ["cohere", "onnx-tensorrt-enabled"]
+# GigaAM v3 RNN-T backend (ONNX-based Russian specialist).
+# CPU-first for v1: no dedicated gigaam-cuda / gigaam-migraphx flag.
+# If the binary was built with another engine's *-cuda feature, the
+# shared onnx_ep helper still registers GPU EPs at session load.
+gigaam = ["onnx-common"]
 # Soniox is unconditional. Its deps (tokio-tungstenite, futures-util, reqwest)
 # add ~1-2 MB after LTO+strip and ride alongside ureq, which every binary
 # already ships for model downloads. Treating it like remote.rs (also always

--- a/Dockerfile.aarch64-onnx
+++ b/Dockerfile.aarch64-onnx
@@ -86,7 +86,7 @@ ENV GGML_NATIVE=OFF
 ENV ORT_STRATEGY=download
 
 # Build with all ONNX engines. CPU-only on aarch64 — no GPU EPs.
-RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,ml-diarization \
+RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,gigaam,ml-diarization \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-aarch64-onnx

--- a/Dockerfile.onnx
+++ b/Dockerfile.onnx
@@ -90,7 +90,7 @@ ENV ORT_STRATEGY=download
 
 # Disable LTO for faster builds (can hang on TrueNAS)
 # Build with all ONNX engines
-RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,ml-diarization \
+RUN cargo build --release --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,gigaam,ml-diarization \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-avx2

--- a/Dockerfile.onnx-avx512
+++ b/Dockerfile.onnx-avx512
@@ -60,7 +60,7 @@ ENV ORT_STRATEGY=download
 
 # Disable LTO for faster builds
 # Build with all ONNX engines
-RUN cargo build --release --target x86_64-unknown-linux-gnu --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,ml-diarization \
+RUN cargo build --release --target x86_64-unknown-linux-gnu --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,gigaam,ml-diarization \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/x86_64-unknown-linux-gnu/release/voxtype /tmp/voxtype-onnx-avx512

--- a/Dockerfile.onnx-cuda-12
+++ b/Dockerfile.onnx-cuda-12
@@ -61,7 +61,7 @@ ENV ORT_CUDA_VERSION=12
 
 # Build with all ONNX engines + CUDA support for NVIDIA GPUs
 # Disable LTO for faster builds
-RUN cargo build --release --features parakeet-cuda,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,ml-diarization \
+RUN cargo build --release --features parakeet-cuda,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,gigaam,ml-diarization \
     --config 'profile.release.lto=false' \
     --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-cuda-12

--- a/Dockerfile.onnx-cuda-13
+++ b/Dockerfile.onnx-cuda-13
@@ -107,6 +107,7 @@ RUN set -eux; \
 #   - parakeet-cuda          → parakeet-rs/cuda  (registers CUDA EP for Parakeet)
 #   - parakeet-load-dynamic  → parakeet-rs/load-dynamic  (dlopen ORT in parakeet-rs)
 #   - {moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere}-cuda
+#   - gigaam                 → CPU-first RNN-T (uses CUDA EP if onnx-cuda-enabled)
 #                            → onnx-cuda-enabled = ort/cuda  (CUDA EP type)
 #   - onnx-load-dynamic      → ort/load-dynamic  (dlopen ORT crate-wide)
 #   - ml-diarization         → ort (no EP gates needed)
@@ -126,7 +127,7 @@ ENV ORT_CUDA_VERSION=13
 #
 # Disable LTO for faster builds; same as the rest of the matrix.
 RUN cargo build --release \
-        --features parakeet-cuda,parakeet-load-dynamic,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,onnx-load-dynamic,ml-diarization \
+        --features parakeet-cuda,parakeet-load-dynamic,moonshine-cuda,sensevoice-cuda,paraformer-cuda,dolphin-cuda,omnilingual-cuda,cohere-cuda,gigaam,onnx-load-dynamic,ml-diarization \
         --config 'profile.release.lto=false' \
         --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-cuda-13

--- a/Dockerfile.onnx-migraphx
+++ b/Dockerfile.onnx-migraphx
@@ -106,7 +106,7 @@ WORKDIR /build/voxtype
 # can't compile their graphs (per-engine notes in src/transcribe/*.rs and
 # Cargo.toml). Cohere is held back until an int4/FP16 model variant ships.
 RUN cargo build --release \
-        --features parakeet-migraphx,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,ml-diarization \
+        --features parakeet-migraphx,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,gigaam,ml-diarization \
         --config 'profile.release.lto=false' \
         --config 'profile.release.codegen-units=8' \
     && cp target/release/voxtype /tmp/voxtype-onnx-migraphx

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,6 +46,7 @@ Selects which speech-to-text engine to use for transcription.
 - `dolphin` - Dictation-optimized CTC via ONNX Runtime (Chinese + English)
 - `omnilingual` - FunASR Omnilingual CTC via ONNX Runtime (50+ languages)
 - `cohere` - Cohere Transcribe encoder-decoder via ONNX Runtime (#1 Open ASR Leaderboard, 14 languages, ~3 GB model)
+- `gigaam` - GigaAM v3 RNN-T via ONNX Runtime (Russian specialist, ~225 MB INT8)
 
 **Example:**
 ```toml
@@ -76,7 +77,7 @@ config changes; restart it with `systemctl --user restart voxtype` for the
 new engine to take effect.
 
 **Notes:**
-- Whisper, Remote Whisper, and Soniox run in every binary. The other engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) require an ONNX-enabled binary (`voxtype-*-onnx-*`)
+- Whisper, Remote Whisper, and Soniox run in every binary. The other engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere, GigaAM) require an ONNX-enabled binary (`voxtype-*-onnx-*`)
 - Each ONNX engine reads its own `[<engine>]` section (e.g. `[parakeet]`, `[cohere]`)
 - See [PARAKEET.md](PARAKEET.md) for detailed Parakeet setup instructions
 - See [MOONSHINE.md](MOONSHINE.md) for detailed Moonshine setup instructions
@@ -1456,6 +1457,64 @@ cargo build --release --features cohere-tensorrt  # NVIDIA + TensorRT EP
 ```
 
 The prebuilt `voxtype-*-onnx-*` release binaries already include `cohere`, so users installing via AUR/.deb/.rpm don't need to rebuild.
+
+---
+
+## [gigaam]
+
+Configuration for the GigaAM v3 RNN-T speech-to-text engine. This section is only used when `engine = "gigaam"`.
+
+GigaAM is a Russian-specialist Conformer + LSTM RNN-T model (SberDevices). voxtype loads the gigastt INT8 bundle (~225 MB): encoder, decoder, joiner, and a 34-token char vocabulary. Output is bare lowercase Russian; there is no punctuation or inverse text normalization in v1.
+
+The catalog entry is `gigaam-v3-rnnt-int8`. Until models.voxtype.io hosts the bundle, copy the four files from [gigastt release `models-v3-2026-06-22`](https://github.com/ekhodzitsky/gigastt/releases/tag/models-v3-2026-06-22) into `~/.local/share/voxtype/models/gigaam-v3-rnnt-int8/`.
+
+### model
+
+**Type:** String
+**Default:** `"gigaam-v3-rnnt-int8"`
+**Required:** No
+
+Model directory name under the models dir, or an absolute path. Expects `v3_rnnt_encoder_int8.onnx`, `v3_rnnt_decoder.onnx`, `v3_rnnt_joint.onnx`, and `v3_vocab.txt`.
+
+**Example:**
+```toml
+[gigaam]
+model = "gigaam-v3-rnnt-int8"
+```
+
+### threads
+
+**Type:** Integer
+**Default:** unset (voxtype picks, typically `min(ncpus, 4)`)
+**Required:** No
+
+ONNX Runtime intra-op threads for the encoder. Decoder and joiner always run on one thread.
+
+### on_demand_loading
+
+**Type:** Boolean
+**Default:** `false`
+**Required:** No
+
+Same behavior as `[whisper].on_demand_loading`.
+
+### Complete Example
+
+```toml
+engine = "gigaam"
+
+[gigaam]
+model = "gigaam-v3-rnnt-int8"
+on_demand_loading = false
+```
+
+Source builds need the `gigaam` Cargo feature:
+
+```bash
+cargo build --release --features gigaam
+```
+
+v1 is CPU-first. There is no `gigaam-cuda` flag; a CUDA ONNX binary still registers GPU execution providers through the shared helper if it was built with another engine's `*-cuda` feature.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -282,14 +282,14 @@ sudo install -Dm755 target/release/voxtype /usr/local/bin/voxtype
 | `parakeet` | Parakeet ASR engine (ONNX-based) |
 | `parakeet-migraphx` | Parakeet on AMD MIGraphX |
 | `parakeet-cuda` | Parakeet on NVIDIA CUDA |
-| `moonshine`, `sensevoice`, `paraformer`, `dolphin`, `omnilingual`, `cohere` | Additional ONNX engines |
+| `moonshine`, `sensevoice`, `paraformer`, `dolphin`, `omnilingual`, `cohere`, `gigaam` | Additional ONNX engines |
 | `osd-gtk4` | GTK4 on-screen visualizer |
 | `osd-native` | wgpu + egui on-screen visualizer |
 
 Example: full ONNX engine set with MIGraphX:
 
 ```bash
-cargo build --release --features parakeet-migraphx,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,ml-diarization
+cargo build --release --features parakeet-migraphx,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,gigaam,ml-diarization
 ```
 
 #### Pre-Haswell CPUs

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
           "dolphin"
           "omnilingual"
           "cohere"
+          "gigaam"
         ];
 
         onnxCudaFeatures = [
@@ -67,6 +68,7 @@
           "dolphin-cuda"
           "omnilingual-cuda"
           "cohere-cuda"
+          "gigaam"
         ];
 
         # Only Parakeet has AMD GPU support (via MIGraphX); other engines run on CPU
@@ -78,6 +80,7 @@
           "paraformer"
           "dolphin"
           "omnilingual"
+          "gigaam"
         ];
 
         # Wrap a package with runtime dependencies

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -57,7 +57,7 @@ let
     cfg.settings;
 
   # Engines that use ONNX Runtime (need model.path, not model.name)
-  onnxEngines = [ "parakeet" "moonshine" "sensevoice" "paraformer" "dolphin" "omnilingual" ];
+  onnxEngines = [ "parakeet" "moonshine" "sensevoice" "paraformer" "dolphin" "omnilingual" "cohere" "gigaam" ];
   isOnnxEngine = builtins.elem cfg.engine onnxEngines;
 
   # Fetch model from HuggingFace if using declarative model management

--- a/quickshell/EnginePicker.qml
+++ b/quickshell/EnginePicker.qml
@@ -158,7 +158,8 @@ PanelWindow {
         { name: "paraformer",  label: "Paraformer",  blurb: "FunASR CTC encoder" },
         { name: "dolphin",     label: "Dolphin",     blurb: "Dictation-optimized CTC" },
         { name: "omnilingual", label: "Omnilingual", blurb: "FunASR 50+ languages" },
-        { name: "cohere",      label: "Cohere",      blurb: "Whisper-style; top of OpenASR" }
+        { name: "cohere",      label: "Cohere",      blurb: "Whisper-style; top of OpenASR" },
+        { name: "gigaam",      label: "GigaAM",      blurb: "Russian specialist RNN-T" }
     ]
 
     // ----- internal state -----

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -5,7 +5,7 @@
 # This script:
 #   1. Downloads Microsoft's official ONNX Runtime prebuilt (cached)
 #   2. Builds with --features "gpu-metal,parakeet-coreml,moonshine,sensevoice,
-#      paraformer,dolphin,omnilingual,cohere"
+#      paraformer,dolphin,omnilingual,cohere,gigaam"
 #   3. Copies the binary and libonnxruntime.dylib into releases/${VERSION}/
 #
 # The DMG packaging step (build-macos-dmg.sh) bundles the dylib into
@@ -44,7 +44,7 @@ ORT_VERSION="1.24.2"
 
 # Engines to build with. Whisper is always on; the rest are opt-in features.
 # parakeet-coreml gives Parakeet CoreML acceleration on Apple Silicon.
-ENGINE_FEATURES="gpu-metal,parakeet-coreml,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere"
+ENGINE_FEATURES="gpu-metal,parakeet-coreml,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,gigaam"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,7 @@ pub use setup::{CompositorType, SetupAction};
 /// `src/config/engines/mod.rs` so a new engine variant forces this string
 /// to update or the build breaks.
 pub const ENGINE_NAMES_CSV: &str =
-    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox";
+    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, gigaam, soniox";
 
 /// Diarization backends the daemon dispatches on. Used by the CLI's
 /// `value_parser` for `--diarization` so unknown values are rejected at

--- a/src/config/engines/gigaam.rs
+++ b/src/config/engines/gigaam.rs
@@ -1,0 +1,33 @@
+//! GigaAM v3 RNN-T engine configuration.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::default_on_demand_loading;
+
+/// GigaAM v3 RNN-T configuration (ONNX-based Russian ASR).
+/// Requires: cargo build --features gigaam
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GigaamConfig {
+    /// Model directory name under the models dir, or an absolute path.
+    /// Expects: v3_rnnt_encoder_int8.onnx, v3_rnnt_decoder.onnx,
+    /// v3_rnnt_joint.onnx, v3_vocab.txt
+    pub model: String,
+
+    /// Number of CPU threads for ONNX Runtime inference
+    #[serde(default)]
+    pub threads: Option<usize>,
+
+    /// Load model on-demand when recording starts (true) or keep loaded (false)
+    #[serde(default = "default_on_demand_loading")]
+    pub on_demand_loading: bool,
+}
+
+impl Default for GigaamConfig {
+    fn default() -> Self {
+        Self {
+            model: "gigaam-v3-rnnt-int8".to_string(),
+            threads: None,
+            on_demand_loading: false,
+        }
+    }
+}

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 mod cohere;
 mod dolphin;
+mod gigaam;
 mod moonshine;
 mod omnilingual;
 mod paraformer;
@@ -13,6 +14,7 @@ mod soniox;
 
 pub use cohere::CohereConfig;
 pub use dolphin::DolphinConfig;
+pub use gigaam::GigaamConfig;
 pub use moonshine::MoonshineConfig;
 pub use omnilingual::OmnilingualConfig;
 pub use paraformer::ParaformerConfig;
@@ -63,6 +65,9 @@ pub enum TranscriptionEngine {
     /// task tokens). Top of the Open ASR Leaderboard.
     /// Requires: cargo build --features cohere
     Cohere,
+    /// Use GigaAM v3 RNN-T (ONNX Runtime). Russian specialist.
+    /// Requires: cargo build --features gigaam
+    Gigaam,
     /// Use Soniox (cloud streaming WebSocket STT).
     Soniox,
 }
@@ -190,6 +195,36 @@ mod tests {
             config.parakeet.as_ref().unwrap().model,
             "parakeet-tdt-0.6b-v3"
         );
+    }
+
+    #[test]
+    fn test_parse_engine_gigaam() {
+        let toml_str = r#"
+            engine = "gigaam"
+
+            [hotkey]
+            key = "SCROLLLOCK"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = "en"
+
+            [output]
+            mode = "type"
+
+            [gigaam]
+            model = "gigaam-v3-rnnt-int8"
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.engine, TranscriptionEngine::Gigaam);
+        assert!(config.gigaam.is_some());
+        assert_eq!(config.gigaam.as_ref().unwrap().model, "gigaam-v3-rnnt-int8");
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,8 +27,9 @@ mod whisper;
 pub use audio::{AudioConfig, AudioFeedbackConfig};
 pub use default_config::{default_config_content, DEFAULT_CONFIG};
 pub use engines::{
-    CohereConfig, DolphinConfig, MoonshineConfig, OmnilingualConfig, ParaformerConfig,
-    ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig, TranscriptionEngine,
+    CohereConfig, DolphinConfig, GigaamConfig, MoonshineConfig, OmnilingualConfig,
+    ParaformerConfig, ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig,
+    TranscriptionEngine,
 };
 pub use hotkey::{ActivationMode, HotkeyConfig};
 pub use language::LanguageConfig;

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -1,7 +1,8 @@
 use super::{
-    AudioConfig, CohereConfig, DolphinConfig, HotkeyConfig, MeetingConfig, MoonshineConfig,
-    OmnilingualConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile, SenseVoiceConfig,
-    SonioxConfig, StatusConfig, TextConfig, TranscriptionEngine, VadConfig, WhisperConfig,
+    AudioConfig, CohereConfig, DolphinConfig, GigaamConfig, HotkeyConfig, MeetingConfig,
+    MoonshineConfig, OmnilingualConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile,
+    SenseVoiceConfig, SonioxConfig, StatusConfig, TextConfig, TranscriptionEngine, VadConfig,
+    WhisperConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -55,6 +56,10 @@ pub struct Config {
     /// Cohere Transcribe configuration (optional, only used when engine = "cohere")
     #[serde(default)]
     pub cohere: Option<CohereConfig>,
+
+    /// GigaAM v3 RNN-T configuration (optional, only used when engine = "gigaam")
+    #[serde(default)]
+    pub gigaam: Option<GigaamConfig>,
 
     /// Soniox cloud streaming WebSocket STT configuration
     /// (optional, only used when engine = "soniox")
@@ -112,6 +117,7 @@ impl Default for Config {
             dolphin: None,
             omnilingual: None,
             cohere: None,
+            gigaam: None,
             soniox: None,
             text: TextConfig::default(),
             vad: VadConfig::default(),
@@ -338,6 +344,11 @@ impl Config {
                 .as_ref()
                 .map(|c| c.on_demand_loading)
                 .unwrap_or(false),
+            TranscriptionEngine::Gigaam => self
+                .gigaam
+                .as_ref()
+                .map(|g| g.on_demand_loading)
+                .unwrap_or(false),
             // Soniox is a cloud backend; nothing to load on demand.
             TranscriptionEngine::Soniox => false,
         }
@@ -382,6 +393,11 @@ impl Config {
                 .as_ref()
                 .map(|c| c.model.as_str())
                 .unwrap_or("cohere (not configured)"),
+            TranscriptionEngine::Gigaam => self
+                .gigaam
+                .as_ref()
+                .map(|g| g.model.as_str())
+                .unwrap_or("gigaam (not configured)"),
             TranscriptionEngine::Soniox => self
                 .soniox
                 .as_ref()

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -186,6 +186,7 @@ pub fn feature_compiled(feature: &str) -> bool {
         "dolphin" => cfg!(feature = "dolphin"),
         "omnilingual" => cfg!(feature = "omnilingual"),
         "cohere" => cfg!(feature = "cohere"),
+        "gigaam" => cfg!(feature = "gigaam"),
         _ => false,
     }
 }
@@ -660,6 +661,37 @@ pub const CONFIG_KEYS: &[KeySpec] = &[
         "Load the model when recording starts and unload at idle.",
     )
     .for_onnx_engine("cohere"),
+    // gigaam
+    spec(
+        "gigaam.model",
+        "gigaam",
+        "model",
+        KeyType::DynamicEnum { source: "models" },
+        "Engine",
+        "Model",
+        "GigaAM v3 RNN-T model directory name.",
+    )
+    .for_onnx_engine("gigaam"),
+    spec(
+        "gigaam.threads",
+        "gigaam",
+        "threads",
+        KeyType::Int { min: 1, max: 256 },
+        "Engine",
+        "Threads",
+        "ONNX Runtime intra-op threads. Unset lets voxtype pick.",
+    )
+    .for_onnx_engine("gigaam"),
+    spec(
+        "gigaam.on_demand_loading",
+        "gigaam",
+        "on_demand_loading",
+        KeyType::Bool,
+        "Engine",
+        "Load on demand",
+        "Load the model when recording starts and unload at idle.",
+    )
+    .for_onnx_engine("gigaam"),
     // -- Hotkey -------------------------------------------------------------
     spec(
         "hotkey.enabled",
@@ -1528,6 +1560,7 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
     let dol = || cfg.dolphin.clone().unwrap_or_default();
     let om = || cfg.omnilingual.clone().unwrap_or_default();
     let co = || cfg.cohere.clone().unwrap_or_default();
+    let ga = || cfg.gigaam.clone().unwrap_or_default();
 
     let v = match key {
         "engine" => json!(cfg.engine.name()),
@@ -1610,6 +1643,13 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
             None => Json::Null,
         },
         "cohere.on_demand_loading" => json!(co().on_demand_loading),
+
+        "gigaam.model" => json!(ga().model),
+        "gigaam.threads" => match ga().threads {
+            Some(n) => json!(n),
+            None => Json::Null,
+        },
+        "gigaam.on_demand_loading" => json!(ga().on_demand_loading),
 
         "hotkey.enabled" => json!(cfg.hotkey.enabled),
         "hotkey.key" => json!(cfg.hotkey.key),

--- a/src/config_set.rs
+++ b/src/config_set.rs
@@ -100,6 +100,7 @@ pub const ENGINE_NAMES: &[&str] = &[
     "dolphin",
     "omnilingual",
     "cohere",
+    "gigaam",
 ];
 
 /// Is the engine name one we recognize at all?
@@ -141,6 +142,7 @@ pub fn engine_feature_compiled(name: &str) -> bool {
         TranscriptionEngine::Dolphin => cfg!(feature = "dolphin"),
         TranscriptionEngine::Omnilingual => cfg!(feature = "omnilingual"),
         TranscriptionEngine::Cohere => cfg!(feature = "cohere"),
+        TranscriptionEngine::Gigaam => cfg!(feature = "gigaam"),
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1385,6 +1385,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Gigaam
                 | crate::config::TranscriptionEngine::Soniox => {
                     if let Some(ref t) = transcriber_preloaded {
                         Ok(t.clone())
@@ -2805,6 +2806,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Gigaam
                 | crate::config::TranscriptionEngine::Soniox => {
                     // Non-Whisper engines do their own setup; Soniox just validates
                     // API key + endpoint at construction (no model to download).
@@ -2925,6 +2927,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Gigaam
                 | crate::config::TranscriptionEngine::Soniox => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
@@ -2955,6 +2958,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Gigaam
                 | crate::config::TranscriptionEngine::Soniox => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
@@ -3138,6 +3142,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Gigaam
                 | crate::config::TranscriptionEngine::Soniox => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
@@ -3168,6 +3173,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Gigaam
                 | crate::config::TranscriptionEngine::Soniox => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
@@ -3617,6 +3623,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Gigaam
                 | crate::config::TranscriptionEngine::Soniox => {
                                     let config = self.config.clone();
                                     self.model_load_task = Some(tokio::task::spawn_blocking(move || {
@@ -3646,6 +3653,7 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
+                | crate::config::TranscriptionEngine::Gigaam
                 | crate::config::TranscriptionEngine::Soniox => {
                                     if let Some(ref t) = transcriber_preloaded {
                                         let transcriber = t.clone();

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -23,6 +23,7 @@ pub const CATALOG_ENGINES: &[&str] = &[
     "dolphin",
     "omnilingual",
     "cohere",
+    "gigaam",
 ];
 
 /// Models voxtype knows how to download for `engine`.
@@ -41,6 +42,7 @@ pub fn model_catalog(engine: &str) -> Vec<&'static str> {
             "cohere-transcribe-int8",
             "cohere-transcribe-fp16",
         ],
+        "gigaam" => vec!["gigaam-v3-rnnt-int8"],
         _ => Vec::new(),
     }
 }
@@ -58,6 +60,7 @@ pub const fn default_model(engine: &str) -> &'static str {
         b"dolphin" => "dolphin-base",
         b"omnilingual" => "omnilingual-300m",
         b"cohere" => "cohere-transcribe-q4f16",
+        b"gigaam" => "gigaam-v3-rnnt-int8",
         _ => "",
     }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -171,6 +171,7 @@ fn send_macos_native(title: &str, body: &str, engine: Option<TranscriptionEngine
         | TranscriptionEngine::Dolphin
         | TranscriptionEngine::Omnilingual
         | TranscriptionEngine::Cohere
+        | TranscriptionEngine::Gigaam
         | TranscriptionEngine::Soniox => None,
     });
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -178,6 +178,7 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
         crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",  // 🐬
         crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
         crate::config::TranscriptionEngine::Cohere => "\u{1F4DD}",   // 📝
+        crate::config::TranscriptionEngine::Gigaam => "\u{1F3A4}",   // 🎤
         crate::config::TranscriptionEngine::Soniox => "\u{2601}\u{FE0F}", // ☁️
     }
 }

--- a/src/setup/binary.rs
+++ b/src/setup/binary.rs
@@ -311,7 +311,7 @@ impl Variant {
     /// True if this variant's binary was compiled with the feature for the
     /// given engine. Whisper variants only support `whisper`; ONNX variants
     /// support every ONNX-based engine the project ships (parakeet,
-    /// moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere).
+    /// moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, gigaam).
     pub const fn supports_engine(self, engine: &str) -> bool {
         match self.family() {
             EngineFamily::Whisper => matches_str(engine, "whisper"),
@@ -323,6 +323,7 @@ impl Variant {
                     || matches_str(engine, "dolphin")
                     || matches_str(engine, "omnilingual")
                     || matches_str(engine, "cohere")
+                    || matches_str(engine, "gigaam")
             }
         }
     }
@@ -382,6 +383,7 @@ pub fn installed_engines(inv: &Inventory) -> std::collections::HashSet<&'static 
         "dolphin",
         "omnilingual",
         "cohere",
+        "gigaam",
     ];
     let mut out = std::collections::HashSet::new();
     for status in &inv.variants {
@@ -751,6 +753,9 @@ pub fn compiled_features() -> Vec<&'static str> {
     if cfg!(feature = "cohere") {
         f.push("cohere");
     }
+    if cfg!(feature = "gigaam") {
+        f.push("gigaam");
+    }
     // Meeting-mode capability: ML-based speaker diarization (ECAPA-TDNN).
     // When absent, meeting mode falls back to source-based attribution.
     if cfg!(feature = "ml-diarization") {
@@ -1091,6 +1096,7 @@ mod tests {
         require_feature_listed!("dolphin");
         require_feature_listed!("omnilingual");
         require_feature_listed!("cohere");
+        require_feature_listed!("gigaam");
         require_feature_listed!("ml-diarization");
         require_feature_listed!("gpu-vulkan");
         require_feature_listed!("gpu-cuda");

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -670,6 +670,49 @@ const COHERE_MODELS: &[CohereModelInfo] = &[
 ];
 
 // =============================================================================
+// GigaAM v3 RNN-T Model Definitions
+// =============================================================================
+//
+// Russian specialist (SberDevices GigaAM v3, RNN-T head). The INT8 bundle
+// voxtype loads is published as GitHub Release tag `models-v3-2026-06-22`
+// on ekhodzitsky/gigastt — not on Hugging Face. `huggingface_repo` is a
+// registry slot so R2 can host `gigaam/gigaam-v3-rnnt-int8/`. The HF
+// mirror script cannot fetch this bundle; seed models.voxtype.io from
+// that GitHub Release (rclone) or a dedicated HF repo if one is published.
+//
+// Files (SHA-256 of the GitHub Release assets):
+//   v3_rnnt_encoder_int8.onnx  225250603 B
+//   v3_rnnt_decoder.onnx
+//   v3_rnnt_joint.onnx
+//   v3_vocab.txt
+
+struct GigaamModelInfo {
+    name: &'static str,
+    dir_name: &'static str,
+    size_mb: u32,
+    description: &'static str,
+    languages: &'static str,
+    files: &'static [(&'static str, &'static str)],
+    huggingface_repo: &'static str,
+}
+
+const GIGAAM_MODELS: &[GigaamModelInfo] = &[GigaamModelInfo {
+    name: "gigaam-v3-rnnt-int8",
+    dir_name: "gigaam-v3-rnnt-int8",
+    size_mb: 225,
+    description: "GigaAM v3 RNN-T INT8 (Russian specialist)",
+    languages: "ru",
+    files: &[
+        ("v3_rnnt_encoder_int8.onnx", "v3_rnnt_encoder_int8.onnx"),
+        ("v3_rnnt_decoder.onnx", "v3_rnnt_decoder.onnx"),
+        ("v3_rnnt_joint.onnx", "v3_rnnt_joint.onnx"),
+        ("v3_vocab.txt", "v3_vocab.txt"),
+    ],
+    // Placeholder: files live on GitHub Releases, not this HF repo.
+    huggingface_repo: "ekhodzitsky/gigastt",
+}];
+
+// =============================================================================
 // ModelArtifact implementations
 // =============================================================================
 //
@@ -856,6 +899,28 @@ impl ModelArtifact for CohereModelInfo {
     }
 }
 
+impl ModelArtifact for GigaamModelInfo {
+    #[allow(clippy::misnamed_getters)]
+    fn name(&self) -> &str {
+        self.dir_name
+    }
+    fn engine_prefix(&self) -> &'static str {
+        "gigaam"
+    }
+    fn upstream_repo(&self) -> &str {
+        self.huggingface_repo
+    }
+    fn expected_files(&self) -> Vec<ExpectedFile> {
+        self.files
+            .iter()
+            .map(|(_repo, local)| ExpectedFile {
+                path: (*local).to_string(),
+                size: 0,
+            })
+            .collect()
+    }
+}
+
 // =============================================================================
 // Registry export (for the mirror script)
 // =============================================================================
@@ -901,8 +966,8 @@ pub(crate) fn expected_file_names(engine: &str, model: &str) -> Vec<String> {
 }
 
 /// Snapshot the full ONNX-engine model registry (Parakeet, Moonshine,
-/// SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) into a single
-/// flat list. Used by `voxtype-mirror-registry` to drive
+/// SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere, GigaAM) into a
+/// single flat list. Used by `voxtype-mirror-registry` to drive
 /// `scripts/mirror-models-to-r2.sh`.
 pub fn registry_snapshot() -> Vec<RegistryEntry> {
     let mut out = Vec::new();
@@ -1001,6 +1066,21 @@ pub fn registry_snapshot() -> Vec<RegistryEntry> {
     for m in COHERE_MODELS {
         out.push(RegistryEntry {
             engine_prefix: "cohere",
+            name: m.dir_name.to_string(),
+            upstream_repo: m.huggingface_repo.to_string(),
+            files: m
+                .files
+                .iter()
+                .map(|(remote, local)| RegistryFile {
+                    upstream_path: (*remote).to_string(),
+                    local_path: (*local).to_string(),
+                })
+                .collect(),
+        });
+    }
+    for m in GIGAAM_MODELS {
+        out.push(RegistryEntry {
+            engine_prefix: "gigaam",
             name: m.dir_name.to_string(),
             upstream_repo: m.huggingface_repo.to_string(),
             files: m
@@ -1386,6 +1466,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let is_dolphin_engine = matches!(config.engine, TranscriptionEngine::Dolphin);
     let is_omnilingual_engine = matches!(config.engine, TranscriptionEngine::Omnilingual);
     let is_cohere_engine = matches!(config.engine, TranscriptionEngine::Cohere);
+    let is_gigaam_engine = matches!(config.engine, TranscriptionEngine::Gigaam);
     let current_whisper_model = &config.whisper.model;
     let current_parakeet_model = config.parakeet.as_ref().map(|p| p.model.as_str());
     let current_moonshine_model = config.moonshine.as_ref().map(|m| m.model.as_str());
@@ -1394,6 +1475,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let current_dolphin_model = config.dolphin.as_ref().map(|d| d.model.as_str());
     let current_omnilingual_model = config.omnilingual.as_ref().map(|o| o.model.as_str());
     let current_cohere_model = config.cohere.as_ref().map(|c| c.model.as_str());
+    let current_gigaam_model = config.gigaam.as_ref().map(|g| g.model.as_str());
     let parakeet_available = cfg!(feature = "parakeet");
     let moonshine_available = cfg!(feature = "moonshine");
     let sensevoice_available = cfg!(feature = "sensevoice");
@@ -1401,6 +1483,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let dolphin_available = cfg!(feature = "dolphin");
     let omnilingual_available = cfg!(feature = "omnilingual");
     let cohere_available = cfg!(feature = "cohere");
+    let gigaam_available = cfg!(feature = "gigaam");
     let whisper_count = MODELS.len();
     let parakeet_count = PARAKEET_MODELS.len();
     let moonshine_count = MOONSHINE_MODELS.len();
@@ -1409,6 +1492,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     let dolphin_count = DOLPHIN_MODELS.len();
     let omnilingual_count = OMNILINGUAL_MODELS.len();
     let cohere_count = COHERE_MODELS.len();
+    let gigaam_count = GIGAAM_MODELS.len();
 
     let available_count = |available: bool, count: usize| if available { count } else { 0 };
     let total_count = whisper_count
@@ -1418,7 +1502,8 @@ pub async fn interactive_select() -> anyhow::Result<()> {
         + available_count(paraformer_available, paraformer_count)
         + available_count(dolphin_available, dolphin_count)
         + available_count(omnilingual_available, omnilingual_count)
-        + available_count(cohere_available, cohere_count);
+        + available_count(cohere_available, cohere_count)
+        + available_count(gigaam_available, gigaam_count);
 
     // --- Whisper Section ---
     println!("--- Whisper (OpenAI, 99+ languages) ---\n");
@@ -1718,6 +1803,42 @@ pub async fn interactive_select() -> anyhow::Result<()> {
         println!("  \x1b[90m(not available - rebuild with --features cohere)\x1b[0m");
     }
 
+    // --- GigaAM Section ---
+    let gigaam_offset = cohere_offset + available_count(cohere_available, cohere_count);
+    println!(
+        "\n--- GigaAM v3 RNN-T (Russian specialist){} ---\n",
+        AMD_CPU_ONLY_TAG
+    );
+
+    if gigaam_available {
+        for (i, model) in GIGAAM_MODELS.iter().enumerate() {
+            let model_path = models_dir.join(model.dir_name);
+            let installed = model_path.exists() && validate_gigaam_model(&model_path).is_ok();
+
+            let is_current = is_gigaam_engine && current_gigaam_model == Some(model.dir_name);
+            let star = if is_current { "*" } else { " " };
+
+            let status = if installed {
+                "\x1b[32m[installed]\x1b[0m"
+            } else {
+                ""
+            };
+
+            println!(
+                " {}[{:>2}] {:<28} ({:>4} MB) {} - {} {}",
+                star,
+                gigaam_offset + i + 1,
+                model.dir_name,
+                model.size_mb,
+                model.languages,
+                model.description,
+                status
+            );
+        }
+    } else {
+        println!("  \x1b[90m(not available - rebuild with --features gigaam)\x1b[0m");
+    }
+
     println!("\n  [ 0] Cancel\n");
 
     // Get user selection
@@ -1764,6 +1885,11 @@ pub async fn interactive_select() -> anyhow::Result<()> {
     } else if cohere_available && selection <= cohere_offset + cohere_count {
         let idx = selection - cohere_offset;
         handle_cohere_selection(idx).await
+    } else if gigaam_available && selection <= gigaam_offset + gigaam_count {
+        let idx = selection - gigaam_offset;
+        let entries: Vec<(&str, &GigaamModelInfo)> =
+            GIGAAM_MODELS.iter().map(|m| (m.name, m)).collect();
+        handle_onnx_engine_selection("gigaam", &entries, idx, validate_gigaam_model).await
     } else {
         println!("\nInvalid selection.");
         Ok(())
@@ -2738,6 +2864,29 @@ pub fn validate_cohere_model(path: &Path) -> anyhow::Result<()> {
         Ok(())
     } else {
         anyhow::bail!("Incomplete Cohere model, missing: {}", missing.join(", "))
+    }
+}
+
+/// Validate that a GigaAM model directory has encoder, decoder, joiner, vocab.
+pub fn validate_gigaam_model(path: &Path) -> anyhow::Result<()> {
+    if !path.exists() {
+        anyhow::bail!("Model directory does not exist: {:?}", path);
+    }
+    let required = [
+        "v3_rnnt_encoder_int8.onnx",
+        "v3_rnnt_decoder.onnx",
+        "v3_rnnt_joint.onnx",
+        "v3_vocab.txt",
+    ];
+    let missing: Vec<&str> = required
+        .iter()
+        .copied()
+        .filter(|f| !path.join(f).exists())
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        anyhow::bail!("Incomplete GigaAM model, missing: {}", missing.join(", "))
     }
 }
 
@@ -4239,6 +4388,45 @@ mode = "type"
             assert_eq!(m.engine_prefix(), "cohere");
             assert_eq!(m.name(), m.dir_name);
         }
+    }
+
+    #[test]
+    fn gigaam_engine_prefix() {
+        for m in GIGAAM_MODELS {
+            assert_eq!(m.engine_prefix(), "gigaam");
+            assert_eq!(m.name(), m.dir_name);
+            assert_eq!(m.upstream_repo(), m.huggingface_repo);
+            assert_eq!(m.expected_files().len(), m.files.len());
+        }
+    }
+
+    #[test]
+    fn test_validate_gigaam_model_accepts_complete_bundle() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let model_dir = tmp.path().join("gigaam-v3-rnnt-int8");
+        std::fs::create_dir_all(&model_dir).unwrap();
+        for name in [
+            "v3_rnnt_encoder_int8.onnx",
+            "v3_rnnt_decoder.onnx",
+            "v3_rnnt_joint.onnx",
+            "v3_vocab.txt",
+        ] {
+            std::fs::write(model_dir.join(name), b"x").unwrap();
+        }
+        validate_gigaam_model(&model_dir).unwrap();
+    }
+
+    #[test]
+    fn test_validate_gigaam_model_reports_missing_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let model_dir = tmp.path().join("gigaam-v3-rnnt-int8");
+        std::fs::create_dir_all(&model_dir).unwrap();
+        std::fs::write(model_dir.join("v3_vocab.txt"), b"x").unwrap();
+        let err = validate_gigaam_model(&model_dir).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("v3_rnnt_encoder_int8.onnx"), "{msg}");
+        assert!(msg.contains("v3_rnnt_decoder.onnx"), "{msg}");
+        assert!(msg.contains("v3_rnnt_joint.onnx"), "{msg}");
     }
 
     /// The `.part` name has to be one no installed-model check can match:

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -674,17 +674,13 @@ const COHERE_MODELS: &[CohereModelInfo] = &[
 // =============================================================================
 //
 // Russian specialist (SberDevices GigaAM v3, RNN-T head). The INT8 bundle
-// voxtype loads is published as GitHub Release tag `models-v3-2026-06-22`
-// on ekhodzitsky/gigastt — not on Hugging Face. `huggingface_repo` is a
-// registry slot so R2 can host `gigaam/gigaam-v3-rnnt-int8/`. The HF
-// mirror script cannot fetch this bundle; seed models.voxtype.io from
-// that GitHub Release (rclone) or a dedicated HF repo if one is published.
-//
-// Files (SHA-256 of the GitHub Release assets):
-//   v3_rnnt_encoder_int8.onnx  225250603 B
-//   v3_rnnt_decoder.onnx
-//   v3_rnnt_joint.onnx
-//   v3_vocab.txt
+// voxtype loads is GitHub Release tag `models-v3-2026-06-22` on
+// ekhodzitsky/gigastt — not Hugging Face. This engine is intentionally
+// omitted from `registry_snapshot()` so `scripts/mirror-models-to-r2.sh`
+// cannot treat a GitHub repo as an HF source. Seed R2 with rclone from
+// that release (or a dedicated HF repo) before adding it to the snapshot.
+// SHA-256 pins for the four files live in `src/transcribe/gigaam.rs` and
+// are checked at engine load.
 
 struct GigaamModelInfo {
     name: &'static str,
@@ -693,7 +689,6 @@ struct GigaamModelInfo {
     description: &'static str,
     languages: &'static str,
     files: &'static [(&'static str, &'static str)],
-    huggingface_repo: &'static str,
 }
 
 const GIGAAM_MODELS: &[GigaamModelInfo] = &[GigaamModelInfo {
@@ -708,8 +703,6 @@ const GIGAAM_MODELS: &[GigaamModelInfo] = &[GigaamModelInfo {
         ("v3_rnnt_joint.onnx", "v3_rnnt_joint.onnx"),
         ("v3_vocab.txt", "v3_vocab.txt"),
     ],
-    // Placeholder: files live on GitHub Releases, not this HF repo.
-    huggingface_repo: "ekhodzitsky/gigastt",
 }];
 
 // =============================================================================
@@ -908,7 +901,9 @@ impl ModelArtifact for GigaamModelInfo {
         "gigaam"
     }
     fn upstream_repo(&self) -> &str {
-        self.huggingface_repo
+        // Not a Hugging Face repo. Do not add this engine to
+        // `registry_snapshot()` until R2 is seeded from this tag.
+        "github.com/ekhodzitsky/gigastt/releases/tag/models-v3-2026-06-22"
     }
     fn expected_files(&self) -> Vec<ExpectedFile> {
         self.files
@@ -957,7 +952,21 @@ pub struct RegistryFile {
 /// published manifest on every download.
 ///
 /// Empty for whisper, whose models are single files with no registry entry.
+/// GigaAM is not in `registry_snapshot` (no HF upstream); its names come
+/// from the local GigaAM table so a copied bundle still has a file-list check.
 pub(crate) fn expected_file_names(engine: &str, model: &str) -> Vec<String> {
+    if engine == "gigaam" {
+        return GIGAAM_MODELS
+            .iter()
+            .find(|m| m.dir_name == model || m.name == model)
+            .map(|m| {
+                m.files
+                    .iter()
+                    .map(|(_, local)| (*local).to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+    }
     registry_snapshot()
         .into_iter()
         .find(|e| e.engine_prefix == engine && e.name == model)
@@ -965,10 +974,11 @@ pub(crate) fn expected_file_names(engine: &str, model: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Snapshot the full ONNX-engine model registry (Parakeet, Moonshine,
-/// SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere, GigaAM) into a
-/// single flat list. Used by `voxtype-mirror-registry` to drive
-/// `scripts/mirror-models-to-r2.sh`.
+/// Snapshot the ONNX-engine model registry for engines that have a Hugging
+/// Face upstream (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin,
+/// Omnilingual, Cohere). Used by `voxtype-mirror-registry` to drive
+/// `scripts/mirror-models-to-r2.sh`. GigaAM is omitted: its INT8 bundle is
+/// a GitHub Release, not an HF repo.
 pub fn registry_snapshot() -> Vec<RegistryEntry> {
     let mut out = Vec::new();
     for m in PARAKEET_MODELS {
@@ -1066,21 +1076,6 @@ pub fn registry_snapshot() -> Vec<RegistryEntry> {
     for m in COHERE_MODELS {
         out.push(RegistryEntry {
             engine_prefix: "cohere",
-            name: m.dir_name.to_string(),
-            upstream_repo: m.huggingface_repo.to_string(),
-            files: m
-                .files
-                .iter()
-                .map(|(remote, local)| RegistryFile {
-                    upstream_path: (*remote).to_string(),
-                    local_path: (*local).to_string(),
-                })
-                .collect(),
-        });
-    }
-    for m in GIGAAM_MODELS {
-        out.push(RegistryEntry {
-            engine_prefix: "gigaam",
             name: m.dir_name.to_string(),
             upstream_repo: m.huggingface_repo.to_string(),
             files: m
@@ -4395,9 +4390,37 @@ mode = "type"
         for m in GIGAAM_MODELS {
             assert_eq!(m.engine_prefix(), "gigaam");
             assert_eq!(m.name(), m.dir_name);
-            assert_eq!(m.upstream_repo(), m.huggingface_repo);
+            assert!(
+                m.upstream_repo().starts_with("github.com/"),
+                "GigaAM upstream must not look like a Hugging Face repo, got {}",
+                m.upstream_repo()
+            );
             assert_eq!(m.expected_files().len(), m.files.len());
         }
+    }
+
+    #[test]
+    fn gigaam_is_not_in_the_hf_mirror_registry() {
+        for e in registry_snapshot() {
+            assert_ne!(
+                e.engine_prefix, "gigaam",
+                "GigaAM has no HF upstream; do not list it in registry_snapshot"
+            );
+        }
+    }
+
+    #[test]
+    fn gigaam_expected_file_names_come_from_the_local_table() {
+        let names = expected_file_names("gigaam", "gigaam-v3-rnnt-int8");
+        assert_eq!(
+            names,
+            vec![
+                "v3_rnnt_encoder_int8.onnx",
+                "v3_rnnt_decoder.onnx",
+                "v3_rnnt_joint.onnx",
+                "v3_vocab.txt",
+            ]
+        );
     }
 
     #[test]

--- a/src/setup/variant_check.rs
+++ b/src/setup/variant_check.rs
@@ -234,6 +234,7 @@ mod tests {
             TranscriptionEngine::Dolphin,
             TranscriptionEngine::Omnilingual,
             TranscriptionEngine::Cohere,
+            TranscriptionEngine::Gigaam,
             TranscriptionEngine::Soniox,
         ];
         for e in engines {

--- a/src/transcribe/gigaam.rs
+++ b/src/transcribe/gigaam.rs
@@ -14,8 +14,10 @@ use ort::session::Session;
 use ort::value::Tensor;
 use rustfft::num_complex::Complex;
 use rustfft::{Fft, FftPlanner};
+use sha2::{Digest, Sha256};
 use std::f32::consts::PI;
-use std::path::PathBuf;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 const SAMPLE_RATE: usize = 16000;
@@ -45,6 +47,27 @@ const ENCODER_FILE: &str = "v3_rnnt_encoder_int8.onnx";
 const DECODER_FILE: &str = "v3_rnnt_decoder.onnx";
 const JOINT_FILE: &str = "v3_rnnt_joint.onnx";
 const VOCAB_FILE: &str = "v3_vocab.txt";
+
+/// SHA-256 of GitHub Release `models-v3-2026-06-22`. Checked at load so a
+/// manual copy (or a renamed istupakov encoder) cannot silently run.
+const GIGAAM_SHA256: &[(&str, &str)] = &[
+    (
+        ENCODER_FILE,
+        "c52665e9d96c4ca3a153c063d2ee9af6c567fe2975ca50fd038b75bbf2f60e7f",
+    ),
+    (
+        DECODER_FILE,
+        "443c3b7bd42b453611618135d6b1e7d9467e5dd97c8a68501da4aa355750c0da",
+    ),
+    (
+        JOINT_FILE,
+        "fd1d02f45c2ad3d6b67cc149811ad794ab4b020ed49a0a9e2790a8619d1cddd8",
+    ),
+    (
+        VOCAB_FILE,
+        "a9143c30844d3c0bee3e9e927e4084774eb1b9eeaafc473b2c4521e4911a7c07",
+    ),
+];
 
 struct SparseMelBand {
     start: usize,
@@ -305,6 +328,7 @@ impl GigaamTranscriber {
                 )));
             }
         }
+        verify_release_checksums(&model_dir)?;
 
         let tokenizer = Tokenizer::load(&vocab_path)?;
         let encoder = load_session(&encoder_path, threads, "encoder")?;
@@ -549,6 +573,37 @@ impl Transcriber for GigaamTranscriber {
     }
 }
 
+fn verify_release_checksums(model_dir: &Path) -> Result<(), TranscribeError> {
+    for (name, expected) in GIGAAM_SHA256 {
+        let path = model_dir.join(name);
+        let got = sha256_file(&path).map_err(|e| {
+            TranscribeError::InitFailed(format!("failed to hash GigaAM {name}: {e}"))
+        })?;
+        if got != *expected {
+            return Err(TranscribeError::InitFailed(format!(
+                "GigaAM {name} sha256 mismatch (got {got}, expected {expected}). \
+                 Use the gigastt GitHub Release models-v3-2026-06-22 files, not \
+                 istupakov/gigaam-v3-onnx."
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
 fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
     let path = PathBuf::from(model);
     if path.is_absolute() && path.exists() {
@@ -629,5 +684,28 @@ mod tests {
     fn resolve_model_path_reports_missing() {
         let err = resolve_model_path("/nonexistent/gigaam").unwrap_err();
         assert!(matches!(err, TranscribeError::ModelNotFound(_)));
+    }
+
+    #[test]
+    fn verify_release_checksums_rejects_wrong_bytes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        for (name, _) in GIGAAM_SHA256 {
+            std::fs::write(dir.path().join(name), b"not the release").unwrap();
+        }
+        let err = verify_release_checksums(dir.path()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("sha256 mismatch"), "{msg}");
+        assert!(msg.contains("models-v3-2026-06-22"), "{msg}");
+    }
+
+    #[test]
+    fn sha256_file_matches_known_vector() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("x");
+        std::fs::write(&path, b"abc").unwrap();
+        assert_eq!(
+            sha256_file(&path).unwrap(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
     }
 }

--- a/src/transcribe/gigaam.rs
+++ b/src/transcribe/gigaam.rs
@@ -1,0 +1,633 @@
+//! GigaAM v3 RNN-T speech-to-text (Russian specialist).
+//!
+//! In-tree ONNX Runtime engine: 64-mel HTK frontend + Conformer encoder +
+//! LSTM prediction network + joiner, greedy decode. Model files come from
+//! the gigastt INT8 bundle (GitHub Release `models-v3-2026-06-22`).
+//!
+//! Pipeline: Audio (f32, 16kHz) -> log-mel [64, T] -> encoder -> greedy RNN-T
+
+use super::onnx_ep;
+use super::Transcriber;
+use crate::config::GigaamConfig;
+use crate::error::TranscribeError;
+use ort::session::Session;
+use ort::value::Tensor;
+use rustfft::num_complex::Complex;
+use rustfft::{Fft, FftPlanner};
+use std::f32::consts::PI;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+const SAMPLE_RATE: usize = 16000;
+const N_MELS: usize = 64;
+const N_FFT: usize = 320;
+const HOP_LENGTH: usize = 160;
+const PRED_HIDDEN: usize = 320;
+const ENC_DIM: usize = 768;
+const MAX_TOKENS_PER_STEP: usize = 10;
+const WORD_BOUNDARY: char = '\u{2581}';
+
+const ENC_IN_AUDIO: &str = "audio_signal";
+const ENC_IN_LENGTH: &str = "length";
+const ENC_OUT_ENCODED: &str = "encoded";
+const ENC_OUT_LEN: &str = "encoded_len";
+const DEC_IN_X: &str = "x";
+const DEC_IN_H: &str = "h.1";
+const DEC_IN_C: &str = "c.1";
+const DEC_OUT_DEC: &str = "dec";
+const DEC_OUT_H: &str = "h";
+const DEC_OUT_C: &str = "c";
+const JOIN_IN_ENC: &str = "enc";
+const JOIN_IN_DEC: &str = "dec";
+const JOIN_OUT: &str = "joint";
+
+const ENCODER_FILE: &str = "v3_rnnt_encoder_int8.onnx";
+const DECODER_FILE: &str = "v3_rnnt_decoder.onnx";
+const JOINT_FILE: &str = "v3_rnnt_joint.onnx";
+const VOCAB_FILE: &str = "v3_vocab.txt";
+
+struct SparseMelBand {
+    start: usize,
+    weights: Vec<f32>,
+}
+
+struct MelSpectrogram {
+    n_fft: usize,
+    hop_length: usize,
+    window: Vec<f32>,
+    mel_bands: Vec<SparseMelBand>,
+    fft: Arc<dyn Fft<f32>>,
+}
+
+impl MelSpectrogram {
+    fn new() -> Self {
+        let n_fft = N_FFT;
+        let n_mels = N_MELS;
+        let sample_rate = SAMPLE_RATE as f32;
+        let window: Vec<f32> = (0..n_fft)
+            .map(|n| 0.5 * (1.0 - (2.0 * PI * n as f32 / (n_fft - 1) as f32).cos()))
+            .collect();
+        let filterbank = create_htk_filterbank(n_fft, n_mels, sample_rate);
+        let n_freqs = n_fft / 2 + 1;
+        let mel_bands = sparsify_mel_filterbank(&filterbank, n_mels, n_freqs);
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(n_fft);
+        Self {
+            n_fft,
+            hop_length: HOP_LENGTH,
+            window,
+            mel_bands,
+            fft,
+        }
+    }
+
+    /// Log-mel spectrogram, channels-first [n_mels, num_frames] as a flat Vec.
+    fn compute(&self, samples: &[f32]) -> (Vec<f32>, usize) {
+        let n_freqs = self.n_fft / 2 + 1;
+        let n_mels = self.mel_bands.len();
+        if samples.len() < self.n_fft {
+            return (vec![0.0; n_mels], 1);
+        }
+        let num_frames = (samples.len() - self.n_fft) / self.hop_length + 1;
+        let mut output = vec![0.0_f32; n_mels * num_frames];
+        let mut fft_input = vec![Complex::new(0.0_f32, 0.0); self.n_fft];
+        let mut power = vec![0.0_f32; n_freqs];
+
+        for frame_idx in 0..num_frames {
+            let start = frame_idx * self.hop_length;
+            for (i, (slot, window)) in fft_input.iter_mut().zip(&self.window).enumerate() {
+                let sample = samples.get(start + i).copied().unwrap_or(0.0);
+                *slot = Complex::new(sample * window, 0.0);
+            }
+            self.fft.process(&mut fft_input[..self.n_fft]);
+            for (slot, bin) in power.iter_mut().zip(fft_input.iter()) {
+                *slot = bin.norm_sqr();
+            }
+            for (m, band) in self.mel_bands.iter().enumerate() {
+                let mut energy = 0.0_f32;
+                for (i, &w) in band.weights.iter().enumerate() {
+                    energy += w * power[band.start + i];
+                }
+                output[m * num_frames + frame_idx] = energy.max(1e-10).ln();
+            }
+        }
+        (output, num_frames)
+    }
+}
+
+fn hz_to_mel(hz: f32) -> f32 {
+    2595.0 * (1.0 + hz / 700.0).log10()
+}
+
+fn mel_to_hz(mel: f32) -> f32 {
+    700.0 * (10.0_f32.powf(mel / 2595.0) - 1.0)
+}
+
+fn create_htk_filterbank(n_fft: usize, n_mels: usize, sample_rate: f32) -> Vec<f32> {
+    let n_freqs = n_fft / 2 + 1;
+    let mel_min = hz_to_mel(0.0);
+    let mel_max = hz_to_mel(sample_rate / 2.0);
+    let mel_points: Vec<f32> = (0..=(n_mels + 1))
+        .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (n_mels + 1) as f32)
+        .collect();
+    let bin_points: Vec<f32> = mel_points
+        .iter()
+        .map(|&m| mel_to_hz(m) * n_fft as f32 / sample_rate)
+        .collect();
+    let mut filterbank = vec![0.0_f32; n_mels * n_freqs];
+    for m in 0..n_mels {
+        let f_left = bin_points[m];
+        let f_center = bin_points[m + 1];
+        let f_right = bin_points[m + 2];
+        let row_start = m * n_freqs;
+        for k in 0..n_freqs {
+            let freq = k as f32;
+            filterbank[row_start + k] = if freq >= f_left && freq <= f_center && f_center > f_left {
+                (freq - f_left) / (f_center - f_left)
+            } else if freq > f_center && freq <= f_right && f_right > f_center {
+                (f_right - freq) / (f_right - f_center)
+            } else {
+                0.0
+            };
+        }
+    }
+    filterbank
+}
+
+fn sparsify_mel_filterbank(
+    filterbank: &[f32],
+    n_mels: usize,
+    n_freqs: usize,
+) -> Vec<SparseMelBand> {
+    let mut bands = Vec::with_capacity(n_mels);
+    for m in 0..n_mels {
+        let row = &filterbank[m * n_freqs..(m + 1) * n_freqs];
+        match (
+            row.iter().position(|&w| w != 0.0),
+            row.iter().rposition(|&w| w != 0.0),
+        ) {
+            (Some(start), Some(end)) => bands.push(SparseMelBand {
+                start,
+                weights: row[start..=end].to_vec(),
+            }),
+            _ => bands.push(SparseMelBand {
+                start: 0,
+                weights: vec![0.0],
+            }),
+        }
+    }
+    bands
+}
+
+struct Tokenizer {
+    tokens: Vec<String>,
+    blank_id: usize,
+}
+
+impl Tokenizer {
+    fn load(path: &std::path::Path) -> Result<Self, TranscribeError> {
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            TranscribeError::ModelNotFound(format!(
+                "failed to read vocab {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+        let mut tokens = Vec::new();
+        for line in content.lines() {
+            if line.is_empty() || line.parse::<usize>().is_ok() {
+                continue;
+            }
+            let token = if let Some(pos) = line.rfind(['\t', ' ']) {
+                let after = line[pos + 1..].trim();
+                if after.parse::<usize>().is_ok() {
+                    line[..pos].to_string()
+                } else {
+                    line.to_string()
+                }
+            } else {
+                line.to_string()
+            };
+            tokens.push(token);
+        }
+        if tokens.is_empty() {
+            return Err(TranscribeError::InitFailed(format!(
+                "vocabulary file is empty: {}",
+                path.display()
+            )));
+        }
+        let blank_id = tokens
+            .iter()
+            .position(|t| t == "<blk>")
+            .unwrap_or_else(|| tokens.len().saturating_sub(1));
+        Ok(Self { tokens, blank_id })
+    }
+
+    fn decode(&self, ids: &[usize]) -> String {
+        let mut text = String::new();
+        for &id in ids {
+            if id == self.blank_id || id >= self.tokens.len() {
+                continue;
+            }
+            let token = &self.tokens[id];
+            if token == "<unk>" {
+                continue;
+            }
+            text.push_str(token);
+        }
+        text.replace(WORD_BOUNDARY, " ").trim().to_string()
+    }
+}
+
+struct DecoderState {
+    h: Vec<f32>,
+    c: Vec<f32>,
+    prev_token: i64,
+}
+
+impl DecoderState {
+    fn new(blank_id: usize) -> Self {
+        Self {
+            h: vec![0.0; PRED_HIDDEN],
+            c: vec![0.0; PRED_HIDDEN],
+            prev_token: blank_id as i64,
+        }
+    }
+}
+
+fn extract_encoder_frame(encoded: &[f32], encoded_len: usize, t: usize, enc_frame: &mut [f32]) {
+    for (ch, slot) in enc_frame.iter_mut().enumerate() {
+        *slot = encoded[ch * encoded_len + t];
+    }
+}
+
+fn argmax(logits: &[f32], blank_id: usize) -> usize {
+    logits
+        .iter()
+        .enumerate()
+        .max_by(|(_i, a), (_j, b)| a.total_cmp(b))
+        .map(|(idx, _)| idx)
+        .unwrap_or(blank_id)
+}
+
+struct Sessions {
+    encoder: Session,
+    decoder: Session,
+    joiner: Session,
+}
+
+/// GigaAM v3 RNN-T transcriber.
+pub struct GigaamTranscriber {
+    sessions: Mutex<Sessions>,
+    tokenizer: Tokenizer,
+    mel: MelSpectrogram,
+}
+
+impl GigaamTranscriber {
+    pub fn new(config: &GigaamConfig) -> Result<Self, TranscribeError> {
+        let model_dir = resolve_model_path(&config.model)?;
+        tracing::info!("Loading GigaAM v3 RNN-T from {:?}", model_dir);
+        let start = std::time::Instant::now();
+
+        let threads = config.threads.unwrap_or_else(|| num_cpus::get().min(4));
+        let encoder_path = model_dir.join(ENCODER_FILE);
+        let decoder_path = model_dir.join(DECODER_FILE);
+        let joint_path = model_dir.join(JOINT_FILE);
+        let vocab_path = model_dir.join(VOCAB_FILE);
+        for path in [&encoder_path, &decoder_path, &joint_path, &vocab_path] {
+            if !path.exists() {
+                return Err(TranscribeError::ModelNotFound(format!(
+                    "GigaAM model file missing: {}\n  \
+                     Expected {ENCODER_FILE}, {DECODER_FILE}, {JOINT_FILE}, {VOCAB_FILE}\n  \
+                     Copy the gigastt INT8 bundle (GitHub Release models-v3-2026-06-22) \
+                     into this directory, or wait for models.voxtype.io to host it.",
+                    path.display()
+                )));
+            }
+        }
+
+        let tokenizer = Tokenizer::load(&vocab_path)?;
+        let encoder = load_session(&encoder_path, threads, "encoder")?;
+        let decoder = load_session(&decoder_path, 1, "decoder")?;
+        let joiner = load_session(&joint_path, 1, "joiner")?;
+
+        tracing::info!(
+            "GigaAM v3 RNN-T loaded in {:.2}s (vocab={}, blank_id={})",
+            start.elapsed().as_secs_f32(),
+            tokenizer.tokens.len(),
+            tokenizer.blank_id,
+        );
+
+        Ok(Self {
+            sessions: Mutex::new(Sessions {
+                encoder,
+                decoder,
+                joiner,
+            }),
+            tokenizer,
+            mel: MelSpectrogram::new(),
+        })
+    }
+
+    fn greedy_decode(
+        &self,
+        sessions: &mut Sessions,
+        encoded: &[f32],
+        encoded_len: usize,
+    ) -> Result<Vec<usize>, TranscribeError> {
+        let blank_id = self.tokenizer.blank_id;
+        let mut state = DecoderState::new(blank_id);
+        let mut tokens = Vec::new();
+        let mut enc_frame = vec![0.0_f32; ENC_DIM];
+        let mut dec_out = vec![0.0_f32; PRED_HIDDEN];
+        let mut new_h = vec![0.0_f32; PRED_HIDDEN];
+        let mut new_c = vec![0.0_f32; PRED_HIDDEN];
+        let mut cache_valid = false;
+        let mut in_blank_run = false;
+
+        if encoded.len() < ENC_DIM * encoded_len {
+            return Err(TranscribeError::InferenceFailed(format!(
+                "encoder output size mismatch: got {}, expected >= {}",
+                encoded.len(),
+                ENC_DIM * encoded_len
+            )));
+        }
+
+        for t in 0..encoded_len {
+            let mut tokens_this_step = 0;
+            extract_encoder_frame(encoded, encoded_len, t, &mut enc_frame);
+            loop {
+                if !in_blank_run {
+                    run_decoder(sessions, &state, &mut dec_out, &mut new_h, &mut new_c)?;
+                    cache_valid = true;
+                } else if !cache_valid {
+                    return Err(TranscribeError::InferenceFailed(
+                        "blank-run decoder cache is stale".to_string(),
+                    ));
+                }
+
+                let logits = run_joiner(sessions, &enc_frame, &dec_out)?;
+                let token = argmax(&logits, blank_id);
+
+                if token == blank_id {
+                    in_blank_run = true;
+                    break;
+                }
+                if tokens_this_step >= MAX_TOKENS_PER_STEP {
+                    in_blank_run = false;
+                    cache_valid = false;
+                    break;
+                }
+
+                in_blank_run = false;
+                state.prev_token = token as i64;
+                state.h.copy_from_slice(&new_h);
+                state.c.copy_from_slice(&new_c);
+                tokens.push(token);
+                tokens_this_step += 1;
+            }
+        }
+        Ok(tokens)
+    }
+}
+
+fn load_session(
+    path: &std::path::Path,
+    threads: usize,
+    label: &str,
+) -> Result<Session, TranscribeError> {
+    let builder = Session::builder()
+        .map_err(|e| TranscribeError::InitFailed(format!("ONNX session builder failed: {e}")))?;
+    let builder = onnx_ep::register_gpu_eps(builder, "GigaAM", label)
+        .map_err(|e| TranscribeError::InitFailed(format!("Failed to register EPs: {e}")))?;
+    builder
+        .with_intra_threads(threads.max(1))
+        .map_err(|e| TranscribeError::InitFailed(format!("Failed to set threads: {e}")))?
+        .commit_from_file(path)
+        .map_err(|e| {
+            TranscribeError::InitFailed(format!(
+                "Failed to load GigaAM {label} from {}: {e}",
+                path.display()
+            ))
+        })
+}
+
+fn run_decoder(
+    sessions: &mut Sessions,
+    state: &DecoderState,
+    dec_out: &mut [f32],
+    new_h: &mut [f32],
+    new_c: &mut [f32],
+) -> Result<(), TranscribeError> {
+    let x = Tensor::<i64>::from_array(([1usize, 1], vec![state.prev_token]))
+        .map_err(|e| TranscribeError::InferenceFailed(format!("decoder token tensor: {e}")))?;
+    let h = Tensor::<f32>::from_array(([1usize, 1, PRED_HIDDEN], state.h.clone()))
+        .map_err(|e| TranscribeError::InferenceFailed(format!("decoder h tensor: {e}")))?;
+    let c = Tensor::<f32>::from_array(([1usize, 1, PRED_HIDDEN], state.c.clone()))
+        .map_err(|e| TranscribeError::InferenceFailed(format!("decoder c tensor: {e}")))?;
+    let inputs: Vec<(std::borrow::Cow<str>, ort::session::SessionInputValue)> = vec![
+        (std::borrow::Cow::Borrowed(DEC_IN_X), x.into()),
+        (std::borrow::Cow::Borrowed(DEC_IN_H), h.into()),
+        (std::borrow::Cow::Borrowed(DEC_IN_C), c.into()),
+    ];
+    let outputs = sessions
+        .decoder
+        .run(inputs)
+        .map_err(|e| TranscribeError::InferenceFailed(format!("GigaAM decoder failed: {e}")))?;
+    copy_named_f32(&outputs, DEC_OUT_DEC, dec_out)?;
+    copy_named_f32(&outputs, DEC_OUT_H, new_h)?;
+    copy_named_f32(&outputs, DEC_OUT_C, new_c)?;
+    Ok(())
+}
+
+fn run_joiner(
+    sessions: &mut Sessions,
+    enc_frame: &[f32],
+    dec_data: &[f32],
+) -> Result<Vec<f32>, TranscribeError> {
+    let enc = Tensor::<f32>::from_array(([1usize, ENC_DIM, 1], enc_frame.to_vec()))
+        .map_err(|e| TranscribeError::InferenceFailed(format!("joiner enc tensor: {e}")))?;
+    let dec = Tensor::<f32>::from_array(([1usize, PRED_HIDDEN, 1], dec_data.to_vec()))
+        .map_err(|e| TranscribeError::InferenceFailed(format!("joiner dec tensor: {e}")))?;
+    let inputs: Vec<(std::borrow::Cow<str>, ort::session::SessionInputValue)> = vec![
+        (std::borrow::Cow::Borrowed(JOIN_IN_ENC), enc.into()),
+        (std::borrow::Cow::Borrowed(JOIN_IN_DEC), dec.into()),
+    ];
+    let outputs = sessions
+        .joiner
+        .run(inputs)
+        .map_err(|e| TranscribeError::InferenceFailed(format!("GigaAM joiner failed: {e}")))?;
+    let val = &outputs[JOIN_OUT];
+    let (_shape, data) = val
+        .try_extract_tensor::<f32>()
+        .map_err(|e| TranscribeError::InferenceFailed(format!("extract joiner logits: {e}")))?;
+    Ok(data.to_vec())
+}
+
+fn copy_named_f32(
+    outputs: &ort::session::SessionOutputs<'_>,
+    name: &str,
+    dest: &mut [f32],
+) -> Result<(), TranscribeError> {
+    let val = &outputs[name];
+    let (_shape, data) = val
+        .try_extract_tensor::<f32>()
+        .map_err(|e| TranscribeError::InferenceFailed(format!("extract {name}: {e}")))?;
+    if data.len() != dest.len() {
+        return Err(TranscribeError::InferenceFailed(format!(
+            "{name} size mismatch: got {}, expected {}",
+            data.len(),
+            dest.len()
+        )));
+    }
+    dest.copy_from_slice(data);
+    Ok(())
+}
+
+impl Transcriber for GigaamTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat("empty audio buffer".into()));
+        }
+        let start = std::time::Instant::now();
+        let (features, num_frames) = self.mel.compute(samples);
+        let mut sessions = self.sessions.lock().map_err(|e| {
+            TranscribeError::InferenceFailed(format!("failed to lock GigaAM sessions: {e}"))
+        })?;
+
+        let audio = Tensor::<f32>::from_array(([1usize, N_MELS, num_frames], features))
+            .map_err(|e| TranscribeError::InferenceFailed(format!("encoder audio tensor: {e}")))?;
+        let length = Tensor::<i64>::from_array(([1usize], vec![num_frames as i64]))
+            .map_err(|e| TranscribeError::InferenceFailed(format!("encoder length tensor: {e}")))?;
+        let inputs: Vec<(std::borrow::Cow<str>, ort::session::SessionInputValue)> = vec![
+            (std::borrow::Cow::Borrowed(ENC_IN_AUDIO), audio.into()),
+            (std::borrow::Cow::Borrowed(ENC_IN_LENGTH), length.into()),
+        ];
+        let outputs = sessions
+            .encoder
+            .run(inputs)
+            .map_err(|e| TranscribeError::InferenceFailed(format!("GigaAM encoder failed: {e}")))?;
+
+        let encoded_val = &outputs[ENC_OUT_ENCODED];
+        let (_enc_shape, encoded_view) = encoded_val
+            .try_extract_tensor::<f32>()
+            .map_err(|e| TranscribeError::InferenceFailed(format!("extract encoded: {e}")))?;
+        let len_val = &outputs[ENC_OUT_LEN];
+        let encoded_len = if let Ok((_, data)) = len_val.try_extract_tensor::<i32>() {
+            data.first().copied().unwrap_or(0).max(0) as usize
+        } else {
+            let (_, data) = len_val.try_extract_tensor::<i64>().map_err(|e| {
+                TranscribeError::InferenceFailed(format!("extract encoded_len: {e}"))
+            })?;
+            data.first().copied().unwrap_or(0).max(0) as usize
+        };
+        let encoded = encoded_view.to_vec();
+        drop(outputs);
+
+        tracing::debug!(
+            encoded_floats = encoded.len(),
+            encoded_len,
+            "GigaAM encoder output"
+        );
+
+        let tokens = self.greedy_decode(&mut sessions, &encoded, encoded_len)?;
+        let text = self.tokenizer.decode(&tokens);
+        tracing::info!(
+            "GigaAM transcription completed in {:.2}s: {:?}",
+            start.elapsed().as_secs_f32(),
+            if text.chars().count() > 50 {
+                format!("{}...", text.chars().take(50).collect::<String>())
+            } else {
+                text.clone()
+            }
+        );
+        Ok(text)
+    }
+
+    fn last_detected_language(&self) -> Option<String> {
+        Some("ru".to_string())
+    }
+}
+
+fn resolve_model_path(model: &str) -> Result<PathBuf, TranscribeError> {
+    let path = PathBuf::from(model);
+    if path.is_absolute() && path.exists() {
+        return Ok(path);
+    }
+    let models_dir = crate::config::Config::models_dir();
+    let candidates = [
+        models_dir.join(model),
+        PathBuf::from(model),
+        PathBuf::from("models").join(model),
+    ];
+    for candidate in &candidates {
+        if candidate.exists() {
+            return Ok(candidate.clone());
+        }
+    }
+    Err(TranscribeError::ModelNotFound(format!(
+        "GigaAM model '{}' not found. Looked in:\n  \
+         - {}\n  \
+         - {}\n  \
+         - {}\n\n\
+         Place the INT8 bundle (v3_rnnt_encoder_int8.onnx, v3_rnnt_decoder.onnx, \
+         v3_rnnt_joint.onnx, v3_vocab.txt) from \
+         https://github.com/ekhodzitsky/gigastt/releases/tag/models-v3-2026-06-22 \
+         into {}.",
+        model,
+        candidates[0].display(),
+        candidates[1].display(),
+        candidates[2].display(),
+        models_dir.join("gigaam-v3-rnnt-int8").display(),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argmax_picks_the_largest() {
+        assert_eq!(argmax(&[0.1, 4.0, 2.0], 0), 1);
+        assert_eq!(argmax(&[], 7), 7);
+    }
+
+    #[test]
+    fn extract_encoder_frame_is_channels_first() {
+        // encoded layout [ENC_DIM, T] with T=2, ENC_DIM=3 for the test.
+        let encoded = vec![
+            1.0, 2.0, // ch 0
+            3.0, 4.0, // ch 1
+            5.0, 6.0, // ch 2
+        ];
+        let mut frame = vec![0.0; 3];
+        extract_encoder_frame(&encoded, 2, 1, &mut frame);
+        assert_eq!(frame, vec![2.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn tokenizer_decodes_char_vocab() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("v3_vocab.txt");
+        std::fs::write(&path, "▁ 0\nа 1\nб 2\n<blk> 3\n").unwrap();
+        let tok = Tokenizer::load(&path).unwrap();
+        assert_eq!(tok.blank_id, 3);
+        assert_eq!(tok.decode(&[0, 1, 2]), "аб");
+    }
+
+    #[test]
+    fn mel_one_second_of_silence_has_expected_frames() {
+        let mel = MelSpectrogram::new();
+        let audio = vec![0.0f32; 16000];
+        let (feats, frames) = mel.compute(&audio);
+        // (16000 - 320) / 160 + 1 = 99
+        assert_eq!(frames, 99);
+        assert_eq!(feats.len(), N_MELS * 99);
+    }
+
+    #[test]
+    fn resolve_model_path_reports_missing() {
+        let err = resolve_model_path("/nonexistent/gigaam").unwrap_err();
+        assert!(matches!(err, TranscribeError::ModelNotFound(_)));
+    }
+}

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -11,6 +11,7 @@
 //! - Optionally Paraformer via ONNX Runtime (when `paraformer` feature is enabled)
 //! - Optionally Dolphin via ONNX Runtime (when `dolphin` feature is enabled)
 //! - Optionally Omnilingual via ONNX Runtime (when `omnilingual` feature is enabled)
+//! - Optionally GigaAM v3 RNN-T via ONNX Runtime (when `gigaam` feature is enabled)
 
 pub mod cli;
 #[cfg(feature = "parakeet")]
@@ -74,6 +75,9 @@ pub mod cohere;
 /// Cohere-specific log-mel feature extractor (NeMo conventions, 128 mels).
 #[cfg(feature = "cohere")]
 pub mod cohere_fbank;
+
+#[cfg(feature = "gigaam")]
+pub mod gigaam;
 
 use crate::config::{Config, TranscriptionEngine, WhisperConfig, WhisperMode};
 use crate::error::TranscribeError;
@@ -266,6 +270,20 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
         #[cfg(not(feature = "cohere"))]
         TranscriptionEngine::Cohere => Err(TranscribeError::InitFailed(
             "Cohere engine requested but voxtype was not compiled with --features cohere"
+                .to_string(),
+        )),
+        #[cfg(feature = "gigaam")]
+        TranscriptionEngine::Gigaam => {
+            let cfg = config.gigaam.as_ref().ok_or_else(|| {
+                TranscribeError::InitFailed(
+                    "GigaAM engine selected but [gigaam] config section is missing".to_string(),
+                )
+            })?;
+            Ok(Box::new(gigaam::GigaamTranscriber::new(cfg)?))
+        }
+        #[cfg(not(feature = "gigaam"))]
+        TranscriptionEngine::Gigaam => Err(TranscribeError::InitFailed(
+            "GigaAM engine requested but voxtype was not compiled with --features gigaam"
                 .to_string(),
         )),
         TranscriptionEngine::Soniox => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -525,6 +525,14 @@ fn detect_missing_model() -> Option<MissingModel> {
         // Cohere — checked but model layout differs by rc/0.7.0; skip the
         // disk probe rather than emit a false-positive missing warning.
         config::TranscriptionEngine::Cohere => return None,
+        config::TranscriptionEngine::Gigaam => (
+            "gigaam",
+            cfg.gigaam
+                .as_ref()
+                .map(|c| c.model.clone())
+                .unwrap_or_default(),
+            "voxtype setup --download",
+        ),
         // Soniox is cloud-only, no local model to probe.
         config::TranscriptionEngine::Soniox => return None,
     };

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -117,6 +117,12 @@ pub struct AllFields {
     pub co_threads: Option<i64>,
     pub co_on_demand_loading: bool,
     pub co_section_existed: bool,
+
+    // GigaAM v3 RNN-T (ONNX, Russian specialist)
+    pub ga_model: String,
+    pub ga_threads: Option<i64>,
+    pub ga_on_demand_loading: bool,
+    pub ga_section_existed: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -186,6 +192,11 @@ pub enum FieldId {
     CoLanguage,
     CoThreads,
     CoOnDemandLoading,
+
+    // GigaAM
+    GaModel,
+    GaThreads,
+    GaOnDemandLoading,
 }
 
 /// Cohere Transcribe officially supports these 14 languages. Token IDs are
@@ -263,6 +274,11 @@ fn rows_for_engine_with_mode(engine: &str, whisper_mode: &str) -> Vec<FieldId> {
             FieldId::CoLanguage,
             FieldId::CoThreads,
             FieldId::CoOnDemandLoading,
+        ]),
+        "gigaam" => rows.extend_from_slice(&[
+            FieldId::GaModel,
+            FieldId::GaThreads,
+            FieldId::GaOnDemandLoading,
         ]),
         _ => {}
     }
@@ -369,6 +385,14 @@ impl EngineState {
             co_threads: ed.get_int("cohere", "threads"),
             co_on_demand_loading: ed.get_bool("cohere", "on_demand_loading").unwrap_or(false),
             co_section_existed: ed.get_string("cohere", "model").is_some(),
+
+            // GigaAM
+            ga_model: ed
+                .get_string("gigaam", "model")
+                .unwrap_or_else(|| default_model("gigaam").to_string()),
+            ga_threads: ed.get_int("gigaam", "threads"),
+            ga_on_demand_loading: ed.get_bool("gigaam", "on_demand_loading").unwrap_or(false),
+            ga_section_existed: ed.get_string("gigaam", "model").is_some(),
         };
         let mut state = Self {
             engine,
@@ -581,6 +605,16 @@ impl EngineState {
                 None => ed.unset("cohere", "threads"),
             }
             ed.set_bool("cohere", "on_demand_loading", f.co_on_demand_loading);
+        }
+
+        // GigaAM
+        if self.engine == "gigaam" || f.ga_section_existed {
+            ed.set_string("gigaam", "model", &f.ga_model);
+            match f.ga_threads {
+                Some(n) => ed.set_int("gigaam", "threads", n),
+                None => ed.unset("gigaam", "threads"),
+            }
+            ed.set_bool("gigaam", "on_demand_loading", f.ga_on_demand_loading);
         }
 
         match ed.save() {
@@ -824,6 +858,10 @@ impl EngineState {
             }
             FieldId::CoThreads => f.co_threads = cycle_threads(f.co_threads, delta),
             FieldId::CoOnDemandLoading => f.co_on_demand_loading = !f.co_on_demand_loading,
+
+            FieldId::GaModel => f.ga_model = cycle_model("gigaam", &f.ga_model, delta),
+            FieldId::GaThreads => f.ga_threads = cycle_threads(f.ga_threads, delta),
+            FieldId::GaOnDemandLoading => f.ga_on_demand_loading = !f.ga_on_demand_loading,
         }
         self.dirty_since_load = true;
         self.feedback = None;
@@ -846,6 +884,7 @@ fn active_model_for_engine(engine: &str, f: &AllFields) -> Option<String> {
         "dolphin" => Some(f.dol_model.clone()),
         "omnilingual" => Some(f.om_model.clone()),
         "cohere" => Some(f.co_model.clone()),
+        "gigaam" => Some(f.ga_model.clone()),
         _ => None,
     }
 }
@@ -881,6 +920,7 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
             "dolphin",
             "omnilingual",
             "cohere",
+            "gigaam",
         ] {
             if variant.supports_engine(engine) {
                 out.insert(engine);
@@ -903,6 +943,7 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
             "dolphin",
             "omnilingual",
             "cohere",
+            "gigaam",
         ] {
             if *f == engine {
                 out.insert(engine);
@@ -1030,6 +1071,7 @@ const AMD_CPU_ONLY_ENGINES: &[&str] = &[
     "dolphin",
     "omnilingual",
     "cohere",
+    "gigaam",
 ];
 
 fn engine_value_for_display(engine: &str) -> String {
@@ -1212,6 +1254,18 @@ fn field_label_value(state: &EngineState, fid: FieldId) -> (&'static str, String
             "Cohere · on-demand model load",
             yesno(f.co_on_demand_loading),
         ),
+
+        FieldId::GaModel => ("GigaAM · model", f.ga_model.clone()),
+        FieldId::GaThreads => (
+            "GigaAM · threads",
+            f.ga_threads
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "auto".to_string()),
+        ),
+        FieldId::GaOnDemandLoading => (
+            "GigaAM · on-demand model load",
+            yesno(f.ga_on_demand_loading),
+        ),
     }
 }
 
@@ -1307,6 +1361,11 @@ fn engine_guidance(state: &EngineState) -> Vec<Line<'static>> {
             "Cohere Transcribe (Cohere Labs). #1 on the Open ASR Leaderboard \
              for English (5.42 WER). 14 languages. ~3 GB on disk.",
         ),
+        (
+            "gigaam",
+            "GigaAM v3 RNN-T via ONNX Runtime. Russian specialist \
+             (char vocab, ~225 MB INT8). Bare lowercase output.",
+        ),
     ] {
         lines.push(Line::from(Span::styled(
             format!("{}: ", name),
@@ -1343,6 +1402,7 @@ fn guidance(state: &EngineState) -> Vec<Line<'_>> {
         FieldId::DolModel => model_guidance("dolphin", &f.dol_model),
         FieldId::OmModel => model_guidance("omnilingual", &f.om_model),
         FieldId::CoModel => model_guidance("cohere", &f.co_model),
+        FieldId::GaModel => model_guidance("gigaam", &f.ga_model),
 
         FieldId::WMode => vec![
             heading("Whisper · execution mode"),
@@ -1636,6 +1696,9 @@ fn guidance(state: &EngineState) -> Vec<Line<'_>> {
         FieldId::CoThreads => threads_guidance("Cohere"),
         FieldId::CoOnDemandLoading => on_demand_guidance("Cohere"),
 
+        FieldId::GaThreads => threads_guidance("GigaAM"),
+        FieldId::GaOnDemandLoading => on_demand_guidance("GigaAM"),
+
         FieldId::WRemoteEndpoint => vec![
             heading("Whisper · remote endpoint"),
             Line::from(""),
@@ -1757,6 +1820,7 @@ fn display_engine(engine: &str) -> &'static str {
         "dolphin" => "Dolphin",
         "omnilingual" => "Omnilingual",
         "cohere" => "Cohere",
+        "gigaam" => "GigaAM",
         _ => "Engine",
     }
 }

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -64,6 +64,7 @@ pub fn create_vad(config: &Config) -> Result<Option<Box<dyn VoiceActivityDetecto
                 | TranscriptionEngine::Dolphin
                 | TranscriptionEngine::Omnilingual
                 | TranscriptionEngine::Cohere
+                | TranscriptionEngine::Gigaam
                 | TranscriptionEngine::Soniox => VadBackend::Energy,
             }
         }


### PR DESCRIPTION
<!--
PRs target the `dev` branch, not `main`.
-->

## Description

Adds GigaAM v3 RNN-T as an in-process ONNX peer of SenseVoice / Dolphin / Cohere, for Russian dictation. This is **not** the gigastt HTTP/WebSocket server and **not** a `gigastt-core` crate dependency: it uses voxtype's existing `ort` 2.0.0-rc.12 stack.

Pipeline: 16 kHz f32 → 64-mel HTK frontend (FFT 320, hop 160) → Conformer encoder → greedy RNN-T (LSTM decoder + joiner) → 34-token char vocab. Output is bare lowercase Russian.

Config section is `[gigaam]` (name pending your preference from #544). v1 catalog has one model: `gigaam-v3-rnnt-int8`.

### Pin (GitHub Release, not Hugging Face)

The INT8 encoder voxtype should load is **not** `istupakov/gigaam-v3-onnx` (`v3_rnnt_encoder.int8.onnx`, SHA-256 `fee39808…`). That is a different encoder. The matching bundle is gigastt release [`models-v3-2026-06-22`](https://github.com/ekhodzitsky/gigastt/releases/tag/models-v3-2026-06-22):

| File | Bytes | SHA-256 |
|---|---:|---|
| `v3_rnnt_encoder_int8.onnx` | 225250603 | `c52665e9d96c4ca3a153c063d2ee9af6c567fe2975ca50fd038b75bbf2f60e7f` |
| `v3_rnnt_decoder.onnx` | 3331429 | `443c3b7bd42b453611618135d6b1e7d9467e5dd97c8a68501da4aa355750c0da` |
| `v3_rnnt_joint.onnx` | 1440448 | `fd1d02f45c2ad3d6b67cc149811ad794ab4b020ed49a0a9e2790a8619d1cddd8` |
| `v3_vocab.txt` | 198 | `a9143c30844d3c0bee3e9e927e4084774eb1b9eeaafc473b2c4521e4911a7c07` |

These four hashes are checked at engine load. GigaAM is **not** in `registry_snapshot()`, so `scripts/mirror-models-to-r2.sh` will not treat a GitHub repo as Hugging Face. Until `models.voxtype.io` hosts `gigaam/gigaam-v3-rnnt-int8/`, copy the four files into `~/.local/share/voxtype/models/gigaam-v3-rnnt-int8/`. Two options for R2:

1. rclone the GitHub Release assets into that prefix (preferred for this bundle)
2. I publish a dedicated HF repo with these exact files if you want the existing mirror script to stay HF-only, then we can add the engine to the snapshot

### Out of scope for v1

- No `ort` bump (stays 2.0.0-rc.12)
- No `gigaam-cuda` / MIGraphX feature (CPU-first; a CUDA ONNX binary still registers GPU EPs via the shared helper if another engine pulled `onnx-cuda-enabled`)
- No RUPunct, `e2e_rnnt`, `ml_ctc` / `ml_ctc_large`
- No streaming Transcriber

## Related Issue

#544

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [ ] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

What actually ran:

- `cargo check` and `cargo check --features gigaam` succeed
- Default `cargo test --lib` wiring / schema / catalog tests pass, including `gigaam_is_not_in_the_hf_mirror_registry` and `gigaam_expected_file_names_come_from_the_local_table`
- Full `cargo test --lib --bins` (no `gigaam` feature): 945 passed, 1 pre-existing macOS `/proc` failure in `running_variant_reads_the_live_process_not_the_symlink`
- `cargo test --lib --features gigaam` does **not** link here: voxtype's `ort` is `default-features = false` without `download-binaries`, and Homebrew's ORT is 1.25.1 vs rc.12's 1.24.2
- No live Russian audio through the new Transcriber in this PR

Pre-existing clippy warnings in `daemon.rs` / `output/mod.rs` / `audio/media.rs` are untouched.

## Documentation

- [x] I have updated documentation as needed
- [ ] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [ ] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

Please say which R2 path you want (rclone from the GitHub Release vs a dedicated HF repo). I'll follow that before marking this ready. Section name is `[gigaam]`; happy to rename if you prefer something else.
