### PR TITLE
Fix: configure TUI reads/writes post-process command in the wrong table

### DIFF
--- a/src/tui/config_editor.rs
+++ b/src/tui/config_editor.rs
@@ -392,6 +392,23 @@ mod tests {
     }
 
     #[test]
+    fn dotted_table_reads_and_writes_nested() {
+        // The output section stores its post-process command under
+        // [output.post_process], so dotted paths must resolve on both
+        // the read and write sides.
+        let (_dir, path) = temp_config("[output.post_process]\ncommand = \"my-cleanup\"\n");
+        let mut ed = ConfigEditor::load_from(path).unwrap();
+        assert_eq!(
+            ed.get_string("output.post_process", "command").as_deref(),
+            Some("my-cleanup")
+        );
+        ed.set_string("output.post_process", "command", "other-cleanup");
+        assert!(ed.document.to_string().contains("command = \"other-cleanup\""));
+        ed.unset("output.post_process", "command");
+        assert_eq!(ed.get_string("output.post_process", "command"), None);
+    }
+
+    #[test]
     fn dirty_tracks_writes() {
         let (_dir, path) = temp_config("[hotkey]\nkey = \"HOME\"\n");
         let mut ed = ConfigEditor::load_from(path).unwrap();

--- a/src/tui/output_section.rs
+++ b/src/tui/output_section.rs
@@ -93,7 +93,7 @@ impl OutputState {
                 .unwrap_or(false),
             pre_type_delay_ms: ed.get_int("output", "pre_type_delay_ms").unwrap_or(0),
             append_text: ed.get_string("output", "append_text"),
-            post_process_command: ed.get_string("post_process", "command"),
+            post_process_command: ed.get_string("output.post_process", "command"),
             field: Field::Mode,
             feedback: None,
             dirty_since_load: false,
@@ -168,8 +168,8 @@ impl OutputState {
             None => ed.unset("output", "append_text"),
         }
         match &self.post_process_command {
-            Some(c) if !c.is_empty() => ed.set_string("post_process", "command", c),
-            _ => ed.unset("post_process", "command"),
+            Some(c) if !c.is_empty() => ed.set_string("output.post_process", "command", c),
+            _ => ed.unset("output.post_process", "command"),
         }
         match ed.save() {
             Ok(()) => {


### PR DESCRIPTION
## Description

The Output section of `voxtype configure` loads and saves the post-process command from a **top-level `[post_process]` table**, but the daemon (and the documented config format in `config/default.toml`) reads it from **`[output.post_process]`**. Two user-visible consequences:

- The TUI always shows `(none)` for "Post-process command", even when post-processing is configured and actively running.
- A command entered and saved through the TUI is written to `[post_process]`, which the daemon never reads — the edit silently does nothing.

This PR points the three accesses in `src/tui/output_section.rs` at the dotted path `output.post_process`. No editor changes were needed: `ConfigEditor` already resolves dotted table paths on both the read side (`table()`) and the write side (`ensure_table()` / `table_mut()`). Also adds a regression test in `config_editor.rs` covering nested get/set/unset.

Note: configs that were previously edited through the TUI may contain a stale top-level `[post_process]` table. It is harmless (the daemon ignores it, as before), so this PR does not attempt a migration.

## Related Issue

None filed — found while debugging why the TUI showed `(none)` on a machine where `[output.post_process]` was set and demonstrably running (verified against v0.7.5 and current `dev`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [ ] I have tested these changes locally
- [ ] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy -- -D warnings` with no warnings
- [ ] I have run `cargo fmt`

Opened as a draft: authored on a machine without a Rust toolchain, so relying on CI for build/test/clippy validation. The change is three string literals plus one test; happy to iterate if CI flags anything.

## Documentation

- [x] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [x] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

Reproduction: set `[output.post_process] command = "..."` in `config.toml`, run `voxtype configure` → Output → "Post-process command" shows `(none)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxirdU16LQ2n49ALW43sS3