### PR TITLE
feat: add xAI Grok STT engine

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,7 +46,7 @@ Selects which speech-to-text engine to use for transcription.
 - `dolphin` - Dictation-optimized CTC via ONNX Runtime (Chinese + English)
 - `omnilingual` - FunASR Omnilingual CTC via ONNX Runtime (50+ languages)
 - `cohere` - Cohere Transcribe encoder-decoder via ONNX Runtime (#1 Open ASR Leaderboard, 14 languages, ~3 GB model)
-- `xai` - xAI Grok Speech-to-Text (cloud batch REST; default binary)
+- `xai` - xAI Grok Speech-to-Text (cloud batch REST; API key or SuperGrok login)
 
 **Example:**
 ```toml

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,6 +46,7 @@ Selects which speech-to-text engine to use for transcription.
 - `dolphin` - Dictation-optimized CTC via ONNX Runtime (Chinese + English)
 - `omnilingual` - FunASR Omnilingual CTC via ONNX Runtime (50+ languages)
 - `cohere` - Cohere Transcribe encoder-decoder via ONNX Runtime (#1 Open ASR Leaderboard, 14 languages, ~3 GB model)
+- `xai` - xAI Grok Speech-to-Text (cloud batch REST; default binary)
 
 **Example:**
 ```toml

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -486,6 +486,19 @@ language_hints = ["en"]
 
 See [SONIOX.md](SONIOX.md) for the full reference (realtime vs async modes, performance tips with dotoold, privacy considerations).
 
+### Cloud Backend: xAI Grok STT
+
+Batch Grok STT after you stop recording. Audio leaves the machine.
+
+```toml
+engine = "xai"
+
+[xai]
+api_key = "xai-..."
+```
+
+See [XAI.md](XAI.md).
+
 ### Creating a Custom Configuration
 
 ```bash

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -488,7 +488,7 @@ See [SONIOX.md](SONIOX.md) for the full reference (realtime vs async modes, perf
 
 ### Cloud Backend: xAI Grok STT
 
-Batch Grok STT after you stop recording. Audio leaves the machine.
+Batch Grok STT after you stop recording. Audio leaves the machine. Pay-per-token API key, or SuperGrok / X Premium+ (`voxtype setup xai --login`) which uses the same plan quota as Grok web / grok CLI.
 
 ```toml
 engine = "xai"

--- a/docs/XAI.md
+++ b/docs/XAI.md
@@ -2,6 +2,8 @@
 
 Batch STT after push-to-talk: `POST https://api.x.ai/v1/stt`. Audio leaves the machine. Not live captions.
 
+## API key (console token billing)
+
 ```toml
 engine = "xai"
 
@@ -10,6 +12,17 @@ api_key = "xai-..."
 # language = "en"   # omit or "auto" to autodetect (then format is omitted)
 ```
 
-Or `VOXTYPE_XAI_API_KEY` / `XAI_API_KEY` / `--xai-api-key`. Then `voxtype config set engine xai` and restart the daemon.
+Or `VOXTYPE_XAI_API_KEY` / `XAI_API_KEY` / `--xai-api-key`.
+
+## SuperGrok / X Premium+ (subscription quota)
+
+Same STT quality, charged against the Grok or X plan you already use on grok.com / grok CLI — not console API tokens.
+
+```bash
+voxtype setup xai --login
+voxtype config set engine xai
+```
+
+Tokens: `$XDG_DATA_HOME/voxtype/xai-oauth.json` (mode 0600). Login uses grok-cli's public OAuth client id (`b1a00492-073a-47ea-816f-4c329264a828`); xAI does not offer third-party CLI registration. The consent screen may say grok-cli. `--login --no-browser` prints the URL only. `voxtype setup xai --status` / `--logout`.
 
 xAI rejects `format=true` without a language code, so autodetect does not send `format`.

--- a/docs/XAI.md
+++ b/docs/XAI.md
@@ -1,0 +1,15 @@
+# xAI Grok Speech-to-Text
+
+Batch STT after push-to-talk: `POST https://api.x.ai/v1/stt`. Audio leaves the machine. Not live captions.
+
+```toml
+engine = "xai"
+
+[xai]
+api_key = "xai-..."
+# language = "en"   # omit or "auto" to autodetect (then format is omitted)
+```
+
+Or `VOXTYPE_XAI_API_KEY` / `XAI_API_KEY` / `--xai-api-key`. Then `voxtype config set engine xai` and restart the daemon.
+
+xAI rejects `format=true` without a language code, so autodetect does not send `format`.

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -339,6 +339,23 @@ pub(crate) async fn dispatch(
                         setup::vad::download_model()?;
                     }
                 }
+                Some(SetupAction::Xai {
+                    login,
+                    logout,
+                    status,
+                    no_browser,
+                }) => {
+                    warn_if_root("xai");
+                    if logout {
+                        voxtype::transcribe::xai_oauth::logout()?;
+                        println!("xAI OAuth session removed.");
+                    } else if login {
+                        voxtype::transcribe::xai_oauth::login_device_code(!no_browser)?;
+                    } else {
+                        println!("{}", voxtype::transcribe::xai_oauth::status_line());
+                        let _ = status;
+                    }
+                }
                 Some(SetupAction::Quickshell {
                     target,
                     source,

--- a/src/app/overrides.rs
+++ b/src/app/overrides.rs
@@ -169,6 +169,12 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
             .get_or_insert_with(config::SonioxConfig::default)
             .api_key = Some(key.clone());
     }
+    if let Some(ref key) = cli.xai_api_key {
+        config
+            .xai
+            .get_or_insert_with(config::XaiConfig::default)
+            .api_key = Some(key.clone());
+    }
 
     // Audio overrides
     if let Some(ref device) = cli.audio_device {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,7 @@ pub use setup::{CompositorType, SetupAction};
 /// `src/config/engines/mod.rs` so a new engine variant forces this string
 /// to update or the build breaks.
 pub const ENGINE_NAMES_CSV: &str =
-    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox";
+    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox, xai";
 
 /// Diarization backends the daemon dispatches on. Used by the CLI's
 /// `value_parser` for `--diarization` so unknown values are rejected at

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -188,6 +188,10 @@ pub struct Cli {
     )]
     pub soniox_api_key: Option<String>,
 
+    /// API key for xAI Grok STT (or VOXTYPE_XAI_API_KEY / XAI_API_KEY)
+    #[arg(long, value_name = "KEY", help_heading = "xAI", hide_short_help = true)]
+    pub xai_api_key: Option<String>,
+
     // -- Hotkey --
     /// Override hotkey (e.g., SCROLLLOCK, PAUSE, F13, MEDIA, WEV_234, EVTEST_226)
     #[arg(long, value_name = "KEY", help_heading = "Hotkey")]

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -184,6 +184,22 @@ pub enum SetupAction {
         status: bool,
     },
 
+    /// xAI Grok STT: SuperGrok / X Premium+ login, logout, or status
+    Xai {
+        /// Sign in (device code). Uses the Grok/X subscription quota, not console tokens.
+        #[arg(long)]
+        login: bool,
+        /// Forget stored xAI OAuth tokens
+        #[arg(long)]
+        logout: bool,
+        /// Show whether an xAI OAuth session exists
+        #[arg(long)]
+        status: bool,
+        /// With --login: print the URL only (no xdg-open)
+        #[arg(long)]
+        no_browser: bool,
+    },
+
     /// Install the Quickshell QML tree for the voxtype-osd-quickshell launcher
     ///
     /// Copies shell.qml, OsdSurface.qml, EnginePicker.qml,
@@ -623,6 +639,29 @@ mod tests {
                 assert!(!qml, "should have qml=false");
             }
             _ => panic!("Expected Setup Dms command"),
+        }
+    }
+
+    #[test]
+    fn test_setup_xai_login() {
+        let cli = Cli::parse_from(["voxtype", "setup", "xai", "--login"]);
+        match cli.command {
+            Some(Commands::Setup {
+                action:
+                    Some(SetupAction::Xai {
+                        login,
+                        logout,
+                        status,
+                        no_browser,
+                    }),
+                ..
+            }) => {
+                assert!(login);
+                assert!(!logout);
+                assert!(!status);
+                assert!(!no_browser);
+            }
+            _ => panic!("Expected Setup Xai command"),
         }
     }
 }

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -10,6 +10,7 @@ mod paraformer;
 mod parakeet;
 mod sensevoice;
 mod soniox;
+mod xai;
 
 pub use cohere::CohereConfig;
 pub use dolphin::DolphinConfig;
@@ -19,6 +20,7 @@ pub use paraformer::ParaformerConfig;
 pub use parakeet::{ParakeetConfig, ParakeetModelType};
 pub use sensevoice::SenseVoiceConfig;
 pub use soniox::SonioxConfig;
+pub use xai::XaiConfig;
 
 /// Transcription engine selection (which ASR technology to use)
 #[derive(
@@ -65,6 +67,8 @@ pub enum TranscriptionEngine {
     Cohere,
     /// Use Soniox (cloud streaming WebSocket STT).
     Soniox,
+    /// Use xAI Grok Speech-to-Text (cloud batch REST `/v1/stt`).
+    Xai,
 }
 
 impl TranscriptionEngine {
@@ -190,6 +194,19 @@ mod tests {
             config.parakeet.as_ref().unwrap().model,
             "parakeet-tdt-0.6b-v3"
         );
+    }
+
+    #[test]
+    fn test_parse_engine_xai() {
+        let toml_str = r#"
+            engine = "xai"
+
+            [xai]
+            language = "en"
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.engine, TranscriptionEngine::Xai);
+        assert_eq!(config.xai.as_ref().unwrap().language.as_deref(), Some("en"));
     }
 
     #[test]

--- a/src/config/engines/xai.rs
+++ b/src/config/engines/xai.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::super::default_true;
 
-/// Cloud batch STT. Auth: `[xai] api_key`, then `VOXTYPE_XAI_API_KEY` / `XAI_API_KEY`.
+/// Cloud batch STT. Auth: `[xai] api_key`, env keys, or `voxtype setup xai --login`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct XaiConfig {
     #[serde(default)]

--- a/src/config/engines/xai.rs
+++ b/src/config/engines/xai.rs
@@ -1,0 +1,39 @@
+//! xAI Grok Speech-to-Text (`POST https://api.x.ai/v1/stt`).
+
+use serde::{Deserialize, Serialize};
+
+use super::super::default_true;
+
+/// Cloud batch STT. Auth: `[xai] api_key`, then `VOXTYPE_XAI_API_KEY` / `XAI_API_KEY`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct XaiConfig {
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Default `https://api.x.ai/v1/stt`. Must be https.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+
+    /// ISO-639-1. Empty or `auto` = autodetect (then `format` is omitted).
+    #[serde(default)]
+    pub language: Option<String>,
+
+    /// Inverse text normalization. xAI requires `language` when this is true.
+    #[serde(default = "default_true")]
+    pub format: bool,
+
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+}
+
+impl Default for XaiConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            endpoint: None,
+            language: None,
+            format: true,
+            timeout_secs: Some(120),
+        }
+    }
+}

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1,5 +1,5 @@
 use super::parse::parse_config_with_defaults;
-use super::{Config, LanguageConfig, OutputMode, SonioxConfig, TranscriptionEngine};
+use super::{Config, LanguageConfig, OutputMode, SonioxConfig, TranscriptionEngine, XaiConfig};
 use crate::error::VoxtypeError;
 use std::path::{Path, PathBuf};
 
@@ -188,6 +188,14 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
             .soniox
             .get_or_insert_with(SonioxConfig::default)
             .api_key = Some(key);
+    }
+    for var in ["VOXTYPE_XAI_API_KEY", "XAI_API_KEY"] {
+        if let Ok(key) = std::env::var(var) {
+            if !key.trim().is_empty() {
+                config.xai.get_or_insert_with(XaiConfig::default).api_key = Some(key);
+                break;
+            }
+        }
     }
     if let Ok(val) = std::env::var("VOXTYPE_RESTORE_CLIPBOARD") {
         config.output.restore_clipboard = parse_bool_env(&val);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,6 +29,7 @@ pub use default_config::{default_config_content, DEFAULT_CONFIG};
 pub use engines::{
     CohereConfig, DolphinConfig, MoonshineConfig, OmnilingualConfig, ParaformerConfig,
     ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig, TranscriptionEngine,
+    XaiConfig,
 };
 pub use hotkey::{ActivationMode, HotkeyConfig};
 pub use language::LanguageConfig;

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -2,6 +2,7 @@ use super::{
     AudioConfig, CohereConfig, DolphinConfig, HotkeyConfig, MeetingConfig, MoonshineConfig,
     OmnilingualConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile, SenseVoiceConfig,
     SonioxConfig, StatusConfig, TextConfig, TranscriptionEngine, VadConfig, WhisperConfig,
+    XaiConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -61,6 +62,10 @@ pub struct Config {
     #[serde(default)]
     pub soniox: Option<SonioxConfig>,
 
+    /// xAI Grok STT (optional, used when engine = "xai")
+    #[serde(default)]
+    pub xai: Option<XaiConfig>,
+
     /// Text processing configuration (replacements, spoken punctuation)
     #[serde(default)]
     pub text: TextConfig,
@@ -113,6 +118,7 @@ impl Default for Config {
             omnilingual: None,
             cohere: None,
             soniox: None,
+            xai: None,
             text: TextConfig::default(),
             vad: VadConfig::default(),
             status: StatusConfig::default(),
@@ -340,6 +346,7 @@ impl Config {
                 .unwrap_or(false),
             // Soniox is a cloud backend; nothing to load on demand.
             TranscriptionEngine::Soniox => false,
+            TranscriptionEngine::Xai => false,
         }
     }
 
@@ -387,6 +394,7 @@ impl Config {
                 .as_ref()
                 .map(|s| s.model.as_str())
                 .unwrap_or("soniox (not configured)"),
+            TranscriptionEngine::Xai => "grok-stt",
         }
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -198,7 +198,7 @@ pub fn feature_compiled(feature: &str) -> bool {
 /// `src/tui/engine.rs` and [`crate::config_set::ENGINE_NAMES`]. Note this is
 /// deliberately narrower than [`super::TranscriptionEngine`], which also has
 /// a `Soniox` variant that neither the TUI picker nor `config set engine`
-/// offers today.
+/// offers today. `Xai` is in ENGINE_NAMES (cloud, but settable).
 const ENGINE_CHOICES: &[&str] = crate::config_set::ENGINE_NAMES;
 
 const WHISPER_MODE_CHOICES: &[&str] = &["local", "remote", "cli"];
@@ -2151,7 +2151,7 @@ mod tests {
     #[test]
     fn feature_gate_agrees_with_config_set() {
         for name in config_set::ENGINE_NAMES {
-            if *name == "whisper" {
+            if *name == "whisper" || *name == "xai" {
                 continue; // always available, so it has no feature entry
             }
             assert_eq!(

--- a/src/config_set.rs
+++ b/src/config_set.rs
@@ -100,6 +100,7 @@ pub const ENGINE_NAMES: &[&str] = &[
     "dolphin",
     "omnilingual",
     "cohere",
+    "xai",
 ];
 
 /// Is the engine name one we recognize at all?
@@ -134,6 +135,7 @@ pub fn engine_feature_compiled(name: &str) -> bool {
     match engine {
         TranscriptionEngine::Whisper => true,
         TranscriptionEngine::Soniox => true,
+        TranscriptionEngine::Xai => true,
         TranscriptionEngine::Parakeet => cfg!(feature = "parakeet"),
         TranscriptionEngine::Moonshine => cfg!(feature = "moonshine"),
         TranscriptionEngine::SenseVoice => cfg!(feature = "sensevoice"),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1413,7 +1413,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Xai => {
                     if let Some(ref t) = transcriber_preloaded {
                         Ok(t.clone())
                     } else {
@@ -2833,7 +2834,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Xai => {
                     // Non-Whisper engines do their own setup; Soniox just validates
                     // API key + endpoint at construction (no model to download).
                     transcriber_preloaded = Some(Arc::from(crate::transcribe::create_transcriber(
@@ -2953,7 +2955,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Xai => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -2983,7 +2986,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Xai => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -3164,7 +3168,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Xai => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -3194,7 +3199,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Xai => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -3635,7 +3641,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Xai => {
                                     let config = self.config.clone();
                                     self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                         crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -3664,7 +3671,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Xai => {
                                     if let Some(ref t) = transcriber_preloaded {
                                         let transcriber = t.clone();
                                         tokio::task::spawn_blocking(move || {

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -557,6 +557,9 @@ mod tests {
     #[test]
     fn catalog_covers_the_settable_engines() {
         for name in ENGINE_NAMES {
+            if *name == "xai" {
+                continue; // cloud STT, no downloadable model
+            }
             assert!(
                 CATALOG_ENGINES.contains(name),
                 "engine '{}' is settable but has no model catalog",

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -289,7 +289,8 @@ fn send_macos_native(title: &str, body: &str, engine: Option<TranscriptionEngine
         | TranscriptionEngine::Dolphin
         | TranscriptionEngine::Omnilingual
         | TranscriptionEngine::Cohere
-        | TranscriptionEngine::Soniox => None,
+        | TranscriptionEngine::Soniox
+        | TranscriptionEngine::Xai => None,
     });
 
     for notifier in notifier_paths {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -178,7 +178,8 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
         crate::config::TranscriptionEngine::Dolphin => "\u{1F42C}",  // 🐬
         crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
         crate::config::TranscriptionEngine::Cohere => "\u{1F4DD}",   // 📝
-        crate::config::TranscriptionEngine::Soniox => "\u{2601}\u{FE0F}", // ☁️
+        crate::config::TranscriptionEngine::Soniox => "\u{2601}\u{FE0F}",
+        crate::config::TranscriptionEngine::Xai => "\u{26A1}",
     }
 }
 

--- a/src/setup/variant_check.rs
+++ b/src/setup/variant_check.rs
@@ -63,7 +63,7 @@ pub enum Remediation {
 /// the feature name is just the engine's canonical name.
 pub fn required_feature(engine: TranscriptionEngine) -> Option<&'static str> {
     match engine {
-        TranscriptionEngine::Whisper => None,
+        TranscriptionEngine::Whisper | TranscriptionEngine::Xai => None,
         other => Some(other.name()),
     }
 }
@@ -244,5 +244,6 @@ mod tests {
             );
         }
         assert_eq!(required_feature(TranscriptionEngine::Whisper), None);
+        assert_eq!(required_feature(TranscriptionEngine::Xai), None);
     }
 }

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -21,6 +21,7 @@ pub mod streaming;
 pub mod subprocess;
 pub mod whisper;
 pub mod worker;
+pub mod xai;
 
 pub use streaming::{SegmentId, StreamHandle, StreamingEvent, StreamingTranscriber};
 
@@ -275,6 +276,10 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
                 )
             })?;
             Ok(Box::new(soniox::SonioxTranscriber::new(cfg.clone())?))
+        }
+        TranscriptionEngine::Xai => {
+            let cfg = config.xai.clone().unwrap_or_default();
+            Ok(Box::new(xai::XaiTranscriber::new(&cfg)?))
         }
     }
 }

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -22,6 +22,7 @@ pub mod subprocess;
 pub mod whisper;
 pub mod worker;
 pub mod xai;
+pub mod xai_oauth;
 
 pub use streaming::{SegmentId, StreamHandle, StreamingEvent, StreamingTranscriber};
 

--- a/src/transcribe/xai.rs
+++ b/src/transcribe/xai.rs
@@ -1,5 +1,6 @@
 //! Grok Speech-to-Text (`POST https://api.x.ai/v1/stt`). Batch after PTT.
 
+use super::xai_oauth;
 use super::Transcriber;
 use crate::config::XaiConfig;
 use crate::error::TranscribeError;
@@ -9,23 +10,24 @@ use ureq::serde_json;
 
 const DEFAULT_ENDPOINT: &str = "https://api.x.ai/v1/stt";
 
-#[derive(Debug)]
 pub struct XaiTranscriber {
     endpoint: String,
     language: Option<String>,
     format: bool,
     timeout: Duration,
-    api_key: String,
+    api_key: Option<String>,
 }
 
 impl XaiTranscriber {
     pub fn new(config: &XaiConfig) -> Result<Self, TranscribeError> {
-        let api_key = api_key(config.api_key.as_deref()).ok_or_else(|| {
-            TranscribeError::ConfigError(
-                "xAI engine needs an API key: [xai] api_key, VOXTYPE_XAI_API_KEY, or XAI_API_KEY"
+        let api_key = explicit_api_key(config.api_key.as_deref());
+        if api_key.is_none() && !xai_oauth::is_logged_in() {
+            return Err(TranscribeError::ConfigError(
+                "xAI engine needs credentials. Set [xai] api_key, VOXTYPE_XAI_API_KEY / XAI_API_KEY, \
+                 or run: voxtype setup xai --login"
                     .into(),
-            )
-        })?;
+            ));
+        }
 
         let endpoint = config
             .endpoint
@@ -49,8 +51,13 @@ impl XaiTranscriber {
             .map(str::to_string);
 
         tracing::info!(
-            "Configured xAI STT: endpoint={endpoint}, language={}",
-            language.as_deref().unwrap_or("auto")
+            "Configured xAI STT: endpoint={endpoint}, language={}, auth={}",
+            language.as_deref().unwrap_or("auto"),
+            if api_key.is_some() {
+                "api_key"
+            } else {
+                "oauth"
+            }
         );
 
         Ok(Self {
@@ -60,6 +67,13 @@ impl XaiTranscriber {
             timeout: Duration::from_secs(config.timeout_secs.unwrap_or(120).max(5)),
             api_key,
         })
+    }
+
+    fn bearer(&self) -> Result<String, TranscribeError> {
+        if let Some(ref k) = self.api_key {
+            return Ok(k.clone());
+        }
+        xai_oauth::access_token().map_err(|e| TranscribeError::ConfigError(e.to_string()))
     }
 
     fn encode_wav(samples: &[f32]) -> Result<Vec<u8>, TranscribeError> {
@@ -110,9 +124,27 @@ impl XaiTranscriber {
         body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
         (boundary, body)
     }
+
+    fn post(
+        &self,
+        bearer: &str,
+        boundary: &str,
+        body: &[u8],
+    ) -> Result<ureq::Response, Box<ureq::Error>> {
+        ureq::post(&self.endpoint)
+            .timeout(self.timeout)
+            .set(
+                "Content-Type",
+                &format!("multipart/form-data; boundary={boundary}"),
+            )
+            .set("Authorization", &format!("Bearer {bearer}"))
+            .set("User-Agent", "voxtype")
+            .send_bytes(body)
+            .map_err(Box::new)
+    }
 }
 
-fn api_key(from_config: Option<&str>) -> Option<String> {
+fn explicit_api_key(from_config: Option<&str>) -> Option<String> {
     if let Some(k) = from_config.map(str::trim).filter(|s| !s.is_empty()) {
         return Some(k.to_string());
     }
@@ -144,24 +176,27 @@ impl Transcriber for XaiTranscriber {
         let start = std::time::Instant::now();
         let wav = Self::encode_wav(samples)?;
         let (boundary, body) = self.build_multipart(&wav);
-        let response = ureq::post(&self.endpoint)
-            .timeout(self.timeout)
-            .set(
-                "Content-Type",
-                &format!("multipart/form-data; boundary={boundary}"),
-            )
-            .set("Authorization", &format!("Bearer {}", self.api_key))
-            .set("User-Agent", "voxtype")
-            .send_bytes(&body)
-            .map_err(|e| match e {
-                ureq::Error::Status(code, resp) => {
-                    let body = resp.into_string().unwrap_or_default();
-                    TranscribeError::RemoteError(format!("xAI STT HTTP {code}: {body}"))
+        let mut bearer = self.bearer()?;
+        let mut response = self.post(&bearer, &boundary, &body);
+        if let Err(e) = &response {
+            if let ureq::Error::Status(code, _) = e.as_ref() {
+                if *code == 401 && self.api_key.is_none() {
+                    if let Ok(tok) = xai_oauth::force_refresh() {
+                        bearer = tok;
+                        response = self.post(&bearer, &boundary, &body);
+                    }
                 }
-                ureq::Error::Transport(t) => {
-                    TranscribeError::NetworkError(format!("xAI STT request failed: {t}"))
-                }
-            })?;
+            }
+        }
+        let response = response.map_err(|e| match *e {
+            ureq::Error::Status(code, resp) => {
+                let body = resp.into_string().unwrap_or_default();
+                TranscribeError::RemoteError(format!("xAI STT HTTP {code}: {body}"))
+            }
+            ureq::Error::Transport(t) => {
+                TranscribeError::NetworkError(format!("xAI STT request failed: {t}"))
+            }
+        })?;
         let json: serde_json::Value = response.into_json().map_err(|e| {
             TranscribeError::RemoteError(format!("Failed to parse xAI STT response: {e}"))
         })?;
@@ -200,7 +235,7 @@ mod tests {
             language: None,
             format: true,
             timeout: Duration::from_secs(5),
-            api_key: "test".into(),
+            api_key: Some("test".into()),
         };
         let (_b, body) = t.build_multipart(b"WAV");
         let s = String::from_utf8_lossy(&body);
@@ -216,14 +251,14 @@ mod tests {
             language: Some("en".into()),
             format: true,
             timeout: Duration::from_secs(5),
-            api_key: "test".into(),
+            api_key: Some("test".into()),
         };
         let (_b, body) = t.build_multipart(b"WAV");
         let s = String::from_utf8_lossy(&body);
+        let lang = s.find("name=\"language\"").unwrap();
+        let format = s.find("name=\"format\"").unwrap();
         let file = s.find("name=\"file\"").unwrap();
-        assert!(s.contains("name=\"language\""));
-        assert!(s.contains("name=\"format\""));
-        assert!(file > s.find("name=\"language\"").unwrap());
+        assert!(lang < format && format < file, "{s}");
     }
 
     #[test]
@@ -233,13 +268,41 @@ mod tests {
             endpoint: Some("http://127.0.0.1/stt".into()),
             ..XaiConfig::default()
         };
-        let msg = XaiTranscriber::new(&cfg).unwrap_err().to_string();
+        let msg = match XaiTranscriber::new(&cfg) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("http endpoint should fail"),
+        };
         assert!(msg.contains("https"), "{msg}");
     }
 
     #[test]
-    fn rejects_missing_key() {
-        let err = XaiTranscriber::new(&XaiConfig::default()).unwrap_err();
-        assert!(err.to_string().contains("API key"));
+    fn rejects_missing_credentials() {
+        let prev_data = std::env::var_os("VOXTYPE_DATA_DIR");
+        let prev_a = std::env::var_os("VOXTYPE_XAI_API_KEY");
+        let prev_b = std::env::var_os("XAI_API_KEY");
+        let dir = std::env::temp_dir().join(format!("voxtype-xai-nocred-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        std::env::set_var("VOXTYPE_DATA_DIR", &dir);
+        std::env::remove_var("VOXTYPE_XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+        let err = match XaiTranscriber::new(&XaiConfig::default()) {
+            Err(e) => e,
+            Ok(_) => panic!("missing credentials should fail"),
+        };
+        match prev_data {
+            Some(v) => std::env::set_var("VOXTYPE_DATA_DIR", v),
+            None => std::env::remove_var("VOXTYPE_DATA_DIR"),
+        }
+        if let Some(v) = prev_a {
+            std::env::set_var("VOXTYPE_XAI_API_KEY", v);
+        }
+        if let Some(v) = prev_b {
+            std::env::set_var("XAI_API_KEY", v);
+        }
+        let msg = err.to_string();
+        assert!(
+            msg.contains("credentials") || msg.contains("API key"),
+            "{msg}"
+        );
     }
 }

--- a/src/transcribe/xai.rs
+++ b/src/transcribe/xai.rs
@@ -1,0 +1,245 @@
+//! Grok Speech-to-Text (`POST https://api.x.ai/v1/stt`). Batch after PTT.
+
+use super::Transcriber;
+use crate::config::XaiConfig;
+use crate::error::TranscribeError;
+use std::io::Cursor;
+use std::time::Duration;
+use ureq::serde_json;
+
+const DEFAULT_ENDPOINT: &str = "https://api.x.ai/v1/stt";
+
+#[derive(Debug)]
+pub struct XaiTranscriber {
+    endpoint: String,
+    language: Option<String>,
+    format: bool,
+    timeout: Duration,
+    api_key: String,
+}
+
+impl XaiTranscriber {
+    pub fn new(config: &XaiConfig) -> Result<Self, TranscribeError> {
+        let api_key = api_key(config.api_key.as_deref()).ok_or_else(|| {
+            TranscribeError::ConfigError(
+                "xAI engine needs an API key: [xai] api_key, VOXTYPE_XAI_API_KEY, or XAI_API_KEY"
+                    .into(),
+            )
+        })?;
+
+        let endpoint = config
+            .endpoint
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(DEFAULT_ENDPOINT)
+            .trim_end_matches('/')
+            .to_string();
+        if !endpoint.starts_with("https://") {
+            return Err(TranscribeError::ConfigError(format!(
+                "xAI endpoint must be https, got: {endpoint}"
+            )));
+        }
+
+        let language = config
+            .language
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("auto"))
+            .map(str::to_string);
+
+        tracing::info!(
+            "Configured xAI STT: endpoint={endpoint}, language={}",
+            language.as_deref().unwrap_or("auto")
+        );
+
+        Ok(Self {
+            endpoint,
+            language,
+            format: config.format,
+            timeout: Duration::from_secs(config.timeout_secs.unwrap_or(120).max(5)),
+            api_key,
+        })
+    }
+
+    fn encode_wav(samples: &[f32]) -> Result<Vec<u8>, TranscribeError> {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut buffer = Cursor::new(Vec::new());
+        let mut writer = hound::WavWriter::new(&mut buffer, spec).map_err(|e| {
+            TranscribeError::AudioFormat(format!("Failed to create WAV writer: {e}"))
+        })?;
+        for &sample in samples {
+            let scaled = (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+            writer.write_sample(scaled).map_err(|e| {
+                TranscribeError::AudioFormat(format!("Failed to write sample: {e}"))
+            })?;
+        }
+        writer
+            .finalize()
+            .map_err(|e| TranscribeError::AudioFormat(format!("Failed to finalize WAV: {e}")))?;
+        Ok(buffer.into_inner())
+    }
+
+    fn build_multipart(&self, wav: &[u8]) -> (String, Vec<u8>) {
+        let boundary = format!(
+            "----VoxtypeXai{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let mut body = Vec::new();
+        if let Some(ref lang) = self.language {
+            push_text_field(&mut body, &boundary, "language", lang);
+            if self.format {
+                push_text_field(&mut body, &boundary, "format", "true");
+            }
+        }
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: audio/wav\r\n\r\n");
+        body.extend_from_slice(wav);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        (boundary, body)
+    }
+}
+
+fn api_key(from_config: Option<&str>) -> Option<String> {
+    if let Some(k) = from_config.map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(k.to_string());
+    }
+    for var in ["VOXTYPE_XAI_API_KEY", "XAI_API_KEY"] {
+        if let Ok(k) = std::env::var(var) {
+            let k = k.trim().to_string();
+            if !k.is_empty() {
+                return Some(k);
+            }
+        }
+    }
+    None
+}
+
+fn push_text_field(body: &mut Vec<u8>, boundary: &str, name: &str, value: &str) {
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+    );
+    body.extend_from_slice(value.as_bytes());
+    body.extend_from_slice(b"\r\n");
+}
+
+impl Transcriber for XaiTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat("Empty audio buffer".into()));
+        }
+        let start = std::time::Instant::now();
+        let wav = Self::encode_wav(samples)?;
+        let (boundary, body) = self.build_multipart(&wav);
+        let response = ureq::post(&self.endpoint)
+            .timeout(self.timeout)
+            .set(
+                "Content-Type",
+                &format!("multipart/form-data; boundary={boundary}"),
+            )
+            .set("Authorization", &format!("Bearer {}", self.api_key))
+            .set("User-Agent", "voxtype")
+            .send_bytes(&body)
+            .map_err(|e| match e {
+                ureq::Error::Status(code, resp) => {
+                    let body = resp.into_string().unwrap_or_default();
+                    TranscribeError::RemoteError(format!("xAI STT HTTP {code}: {body}"))
+                }
+                ureq::Error::Transport(t) => {
+                    TranscribeError::NetworkError(format!("xAI STT request failed: {t}"))
+                }
+            })?;
+        let json: serde_json::Value = response.into_json().map_err(|e| {
+            TranscribeError::RemoteError(format!("Failed to parse xAI STT response: {e}"))
+        })?;
+        let text = json
+            .get("text")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                TranscribeError::RemoteError(format!("xAI STT response missing 'text': {json}"))
+            })?
+            .trim()
+            .to_string();
+        tracing::info!(
+            "xAI transcription completed in {:.2}s ({} chars)",
+            start.elapsed().as_secs_f32(),
+            text.chars().count()
+        );
+        Ok(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wav_has_riff_header() {
+        let wav = XaiTranscriber::encode_wav(&[0.1_f32; 160]).unwrap();
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+    }
+
+    #[test]
+    fn autodetect_omits_format_field() {
+        let t = XaiTranscriber {
+            endpoint: DEFAULT_ENDPOINT.into(),
+            language: None,
+            format: true,
+            timeout: Duration::from_secs(5),
+            api_key: "test".into(),
+        };
+        let (_b, body) = t.build_multipart(b"WAV");
+        let s = String::from_utf8_lossy(&body);
+        assert!(!s.contains("name=\"format\""));
+        assert!(!s.contains("name=\"language\""));
+        assert!(s.contains("name=\"file\""));
+    }
+
+    #[test]
+    fn language_includes_format_before_file() {
+        let t = XaiTranscriber {
+            endpoint: DEFAULT_ENDPOINT.into(),
+            language: Some("en".into()),
+            format: true,
+            timeout: Duration::from_secs(5),
+            api_key: "test".into(),
+        };
+        let (_b, body) = t.build_multipart(b"WAV");
+        let s = String::from_utf8_lossy(&body);
+        let file = s.find("name=\"file\"").unwrap();
+        assert!(s.contains("name=\"language\""));
+        assert!(s.contains("name=\"format\""));
+        assert!(file > s.find("name=\"language\"").unwrap());
+    }
+
+    #[test]
+    fn rejects_http_endpoint() {
+        let cfg = XaiConfig {
+            api_key: Some("xai-test".into()),
+            endpoint: Some("http://127.0.0.1/stt".into()),
+            ..XaiConfig::default()
+        };
+        let msg = XaiTranscriber::new(&cfg).unwrap_err().to_string();
+        assert!(msg.contains("https"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_missing_key() {
+        let err = XaiTranscriber::new(&XaiConfig::default()).unwrap_err();
+        assert!(err.to_string().contains("API key"));
+    }
+}

--- a/src/transcribe/xai_oauth.rs
+++ b/src/transcribe/xai_oauth.rs
@@ -1,0 +1,458 @@
+//! SuperGrok / X Premium+ device-code login. Tokens stay in Voxtype's data dir.
+//!
+//! Client id is grok-cli's public id (xAI has no third-party CLI registration).
+
+use crate::config::Config;
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const DISCOVERY_URL: &str = "https://auth.x.ai/.well-known/openid-configuration";
+const DEVICE_CODE_URL: &str = "https://auth.x.ai/oauth2/device/code";
+const CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+const SCOPE: &str = "openid profile email offline_access grok-cli:access api:access";
+/// Must stay well below typical `expires_in` (~3600s).
+const REFRESH_SKEW_SECS: u64 = 120;
+
+static REFRESH_LOCK: Mutex<()> = Mutex::new(());
+static TOKEN_CACHE: Mutex<Option<(String, u64)>> = Mutex::new(None);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OAuthTokens {
+    access_token: String,
+    refresh_token: String,
+    #[serde(default)]
+    expires_in: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredAuth {
+    version: u32,
+    tokens: OAuthTokens,
+    #[serde(default)]
+    token_endpoint: String,
+    #[serde(default)]
+    last_refresh_unix: u64,
+}
+
+pub fn store_path() -> PathBuf {
+    if let Some(base) = std::env::var_os("VOXTYPE_DATA_DIR") {
+        return PathBuf::from(base).join("xai-oauth.json");
+    }
+    Config::data_dir().join("xai-oauth.json")
+}
+
+fn validate_oauth_url(url: &str) -> Result<()> {
+    let ok = (url.starts_with("https://auth.x.ai/") || url.starts_with("https://accounts.x.ai/"))
+        && !url.contains(' ')
+        && url.is_ascii();
+    if !ok {
+        bail!(
+            "refusing xAI OAuth URL (expected https://auth.x.ai/ or https://accounts.x.ai/): {url}"
+        );
+    }
+    Ok(())
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn token_exp_unix(auth: &StoredAuth) -> u64 {
+    let lifetime = auth.tokens.expires_in.unwrap_or(15 * 60);
+    auth.last_refresh_unix.saturating_add(lifetime)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RefreshPlan {
+    UseStore,
+    Redeem,
+    LoggedOut,
+}
+
+fn plan_refresh(caller: &StoredAuth, store: Option<&StoredAuth>, force: bool) -> RefreshPlan {
+    let Some(fresh) = store else {
+        return RefreshPlan::LoggedOut;
+    };
+    if fresh.tokens.refresh_token != caller.tokens.refresh_token
+        || fresh.tokens.access_token != caller.tokens.access_token
+    {
+        return RefreshPlan::UseStore;
+    }
+    if !force && !needs_refresh_auth(fresh) {
+        return RefreshPlan::UseStore;
+    }
+    RefreshPlan::Redeem
+}
+
+fn needs_refresh_auth(auth: &StoredAuth) -> bool {
+    now_unix() + REFRESH_SKEW_SECS >= token_exp_unix(auth)
+}
+
+fn read_store() -> Result<Option<StoredAuth>> {
+    let path = store_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let auth: StoredAuth = serde_json::from_str(&raw).context("parse xai-oauth.json")?;
+    Ok(Some(auth))
+}
+
+fn write_store(auth: &StoredAuth) -> Result<()> {
+    let path = store_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(auth)?;
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut opts = fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut f = opts.open(&tmp)?;
+        f.write_all(json.as_bytes())?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn cache_put(token: &str, exp_unix: u64) {
+    if let Ok(mut g) = TOKEN_CACHE.lock() {
+        *g = Some((token.to_string(), exp_unix));
+    }
+}
+
+fn cache_get_if_fresh() -> Option<String> {
+    let g = TOKEN_CACHE.lock().ok()?;
+    let (tok, exp) = g.as_ref()?;
+    if now_unix() + REFRESH_SKEW_SECS >= *exp {
+        return None;
+    }
+    Some(tok.clone())
+}
+
+pub fn is_logged_in() -> bool {
+    read_store().ok().flatten().is_some()
+}
+
+pub fn logout() -> Result<()> {
+    let path = store_path();
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    if let Ok(mut g) = TOKEN_CACHE.lock() {
+        *g = None;
+    }
+    Ok(())
+}
+
+pub fn status_line() -> String {
+    match read_store() {
+        Ok(Some(_)) => format!("xAI OAuth: signed in ({})", store_path().display()),
+        Ok(None) => "xAI OAuth: not signed in (run: voxtype setup xai --login)".into(),
+        Err(e) => format!("xAI OAuth: error reading store: {e}"),
+    }
+}
+
+fn discovery() -> Result<String> {
+    let resp: serde_json::Value = ureq::get(DISCOVERY_URL)
+        .timeout(Duration::from_secs(20))
+        .call()
+        .context("xAI OIDC discovery")?
+        .into_json()
+        .context("discovery JSON")?;
+    let token = resp
+        .get("token_endpoint")
+        .and_then(|v| v.as_str())
+        .context("missing token_endpoint")?
+        .to_string();
+    validate_oauth_url(&token)?;
+    Ok(token)
+}
+
+fn refresh_tokens(auth: &StoredAuth, force: bool) -> Result<StoredAuth> {
+    let _guard = REFRESH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let store = read_store()?;
+    match plan_refresh(auth, store.as_ref(), force) {
+        RefreshPlan::LoggedOut => {
+            bail!("xAI OAuth session gone (logged out?) — run: voxtype setup xai --login")
+        }
+        RefreshPlan::UseStore => {
+            return Ok(store.expect("UseStore implies Some"));
+        }
+        RefreshPlan::Redeem => {}
+    }
+    let auth = store.unwrap_or_else(|| auth.clone());
+    let token_endpoint = if !auth.token_endpoint.is_empty() {
+        validate_oauth_url(&auth.token_endpoint)?;
+        auth.token_endpoint.clone()
+    } else {
+        discovery()?
+    };
+    let resp = ureq::post(&token_endpoint)
+        .timeout(Duration::from_secs(30))
+        .set("Accept", "application/json")
+        .send_form(&[
+            ("grant_type", "refresh_token"),
+            ("client_id", CLIENT_ID),
+            ("refresh_token", auth.tokens.refresh_token.as_str()),
+        ])
+        .context("xAI token refresh")?;
+    let v: serde_json::Value = resp.into_json().context("refresh JSON")?;
+    let access = v
+        .get("access_token")
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string();
+    if access.is_empty() {
+        bail!("xAI refresh missing access_token — run: voxtype setup xai --login");
+    }
+    let refresh = v
+        .get("refresh_token")
+        .and_then(|x| x.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| auth.tokens.refresh_token.clone());
+    let mut next = auth.clone();
+    next.tokens.access_token = access;
+    next.tokens.refresh_token = refresh;
+    next.tokens.expires_in = v.get("expires_in").and_then(|x| x.as_u64());
+    next.token_endpoint = token_endpoint;
+    next.last_refresh_unix = now_unix();
+    write_store(&next)?;
+    Ok(next)
+}
+
+pub fn access_token() -> Result<String> {
+    if let Some(tok) = cache_get_if_fresh() {
+        return Ok(tok);
+    }
+    let auth = read_store()?.context("no xAI OAuth session — run: voxtype setup xai --login")?;
+    if !needs_refresh_auth(&auth) {
+        cache_put(&auth.tokens.access_token, token_exp_unix(&auth));
+        return Ok(auth.tokens.access_token);
+    }
+    tracing::info!("xAI OAuth access token near expiry; refreshing");
+    let next = refresh_tokens(&auth, false)?;
+    cache_put(&next.tokens.access_token, token_exp_unix(&next));
+    Ok(next.tokens.access_token)
+}
+
+pub fn force_refresh() -> Result<String> {
+    if let Ok(mut g) = TOKEN_CACHE.lock() {
+        *g = None;
+    }
+    let auth = read_store()?.context("no xAI OAuth session")?;
+    let next = refresh_tokens(&auth, true)?;
+    cache_put(&next.tokens.access_token, token_exp_unix(&next));
+    Ok(next.tokens.access_token)
+}
+
+pub fn login_device_code(open_browser: bool) -> Result<()> {
+    let token_endpoint = discovery()?;
+    let resp = ureq::post(DEVICE_CODE_URL)
+        .timeout(Duration::from_secs(20))
+        .set("Accept", "application/json")
+        .send_form(&[("client_id", CLIENT_ID), ("scope", SCOPE)])
+        .context("xAI device-code request")?;
+    let device: serde_json::Value = resp.into_json().context("device-code JSON")?;
+    let device_code = device
+        .get("device_code")
+        .and_then(|x| x.as_str())
+        .context("missing device_code")?
+        .to_string();
+    let user_code = device
+        .get("user_code")
+        .and_then(|x| x.as_str())
+        .unwrap_or("?");
+    let verification = device
+        .get("verification_uri_complete")
+        .and_then(|x| x.as_str())
+        .or_else(|| device.get("verification_uri").and_then(|x| x.as_str()))
+        .unwrap_or("https://accounts.x.ai/oauth2/device");
+    let expires_in = device
+        .get("expires_in")
+        .and_then(|x| x.as_u64())
+        .unwrap_or(1800);
+    let mut interval = device
+        .get("interval")
+        .and_then(|x| x.as_u64())
+        .unwrap_or(5)
+        .max(1);
+
+    validate_oauth_url(verification)?;
+    eprintln!();
+    eprintln!("Sign in with SuperGrok or X Premium+:");
+    eprintln!("  1. Open: {verification}");
+    eprintln!("  2. If prompted, enter code: {user_code}");
+    if open_browser {
+        let _ = std::process::Command::new("xdg-open")
+            .arg(verification)
+            .spawn();
+        eprintln!("  (Tried to open a browser)");
+    }
+    eprintln!("Waiting for approval (polling every {interval}s, up to {expires_in}s)...");
+
+    let deadline = Instant::now() + Duration::from_secs(expires_in);
+    loop {
+        if Instant::now() >= deadline {
+            bail!("Timed out waiting for xAI device authorization");
+        }
+        std::thread::sleep(Duration::from_secs(interval));
+        let poll = ureq::post(&token_endpoint)
+            .timeout(Duration::from_secs(30))
+            .set("Accept", "application/json")
+            .send_form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                ("client_id", CLIENT_ID),
+                ("device_code", device_code.as_str()),
+            ]);
+        match poll {
+            Ok(resp) => {
+                let v: serde_json::Value = resp.into_json().context("token JSON")?;
+                let access = v
+                    .get("access_token")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let refresh = v
+                    .get("refresh_token")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if access.is_empty() || refresh.is_empty() {
+                    bail!("xAI token response missing access/refresh token");
+                }
+                let auth = StoredAuth {
+                    version: 1,
+                    tokens: OAuthTokens {
+                        access_token: access.clone(),
+                        refresh_token: refresh,
+                        expires_in: v.get("expires_in").and_then(|x| x.as_u64()),
+                    },
+                    token_endpoint,
+                    last_refresh_unix: now_unix(),
+                };
+                write_store(&auth)?;
+                cache_put(&access, token_exp_unix(&auth));
+                eprintln!("Signed in. Tokens stored at {}", store_path().display());
+                return Ok(());
+            }
+            Err(ureq::Error::Status(code, resp)) => {
+                let body = resp.into_string().unwrap_or_default();
+                if body.contains("authorization_pending") {
+                    continue;
+                }
+                if body.contains("slow_down") {
+                    interval += 5;
+                    continue;
+                }
+                bail!("xAI device token poll HTTP {code}: {body}");
+            }
+            Err(e) => bail!("xAI device token poll failed: {e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn store_path_honors_voxtype_data_dir() {
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var_os("VOXTYPE_DATA_DIR");
+        std::env::set_var("VOXTYPE_DATA_DIR", "/tmp/voxtype-xai-test-data");
+        let p = store_path();
+        match prev {
+            Some(v) => std::env::set_var("VOXTYPE_DATA_DIR", v),
+            None => std::env::remove_var("VOXTYPE_DATA_DIR"),
+        }
+        assert!(p.ends_with("xai-oauth.json"));
+        assert!(p.to_string_lossy().contains("voxtype-xai-test-data"));
+    }
+
+    #[test]
+    fn validate_oauth_url_rejects_api_host() {
+        assert!(validate_oauth_url("https://api.x.ai/v1/stt").is_err());
+        assert!(validate_oauth_url("http://auth.x.ai/oauth2/token").is_err());
+        assert!(validate_oauth_url("https://auth.x.ai/oauth2/token").is_ok());
+    }
+
+    fn sample(last_refresh_unix: u64, expires_in: u64) -> StoredAuth {
+        StoredAuth {
+            version: 1,
+            tokens: OAuthTokens {
+                access_token: "a".into(),
+                refresh_token: "r".into(),
+                expires_in: Some(expires_in),
+            },
+            token_endpoint: "https://auth.x.ai/oauth2/token".into(),
+            last_refresh_unix,
+        }
+    }
+
+    #[test]
+    fn hour_token_is_fresh_just_after_issue() {
+        let auth = sample(now_unix(), 3600);
+        assert!(!needs_refresh_auth(&auth));
+    }
+
+    #[test]
+    fn token_shorter_than_skew_always_needs_refresh() {
+        let auth = sample(now_unix(), 60);
+        assert!(needs_refresh_auth(&auth));
+    }
+
+    #[test]
+    fn cache_ttl_follows_expires_in_not_a_fixed_five_hours() {
+        cache_put("dead", now_unix());
+        assert!(cache_get_if_fresh().is_none());
+        cache_put("live", now_unix() + 3600);
+        assert_eq!(cache_get_if_fresh().as_deref(), Some("live"));
+    }
+
+    #[test]
+    fn force_refresh_redeems_even_when_ttl_says_fresh() {
+        let auth = sample(now_unix(), 3600);
+        assert!(!needs_refresh_auth(&auth));
+        assert_eq!(plan_refresh(&auth, Some(&auth), true), RefreshPlan::Redeem);
+        assert_eq!(
+            plan_refresh(&auth, Some(&auth), false),
+            RefreshPlan::UseStore
+        );
+    }
+
+    #[test]
+    fn concurrent_rotation_does_not_redeem_stale_refresh() {
+        let caller = sample(now_unix(), 3600);
+        let mut store = caller.clone();
+        store.tokens.access_token = "new-a".into();
+        store.tokens.refresh_token = "new-r".into();
+        assert_eq!(
+            plan_refresh(&caller, Some(&store), true),
+            RefreshPlan::UseStore
+        );
+    }
+
+    #[test]
+    fn logout_during_refresh_is_logged_out() {
+        let auth = sample(now_unix(), 3600);
+        assert_eq!(plan_refresh(&auth, None, true), RefreshPlan::LoggedOut);
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -527,6 +527,7 @@ fn detect_missing_model() -> Option<MissingModel> {
         config::TranscriptionEngine::Cohere => return None,
         // Soniox is cloud-only, no local model to probe.
         config::TranscriptionEngine::Soniox => return None,
+        config::TranscriptionEngine::Xai => return None,
     };
 
     if model.is_empty() {

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -894,6 +894,7 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
     // Whisper is always present.
     let inv = binary::inventory();
     out.insert("whisper");
+    out.insert("xai");
     for f in &inv.compiled_features {
         for engine in [
             "parakeet",

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -64,7 +64,8 @@ pub fn create_vad(config: &Config) -> Result<Option<Box<dyn VoiceActivityDetecto
                 | TranscriptionEngine::Dolphin
                 | TranscriptionEngine::Omnilingual
                 | TranscriptionEngine::Cohere
-                | TranscriptionEngine::Soniox => VadBackend::Energy,
+                | TranscriptionEngine::Soniox
+                | TranscriptionEngine::Xai => VadBackend::Energy,
             }
         }
         explicit => explicit,


### PR DESCRIPTION
## Summary

Two commits. Cherry-pick the first to ship the engine without SuperGrok login.

- `feat: add xAI Grok STT engine` — `engine = "xai"`, batch `POST https://api.x.ai/v1/stt`. Auth: `[xai] api_key`, `VOXTYPE_XAI_API_KEY` / `XAI_API_KEY`, `--xai-api-key`.
- `feat: SuperGrok OAuth for xAI STT` — `voxtype setup xai --login`. Same STT quality, charged against the Grok or X plan already used on grok.com / grok CLI, not console API tokens.

## Motivation

Closes #682

## Test Plan

- [x] `cargo fmt && cargo clippy --all-targets --no-deps -- -D warnings && cargo test --lib`

## Notes for Reviewers

OAuth uses grok-cli’s public client id (`b1a00492-073a-47ea-816f-4c329264a828`) because xAI does not offer third-party CLI registration. Hermes and other SuperGrok clients do the same. The consent screen may say grok-cli. Tokens are Voxtype-only (`$XDG_DATA_HOME/voxtype/xai-oauth.json`, mode 0600). If you do not want that id in tree, take commit 1 only.
