### PR TITLE
fix: KDE Wayland output driver via kwtype

### DIFF
--- a/src/config/output.rs
+++ b/src/config/output.rs
@@ -350,6 +350,8 @@ pub enum OutputMode {
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputDriver {
+    /// kwtype - KDE Plasma Wayland via KWin's Fake Input protocol
+    Kwtype,
     /// wtype - Wayland-native via virtual-keyboard protocol, best Unicode/CJK support
     Wtype,
     /// eitype - Wayland via libei/EI protocol, works on GNOME/KDE
@@ -367,6 +369,7 @@ pub enum OutputDriver {
 impl std::fmt::Display for OutputDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            OutputDriver::Kwtype => write!(f, "kwtype"),
             OutputDriver::Wtype => write!(f, "wtype"),
             OutputDriver::Eitype => write!(f, "eitype"),
             OutputDriver::Dotool => write!(f, "dotool"),
@@ -382,6 +385,7 @@ impl std::str::FromStr for OutputDriver {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "kwtype" => Ok(OutputDriver::Kwtype),
             "wtype" => Ok(OutputDriver::Wtype),
             "eitype" => Ok(OutputDriver::Eitype),
             "dotool" => Ok(OutputDriver::Dotool),
@@ -389,7 +393,7 @@ impl std::str::FromStr for OutputDriver {
             "clipboard" => Ok(OutputDriver::Clipboard),
             "xclip" => Ok(OutputDriver::Xclip),
             _ => Err(format!(
-                "Unknown driver '{}'. Valid options: wtype, eitype, dotool, ydotool, clipboard, xclip",
+                "Unknown driver '{}'. Valid options: kwtype, wtype, eitype, dotool, ydotool, clipboard, xclip",
                 s
             )),
         }
@@ -462,6 +466,10 @@ mod tests {
     #[test]
     fn test_output_driver_from_str() {
         assert_eq!(
+            "kwtype".parse::<OutputDriver>().unwrap(),
+            OutputDriver::Kwtype
+        );
+        assert_eq!(
             "wtype".parse::<OutputDriver>().unwrap(),
             OutputDriver::Wtype
         );
@@ -500,6 +508,7 @@ mod tests {
 
     #[test]
     fn test_output_driver_display() {
+        assert_eq!(OutputDriver::Kwtype.to_string(), "kwtype");
         assert_eq!(OutputDriver::Wtype.to_string(), "wtype");
         assert_eq!(OutputDriver::Dotool.to_string(), "dotool");
         assert_eq!(OutputDriver::Ydotool.to_string(), "ydotool");

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,6 +127,9 @@ pub enum OutputError {
     #[error("wtype not found in PATH. Install via your package manager.")]
     WtypeNotFound,
 
+    #[error("kwtype not found in PATH. Install from https://github.com/Sporif/KWtype")]
+    KwtypeNotFound,
+
     #[error("eitype not found in PATH. Install via: cargo install eitype")]
     EitypeNotFound,
 
@@ -155,7 +158,7 @@ pub enum OutputError {
     CtrlVFailed(String),
 
     #[error(
-        "All output methods failed. Ensure wtype, dotool, ydotool, wl-copy, or xclip is available."
+        "All output methods failed. Ensure kwtype, wtype, dotool, ydotool, wl-copy, or xclip is available."
     )]
     AllMethodsFailed,
 }

--- a/src/output/kwtype.rs
+++ b/src/output/kwtype.rs
@@ -1,0 +1,96 @@
+//! kwtype-based text output for KDE Plasma Wayland
+
+use super::TextOutput;
+use crate::error::OutputError;
+use std::process::Stdio;
+use tokio::process::Command;
+
+/// KDE Plasma Wayland text output via KWin's Fake Input protocol.
+pub struct KwtypeOutput {
+    auto_submit: bool,
+    append_text: Option<String>,
+    pre_type_delay_ms: u32,
+}
+
+impl KwtypeOutput {
+    pub fn new(auto_submit: bool, append_text: Option<String>, pre_type_delay_ms: u32) -> Self {
+        Self {
+            auto_submit,
+            append_text,
+            pre_type_delay_ms,
+        }
+    }
+
+    fn is_kde_wayland() -> bool {
+        let is_kde = std::env::var("XDG_CURRENT_DESKTOP").is_ok_and(|desktop| {
+            desktop
+                .split(':')
+                .any(|component| component.eq_ignore_ascii_case("kde"))
+        });
+        is_kde && super::session::detect() == super::session::DisplaySession::Wayland
+    }
+}
+
+#[async_trait::async_trait]
+impl TextOutput for KwtypeOutput {
+    async fn output(&self, text: &str) -> Result<(), OutputError> {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        if self.pre_type_delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(
+                self.pre_type_delay_ms as u64,
+            ))
+            .await;
+        }
+
+        let mut text = text.to_owned();
+        if let Some(append) = &self.append_text {
+            text.push_str(append);
+        }
+        if self.auto_submit {
+            text.push('\n');
+        }
+
+        let output = Command::new("kwtype")
+            .arg("--")
+            .arg(text)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    OutputError::KwtypeNotFound
+                } else {
+                    OutputError::InjectionFailed(error.to_string())
+                }
+            })?;
+
+        if !output.status.success() {
+            return Err(OutputError::InjectionFailed(format!(
+                "kwtype failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        Ok(())
+    }
+
+    async fn is_available(&self) -> bool {
+        if !Self::is_kde_wayland() {
+            return false;
+        }
+        Command::new("which")
+            .arg("kwtype")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .is_ok_and(|status| status.success())
+    }
+
+    fn name(&self) -> &'static str {
+        "kwtype"
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,12 +5,13 @@
 //! Fallback chain for `mode = "type"`:
 //!
 //! Linux:
-//! 1. wtype - Wayland-native via virtual-keyboard protocol, best Unicode/CJK support, no daemon needed
-//! 2. eitype - Wayland via libei/EI protocol, works on GNOME/KDE (no virtual-keyboard support)
-//! 3. dotool - Works on X11/Wayland/TTY, supports keyboard layouts, no daemon needed
-//! 4. ydotool - Works on X11/Wayland/TTY, requires daemon
-//! 5. clipboard (wl-copy) - Wayland clipboard fallback
-//! 6. xclip - X11 clipboard fallback
+//! 1. kwtype - KDE Plasma Wayland via KWin's Fake Input protocol
+//! 2. wtype - Wayland-native via virtual-keyboard protocol, best Unicode/CJK support, no daemon needed
+//! 3. eitype - Wayland via libei/EI protocol, works on GNOME/KDE (no virtual-keyboard support)
+//! 4. dotool - Works on X11/Wayland/TTY, supports keyboard layouts, no daemon needed
+//! 5. ydotool - Works on X11/Wayland/TTY, requires daemon
+//! 6. clipboard (wl-copy) - Wayland clipboard fallback
+//! 7. xclip - X11 clipboard fallback
 //!
 //! macOS:
 //! 1. cgevent - Native CGEvent API for keyboard simulation (best performance)
@@ -24,6 +25,7 @@ pub mod cgevent;
 pub mod clipboard;
 pub mod dotool;
 pub mod eitype;
+pub mod kwtype;
 // modifier_guard is evdev-based; macOS has its own osascript modifier handling.
 #[cfg(target_os = "linux")]
 pub mod modifier_guard;
@@ -241,6 +243,7 @@ pub trait TextOutput: Send + Sync {
 /// Default driver order for type mode
 #[cfg(not(target_os = "macos"))]
 const DEFAULT_DRIVER_ORDER: &[OutputDriver] = &[
+    OutputDriver::Kwtype,
     OutputDriver::Wtype,
     OutputDriver::Eitype,
     OutputDriver::Dotool,
@@ -257,6 +260,11 @@ fn create_driver_output(
     pre_type_delay_ms: u32,
 ) -> Box<dyn TextOutput> {
     match driver {
+        OutputDriver::Kwtype => Box::new(kwtype::KwtypeOutput::new(
+            config.auto_submit,
+            config.append_text.clone(),
+            pre_type_delay_ms,
+        )),
         OutputDriver::Wtype => Box::new(wtype::WtypeOutput::new(
             config.auto_submit,
             config.append_text.clone(),
@@ -454,7 +462,8 @@ pub struct OutputOptions<'a> {
 /// keybindings when modifiers are held. Used to filter the chain when the
 /// modifier-release wait times out.
 fn is_keystroke_method(name: &str) -> bool {
-    matches!(name, "wtype" | "eitype" | "dotool" | "ydotool") || name.starts_with("paste")
+    matches!(name, "kwtype" | "wtype" | "eitype" | "dotool" | "ydotool")
+        || name.starts_with("paste")
 }
 
 /// Try each output method in the chain until one succeeds


### PR DESCRIPTION
Fixes #649.

## Summary

[Feature] KDE Wayland output driver via kwtype

## Validation

- Mechanical gate: +126/-9, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->