### PR TITLE
Fix notification stacking on KDE and keep the recording banner up

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2146,6 +2146,11 @@ Controls desktop notifications at various stages.
 
 When `true`, shows a notification when recording starts (hotkey pressed).
 
+This notification has no timeout: it stays on screen for as long as the
+recording runs, and is replaced or dismissed when the recording ends. A banner
+that expired after a couple of seconds would leave the microphone live with
+nothing on screen to say so.
+
 ### on_recording_stop
 
 **Type:** Boolean
@@ -2153,6 +2158,8 @@ When `true`, shows a notification when recording starts (hotkey pressed).
 **Required:** No
 
 When `true`, shows a notification when recording stops (transcription begins).
+This one replaces the recording notification in place rather than appearing
+beside it.
 
 ### on_transcription
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -457,7 +457,8 @@ fallback_to_clipboard = true
 type_delay_ms = 0
 
 [output.notification]
-# Show notification when recording starts (hotkey pressed)
+# Show notification when recording starts (hotkey pressed).
+# Stays on screen until the recording ends.
 on_recording_start = false
 
 # Show notification when recording stops (transcription begins)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,6 @@ use crate::hotkey::{self, HotkeyEvent};
 use crate::hotkey_macos::{self as hotkey, HotkeyEvent};
 use crate::meeting::{self, MeetingDaemon, MeetingEvent, StorageConfig};
 use crate::model_manager::ModelManager;
-#[cfg(target_os = "macos")]
 use crate::notification;
 use crate::output;
 use crate::output::post_process::PostProcessor;
@@ -25,10 +24,8 @@ use crate::text::TextProcessor;
 use crate::transcribe::{StreamHandle, StreamingEvent, Transcriber};
 use pidlock::Pidlock;
 use std::path::PathBuf;
-use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::process::Command;
 use tokio::signal::unix::{signal, SignalKind};
 
 /// Send a desktop notification with optional engine icon
@@ -51,26 +48,12 @@ async fn send_notification(
 
     #[cfg(target_os = "linux")]
     {
-        let urgency_arg = format!("--urgency={}", crate::output::sanitize_urgency(urgency));
-        // Synchronous + transient hints ([#345]): force a single Voxtype
-        // notification slot the compositor overwrites in place, and prevent
-        // status updates from accumulating in the notification history.
-        let _ = Command::new("notify-send")
-            .args([
-                "--app-name=Voxtype",
-                &urgency_arg,
-                "--expire-time=2000",
-                "-h",
-                "string:x-canonical-private-synchronous:voxtype",
-                "-h",
-                "int:transient:1",
-                &title,
-                body,
-            ])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
+        // Through the notification module rather than straight to
+        // notify-send: that module owns the --replace-id bookkeeping that
+        // keeps every Voxtype notification in a single slot. Posting from
+        // here directly is why status notifications carried on stacking on
+        // KDE after #532, which only fixed the module.
+        notification::send_status(&title, body, urgency, 2000).await;
     }
 
     #[cfg(target_os = "macos")]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,7 @@ use crate::hotkey::{self, HotkeyEvent};
 use crate::hotkey_macos::{self as hotkey, HotkeyEvent};
 use crate::meeting::{self, MeetingDaemon, MeetingEvent, StorageConfig};
 use crate::model_manager::ModelManager;
-use crate::notification;
+use crate::notification::{self, Lifetime};
 use crate::output;
 use crate::output::post_process::PostProcessor;
 use crate::output::streaming::StreamingSession;
@@ -36,6 +36,26 @@ async fn send_notification(
     engine: crate::config::TranscriptionEngine,
     urgency: &str,
 ) {
+    send_notification_with_lifetime(
+        title,
+        body,
+        show_engine_icon,
+        engine,
+        urgency,
+        Lifetime::Millis(2000),
+    )
+    .await;
+}
+
+/// As `send_notification`, but the caller decides how long it stays on screen.
+async fn send_notification_with_lifetime(
+    title: &str,
+    body: &str,
+    show_engine_icon: bool,
+    engine: crate::config::TranscriptionEngine,
+    urgency: &str,
+    lifetime: Lifetime,
+) {
     // On Linux, add emoji to title. On macOS, use content image instead.
     #[cfg(target_os = "linux")]
     let title = if show_engine_icon {
@@ -53,15 +73,40 @@ async fn send_notification(
         // keeps every Voxtype notification in a single slot. Posting from
         // here directly is why status notifications carried on stacking on
         // KDE after #532, which only fixed the module.
-        notification::send_status(&title, body, urgency, 2000).await;
+        notification::send_status(&title, body, urgency, lifetime).await;
     }
 
     #[cfg(target_os = "macos")]
     {
-        // terminal-notifier has no urgency concept; ignore the arg on macOS.
-        let _ = urgency;
+        // terminal-notifier has no urgency or lifetime concept; ignore both.
+        let _ = (urgency, lifetime);
         let engine_for_icon = if show_engine_icon { Some(engine) } else { None };
         notification::send_with_engine(&title, body, engine_for_icon).await;
+    }
+}
+
+/// Take down the recording banner now that the recording has ended.
+///
+/// With stop notifications enabled the stop message replaces the banner in
+/// place, which is smoother than closing one and posting another. Without
+/// them nothing else would ever take the banner down, so it is closed.
+async fn end_recording_notification(
+    title: &str,
+    body: &str,
+    notification_config: &crate::config::NotificationConfig,
+    engine: crate::config::TranscriptionEngine,
+) {
+    if notification_config.on_recording_stop {
+        send_notification(
+            title,
+            body,
+            notification_config.show_engine_icon,
+            engine,
+            &notification_config.urgency,
+        )
+        .await;
+    } else {
+        notification::close_persistent().await;
     }
 }
 
@@ -2885,7 +2930,7 @@ impl Daemon {
 
                                 // Send notification if enabled
                                 if self.config.output.notification.on_recording_start {
-                                    send_notification("Push to Talk Active", "Recording...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
+                                    send_notification_with_lifetime("Push to Talk Active", "Recording...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency, Lifetime::UntilClosed).await;
                                 }
 
                                 // Prepare model for transcription
@@ -3053,9 +3098,7 @@ impl Daemon {
 
                                 self.play_feedback(SoundEvent::RecordingStop);
 
-                                if self.config.output.notification.on_recording_stop {
-                                    send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
-                                }
+                                end_recording_notification("Recording Stopped", "Transcribing...", &self.config.output.notification, self.config.engine).await;
 
                                 let transcriber = match self.get_transcriber_for_recording(
                                     model_override.as_deref(),
@@ -3098,7 +3141,7 @@ impl Daemon {
                                 tracing::info!("Recording started (toggle mode)");
 
                                 if self.config.output.notification.on_recording_start {
-                                    send_notification("Recording Started", "Press hotkey again to stop", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
+                                    send_notification_with_lifetime("Recording Started", "Press hotkey again to stop", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency, Lifetime::UntilClosed).await;
                                 }
 
                                 // Prepare model for transcription
@@ -3248,9 +3291,7 @@ impl Daemon {
 
                                 self.play_feedback(SoundEvent::RecordingStop);
 
-                                if self.config.output.notification.on_recording_stop {
-                                    send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
-                                }
+                                end_recording_notification("Recording Stopped", "Transcribing...", &self.config.output.notification, self.config.engine).await;
 
                                 let transcriber = match self.get_transcriber_for_recording(
                                     model_override.as_deref(),
@@ -3330,9 +3371,7 @@ impl Daemon {
                                     }
                                 }
 
-                                if self.config.output.notification.on_recording_stop {
-                                    send_notification("Cancelled", "Recording discarded", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
-                                }
+                                end_recording_notification("Cancelled", "Recording discarded", &self.config.output.notification, self.config.engine).await;
                             } else if matches!(state, State::Transcribing { .. }) {
                                 tracing::info!("Transcription cancelled via hotkey");
 
@@ -3359,9 +3398,7 @@ impl Daemon {
                                     }
                                 }
 
-                                if self.config.output.notification.on_recording_stop {
-                                    send_notification("Cancelled", "Transcription aborted", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
-                                }
+                                end_recording_notification("Cancelled", "Transcription aborted", &self.config.output.notification, self.config.engine).await;
                             } else {
                                 tracing::trace!("Cancel ignored - not recording or transcribing");
                             }
@@ -3421,9 +3458,7 @@ impl Daemon {
                             }
                         }
 
-                        if self.config.output.notification.on_recording_stop {
-                            send_notification("Cancelled", "Recording discarded", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
-                        }
+                        end_recording_notification("Cancelled", "Recording discarded", &self.config.output.notification, self.config.engine).await;
 
                         continue;
                     }
@@ -3577,7 +3612,7 @@ impl Daemon {
                         tracing::info!("Recording started (external trigger), model_override = {:?}", model_override);
 
                         if self.config.output.notification.on_recording_start {
-                            send_notification("Recording Started", "External trigger", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
+                            send_notification_with_lifetime("Recording Started", "External trigger", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency, Lifetime::UntilClosed).await;
                         }
 
                         // Prepare model for transcription
@@ -3738,9 +3773,7 @@ impl Daemon {
 
                         self.play_feedback(SoundEvent::RecordingStop);
 
-                        if self.config.output.notification.on_recording_stop {
-                            send_notification("Recording Stopped", "Transcribing...", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
-                        }
+                        end_recording_notification("Recording Stopped", "Transcribing...", &self.config.output.notification, self.config.engine).await;
 
                         let transcriber = match self.get_transcriber_for_recording(
                             model_override.as_deref(),
@@ -3902,9 +3935,7 @@ impl Daemon {
                             }
                         }
 
-                        if self.config.output.notification.on_recording_stop {
-                            send_notification("Cancelled", "Transcription aborted", self.config.output.notification.show_engine_icon, self.config.engine, &self.config.output.notification.urgency).await;
-                        }
+                        end_recording_notification("Cancelled", "Transcription aborted", &self.config.output.notification, self.config.engine).await;
                     }
                 }
 
@@ -4086,6 +4117,7 @@ impl Daemon {
             let _ = capture.stop().await;
         }
         self.restore_recording_media();
+        notification::close_persistent().await;
         if let Some(task) = streaming_task {
             let _ = task.await;
         }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -28,7 +28,7 @@ pub async fn send_with_engine(title: &str, body: &str, engine: Option<Transcript
     #[cfg(target_os = "linux")]
     {
         let _ = engine; // Linux doesn't use engine icons in notifications
-        send_linux(title, body).await;
+        send_linux(title, body, 2000, None).await;
     }
 
     #[cfg(target_os = "macos")]
@@ -60,18 +60,26 @@ static LAST_NOTIFICATION_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::A
 static REPLACE_UNSUPPORTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
-/// Arguments shared by both Linux paths: identity, lifetime, and the GNOME
-/// hints, which stay because they are still what suppresses stacking there.
+/// Arguments shared by both Linux paths: identity, lifetime, urgency, and the
+/// GNOME hints, which stay because they are still what suppresses stacking
+/// there.
 #[cfg(target_os = "linux")]
-fn linux_common_args(expire_ms: &str) -> Vec<String> {
-    vec![
+fn linux_common_args(expire_ms: u32, urgency: Option<&str>) -> Vec<String> {
+    let mut args = vec![
         "--app-name=Voxtype".to_string(),
         format!("--expire-time={}", expire_ms),
         "-h".to_string(),
         "string:x-canonical-private-synchronous:voxtype".to_string(),
         "-h".to_string(),
         "int:transient:1".to_string(),
-    ]
+    ];
+    if let Some(urgency) = urgency {
+        args.push(format!(
+            "--urgency={}",
+            crate::output::sanitize_urgency(urgency)
+        ));
+    }
+    args
 }
 
 /// `--replace-id <n>` for the notification we last posted, or nothing if we
@@ -98,14 +106,14 @@ fn remember_notification_id(stdout: &[u8]) {
 
 /// Send a notification on Linux using notify-send
 #[cfg(target_os = "linux")]
-async fn send_linux(title: &str, body: &str) {
+async fn send_linux(title: &str, body: &str, expire_ms: u32, urgency: Option<&str>) {
     // Synchronous + transient hints ([#345]) keep this in the same
     // overwrite slot as the daemon's recording/transcribing notifications
     // and prevent stacking in the GNOME/Ubuntu notification history.
     use std::sync::atomic::Ordering;
 
     if !REPLACE_UNSUPPORTED.load(Ordering::Relaxed) {
-        let mut args = linux_common_args("2000");
+        let mut args = linux_common_args(expire_ms, urgency);
         args.push("--print-id".to_string());
         args.extend(replace_args());
         args.push(title.to_string());
@@ -133,7 +141,7 @@ async fn send_linux(title: &str, body: &str) {
         }
     }
 
-    let mut args = linux_common_args("2000");
+    let mut args = linux_common_args(expire_ms, urgency);
     args.push(title.to_string());
     args.push(body.to_string());
     if let Err(e) = Command::new("notify-send")
@@ -145,6 +153,26 @@ async fn send_linux(title: &str, body: &str) {
     {
         tracing::debug!("Failed to send notification: {}", e);
     }
+}
+
+/// Send a status notification: the same single-slot behaviour as `send`, plus
+/// the caller's urgency and expiry.
+///
+/// Every Voxtype notification on Linux belongs here. A caller that shells out
+/// to `notify-send` itself gets a fresh ID from the server and stacks beside
+/// the previous notification instead of replacing it, which is how the daemon
+/// kept stacking on KDE long after the fix in #532.
+#[cfg(target_os = "linux")]
+pub async fn send_status(title: &str, body: &str, urgency: &str, expire_ms: u32) {
+    send_linux(title, body, expire_ms, Some(urgency)).await;
+}
+
+/// No-op off Linux: the macOS output drivers post their own completion
+/// notifications through terminal-notifier (see `output/cgevent.rs`), and
+/// there is no freedesktop server to talk to.
+#[cfg(not(target_os = "linux"))]
+pub async fn send_status(title: &str, body: &str, urgency: &str, expire_ms: u32) {
+    let _ = (title, body, urgency, expire_ms);
 }
 
 /// Send a macOS notification using terminal-notifier
@@ -257,7 +285,7 @@ fn send_linux_sync(title: &str, body: &str) {
     use std::sync::atomic::Ordering;
 
     if !REPLACE_UNSUPPORTED.load(Ordering::Relaxed) {
-        let mut args = linux_common_args("5000");
+        let mut args = linux_common_args(5000, None);
         args.push("--print-id".to_string());
         args.extend(replace_args());
         args.push(title.to_string());
@@ -280,7 +308,7 @@ fn send_linux_sync(title: &str, body: &str) {
         }
     }
 
-    let mut args = linux_common_args("5000");
+    let mut args = linux_common_args(5000, None);
     args.push(title.to_string());
     args.push(body.to_string());
     let _ = std::process::Command::new("notify-send")
@@ -331,12 +359,24 @@ mod linux_tests {
 
     #[test]
     fn common_args_carry_identity_and_gnome_hints() {
-        let args = linux_common_args("2000");
+        let args = linux_common_args(2000, None);
         assert!(args.contains(&"--app-name=Voxtype".to_string()));
         assert!(args.contains(&"--expire-time=2000".to_string()));
         // The GNOME hint stays: it is what suppresses stacking there, while
         // --replace-id is what does it on KDE.
         assert!(args.contains(&"string:x-canonical-private-synchronous:voxtype".to_string()));
+        // No urgency unless the caller asked for one, so the server keeps its
+        // own default rather than being pinned to "normal".
+        assert!(!args.iter().any(|a| a.starts_with("--urgency=")));
+    }
+
+    #[test]
+    fn common_args_carry_sanitized_urgency() {
+        let args = linux_common_args(2000, Some("critical"));
+        assert!(args.contains(&"--urgency=critical".to_string()));
+
+        let args = linux_common_args(2000, Some("nonsense"));
+        assert!(args.contains(&"--urgency=normal".to_string()));
     }
 }
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -12,6 +12,45 @@ use tokio::process::Command;
 
 use crate::config::TranscriptionEngine;
 
+/// How long the notification server keeps a notification on screen.
+///
+/// Most notifications are a message: once it has been on screen for a moment
+/// it has done its job. A few describe state instead, and state outlives a
+/// banner. A "recording" popup that disappears after two seconds tells the
+/// user the microphone is off while it is still live, so those stay up until
+/// something takes them down.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Lifetime {
+    /// Let the server expire the notification after this many milliseconds.
+    Millis(u32),
+    /// Keep it up until it is replaced or closed. Requires a known
+    /// notification ID, since closing it is the only way it ever goes away.
+    UntilClosed,
+}
+
+#[cfg(target_os = "linux")]
+impl Lifetime {
+    /// The freedesktop `expire-timeout` for this lifetime. 0 is the
+    /// specification's "never expire".
+    fn expire_ms(self) -> u32 {
+        match self {
+            Lifetime::Millis(ms) => ms,
+            Lifetime::UntilClosed => 0,
+        }
+    }
+
+    /// Downgrade to a timed lifetime for the paths where we cannot learn the
+    /// notification's ID. Nothing may stay up that we have no way to take
+    /// down: an unclosable recording banner would outlive the recording, and
+    /// every later one would pile up behind it.
+    fn bounded(self, fallback_ms: u32) -> Self {
+        match self {
+            Lifetime::UntilClosed => Lifetime::Millis(fallback_ms),
+            timed => timed,
+        }
+    }
+}
+
 /// Send a desktop notification with the given title and body.
 ///
 /// This function is async and non-blocking. Notification failures are
@@ -28,7 +67,7 @@ pub async fn send_with_engine(title: &str, body: &str, engine: Option<Transcript
     #[cfg(target_os = "linux")]
     {
         let _ = engine; // Linux doesn't use engine icons in notifications
-        send_linux(title, body, 2000, None).await;
+        send_linux(title, body, Lifetime::Millis(2000), None).await;
     }
 
     #[cfg(target_os = "macos")]
@@ -60,14 +99,21 @@ static LAST_NOTIFICATION_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::A
 static REPLACE_UNSUPPORTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// Whether the notification currently occupying the slot was posted with
+/// `Lifetime::UntilClosed`. Only such a notification is closed by
+/// `close_persistent`; a timed one is already on its way out, and closing it
+/// early would cut short a message the user is still reading.
+#[cfg(target_os = "linux")]
+static PERSISTENT_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 /// Arguments shared by both Linux paths: identity, lifetime, urgency, and the
 /// GNOME hints, which stay because they are still what suppresses stacking
 /// there.
 #[cfg(target_os = "linux")]
-fn linux_common_args(expire_ms: u32, urgency: Option<&str>) -> Vec<String> {
+fn linux_common_args(lifetime: Lifetime, urgency: Option<&str>) -> Vec<String> {
     let mut args = vec![
         "--app-name=Voxtype".to_string(),
-        format!("--expire-time={}", expire_ms),
+        format!("--expire-time={}", lifetime.expire_ms()),
         "-h".to_string(),
         "string:x-canonical-private-synchronous:voxtype".to_string(),
         "-h".to_string(),
@@ -95,25 +141,26 @@ fn replace_args() -> Vec<String> {
 }
 
 /// Remember the ID `notify-send -p` printed so the next notification can
-/// replace this one.
+/// replace this one, and whether that notification needs closing to go away.
 #[cfg(target_os = "linux")]
-fn remember_notification_id(stdout: &[u8]) {
+fn remember_notification_id(stdout: &[u8], lifetime: Lifetime) {
     use std::sync::atomic::Ordering;
     if let Ok(id) = String::from_utf8_lossy(stdout).trim().parse::<u32>() {
         LAST_NOTIFICATION_ID.store(id, Ordering::Relaxed);
+        PERSISTENT_ACTIVE.store(lifetime == Lifetime::UntilClosed, Ordering::Relaxed);
     }
 }
 
 /// Send a notification on Linux using notify-send
 #[cfg(target_os = "linux")]
-async fn send_linux(title: &str, body: &str, expire_ms: u32, urgency: Option<&str>) {
+async fn send_linux(title: &str, body: &str, lifetime: Lifetime, urgency: Option<&str>) {
     // Synchronous + transient hints ([#345]) keep this in the same
     // overwrite slot as the daemon's recording/transcribing notifications
     // and prevent stacking in the GNOME/Ubuntu notification history.
     use std::sync::atomic::Ordering;
 
     if !REPLACE_UNSUPPORTED.load(Ordering::Relaxed) {
-        let mut args = linux_common_args(expire_ms, urgency);
+        let mut args = linux_common_args(lifetime, urgency);
         args.push("--print-id".to_string());
         args.extend(replace_args());
         args.push(title.to_string());
@@ -126,7 +173,7 @@ async fn send_linux(title: &str, body: &str, expire_ms: u32, urgency: Option<&st
             .await
         {
             Ok(out) if out.status.success() => {
-                remember_notification_id(&out.stdout);
+                remember_notification_id(&out.stdout, lifetime);
                 return;
             }
             Ok(_) => {
@@ -141,7 +188,7 @@ async fn send_linux(title: &str, body: &str, expire_ms: u32, urgency: Option<&st
         }
     }
 
-    let mut args = linux_common_args(expire_ms, urgency);
+    let mut args = linux_common_args(lifetime.bounded(2000), urgency);
     args.push(title.to_string());
     args.push(body.to_string());
     if let Err(e) = Command::new("notify-send")
@@ -156,24 +203,67 @@ async fn send_linux(title: &str, body: &str, expire_ms: u32, urgency: Option<&st
 }
 
 /// Send a status notification: the same single-slot behaviour as `send`, plus
-/// the caller's urgency and expiry.
+/// the configured urgency and a caller-chosen lifetime.
 ///
 /// Every Voxtype notification on Linux belongs here. A caller that shells out
 /// to `notify-send` itself gets a fresh ID from the server and stacks beside
 /// the previous notification instead of replacing it, which is how the daemon
 /// kept stacking on KDE long after the fix in #532.
 #[cfg(target_os = "linux")]
-pub async fn send_status(title: &str, body: &str, urgency: &str, expire_ms: u32) {
-    send_linux(title, body, expire_ms, Some(urgency)).await;
+pub async fn send_status(title: &str, body: &str, urgency: &str, lifetime: Lifetime) {
+    send_linux(title, body, lifetime, Some(urgency)).await;
 }
 
 /// No-op off Linux: the macOS output drivers post their own completion
 /// notifications through terminal-notifier (see `output/cgevent.rs`), and
 /// there is no freedesktop server to talk to.
 #[cfg(not(target_os = "linux"))]
-pub async fn send_status(title: &str, body: &str, urgency: &str, expire_ms: u32) {
-    let _ = (title, body, urgency, expire_ms);
+pub async fn send_status(title: &str, body: &str, urgency: &str, lifetime: Lifetime) {
+    let _ = (title, body, urgency, lifetime);
 }
+
+/// Close the notification posted with `Lifetime::UntilClosed`, if one is still
+/// up. Does nothing when the slot holds a timed notification.
+///
+/// `notify-send` cannot close a notification, so this goes to the server
+/// directly. Best effort: if the call fails the banner stays until the next
+/// notification replaces it.
+#[cfg(target_os = "linux")]
+pub async fn close_persistent() {
+    use std::sync::atomic::Ordering;
+
+    if !PERSISTENT_ACTIVE.swap(false, Ordering::Relaxed) {
+        return;
+    }
+    let id = LAST_NOTIFICATION_ID.swap(0, Ordering::Relaxed);
+    if id == 0 {
+        return;
+    }
+
+    let conn = match zbus::Connection::session().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            tracing::debug!("No session bus to close notification {}: {}", id, e);
+            return;
+        }
+    };
+    if let Err(e) = conn
+        .call_method(
+            Some("org.freedesktop.Notifications"),
+            "/org/freedesktop/Notifications",
+            Some("org.freedesktop.Notifications"),
+            "CloseNotification",
+            &(id,),
+        )
+        .await
+    {
+        tracing::debug!("Failed to close notification {}: {}", id, e);
+    }
+}
+
+/// No-op off Linux, where nothing posts a notification without an expiry.
+#[cfg(not(target_os = "linux"))]
+pub async fn close_persistent() {}
 
 /// Send a macOS notification using terminal-notifier
 /// Falls back to osascript if terminal-notifier is not installed
@@ -285,7 +375,7 @@ fn send_linux_sync(title: &str, body: &str) {
     use std::sync::atomic::Ordering;
 
     if !REPLACE_UNSUPPORTED.load(Ordering::Relaxed) {
-        let mut args = linux_common_args(5000, None);
+        let mut args = linux_common_args(Lifetime::Millis(5000), None);
         args.push("--print-id".to_string());
         args.extend(replace_args());
         args.push(title.to_string());
@@ -300,7 +390,7 @@ fn send_linux_sync(title: &str, body: &str) {
             .output()
         {
             Ok(out) if out.status.success() => {
-                remember_notification_id(&out.stdout);
+                remember_notification_id(&out.stdout, Lifetime::Millis(5000));
                 return;
             }
             Ok(_) => REPLACE_UNSUPPORTED.store(true, Ordering::Relaxed),
@@ -308,7 +398,7 @@ fn send_linux_sync(title: &str, body: &str) {
         }
     }
 
-    let mut args = linux_common_args(5000, None);
+    let mut args = linux_common_args(Lifetime::Millis(5000), None);
     args.push(title.to_string());
     args.push(body.to_string());
     let _ = std::process::Command::new("notify-send")
@@ -333,14 +423,14 @@ mod linux_tests {
         // notification rather than being handed an ID it never issued.
         assert!(replace_args().is_empty());
 
-        remember_notification_id(b"778\n");
+        remember_notification_id(b"778\n", Lifetime::Millis(2000));
         assert_eq!(
             replace_args(),
             vec!["--replace-id".to_string(), "778".to_string()]
         );
 
         // A later notification replaces the newer ID, not the first one.
-        remember_notification_id(b"779");
+        remember_notification_id(b"779", Lifetime::Millis(2000));
         assert_eq!(
             replace_args(),
             vec!["--replace-id".to_string(), "779".to_string()]
@@ -348,18 +438,26 @@ mod linux_tests {
 
         // Garbage on stdout must not clobber a good ID: better to replace the
         // previous notification than to start stacking again.
-        remember_notification_id(b"not an id");
+        remember_notification_id(b"not an id", Lifetime::Millis(2000));
         assert_eq!(
             replace_args(),
             vec!["--replace-id".to_string(), "779".to_string()]
         );
+
+        // The close path keys off the lifetime of the notification in the
+        // slot. A timed one must never arm it: closing one early would cut
+        // short a message the user is still reading.
+        remember_notification_id(b"901", Lifetime::UntilClosed);
+        assert!(PERSISTENT_ACTIVE.load(Ordering::Relaxed));
+        remember_notification_id(b"902", Lifetime::Millis(2000));
+        assert!(!PERSISTENT_ACTIVE.load(Ordering::Relaxed));
 
         LAST_NOTIFICATION_ID.store(0, Ordering::Relaxed);
     }
 
     #[test]
     fn common_args_carry_identity_and_gnome_hints() {
-        let args = linux_common_args(2000, None);
+        let args = linux_common_args(Lifetime::Millis(2000), None);
         assert!(args.contains(&"--app-name=Voxtype".to_string()));
         assert!(args.contains(&"--expire-time=2000".to_string()));
         // The GNOME hint stays: it is what suppresses stacking there, while
@@ -372,11 +470,26 @@ mod linux_tests {
 
     #[test]
     fn common_args_carry_sanitized_urgency() {
-        let args = linux_common_args(2000, Some("critical"));
+        let args = linux_common_args(Lifetime::Millis(2000), Some("critical"));
         assert!(args.contains(&"--urgency=critical".to_string()));
 
-        let args = linux_common_args(2000, Some("nonsense"));
+        let args = linux_common_args(Lifetime::Millis(2000), Some("nonsense"));
         assert!(args.contains(&"--urgency=normal".to_string()));
+    }
+
+    #[test]
+    fn until_closed_never_expires() {
+        // 0 is the freedesktop value for "no timeout".
+        let args = linux_common_args(Lifetime::UntilClosed, None);
+        assert!(args.contains(&"--expire-time=0".to_string()));
+    }
+
+    #[test]
+    fn bounded_downgrades_only_the_unbounded_lifetime() {
+        // Without --print-id we never learn the ID, so an unbounded
+        // notification could never be closed again.
+        assert_eq!(Lifetime::UntilClosed.bounded(2000), Lifetime::Millis(2000));
+        assert_eq!(Lifetime::Millis(3000).bounded(2000), Lifetime::Millis(3000));
     }
 }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -212,25 +212,11 @@ pub async fn send_transcription_notification(
         "Transcribed".to_string()
     };
 
-    let urgency_arg = format!("--urgency={}", sanitize_urgency(urgency));
-    // Synchronous + transient hints ([#345]): single Voxtype notification slot
-    // that the compositor overwrites in place, and no stacking in the history.
-    let _ = Command::new("notify-send")
-        .args([
-            "--app-name=Voxtype",
-            &urgency_arg,
-            "--expire-time=3000",
-            "-h",
-            "string:x-canonical-private-synchronous:voxtype",
-            "-h",
-            "int:transient:1",
-            &title,
-            &preview,
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await;
+    // Through the notification module rather than straight to notify-send:
+    // that module owns the --replace-id bookkeeping that keeps every Voxtype
+    // notification in a single slot, and a notification posted from here
+    // stacks beside the daemon's instead of replacing it ([#532]).
+    crate::notification::send_status(&title, &preview, urgency, 3000).await;
 }
 
 /// Trait for text output implementations

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -216,7 +216,13 @@ pub async fn send_transcription_notification(
     // that module owns the --replace-id bookkeeping that keeps every Voxtype
     // notification in a single slot, and a notification posted from here
     // stacks beside the daemon's instead of replacing it ([#532]).
-    crate::notification::send_status(&title, &preview, urgency, 3000).await;
+    crate::notification::send_status(
+        &title,
+        &preview,
+        urgency,
+        crate::notification::Lifetime::Millis(3000),
+    )
+    .await;
 }
 
 /// Trait for text output implementations


### PR DESCRIPTION
## Description

Two commits:

**`fix(notification): route daemon notifications through the shared slot`**

The `--replace-id` bookkeeping added by #532 lives in `src/notification.rs`, but the daemon (`src/daemon.rs`) and the transcription path (`src/output/mod.rs`) each shelled out to `notify-send` themselves, passing only the GNOME-specific `x-canonical-private-synchronous` hint that KDE ignores. Every status notification got a fresh ID from the server and stacked. Both now go through `notification::send_status`, so all Voxtype notifications share one replaceable slot, and two copies of the argument list go away.

**`feat(notification): keep the recording banner up for the whole recording`**

The recording notification no longer expires after two seconds while the microphone is still live. It stays up until the recording ends, which is what #532 asked for: "a single notification ... remains active during recording". Nothing can get stuck on screen: the stop or cancel notification replaces it in place, with those disabled the daemon closes it over the bus since `notify-send` cannot, the daemon closes any survivor on shutdown, and where the notification ID is unknowable (libnotify older than 0.7.9) the unbounded lifetime degrades to the previous timed behaviour.

The second commit changes behaviour for anyone running `on_recording_start = true`, which defaults to `false`. No new config key, and it is a separate commit if you would rather not take it.

## Related Issue

Fixes #678 

Follows #532, which fixed the module but not its callers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [x] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

1016 tests pass, and the first commit is green on its own. New unit tests cover the urgency argument, the never-expire lifetime, the downgrade when the notification ID cannot be learned, and the flag deciding whether a notification may be closed early.

## Documentation

- [x] I have updated documentation as needed
- [ ] No documentation changes are needed

`docs/CONFIGURATION.md` and `docs/USER_MANUAL.md` note that the recording notification stays up until the recording ends.

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [ ] Wait for `ci-success` to pass before marking Ready for Review

## Additional Notes

On GNOME the `x-canonical-private-synchronous` hint makes Shell treat these as transient OSD banners, so the never-expire lifetime may not be honoured there. The hint stays because it is still what suppresses stacking on GNOME.

The TUI's background model-download notifications (`src/tui/advanced_section.rs`) still post directly and still stack among themselves. They use a separate synchronous-hint slot on purpose and run on a thread with no tokio runtime, so they are left for a follow-up.
