### PR TITLE
docs: a popup to review and enhance your dictation before it lands

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -93,6 +93,43 @@ decides for itself when to send it.
 A `[profiles.agent]` block with a `post_process_command` is a good place to
 normalise dictation before an agent sees it, stripping filler words for instance.
 
+## A review gate before text lands
+
+`post_process` is a gate, not just a filter: whatever the hook prints on
+stdout is what lands, and a hook that is killed at `timeout_ms` — or exits
+non-zero — falls back to the raw transcript. That makes a human review step
+possible without touching Voxtype itself.
+
+The contract a review hook must honour:
+
+- read the transcript on stdin
+- print the final text on stdout, nothing else
+- exit `0`; any other exit, or the `timeout_ms` kill, means "use the raw
+  transcript" — a hook must never block past the timeout or the dictation
+  is silently lost
+- the text lands wherever the user was; the hook never needs to know
+
+A 30-second human will routinely exceed the default timeout, so raise it:
+
+```toml
+[output.post_process]
+command = "/usr/local/bin/my-review-gui"
+timeout_ms = 600000     # a human reading their own words, not a model answering
+trim = false            # the hook owns whitespace
+```
+
+Terminal targets paste with `Ctrl+Shift+V`, not `Ctrl+V`; point
+`output.paste_keys` at the chord your targets actually bind, or the paste
+silently does nothing in some of them.
+
+One maintained implementation of this pattern is
+[`voxtype-review`](https://github.com/DimitriGeelen/voxtype-review): a small
+Rust/egui popup that shows the transcript for editing, runs configurable
+actions (tidy, translate, bullets — local LLM or HTTP), keeps a per-round
+instruction box that accepts spoken input, and steps back through every
+round with `Alt+arrow`. `Esc` always emits the raw transcript; `Enter`
+commits what the box holds.
+
 ## What Voxtype will not do for you
 
 Voxtype does not edit your configuration, and asks that you not edit its own:

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -107,7 +107,10 @@ One maintained implementation is
 [`voxtype-review`](https://github.com/DimitriGeelen/voxtype-review): the
 transcript in an editable box, an extensible action list on number
 shortcuts, results shown before they are committed, `Alt+arrow` through
-every round, and `Esc` always returns your original words.
+every round, `Esc` aborts: the hook prints nothing and exits 0, and with
+`fallback_on_empty = false` nothing lands at all — no paste, not even the
+original. (Keep that flag in mind when you build your own menu: it is the
+difference between "cancel to the original" and "cancel to nothing".)
 
 The pattern needs nothing from Voxtype but the hook it already has:
 `post_process` is a gate, not just a filter — whatever the hook prints on

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -93,12 +93,26 @@ decides for itself when to send it.
 A `[profiles.agent]` block with a `post_process_command` is a good place to
 normalise dictation before an agent sees it, stripping filler words for instance.
 
-## A review gate before text lands
+## A menu for your dictation, before it lands
 
-`post_process` is a gate, not just a filter: whatever the hook prints on
+Dictation is instant, but speech is not text: no punctuation, filler words,
+half-finished thoughts. `post_process` can open a small menu over the
+transcript — edit it, run actions on it (tidy, translate, reformat — any
+shell pipeline), steer a local model with typed or spoken instructions — and
+only then commit what you see.
+
+![The voxtype-review menu](https://raw.githubusercontent.com/DimitriGeelen/voxtype-review/master/docs/screenshot.png)
+
+One maintained implementation is
+[`voxtype-review`](https://github.com/DimitriGeelen/voxtype-review): the
+transcript in an editable box, an extensible action list on number
+shortcuts, results shown before they are committed, `Alt+arrow` through
+every round, and `Esc` always returns your original words.
+
+The pattern needs nothing from Voxtype but the hook it already has:
+`post_process` is a gate, not just a filter — whatever the hook prints on
 stdout is what lands, and a hook that is killed at `timeout_ms` — or exits
-non-zero — falls back to the raw transcript. That makes a human review step
-possible without touching Voxtype itself.
+non-zero — falls back to the raw transcript.
 
 The contract a review hook must honour:
 


### PR DESCRIPTION
Hi Pete,

So what I did: I created a menu that captures the dictation and then allows you to do extra actions on it. Send it back for refinement, translate it, tidy it up — often I just make it more concise, or make it bullet points. You could also extend it with canned responses or canned prompts to run on your text. And I tried to make it hook into the existing codebase, so it can be used by other people too. That's why I want to share it here — I hope others can use it as well.

![The voxtype-review popup: my transcript, an instruction box, and the action menu](https://raw.githubusercontent.com/DimitriGeelen/voxtype-review/master/docs/screenshot.png)

In practice: I speak, the menu opens with my words. I press 1 (tidy up), the cleaned-up text shows in the menu first, and only Enter puts it where I was typing. The actions are just shell commands, so anyone can add their own to the menu.

The part I like most is the instruction box: I tell the model what to do with my text — "keep it formal", "drop the repetitions" — typed or spoken. If a result isn't right, I step back through the earlier versions with the arrow keys. And if I change my mind completely, Esc just exits: nothing lands at all.

Nothing in Voxtype itself needed to change. It hooks into the existing post_process support: the menu reads the transcript on stdin, prints the final text on stdout, and if it takes too long or crashes, Voxtype just uses the raw transcription. The one flag worth knowing about is `fallback_on_empty = false` — that's what makes "Esc exits and nothing happens" possible instead of falling back to the original.

The pattern is now documented in INTEGRATIONS.md so others can build their own menu; the code lives at https://github.com/DimitriGeelen/voxtype-review (a small Rust/egui popup, MIT). Happy to answer anything right here.

If it belongs somewhere else in the docs — CONFIGURATION.md, the FAQ — just say where and I'll move it.

**Update (Sep 7):** the "you could extend it with" list from my opening note now exists in the linked project, so I refreshed the INTEGRATIONS.md section to match: a canned-prompt library where one digit steers the next action, an in-app config page (actions + the daemon settings + mic picker), a history of pasted dictations, and a start/stop recording key that ends long dictations on silence instead of a timer. The one contract correction worth highlighting for reviewers: with `fallback_on_empty = false`, `Esc` aborts to *nothing* — no paste and no original — which the doc previously overstated as "always emits the raw transcript". The post_process contract itself is unchanged; everything above is inside the hook.
