### PR TITLE
fix: warn when XKB overrides bypass dotoold

### DIFF
--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -51,9 +51,12 @@ use super::TextOutput;
 use crate::error::OutputError;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::OnceLock;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+
+static SLOW_PATH_WARNING_EMITTED: OnceLock<()> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DotoolInvocation {
@@ -104,6 +107,7 @@ impl DotoolOutput {
         if let Some(ref layout) = xkb_layout {
             tracing::debug!("dotool: using keyboard layout '{}'", layout);
         }
+        Self::maybe_warn_slow_path(xkb_layout.as_deref(), xkb_variant.as_deref());
         Self {
             type_delay_ms,
             pre_type_delay_ms,
@@ -141,6 +145,23 @@ impl DotoolOutput {
             .open(&path)
             .ok()?;
         Some(path)
+    }
+
+    /// Warn if user has XKB override configured while dotoold is running.
+    fn maybe_warn_slow_path(xkb_layout: Option<&str>, xkb_variant: Option<&str>) {
+        if (xkb_layout.is_some() || xkb_variant.is_some()) && Self::daemon_pipe_path().is_some() {
+            let _ = SLOW_PATH_WARNING_EMITTED.get_or_init(|| {
+                if xkb_variant.is_some() {
+                    tracing::error!(
+                        "dotool configuration warning: XKB variant override detected while dotoold is running; dotoolc cannot receive per-call layout/variant hints, so voxtype will use direct dotool (~750ms vs ~3ms per output). If a fixed layout without variants is enough, configure DOTOOL_XKB_LAYOUT on dotoold and remove voxtype's dotool XKB override; otherwise this slowdown is expected."
+                    );
+                } else {
+                    tracing::error!(
+                        "dotool configuration warning: XKB layout override detected while dotoold is running; voxtype will use direct dotool (~750ms vs ~3ms per output). For the fast path, move DOTOOL_XKB_LAYOUT to dotoold's service environment and remove voxtype's dotool XKB layout override."
+                    );
+                }
+            });
+        }
     }
 
     fn build_commands(&self, text: &str) -> String {
@@ -434,5 +455,10 @@ mod tests {
     fn daemon_pipe_detection_respects_env_var() {
         let _guard = DotoolPipeEnvGuard::set("/nonexistent/dotool-pipe-test");
         assert!(DotoolOutput::daemon_pipe_path().is_none());
+    }
+    #[test]
+    fn maybe_warn_slow_path_does_not_panic() {
+        DotoolOutput::maybe_warn_slow_path(None, None);
+        DotoolOutput::maybe_warn_slow_path(Some("us"), None);
     }
 }

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -147,16 +147,20 @@ impl DotoolOutput {
         Some(path)
     }
 
-    /// Emit a visible configuration error when XKB overrides force the slow direct-dotool path.
+    /// Emit a visible configuration warning when XKB overrides force the slow direct-dotool path.
     fn maybe_warn_slow_path(xkb_layout: Option<&str>, xkb_variant: Option<&str>) {
+        if SLOW_PATH_WARNING_EMITTED.get().is_some() {
+            return;
+        }
+
         if (xkb_layout.is_some() || xkb_variant.is_some()) && Self::daemon_pipe_path().is_some() {
             let _ = SLOW_PATH_WARNING_EMITTED.get_or_init(|| {
                 if xkb_variant.is_some() {
-                    tracing::error!(
+                    tracing::warn!(
                         "dotool configuration warning: XKB variant override detected while dotoold is running; dotoolc cannot receive per-call layout/variant hints, so voxtype will use direct dotool (~750ms vs ~3ms per output). If a fixed layout without variants is enough, configure DOTOOL_XKB_LAYOUT on dotoold and remove voxtype's dotool XKB override; otherwise this slowdown is expected."
                     );
                 } else {
-                    tracing::error!(
+                    tracing::warn!(
                         "dotool configuration warning: XKB layout override detected while dotoold is running; voxtype will use direct dotool (~750ms vs ~3ms per output). For the fast path, move DOTOOL_XKB_LAYOUT to dotoold's service environment and remove voxtype's dotool XKB layout override."
                     );
                 }

--- a/src/output/dotool.rs
+++ b/src/output/dotool.rs
@@ -147,7 +147,7 @@ impl DotoolOutput {
         Some(path)
     }
 
-    /// Warn if user has XKB override configured while dotoold is running.
+    /// Emit a visible configuration error when XKB overrides force the slow direct-dotool path.
     fn maybe_warn_slow_path(xkb_layout: Option<&str>, xkb_variant: Option<&str>) {
         if (xkb_layout.is_some() || xkb_variant.is_some()) && Self::daemon_pipe_path().is_some() {
             let _ = SLOW_PATH_WARNING_EMITTED.get_or_init(|| {
@@ -456,8 +456,10 @@ mod tests {
         let _guard = DotoolPipeEnvGuard::set("/nonexistent/dotool-pipe-test");
         assert!(DotoolOutput::daemon_pipe_path().is_none());
     }
+
     #[test]
     fn maybe_warn_slow_path_does_not_panic() {
+        let _guard = DotoolPipeEnvGuard::set("/nonexistent/dotool-pipe-test");
         DotoolOutput::maybe_warn_slow_path(None, None);
         DotoolOutput::maybe_warn_slow_path(Some("us"), None);
     }


### PR DESCRIPTION
## Summary

- Warn once when a Voxtype dotool XKB override forces the slower direct-dotool path while dotoold is running
- Give separate guidance for layout-only and variant overrides
- Isolate the environment-dependent warning test

## Context

This extracts the dotool-specific commits from #503 so #494 and #497 can remain focused on streaming pacing and audio-device warm-up.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`