### PR TITLE
Drop redundant on_recording_stop note in CONFIGURATION.md

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2158,8 +2158,6 @@ nothing on screen to say so.
 **Required:** No
 
 When `true`, shows a notification when recording stops (transcription begins).
-This one replaces the recording notification in place rather than appearing
-beside it.
 
 ### on_transcription
 


### PR DESCRIPTION
## Summary

PR #679 added a two-line note under `on_recording_stop` in `docs/CONFIGURATION.md` explaining that the stop notification replaces the recording banner in place. That's describing the notification module's internal single-slot mechanism, not something a user needs to know or configure — pulling it out.

The `on_recording_start` addition in the same PR (explaining the new no-timeout behavior) stays; that one documents an actual behavior change relevant to the option.