### PR TITLE
feat: add Deepgram batch transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Voice-to-text for Linux. 9-11× realtime on your CPU. Local by default.
 
-Hold a hotkey (default: ScrollLock) while speaking, release to transcribe and output the text at your cursor position. Voxtype runs Cohere Transcribe (#1 on the Open ASR Leaderboard) faster than realtime on a plain Zen 4 CPU. Parakeet, Whisper, and five more engines if you want them. No cloud, no subscription, no telemetry.
+Hold a hotkey (default: ScrollLock) while speaking, release to transcribe and output the text at your cursor position. Voxtype runs Cohere Transcribe (#1 on the Open ASR Leaderboard) faster than realtime on a plain Zen 4 CPU. Local engines are the default; Deepgram and Soniox are optional cloud backends.
 
 ## Features
 
@@ -16,7 +16,7 @@ Hold a hotkey (default: ScrollLock) while speaking, release to transcribe and ou
 - **Parakeet on AMD and NVIDIA GPUs.** MIGraphX 7.2 for Radeon, separate CUDA 12 and CUDA 13 binaries for every NVIDIA driver generation, Vulkan for Whisper across vendors. *(MIGraphX new in 0.7.0)*
 - **Text processing built in.** Spoken punctuation (`"comma"` → `,`), per-user replacement tables for common mistranscriptions, and an optional post-processing pipe through any LLM or shell script. Fix domain terms, drop filler words, polish grammar — all without leaving voxtype.
 - **Dynamic per-engine model loading.** Configure all 7 engines, pay memory only for the active one. Models load on first use and unload when idle.
-- **Seven transcription engines.** Whisper, Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual. Switch with `voxtype configure` or one config line. CJK and 1600+ languages covered by the multilingual engines.
+- **Local and cloud transcription engines.** Whisper plus seven ONNX engines run locally; Deepgram batch and Soniox streaming are built-in cloud options. Switch with `voxtype configure` or one config line.
 - **Meeting mode.** Continuous transcription with chunked processing, speaker attribution, and export to Markdown, JSON, SRT, or VTT.
 
 ### Native Linux integration
@@ -370,12 +370,16 @@ Voxtype ships separate binaries for Whisper and ONNX engines. Use `voxtype setup
 | **Paraformer** | zh+en, zh+yue+en | Non-autoregressive (ONNX) | Chinese-English bilingual |
 | **Dolphin** | 40 languages + 22 Chinese dialects | CTC E-Branchformer (ONNX) | Eastern languages (no English) |
 | **Omnilingual** | 1600+ languages | wav2vec2 CTC (ONNX) | Low-resource and rare languages |
+| **Deepgram** (cloud) | Multilingual | Batch HTTPS API | Low-power computers, formatted dictation |
+| **Soniox** (cloud) | 60+ languages | Streaming/REST API | Live cloud partials |
 
 To set the engine in your config:
 
 ```toml
-engine = "sensevoice"  # or: whisper, parakeet, moonshine, paraformer, dolphin, omnilingual
+engine = "sensevoice"  # also: whisper, deepgram, soniox, or an ONNX engine
 ```
+
+Deepgram ships in every binary. See [Deepgram setup and privacy notes](docs/DEEPGRAM.md).
 
 Or override on the command line:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,6 +46,8 @@ Selects which speech-to-text engine to use for transcription.
 - `dolphin` - Dictation-optimized CTC via ONNX Runtime (Chinese + English)
 - `omnilingual` - FunASR Omnilingual CTC via ONNX Runtime (50+ languages)
 - `cohere` - Cohere Transcribe encoder-decoder via ONNX Runtime (#1 Open ASR Leaderboard, 14 languages, ~3 GB model)
+- `deepgram` - Deepgram pre-recorded HTTPS API (batch cloud transcription, built in)
+- `soniox` - Soniox WebSocket/REST cloud transcription (built in)
 
 **Example:**
 ```toml
@@ -76,10 +78,11 @@ config changes; restart it with `systemctl --user restart voxtype` for the
 new engine to take effect.
 
 **Notes:**
-- Whisper, Remote Whisper, and Soniox run in every binary. The other engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) require an ONNX-enabled binary (`voxtype-*-onnx-*`)
+- Whisper, Remote Whisper, Deepgram, and Soniox run in every binary. The other engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) require an ONNX-enabled binary (`voxtype-*-onnx-*`)
 - Each ONNX engine reads its own `[<engine>]` section (e.g. `[parakeet]`, `[cohere]`)
 - See [PARAKEET.md](PARAKEET.md) for detailed Parakeet setup instructions
 - See [MOONSHINE.md](MOONSHINE.md) for detailed Moonshine setup instructions
+- See [DEEPGRAM.md](DEEPGRAM.md) for Deepgram credentials, privacy, and request behavior
 - Cohere Transcribe is the largest model voxtype ships (~3 GB int8); use `voxtype setup model` to download it
 
 ---

--- a/docs/DEEPGRAM.md
+++ b/docs/DEEPGRAM.md
@@ -1,0 +1,54 @@
+# Deepgram Batch Transcription
+
+Voxtype can send a completed recording to Deepgram's pre-recorded speech-to-text API. Deepgram is available in every binary and does not run a model locally, which makes it useful on low-power computers. Recording, VAD, text processing, notifications, and cursor output remain local Voxtype behavior; only the recorded WAV is sent to Deepgram after the recording stops.
+
+## Configuration
+
+```toml
+engine = "deepgram"
+
+[deepgram]
+model = "nova-3"
+language = "en"
+smart_format = true
+mip_opt_out = true
+timeout_secs = 30
+endpoint = "https://api.deepgram.com/v1/listen"
+```
+
+`language` accepts a BCP-47 language code such as `en`, `en-US`, or `fr`; `auto` enables language detection; and `multi` enables multilingual recognition. `mip_opt_out = true` asks Deepgram to exclude the request from its Model Improvement Program.
+
+## Credentials
+
+Set `DEEPGRAM_API_KEY` in the daemon environment. It takes precedence over the optional `[deepgram] api_key` fallback:
+
+```bash
+export DEEPGRAM_API_KEY="..."
+voxtype daemon
+```
+
+Avoid putting the key in shell history or a world-readable config. On Linux, a user service can retrieve it from Secret Service immediately before launching Voxtype:
+
+```bash
+key="$(secret-tool lookup application voxtype provider deepgram)"
+export DEEPGRAM_API_KEY="$key"
+exec voxtype daemon
+```
+
+The configuration TUI reports whether a credential came from the environment or config, but never displays its value. Voxtype does not log the credential or audio.
+
+## Request behavior
+
+Voxtype encodes the completed 16 kHz mono recording as PCM WAV and sends one HTTPS `POST` with `Content-Type: audio/wav` and `Authorization: Token ...`. This is batch mode: it does not keep streaming state or type partial results. The final transcript is processed and inserted at the cursor through the same output path as local engines.
+
+Authentication, insufficient-credit, rate-limit, network, timeout, empty-result, and malformed-response failures are surfaced as transcription errors. No automatic retry is performed, so a repeated hotkey press cannot accidentally duplicate text.
+
+## Live smoke test
+
+With a key present, record a short sample using the normal hotkey and confirm that the transcript appears at the cursor. For an isolated WAV test, use:
+
+```bash
+DEEPGRAM_LIVE_TEST_WAV=/absolute/path/to/short.wav cargo test deepgram_live -- --ignored
+```
+
+The live test is ignored in normal CI and also requires `DEEPGRAM_API_KEY`.

--- a/docs/MODEL_SELECTION_GUIDE.md
+++ b/docs/MODEL_SELECTION_GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide helps you choose the right transcription engine and model for voxtype v0.6.0. The choice depends on your language, hardware, and how you use dictation.
 
-Voxtype has eight transcription engines. Three ship in every binary — Whisper (local), Remote Whisper (HTTP API), and Soniox (cloud streaming). The other five require the ONNX binary variant.
+Voxtype includes local engines plus two native cloud providers. Whisper, Remote Whisper, Deepgram batch, and Soniox streaming ship in every binary; ONNX engines require an ONNX binary variant.
 
 ---
 
@@ -19,8 +19,9 @@ Voxtype has eight transcription engines. Three ship in every binary — Whisper 
 | **Omnilingual** | 1600+ | CTC wav2vec2 | 3.9 GB | Moderate | No | ONNX |
 | **Cohere** | 14 | Encoder-decoder | 1.5 - 3.9 GB | Slow (CPU) | Yes | ONNX |
 | **Soniox** (cloud) | 60+ | Cloud (WebSocket / REST) | n/a (no local model) | Cloud-bound | Yes | Built-in |
+| **Deepgram** (cloud) | Multilingual | Cloud (batch HTTPS) | n/a (no local model) | Cloud-bound | Yes | Built-in |
 
-**Soniox** is different from the others — it's a paid cloud service over WebSocket / REST. No local model, no GPU. Sub-second partial latency. Strong for non-English languages where local Whisper-based engines struggle on lower-end hardware. Ships in every release binary; you only need a `SONIOX_API_KEY`. See [SONIOX.md](SONIOX.md) for the full story.
+**Deepgram** sends each completed recording as a WAV and returns one final transcript, making it a simple fit for low-power computers. **Soniox** supports streaming partials as well as REST. Both are paid cloud services and send audio off-device. See [DEEPGRAM.md](DEEPGRAM.md) and [SONIOX.md](SONIOX.md).
 
 ---
 
@@ -35,6 +36,7 @@ What language(s) do you speak?
 │   ├─ Want best accuracy + punctuation? → Parakeet TDT (ONNX binary)
 │   ├─ Want smallest/fastest model?      → Moonshine tiny (ONNX binary)
 │   ├─ Want simplest setup?              → Whisper small.en (standard binary)
+│   ├─ Want to offload a slow laptop?     → Deepgram (cloud batch)
 │   └─ On a laptop / saving battery?     → Whisper small.en + on_demand_loading
 │
 ├─ Chinese (Mandarin or Cantonese)
@@ -68,7 +70,7 @@ OR — independently of language:
 │   └─ Soniox async API (cloud, stt-async-v4)
 │
 └─ Cannot send audio off-device (privacy-sensitive)?
-    └─ Pick any *local* engine above. Never Soniox.
+    └─ Pick any *local* engine above. Never Deepgram or Soniox.
 ```
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1030,6 +1030,28 @@ model = "tiny.en"
 
 ---
 
+## Deepgram Backend Issues
+
+### "Deepgram API key required"
+
+Set `DEEPGRAM_API_KEY` in the environment of the Voxtype daemon. An optional `[deepgram] api_key` value is supported as a less-safe fallback. The environment variable wins when both are present.
+
+### Deepgram authentication, billing, or rate-limit errors
+
+HTTP 401/403 means the key was rejected, 402 indicates insufficient credit, and 429 means the account is rate limited. Check the Deepgram console, then retry the recording after resolving the account condition.
+
+### Deepgram timeout or network error
+
+Confirm the machine can reach `https://api.deepgram.com` over HTTPS. Increase `[deepgram] timeout_secs` if a proxy or slow connection routinely exceeds 30 seconds. Voxtype never retries automatically.
+
+### Deepgram returns an empty or malformed result
+
+An empty transcript, missing channel alternative, or malformed JSON is reported as a transcription error instead of inserting blank text. Check the journal for the category; Voxtype does not log the request audio or credential.
+
+See [DEEPGRAM.md](DEEPGRAM.md) for the complete provider configuration.
+
+---
+
 ## Soniox Backend Issues
 
 ### "Soniox API key required: set [soniox] api_key or SONIOX_API_KEY"

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -468,6 +468,22 @@ on_recording_stop = false
 on_transcription = true
 ```
 
+### Cloud Backend: Deepgram
+
+Deepgram provides batch transcription without running a model on your computer. It ships in every Voxtype binary. Set `DEEPGRAM_API_KEY`, then configure:
+
+```toml
+engine = "deepgram"
+
+[deepgram]
+model = "nova-3"
+language = "en"
+smart_format = true
+mip_opt_out = true
+```
+
+Voxtype uploads one completed WAV after recording stops, then inserts the final transcript through the normal cursor-output path. See [DEEPGRAM.md](DEEPGRAM.md) for credentials, privacy, language detection, and error handling.
+
 ### Cloud Backend: Soniox
 
 For a cloud streaming alternative to the local engines above, voxtype supports [Soniox](https://soniox.com). Different trade-off space: paid SaaS, no local model, 60+ languages with strong Hungarian/EU coverage, sub-second partials at the cursor.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,7 @@ pub use setup::{CompositorType, SetupAction};
 /// `src/config/engines/mod.rs` so a new engine variant forces this string
 /// to update or the build breaks.
 pub const ENGINE_NAMES_CSV: &str =
-    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox";
+    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, soniox, deepgram";
 
 /// Diarization backends the daemon dispatches on. Used by the CLI's
 /// `value_parser` for `--diarization` so unknown values are rejected at

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -183,6 +183,18 @@ translate = false
 # own -l setting (default "en"); enable this so "auto" is sent explicitly.
 # remote_send_auto_language = true
 
+# --- Deepgram batch cloud transcription ---
+# Select with the root setting: engine = "deepgram"
+# Credentials: set DEEPGRAM_API_KEY (recommended), or add api_key here.
+# Audio is sent as a completed 16 kHz mono WAV after recording stops.
+# [deepgram]
+# model = "nova-3"
+# language = "en"       # BCP-47 code, "auto", or "multi"
+# smart_format = true
+# mip_opt_out = true
+# timeout_secs = 30
+# endpoint = "https://api.deepgram.com/v1/listen"
+
 [output]
 # Primary output mode: "type" or "clipboard"
 # - type: Simulates keyboard input at cursor position (requires ydotool)

--- a/src/config/engines/deepgram.rs
+++ b/src/config/engines/deepgram.rs
@@ -1,0 +1,98 @@
+//! Deepgram batch speech-to-text engine configuration.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::default_true;
+
+/// Deepgram pre-recorded speech-to-text configuration.
+///
+/// Credentials are resolved from `DEEPGRAM_API_KEY` first. `api_key` exists
+/// as a fallback for environments where injecting an environment variable is
+/// impractical, but storing secrets in the config file is discouraged.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DeepgramConfig {
+    /// API key fallback. Prefer the DEEPGRAM_API_KEY environment variable.
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Deepgram model identifier.
+    #[serde(default = "default_model")]
+    pub model: String,
+
+    /// BCP-47 language code, `auto` for language detection, or `multi` for
+    /// Nova multilingual code-switching.
+    #[serde(default = "default_language")]
+    pub language: String,
+
+    /// Apply punctuation, paragraphs, numerals, dates, and related formatting.
+    #[serde(default = "default_true")]
+    pub smart_format: bool,
+
+    /// Opt audio out of Deepgram's Model Improvement Program.
+    #[serde(default = "default_true")]
+    pub mip_opt_out: bool,
+
+    /// Total request timeout in seconds.
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
+
+    /// Pre-recorded transcription endpoint. Configurable for regional and
+    /// self-hosted deployments as well as deterministic local tests.
+    #[serde(default = "default_endpoint")]
+    pub endpoint: String,
+}
+
+fn default_model() -> String {
+    "nova-3".to_string()
+}
+
+fn default_language() -> String {
+    "en".to_string()
+}
+
+fn default_timeout_secs() -> u64 {
+    30
+}
+
+fn default_endpoint() -> String {
+    "https://api.deepgram.com/v1/listen".to_string()
+}
+
+impl Default for DeepgramConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            model: default_model(),
+            language: default_language(),
+            smart_format: true,
+            mip_opt_out: true,
+            timeout_secs: default_timeout_secs(),
+            endpoint: default_endpoint(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_dictation_friendly() {
+        let config = DeepgramConfig::default();
+        assert_eq!(config.model, "nova-3");
+        assert_eq!(config.language, "en");
+        assert!(config.smart_format);
+        assert!(config.mip_opt_out);
+        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.endpoint, "https://api.deepgram.com/v1/listen");
+    }
+
+    #[test]
+    fn partial_toml_uses_defaults() {
+        let config: DeepgramConfig = toml::from_str("language = \"multi\"").unwrap();
+        assert_eq!(config.model, "nova-3");
+        assert_eq!(config.language, "multi");
+        assert!(config.smart_format);
+        assert!(config.mip_opt_out);
+    }
+}

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 mod cohere;
+mod deepgram;
 mod dolphin;
 mod moonshine;
 mod omnilingual;
@@ -12,6 +13,7 @@ mod sensevoice;
 mod soniox;
 
 pub use cohere::CohereConfig;
+pub use deepgram::DeepgramConfig;
 pub use dolphin::DolphinConfig;
 pub use moonshine::MoonshineConfig;
 pub use omnilingual::OmnilingualConfig;
@@ -65,6 +67,8 @@ pub enum TranscriptionEngine {
     Cohere,
     /// Use Soniox (cloud streaming WebSocket STT).
     Soniox,
+    /// Use Deepgram's pre-recorded cloud speech-to-text API.
+    Deepgram,
 }
 
 impl TranscriptionEngine {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,8 +27,9 @@ mod whisper;
 pub use audio::{AudioConfig, AudioFeedbackConfig};
 pub use default_config::{default_config_content, DEFAULT_CONFIG};
 pub use engines::{
-    CohereConfig, DolphinConfig, MoonshineConfig, OmnilingualConfig, ParaformerConfig,
-    ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig, TranscriptionEngine,
+    CohereConfig, DeepgramConfig, DolphinConfig, MoonshineConfig, OmnilingualConfig,
+    ParaformerConfig, ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig,
+    TranscriptionEngine,
 };
 pub use hotkey::{ActivationMode, HotkeyConfig};
 pub use language::LanguageConfig;

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -1,7 +1,8 @@
 use super::{
-    AudioConfig, CohereConfig, DolphinConfig, HotkeyConfig, MeetingConfig, MoonshineConfig,
-    OmnilingualConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile, SenseVoiceConfig,
-    SonioxConfig, StatusConfig, TextConfig, TranscriptionEngine, VadConfig, WhisperConfig,
+    AudioConfig, CohereConfig, DeepgramConfig, DolphinConfig, HotkeyConfig, MeetingConfig,
+    MoonshineConfig, OmnilingualConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile,
+    SenseVoiceConfig, SonioxConfig, StatusConfig, TextConfig, TranscriptionEngine, VadConfig,
+    WhisperConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -61,6 +62,11 @@ pub struct Config {
     #[serde(default)]
     pub soniox: Option<SonioxConfig>,
 
+    /// Deepgram cloud batch STT configuration
+    /// (optional, only used when engine = "deepgram")
+    #[serde(default)]
+    pub deepgram: Option<DeepgramConfig>,
+
     /// Text processing configuration (replacements, spoken punctuation)
     #[serde(default)]
     pub text: TextConfig,
@@ -113,6 +119,7 @@ impl Default for Config {
             omnilingual: None,
             cohere: None,
             soniox: None,
+            deepgram: None,
             text: TextConfig::default(),
             vad: VadConfig::default(),
             status: StatusConfig::default(),
@@ -338,8 +345,8 @@ impl Config {
                 .as_ref()
                 .map(|c| c.on_demand_loading)
                 .unwrap_or(false),
-            // Soniox is a cloud backend; nothing to load on demand.
-            TranscriptionEngine::Soniox => false,
+            // Cloud backends have no local model to load on demand.
+            TranscriptionEngine::Soniox | TranscriptionEngine::Deepgram => false,
         }
     }
 
@@ -361,6 +368,7 @@ impl Config {
                 super::language::LanguageConfig::Multiple(_) => return None,
             },
             TranscriptionEngine::Cohere => self.cohere.as_ref().map(|c| c.language.as_str())?,
+            TranscriptionEngine::Deepgram => self.deepgram.as_ref().map(|d| d.language.as_str())?,
             TranscriptionEngine::SenseVoice => {
                 self.sensevoice.as_ref().map(|s| s.language.as_str())?
             }
@@ -419,6 +427,11 @@ impl Config {
                 .as_ref()
                 .map(|s| s.model.as_str())
                 .unwrap_or("soniox (not configured)"),
+            TranscriptionEngine::Deepgram => self
+                .deepgram
+                .as_ref()
+                .map(|d| d.model.as_str())
+                .unwrap_or("deepgram (not configured)"),
         }
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -205,6 +205,7 @@ const WHISPER_MODE_CHOICES: &[&str] = &["local", "remote", "cli"];
 const WHISPER_LANG_CHOICES: &[&str] = &[
     "auto", "en", "fr", "de", "it", "es", "pt", "nl", "pl", "zh", "ja", "ko", "ru", "ar",
 ];
+const DEEPGRAM_LANG_CHOICES: &[&str] = &["auto", "multi", "en", "en-US", "en-GB"];
 const SENSEVOICE_LANG_CHOICES: &[&str] = &["auto", "zh", "en", "ja", "ko", "yue"];
 const COHERE_LANG_CHOICES: &[&str] = &[
     "ar", "de", "en", "es", "fr", "hi", "it", "ja", "ko", "nl", "pt", "ru", "tr", "zh",
@@ -403,6 +404,69 @@ pub const CONFIG_KEYS: &[KeySpec] = &[
         "Model name to request from the remote endpoint (e.g. whisper-1).",
     )
     .for_engine("whisper"),
+    // deepgram. `api_key` is intentionally omitted: credentials may be read
+    // from config for compatibility, but schema consumers must not display or
+    // round-trip secret values.
+    spec(
+        "deepgram.model",
+        "deepgram",
+        "model",
+        KeyType::String,
+        "Engine",
+        "Model",
+        "Deepgram model identifier (nova-3 by default).",
+    )
+    .for_engine("deepgram"),
+    spec(
+        "deepgram.language",
+        "deepgram",
+        "language",
+        open(DEEPGRAM_LANG_CHOICES),
+        "Engine",
+        "Language",
+        "BCP-47 language code, auto for detection, or multi for multilingual recognition.",
+    )
+    .for_engine("deepgram"),
+    spec(
+        "deepgram.smart_format",
+        "deepgram",
+        "smart_format",
+        KeyType::Bool,
+        "Engine",
+        "Smart format",
+        "Format dates, numbers, punctuation, and other entities in the transcript.",
+    )
+    .for_engine("deepgram"),
+    spec(
+        "deepgram.mip_opt_out",
+        "deepgram",
+        "mip_opt_out",
+        KeyType::Bool,
+        "Engine",
+        "Model improvement opt-out",
+        "Exclude request audio from Deepgram's Model Improvement Program.",
+    )
+    .for_engine("deepgram"),
+    spec(
+        "deepgram.timeout_secs",
+        "deepgram",
+        "timeout_secs",
+        KeyType::Int { min: 1, max: 300 },
+        "Engine",
+        "Timeout",
+        "Maximum number of seconds to wait for a Deepgram response.",
+    )
+    .for_engine("deepgram"),
+    spec(
+        "deepgram.endpoint",
+        "deepgram",
+        "endpoint",
+        KeyType::String,
+        "Engine",
+        "Endpoint",
+        "Deepgram pre-recorded transcription endpoint. HTTPS is required except for localhost testing.",
+    )
+    .for_engine("deepgram"),
     // parakeet
     spec(
         "parakeet.model",
@@ -1456,7 +1520,7 @@ pub fn validate_value(spec: &KeySpec, raw: &str) -> Result<TypedValue, ValueErro
 fn ensure_required_siblings(editor: &mut ConfigEditor, spec: &KeySpec) {
     let Some(engine) = spec.engine else { return };
     // Whisper's table is not optional and its `model` has a serde default.
-    if engine == "whisper" || spec.field == "model" {
+    if engine == "whisper" || engine == "deepgram" || spec.field == "model" {
         return;
     }
     if editor.get_string(spec.table, "model").is_none() {
@@ -1528,6 +1592,7 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
     let dol = || cfg.dolphin.clone().unwrap_or_default();
     let om = || cfg.omnilingual.clone().unwrap_or_default();
     let co = || cfg.cohere.clone().unwrap_or_default();
+    let dg = || cfg.deepgram.clone().unwrap_or_default();
 
     let v = match key {
         "engine" => json!(cfg.engine.name()),
@@ -1556,6 +1621,13 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
             Some(n) => json!(n),
             None => Json::Null,
         },
+
+        "deepgram.model" => json!(dg().model),
+        "deepgram.language" => json!(dg().language),
+        "deepgram.smart_format" => json!(dg().smart_format),
+        "deepgram.mip_opt_out" => json!(dg().mip_opt_out),
+        "deepgram.timeout_secs" => json!(dg().timeout_secs),
+        "deepgram.endpoint" => json!(dg().endpoint),
 
         "parakeet.model" => json!(pk().model),
         "parakeet.model_type" => match pk().model_type {
@@ -2161,8 +2233,8 @@ mod tests {
     #[test]
     fn feature_gate_agrees_with_config_set() {
         for name in config_set::ENGINE_NAMES {
-            if *name == "whisper" {
-                continue; // always available, so it has no feature entry
+            if matches!(*name, "whisper" | "deepgram") {
+                continue; // unconditional engines have no Cargo feature entry
             }
             assert_eq!(
                 feature_compiled(name),
@@ -2179,11 +2251,12 @@ mod tests {
     fn onnx_engine_keys_are_feature_gated() {
         for s in CONFIG_KEYS {
             let Some(engine) = s.engine else { continue };
-            if engine == "whisper" {
+            if matches!(engine, "whisper" | "deepgram") {
                 assert!(
                     s.requires_feature.is_none(),
-                    "{} should not be feature-gated; whisper is always compiled in",
-                    s.key
+                    "{} should not be feature-gated; {} is always compiled in",
+                    s.key,
+                    engine,
                 );
             } else {
                 assert_eq!(

--- a/src/config_set.rs
+++ b/src/config_set.rs
@@ -100,6 +100,7 @@ pub const ENGINE_NAMES: &[&str] = &[
     "dolphin",
     "omnilingual",
     "cohere",
+    "deepgram",
 ];
 
 /// Is the engine name one we recognize at all?
@@ -115,8 +116,9 @@ pub fn parse_engine(name: &str) -> Option<TranscriptionEngine> {
 
 /// Was this binary compiled with the feature needed to run the given engine?
 ///
-/// Whisper and Soniox are unconditional (Soniox was un-feature-gated in
-/// #441); every other engine is gated on the corresponding Cargo feature.
+/// Whisper, Soniox, and Deepgram are unconditional (Soniox was
+/// un-feature-gated in #441); every local ONNX engine is gated on the
+/// corresponding Cargo feature.
 /// This is the source-of-truth check that matches what the TUI shows on
 /// source builds (see `EngineState::refresh_binary_match` in
 /// `src/tui/engine.rs`). The TUI's `compiled_features()` list in
@@ -134,6 +136,7 @@ pub fn engine_feature_compiled(name: &str) -> bool {
     match engine {
         TranscriptionEngine::Whisper => true,
         TranscriptionEngine::Soniox => true,
+        TranscriptionEngine::Deepgram => true,
         TranscriptionEngine::Parakeet => cfg!(feature = "parakeet"),
         TranscriptionEngine::Moonshine => cfg!(feature = "moonshine"),
         TranscriptionEngine::SenseVoice => cfg!(feature = "sensevoice"),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1462,7 +1462,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Deepgram => {
                     if let Some(ref t) = transcriber_preloaded {
                         Ok(t.clone())
                     } else {
@@ -2886,7 +2887,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Deepgram => {
                     // Non-Whisper engines do their own setup; Soniox just validates
                     // API key + endpoint at construction (no model to download).
                     transcriber_preloaded = Some(Arc::from(crate::transcribe::create_transcriber(
@@ -3006,7 +3008,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Deepgram => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -3036,7 +3039,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Deepgram => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -3217,7 +3221,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Deepgram => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -3247,7 +3252,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Deepgram => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -3688,7 +3694,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Deepgram => {
                                     let config = self.config.clone();
                                     self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                         crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -3717,7 +3724,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Dolphin
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::Deepgram => {
                                     if let Some(ref t) = transcriber_preloaded {
                                         let transcriber = t.clone();
                                         tokio::task::spawn_blocking(move || {

--- a/src/model_catalog.rs
+++ b/src/model_catalog.rs
@@ -557,6 +557,9 @@ mod tests {
     #[test]
     fn catalog_covers_the_settable_engines() {
         for name in ENGINE_NAMES {
+            if *name == "deepgram" {
+                continue;
+            }
             assert!(
                 CATALOG_ENGINES.contains(name),
                 "engine '{}' is settable but has no model catalog",

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -289,7 +289,8 @@ fn send_macos_native(title: &str, body: &str, engine: Option<TranscriptionEngine
         | TranscriptionEngine::Dolphin
         | TranscriptionEngine::Omnilingual
         | TranscriptionEngine::Cohere
-        | TranscriptionEngine::Soniox => None,
+        | TranscriptionEngine::Soniox
+        | TranscriptionEngine::Deepgram => None,
     });
 
     for notifier in notifier_paths {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -179,6 +179,7 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
         crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
         crate::config::TranscriptionEngine::Cohere => "\u{1F4DD}",   // 📝
         crate::config::TranscriptionEngine::Soniox => "\u{2601}\u{FE0F}", // ☁️
+        crate::config::TranscriptionEngine::Deepgram => "\u{26A1}",  // ⚡
     }
 }
 

--- a/src/setup/variant_check.rs
+++ b/src/setup/variant_check.rs
@@ -63,7 +63,9 @@ pub enum Remediation {
 /// the feature name is just the engine's canonical name.
 pub fn required_feature(engine: TranscriptionEngine) -> Option<&'static str> {
     match engine {
-        TranscriptionEngine::Whisper => None,
+        TranscriptionEngine::Whisper
+        | TranscriptionEngine::Soniox
+        | TranscriptionEngine::Deepgram => None,
         other => Some(other.name()),
     }
 }
@@ -222,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    fn every_non_whisper_engine_has_a_required_feature() {
+    fn every_optional_engine_has_a_required_feature() {
         // Regression guard: if a new engine is added to TranscriptionEngine
         // without updating required_feature, this catches it before it
         // ships as a silent always-passes mismatch check.
@@ -234,7 +236,6 @@ mod tests {
             TranscriptionEngine::Dolphin,
             TranscriptionEngine::Omnilingual,
             TranscriptionEngine::Cohere,
-            TranscriptionEngine::Soniox,
         ];
         for e in engines {
             assert!(
@@ -244,5 +245,7 @@ mod tests {
             );
         }
         assert_eq!(required_feature(TranscriptionEngine::Whisper), None);
+        assert_eq!(required_feature(TranscriptionEngine::Soniox), None);
+        assert_eq!(required_feature(TranscriptionEngine::Deepgram), None);
     }
 }

--- a/src/transcribe/audio.rs
+++ b/src/transcribe/audio.rs
@@ -1,0 +1,53 @@
+//! Shared audio encoders used by remote transcription backends.
+
+use crate::error::TranscribeError;
+use std::io::Cursor;
+
+pub const SAMPLE_RATE: u32 = 16_000;
+
+/// Encode 16 kHz mono floating-point samples as PCM signed 16-bit WAV.
+pub fn encode_wav_s16le(samples: &[f32]) -> Result<Vec<u8>, TranscribeError> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: SAMPLE_RATE,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    let mut buffer = Cursor::new(Vec::new());
+    let mut writer = hound::WavWriter::new(&mut buffer, spec)
+        .map_err(|e| TranscribeError::AudioFormat(format!("WAV writer init: {}", e)))?;
+
+    for &sample in samples {
+        let sample = (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+        writer
+            .write_sample(sample)
+            .map_err(|e| TranscribeError::AudioFormat(format!("WAV sample write: {}", e)))?;
+    }
+
+    writer
+        .finalize()
+        .map_err(|e| TranscribeError::AudioFormat(format!("WAV finalize: {}", e)))?;
+    Ok(buffer.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wav_has_expected_header_and_size() {
+        let samples = vec![0.0; SAMPLE_RATE as usize];
+        let wav = encode_wav_s16le(&samples).unwrap();
+        assert_eq!(wav.len(), 44 + samples.len() * 2);
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+    }
+
+    #[test]
+    fn wav_clamps_samples_outside_unit_range() {
+        let wav = encode_wav_s16le(&[-2.0, 2.0]).unwrap();
+        assert_eq!(i16::from_le_bytes([wav[44], wav[45]]), i16::MIN + 1);
+        assert_eq!(i16::from_le_bytes([wav[46], wav[47]]), i16::MAX);
+    }
+}

--- a/src/transcribe/deepgram.rs
+++ b/src/transcribe/deepgram.rs
@@ -1,0 +1,460 @@
+//! Deepgram pre-recorded speech-to-text backend.
+
+use super::audio::{encode_wav_s16le, SAMPLE_RATE};
+use super::Transcriber;
+use crate::config::DeepgramConfig;
+use crate::error::TranscribeError;
+use serde::Deserialize;
+use std::net::IpAddr;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct DeepgramTranscriber {
+    config: DeepgramConfig,
+    api_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepgramResponse {
+    results: DeepgramResults,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepgramResults {
+    channels: Vec<DeepgramChannel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepgramChannel {
+    alternatives: Vec<DeepgramAlternative>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeepgramAlternative {
+    transcript: String,
+}
+
+impl DeepgramTranscriber {
+    pub fn new(config: DeepgramConfig) -> Result<Self, TranscribeError> {
+        validate_config(&config)?;
+
+        let api_key = std::env::var("DEEPGRAM_API_KEY")
+            .ok()
+            .filter(|key| !key.trim().is_empty())
+            .or_else(|| config.api_key.clone().filter(|key| !key.trim().is_empty()))
+            .ok_or_else(|| {
+                TranscribeError::ConfigError(
+                    "Deepgram API key required: set DEEPGRAM_API_KEY or [deepgram] api_key".into(),
+                )
+            })?;
+
+        tracing::info!(
+            "Deepgram backend configured: endpoint={}, model={}, language={}, smart_format={}, mip_opt_out={}, timeout={}s",
+            config.endpoint,
+            config.model,
+            config.language,
+            config.smart_format,
+            config.mip_opt_out,
+            config.timeout_secs,
+        );
+
+        Ok(Self { config, api_key })
+    }
+
+    fn request(&self) -> ureq::Request {
+        let mut request = ureq::post(&self.config.endpoint)
+            .timeout(Duration::from_secs(self.config.timeout_secs))
+            .set("Authorization", &format!("Token {}", self.api_key))
+            .set("Content-Type", "audio/wav")
+            .query("model", &self.config.model)
+            .query(
+                "smart_format",
+                if self.config.smart_format {
+                    "true"
+                } else {
+                    "false"
+                },
+            )
+            .query(
+                "mip_opt_out",
+                if self.config.mip_opt_out {
+                    "true"
+                } else {
+                    "false"
+                },
+            );
+
+        request = match self.config.language.as_str() {
+            "auto" => request.query("detect_language", "true"),
+            language => request.query("language", language),
+        };
+        request
+    }
+
+    fn parse_response(body: &str) -> Result<String, TranscribeError> {
+        let response: DeepgramResponse = serde_json::from_str(body).map_err(|e| {
+            TranscribeError::RemoteError(format!("Deepgram returned malformed JSON: {}", e))
+        })?;
+
+        let transcript = response
+            .results
+            .channels
+            .first()
+            .and_then(|channel| channel.alternatives.first())
+            .map(|alternative| alternative.transcript.trim().to_string())
+            .ok_or_else(|| {
+                TranscribeError::RemoteError(
+                    "Deepgram response contained no channel alternatives".into(),
+                )
+            })?;
+
+        if transcript.is_empty() {
+            return Err(TranscribeError::RemoteError(
+                "Deepgram returned an empty transcript".into(),
+            ));
+        }
+
+        Ok(transcript)
+    }
+}
+
+impl Transcriber for DeepgramTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat("Empty audio buffer".into()));
+        }
+
+        let wav = encode_wav_s16le(samples)?;
+        let duration_secs = samples.len() as f32 / SAMPLE_RATE as f32;
+        tracing::debug!(
+            "Sending {:.2}s of audio to Deepgram ({} KiB WAV)",
+            duration_secs,
+            wav.len() / 1024
+        );
+        let started = std::time::Instant::now();
+
+        let response = self.request().send_bytes(&wav).map_err(map_request_error)?;
+        let body = response.into_string().map_err(|e| {
+            TranscribeError::RemoteError(format!("Failed to read Deepgram response: {}", e))
+        })?;
+        let transcript = Self::parse_response(&body)?;
+
+        tracing::info!(
+            "Deepgram transcription completed in {:.2}s",
+            started.elapsed().as_secs_f32()
+        );
+        Ok(transcript)
+    }
+
+    fn last_detected_language(&self) -> Option<String> {
+        match self.config.language.as_str() {
+            "auto" | "multi" => None,
+            language => Some(language.to_string()),
+        }
+    }
+}
+
+fn validate_config(config: &DeepgramConfig) -> Result<(), TranscribeError> {
+    let endpoint = reqwest::Url::parse(&config.endpoint).map_err(|e| {
+        TranscribeError::ConfigError(format!("Invalid Deepgram endpoint URL: {}", e))
+    })?;
+    if !endpoint.username().is_empty() || endpoint.password().is_some() {
+        return Err(TranscribeError::ConfigError(
+            "Deepgram endpoint must not contain credentials".into(),
+        ));
+    }
+    let is_loopback = endpoint.host_str().is_some_and(|host| {
+        host == "localhost"
+            || host
+                .parse::<IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    });
+    if endpoint.scheme() != "https" && !(endpoint.scheme() == "http" && is_loopback) {
+        return Err(TranscribeError::ConfigError(
+            "Deepgram endpoint must use HTTPS (HTTP is allowed only for localhost tests)".into(),
+        ));
+    }
+    if config.model.trim().is_empty() {
+        return Err(TranscribeError::ConfigError(
+            "Deepgram model must not be empty".into(),
+        ));
+    }
+    if config.language.trim().is_empty() {
+        return Err(TranscribeError::ConfigError(
+            "Deepgram language must not be empty".into(),
+        ));
+    }
+    if config.timeout_secs == 0 {
+        return Err(TranscribeError::ConfigError(
+            "Deepgram timeout_secs must be greater than zero".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn map_request_error(error: ureq::Error) -> TranscribeError {
+    match error {
+        ureq::Error::Status(code, response) => {
+            let detail = response.into_string().unwrap_or_default();
+            let summary = match code {
+                401 | 403 => "authentication failed",
+                402 => "account has insufficient credit",
+                429 => "rate limit exceeded",
+                _ => "request failed",
+            };
+            if detail.is_empty() {
+                TranscribeError::RemoteError(format!("Deepgram {} (HTTP {})", summary, code))
+            } else {
+                TranscribeError::RemoteError(format!(
+                    "Deepgram {} (HTTP {}): {}",
+                    summary,
+                    code,
+                    truncate_detail(&detail)
+                ))
+            }
+        }
+        ureq::Error::Transport(error) => {
+            TranscribeError::NetworkError(format!("Deepgram request failed: {}", error))
+        }
+    }
+}
+
+fn truncate_detail(detail: &str) -> String {
+    const MAX_CHARS: usize = 500;
+    let trimmed = detail.trim();
+    if trimmed.chars().count() <= MAX_CHARS {
+        trimmed.to_string()
+    } else {
+        format!("{}…", trimmed.chars().take(MAX_CHARS).collect::<String>())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    fn config_with_key() -> DeepgramConfig {
+        DeepgramConfig {
+            api_key: Some("config-key".into()),
+            ..Default::default()
+        }
+    }
+
+    fn spawn_server(
+        status: &str,
+        response_body: &str,
+    ) -> (String, std::thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let status = status.to_string();
+        let response_body = response_body.to_string();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut headers = [0u8; 4096];
+            let read = stream.read(&mut headers).unwrap();
+            request.extend_from_slice(&headers[..read]);
+
+            let header_end = request
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+                .map(|position| position + 4)
+                .unwrap();
+            let header_text = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = header_text
+                .lines()
+                .find_map(|line| {
+                    line.strip_prefix("Content-Length: ")
+                        .or_else(|| line.strip_prefix("content-length: "))
+                })
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .unwrap_or(0);
+            while request.len() - header_end < content_length {
+                let mut chunk = [0u8; 4096];
+                let read = stream.read(&mut chunk).unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&chunk[..read]);
+            }
+
+            let response = format!(
+                "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                status,
+                response_body.len(),
+                response_body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            String::from_utf8_lossy(&request).into_owned()
+        });
+        (format!("http://{}/v1/listen", address), handle)
+    }
+
+    #[test]
+    fn environment_key_takes_precedence() {
+        let _guard = env_lock();
+        std::env::set_var("DEEPGRAM_API_KEY", "environment-key");
+        let transcriber = DeepgramTranscriber::new(config_with_key()).unwrap();
+        std::env::remove_var("DEEPGRAM_API_KEY");
+        assert_eq!(transcriber.api_key, "environment-key");
+    }
+
+    #[test]
+    fn config_key_is_fallback() {
+        let _guard = env_lock();
+        std::env::remove_var("DEEPGRAM_API_KEY");
+        let transcriber = DeepgramTranscriber::new(config_with_key()).unwrap();
+        assert_eq!(transcriber.api_key, "config-key");
+    }
+
+    #[test]
+    fn missing_key_is_rejected() {
+        let _guard = env_lock();
+        std::env::remove_var("DEEPGRAM_API_KEY");
+        let error = DeepgramTranscriber::new(DeepgramConfig::default()).unwrap_err();
+        assert!(error.to_string().contains("DEEPGRAM_API_KEY"));
+    }
+
+    #[test]
+    fn endpoint_requires_https_except_localhost() {
+        let mut config = config_with_key();
+        config.endpoint = "http://example.com/v1/listen".into();
+        let error = DeepgramTranscriber::new(config).unwrap_err();
+        assert!(error.to_string().contains("HTTPS"));
+
+        let mut lookalike = config_with_key();
+        lookalike.endpoint = "http://localhost.example.com/v1/listen".into();
+        assert!(DeepgramTranscriber::new(lookalike).is_err());
+
+        let mut credentials = config_with_key();
+        credentials.endpoint = "https://user:password@api.deepgram.com/v1/listen".into();
+        assert!(DeepgramTranscriber::new(credentials)
+            .unwrap_err()
+            .to_string()
+            .contains("must not contain credentials"));
+    }
+
+    #[test]
+    fn parses_transcript_and_rejects_empty_transcript() {
+        let body =
+            r#"{"results":{"channels":[{"alternatives":[{"transcript":" hello world "}]}]}}"#;
+        assert_eq!(
+            DeepgramTranscriber::parse_response(body).unwrap(),
+            "hello world"
+        );
+
+        let empty = r#"{"results":{"channels":[{"alternatives":[{"transcript":""}]}]}}"#;
+        assert!(DeepgramTranscriber::parse_response(empty)
+            .unwrap_err()
+            .to_string()
+            .contains("empty transcript"));
+    }
+
+    #[test]
+    fn malformed_and_missing_results_are_rejected() {
+        assert!(DeepgramTranscriber::parse_response("not json").is_err());
+        assert!(DeepgramTranscriber::parse_response(
+            r#"{"results":{"channels":[{"alternatives":[]}]}}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn request_contains_expected_headers_query_and_wav() {
+        let body = r#"{"results":{"channels":[{"alternatives":[{"transcript":"test"}]}]}}"#;
+        let (endpoint, server) = spawn_server("200 OK", body);
+        let transcriber = DeepgramTranscriber::new(DeepgramConfig {
+            endpoint,
+            api_key: Some("secret-test-key".into()),
+            language: "auto".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let transcript = transcriber.transcribe(&[0.0; 160]).unwrap();
+        assert_eq!(transcript, "test");
+        let request = server.join().unwrap();
+        assert!(request.starts_with("POST /v1/listen?"));
+        assert!(request.contains("model=nova-3"));
+        assert!(request.contains("smart_format=true"));
+        assert!(request.contains("mip_opt_out=true"));
+        assert!(request.contains("detect_language=true"));
+        assert!(!request.contains("&language="));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("content-type: audio/wav"));
+        assert!(request.contains("Authorization: Token secret-test-key"));
+        assert!(request.contains("RIFF"));
+        assert!(request.contains("WAVE"));
+    }
+
+    #[test]
+    fn http_errors_have_actionable_categories() {
+        let (endpoint, server) =
+            spawn_server("429 Too Many Requests", r#"{"err_code":"TooManyRequests"}"#);
+        let transcriber = DeepgramTranscriber::new(DeepgramConfig {
+            endpoint,
+            api_key: Some("key".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        let error = transcriber.transcribe(&[0.0; 16]).unwrap_err();
+        server.join().unwrap();
+        assert!(error.to_string().contains("rate limit exceeded"));
+        assert!(error.to_string().contains("429"));
+    }
+
+    #[test]
+    fn request_timeout_is_a_network_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!("http://{}/v1/listen", listener.local_addr().unwrap());
+        let server = std::thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            std::thread::sleep(Duration::from_secs(2));
+        });
+        let transcriber = DeepgramTranscriber::new(DeepgramConfig {
+            endpoint,
+            api_key: Some("key".into()),
+            timeout_secs: 1,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let error = transcriber.transcribe(&[0.0; 16]).unwrap_err();
+        server.join().unwrap();
+        assert!(matches!(error, TranscribeError::NetworkError(_)));
+    }
+
+    #[test]
+    #[ignore = "requires DEEPGRAM_API_KEY and DEEPGRAM_LIVE_TEST_WAV"]
+    fn deepgram_live() {
+        let path = std::env::var("DEEPGRAM_LIVE_TEST_WAV")
+            .expect("set DEEPGRAM_LIVE_TEST_WAV to a short 16 kHz mono PCM WAV");
+        let mut reader = hound::WavReader::open(path).expect("open live-test WAV");
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 1, "live-test WAV must be mono");
+        assert_eq!(
+            spec.sample_rate, SAMPLE_RATE,
+            "live-test WAV must be 16 kHz"
+        );
+        assert_eq!(spec.bits_per_sample, 16, "live-test WAV must be 16-bit PCM");
+        let samples = reader
+            .samples::<i16>()
+            .map(|sample| sample.expect("decode live-test sample") as f32 / i16::MAX as f32)
+            .collect::<Vec<_>>();
+
+        let transcript = DeepgramTranscriber::new(DeepgramConfig::default())
+            .expect("configure Deepgram from DEEPGRAM_API_KEY")
+            .transcribe(&samples)
+            .expect("live Deepgram transcription");
+        assert!(!transcript.trim().is_empty());
+    }
+}

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -11,8 +11,11 @@
 //! - Optionally Paraformer via ONNX Runtime (when `paraformer` feature is enabled)
 //! - Optionally Dolphin via ONNX Runtime (when `dolphin` feature is enabled)
 //! - Optionally Omnilingual via ONNX Runtime (when `omnilingual` feature is enabled)
+//! - Deepgram batch transcription over HTTPS (available in every binary)
 
+pub mod audio;
 pub mod cli;
+pub mod deepgram;
 #[cfg(feature = "parakeet")]
 pub mod parakeet_streaming;
 pub mod remote;
@@ -275,6 +278,14 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
                 )
             })?;
             Ok(Box::new(soniox::SonioxTranscriber::new(cfg.clone())?))
+        }
+        TranscriptionEngine::Deepgram => {
+            let cfg = config.deepgram.as_ref().ok_or_else(|| {
+                TranscribeError::InitFailed(
+                    "Deepgram engine selected but [deepgram] config section is missing".to_string(),
+                )
+            })?;
+            Ok(Box::new(deepgram::DeepgramTranscriber::new(cfg.clone())?))
         }
     }
 }

--- a/src/transcribe/remote.rs
+++ b/src/transcribe/remote.rs
@@ -6,10 +6,10 @@
 //! Note: Remote APIs don't support language arrays. When a language array is
 //! configured, the first/primary language is used.
 
+use super::audio::encode_wav_s16le;
 use super::Transcriber;
 use crate::config::{LanguageConfig, WhisperConfig};
 use crate::error::TranscribeError;
-use std::io::Cursor;
 use std::time::Duration;
 use ureq::serde_json;
 
@@ -113,36 +113,6 @@ impl RemoteTranscriber {
         })
     }
 
-    /// Encode f32 samples to WAV format
-    fn encode_wav(&self, samples: &[f32]) -> Result<Vec<u8>, TranscribeError> {
-        let spec = hound::WavSpec {
-            channels: 1,
-            sample_rate: 16000,
-            bits_per_sample: 16,
-            sample_format: hound::SampleFormat::Int,
-        };
-
-        let mut buffer = Cursor::new(Vec::new());
-        let mut writer = hound::WavWriter::new(&mut buffer, spec).map_err(|e| {
-            TranscribeError::AudioFormat(format!("Failed to create WAV writer: {}", e))
-        })?;
-
-        // Convert f32 [-1.0, 1.0] to i16
-        for &sample in samples {
-            let clamped = sample.clamp(-1.0, 1.0);
-            let scaled = (clamped * i16::MAX as f32) as i16;
-            writer.write_sample(scaled).map_err(|e| {
-                TranscribeError::AudioFormat(format!("Failed to write sample: {}", e))
-            })?;
-        }
-
-        writer
-            .finalize()
-            .map_err(|e| TranscribeError::AudioFormat(format!("Failed to finalize WAV: {}", e)))?;
-
-        Ok(buffer.into_inner())
-    }
-
     /// Build the multipart form body for the API request
     fn build_multipart_body(&self, wav_data: &[u8]) -> (String, Vec<u8>) {
         let boundary = format!(
@@ -217,7 +187,7 @@ impl Transcriber for RemoteTranscriber {
         let start = std::time::Instant::now();
 
         // Encode audio to WAV
-        let wav_data = self.encode_wav(samples)?;
+        let wav_data = encode_wav_s16le(samples)?;
         tracing::debug!("Encoded WAV: {} bytes", wav_data.len());
 
         // Build multipart form
@@ -295,14 +265,14 @@ mod tests {
             ..Default::default()
         };
 
-        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        RemoteTranscriber::new(&config).unwrap();
 
         // Create a simple sine wave
         let samples: Vec<f32> = (0..16000)
             .map(|i| (i as f32 * 440.0 * 2.0 * std::f32::consts::PI / 16000.0).sin() * 0.5)
             .collect();
 
-        let wav = transcriber.encode_wav(&samples).unwrap();
+        let wav = encode_wav_s16le(&samples).unwrap();
 
         // WAV header is 44 bytes, then 16000 samples * 2 bytes = 32000 bytes
         assert_eq!(wav.len(), 44 + 32000);

--- a/src/transcribe/soniox.rs
+++ b/src/transcribe/soniox.rs
@@ -45,6 +45,7 @@
 //! The daemon disowns the session on `Error`/`Ended` so post-stop
 //! emissions are dropped (matches the v0.7.2 disown-on-stop fix).
 
+use super::audio::encode_wav_s16le;
 use super::streaming::{SegmentId, StreamHandle, StreamingEvent, StreamingTranscriber};
 use super::Transcriber;
 use crate::config::SonioxConfig;
@@ -637,30 +638,6 @@ impl SonioxTranscriber {
         let _ = write.send(Message::Close(None)).await;
         Ok(transcript.trim().to_string())
     }
-}
-
-/// Encode 16 kHz f32 mono samples as a WAV byte buffer (PCM 16-bit LE)
-/// for upload to the Soniox async API. Mirrors the helper in
-/// `transcribe/remote.rs` so both cloud backends share one WAV format.
-fn encode_wav_s16le(samples: &[f32]) -> Result<Vec<u8>, TranscribeError> {
-    let spec = hound::WavSpec {
-        channels: 1,
-        sample_rate: SAMPLE_RATE,
-        bits_per_sample: 16,
-        sample_format: hound::SampleFormat::Int,
-    };
-    let mut buffer = std::io::Cursor::new(Vec::new());
-    let mut writer = hound::WavWriter::new(&mut buffer, spec)
-        .map_err(|e| TranscribeError::AudioFormat(format!("WAV writer init: {}", e)))?;
-    for &s in samples {
-        writer
-            .write_sample(f32_to_i16(s))
-            .map_err(|e| TranscribeError::AudioFormat(format!("WAV sample write: {}", e)))?;
-    }
-    writer
-        .finalize()
-        .map_err(|e| TranscribeError::AudioFormat(format!("WAV finalize: {}", e)))?;
-    Ok(buffer.into_inner())
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -534,7 +534,7 @@ fn detect_missing_model() -> Option<MissingModel> {
         // disk probe rather than emit a false-positive missing warning.
         config::TranscriptionEngine::Cohere => return None,
         // Soniox is cloud-only, no local model to probe.
-        config::TranscriptionEngine::Soniox => return None,
+        config::TranscriptionEngine::Soniox | config::TranscriptionEngine::Deepgram => return None,
     };
 
     if model.is_empty() {

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -117,6 +117,17 @@ pub struct AllFields {
     pub co_threads: Option<i64>,
     pub co_on_demand_loading: bool,
     pub co_section_existed: bool,
+
+    // Deepgram (cloud batch STT)
+    pub dg_model: String,
+    pub dg_language: String,
+    pub dg_smart_format: bool,
+    pub dg_mip_opt_out: bool,
+    pub dg_timeout_secs: i64,
+    pub dg_endpoint: String,
+    pub dg_api_key_in_config: bool,
+    pub dg_api_key_in_environment: bool,
+    pub dg_section_existed: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -186,6 +197,15 @@ pub enum FieldId {
     CoLanguage,
     CoThreads,
     CoOnDemandLoading,
+
+    // Deepgram
+    DgModel,
+    DgLanguage,
+    DgSmartFormat,
+    DgMipOptOut,
+    DgTimeout,
+    DgEndpoint,
+    DgCredential,
 }
 
 /// Cohere Transcribe officially supports these 14 languages. Token IDs are
@@ -198,6 +218,9 @@ const CO_LANG_CHOICES: &[&str] = &[
 const MODE_CHOICES: &[&str] = &["local", "remote", "cli"];
 const LANG_CHOICES: &[&str] = &[
     "auto", "en", "fr", "de", "it", "es", "pt", "nl", "pl", "zh", "ja", "ko", "ru", "ar",
+];
+const DEEPGRAM_LANG_CHOICES: &[&str] = &[
+    "en", "auto", "multi", "es", "fr", "de", "it", "pt", "nl", "hi", "ja", "ru",
 ];
 const SV_LANG_CHOICES: &[&str] = &["auto", "zh", "en", "ja", "ko", "yue"];
 const PARAKEET_MODEL_TYPES: &[Option<&str>] = &[None, Some("tdt"), Some("ctc")];
@@ -263,6 +286,15 @@ fn rows_for_engine_with_mode(engine: &str, whisper_mode: &str) -> Vec<FieldId> {
             FieldId::CoLanguage,
             FieldId::CoThreads,
             FieldId::CoOnDemandLoading,
+        ]),
+        "deepgram" => rows.extend_from_slice(&[
+            FieldId::DgModel,
+            FieldId::DgLanguage,
+            FieldId::DgSmartFormat,
+            FieldId::DgMipOptOut,
+            FieldId::DgTimeout,
+            FieldId::DgEndpoint,
+            FieldId::DgCredential,
         ]),
         _ => {}
     }
@@ -369,6 +401,27 @@ impl EngineState {
             co_threads: ed.get_int("cohere", "threads"),
             co_on_demand_loading: ed.get_bool("cohere", "on_demand_loading").unwrap_or(false),
             co_section_existed: ed.get_string("cohere", "model").is_some(),
+
+            // Deepgram
+            dg_model: ed
+                .get_string("deepgram", "model")
+                .unwrap_or_else(|| "nova-3".to_string()),
+            dg_language: ed
+                .get_string("deepgram", "language")
+                .unwrap_or_else(|| "en".to_string()),
+            dg_smart_format: ed.get_bool("deepgram", "smart_format").unwrap_or(true),
+            dg_mip_opt_out: ed.get_bool("deepgram", "mip_opt_out").unwrap_or(true),
+            dg_timeout_secs: ed.get_int("deepgram", "timeout_secs").unwrap_or(30),
+            dg_endpoint: ed
+                .get_string("deepgram", "endpoint")
+                .unwrap_or_else(|| "https://api.deepgram.com/v1/listen".to_string()),
+            dg_api_key_in_config: ed
+                .get_string("deepgram", "api_key")
+                .is_some_and(|key| !key.trim().is_empty()),
+            dg_api_key_in_environment: std::env::var("DEEPGRAM_API_KEY")
+                .is_ok_and(|key| !key.trim().is_empty()),
+            dg_section_existed: ed.get_string("deepgram", "model").is_some()
+                || ed.get_string("deepgram", "endpoint").is_some(),
         };
         let mut state = Self {
             engine,
@@ -387,7 +440,7 @@ impl EngineState {
     /// Required binary family for an engine name. Whisper needs a Whisper
     /// binary; everything ONNX-based needs an ONNX binary.
     fn required_family(engine: &str) -> EngineFamily {
-        if engine == "whisper" {
+        if matches!(engine, "whisper" | "deepgram" | "soniox") {
             EngineFamily::Whisper
         } else {
             EngineFamily::Onnx
@@ -400,13 +453,19 @@ impl EngineState {
         self.pending_variant_switch = None;
         self.binary_switch_blocked = None;
 
+        // Cloud engines are compiled into every binary and do not require a
+        // local model family or variant switch.
+        if matches!(self.engine.as_str(), "deepgram" | "soniox") {
+            return;
+        }
+
         let inv = binary::inventory();
         if inv.install_kind == InstallKind::Source {
             // Source builds can't be hot-swapped; whether the running binary
             // supports the chosen engine depends on its compiled features.
             // Best we can do is flag it.
             let supported = match self.engine.as_str() {
-                "whisper" => true,
+                "whisper" | "deepgram" | "soniox" => true,
                 "parakeet" => inv.compiled_features.contains(&"parakeet"),
                 _ => inv.compiled_features.contains(&self.engine.as_str()),
             };
@@ -583,6 +642,17 @@ impl EngineState {
             ed.set_bool("cohere", "on_demand_loading", f.co_on_demand_loading);
         }
 
+        // Deepgram. Never rewrite api_key: the TUI reports credential source
+        // but intentionally does not expose or edit the secret.
+        if self.engine == "deepgram" || f.dg_section_existed {
+            ed.set_string("deepgram", "model", &f.dg_model);
+            ed.set_string("deepgram", "language", &f.dg_language);
+            ed.set_bool("deepgram", "smart_format", f.dg_smart_format);
+            ed.set_bool("deepgram", "mip_opt_out", f.dg_mip_opt_out);
+            ed.set_int("deepgram", "timeout_secs", f.dg_timeout_secs);
+            ed.set_string("deepgram", "endpoint", &f.dg_endpoint);
+        }
+
         match ed.save() {
             Ok(()) => {
                 self.dirty_since_load = false;
@@ -689,6 +759,8 @@ impl EngineState {
                 | FieldId::WRemoteEndpoint
                 | FieldId::WRemoteApiKey
                 | FieldId::WRemoteModel
+                | FieldId::DgModel
+                | FieldId::DgEndpoint
         )
     }
 
@@ -702,6 +774,8 @@ impl EngineState {
             FieldId::WRemoteEndpoint => self.fields.w_remote_endpoint.clone().unwrap_or_default(),
             FieldId::WRemoteApiKey => self.fields.w_remote_api_key.clone().unwrap_or_default(),
             FieldId::WRemoteModel => self.fields.w_remote_model.clone().unwrap_or_default(),
+            FieldId::DgModel => self.fields.dg_model.clone(),
+            FieldId::DgEndpoint => self.fields.dg_endpoint.clone(),
             _ => String::new(),
         };
         self.editing = Some(TextEdit {
@@ -723,6 +797,16 @@ impl EngineState {
             FieldId::WRemoteEndpoint => self.fields.w_remote_endpoint = opt,
             FieldId::WRemoteApiKey => self.fields.w_remote_api_key = opt,
             FieldId::WRemoteModel => self.fields.w_remote_model = opt,
+            FieldId::DgModel => {
+                if let Some(value) = opt {
+                    self.fields.dg_model = value;
+                }
+            }
+            FieldId::DgEndpoint => {
+                if let Some(value) = opt {
+                    self.fields.dg_endpoint = value;
+                }
+            }
             _ => {}
         }
         self.dirty_since_load = true;
@@ -824,6 +908,20 @@ impl EngineState {
             }
             FieldId::CoThreads => f.co_threads = cycle_threads(f.co_threads, delta),
             FieldId::CoOnDemandLoading => f.co_on_demand_loading = !f.co_on_demand_loading,
+
+            FieldId::DgModel | FieldId::DgEndpoint => {
+                self.start_edit_if_text_field();
+                return;
+            }
+            FieldId::DgLanguage => {
+                f.dg_language = cycle_str(DEEPGRAM_LANG_CHOICES, &f.dg_language, delta)
+            }
+            FieldId::DgSmartFormat => f.dg_smart_format = !f.dg_smart_format,
+            FieldId::DgMipOptOut => f.dg_mip_opt_out = !f.dg_mip_opt_out,
+            FieldId::DgTimeout => {
+                f.dg_timeout_secs = (f.dg_timeout_secs + delta as i64 * 5).clamp(5, 300)
+            }
+            FieldId::DgCredential => return,
         }
         self.dirty_since_load = true;
         self.feedback = None;
@@ -838,7 +936,7 @@ impl EngineState {
 /// skip the on-disk check for Whisper. Returns None for unknown engines.
 fn active_model_for_engine(engine: &str, f: &AllFields) -> Option<String> {
     match engine {
-        "whisper" => None,
+        "whisper" | "deepgram" | "soniox" => None,
         "parakeet" => Some(f.pk_model.clone()),
         "moonshine" => Some(f.mn_model.clone()),
         "sensevoice" => Some(f.sv_model.clone()),
@@ -894,6 +992,7 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
     // Whisper is always present.
     let inv = binary::inventory();
     out.insert("whisper");
+    out.insert("deepgram");
     for f in &inv.compiled_features {
         for engine in [
             "parakeet",
@@ -1211,6 +1310,38 @@ fn field_label_value(state: &EngineState, fid: FieldId) -> (&'static str, String
         FieldId::CoOnDemandLoading => (
             "Cohere · on-demand model load",
             yesno(f.co_on_demand_loading),
+        ),
+
+        FieldId::DgModel => (
+            "Deepgram · model",
+            match state.editing.as_ref() {
+                Some(e) if e.field == FieldId::DgModel => e.input.caret_string(),
+                _ => f.dg_model.clone(),
+            },
+        ),
+        FieldId::DgLanguage => ("Deepgram · language", f.dg_language.clone()),
+        FieldId::DgSmartFormat => ("Deepgram · smart format", yesno(f.dg_smart_format)),
+        FieldId::DgMipOptOut => (
+            "Deepgram · model improvement opt-out",
+            yesno(f.dg_mip_opt_out),
+        ),
+        FieldId::DgTimeout => ("Deepgram · timeout", format!("{}s", f.dg_timeout_secs)),
+        FieldId::DgEndpoint => (
+            "Deepgram · endpoint",
+            match state.editing.as_ref() {
+                Some(e) if e.field == FieldId::DgEndpoint => e.input.caret_string(),
+                _ => f.dg_endpoint.clone(),
+            },
+        ),
+        FieldId::DgCredential => (
+            "Deepgram · credentials",
+            if f.dg_api_key_in_environment {
+                "set via DEEPGRAM_API_KEY".to_string()
+            } else if f.dg_api_key_in_config {
+                "set in config (plain text)".to_string()
+            } else {
+                "missing".to_string()
+            },
         ),
     }
 }
@@ -1636,6 +1767,53 @@ fn guidance(state: &EngineState) -> Vec<Line<'_>> {
         FieldId::CoThreads => threads_guidance("Cohere"),
         FieldId::CoOnDemandLoading => on_demand_guidance("Cohere"),
 
+        FieldId::DgModel => vec![
+            heading("Deepgram · model"),
+            Line::from(""),
+            Line::from("Deepgram model identifier. nova-3 is the recommended general-purpose batch model."),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Press Enter to edit.",
+                Style::default().fg(Color::Gray),
+            )),
+        ],
+        FieldId::DgLanguage => vec![
+            heading("Deepgram · language"),
+            Line::from(""),
+            Line::from("Use a BCP-47 language code, auto to detect one language per recording, or multi for code-switching."),
+            Line::from(""),
+            Line::from("A fixed language such as en usually improves latency and short-utterance accuracy."),
+        ],
+        FieldId::DgSmartFormat => vec![
+            heading("Deepgram · smart format"),
+            Line::from(""),
+            Line::from("Adds punctuation, capitalization, paragraphs, numerals, dates, and other readable formatting."),
+        ],
+        FieldId::DgMipOptOut => vec![
+            heading("Deepgram · model improvement opt-out"),
+            Line::from(""),
+            Line::from("When enabled, each request sends mip_opt_out=true so dictation is excluded from Deepgram's Model Improvement Program."),
+        ],
+        FieldId::DgTimeout => vec![
+            heading("Deepgram · request timeout"),
+            Line::from(""),
+            Line::from("Maximum time to wait for upload and transcription. Five-second steps; default 30 seconds."),
+        ],
+        FieldId::DgEndpoint => vec![
+            heading("Deepgram · endpoint"),
+            Line::from(""),
+            Line::from("Pre-recorded STT endpoint. HTTPS is required except for localhost testing."),
+            Line::from(""),
+            Line::from("Use api.eu.deepgram.com or api.au.deepgram.com here when regional processing is required."),
+        ],
+        FieldId::DgCredential => vec![
+            heading("Deepgram · credentials"),
+            Line::from(""),
+            Line::from("Set DEEPGRAM_API_KEY in the daemon environment (recommended). The secret is never displayed here."),
+            Line::from(""),
+            Line::from("An api_key value in [deepgram] is supported as a plain-text fallback."),
+        ],
+
         FieldId::WRemoteEndpoint => vec![
             heading("Whisper · remote endpoint"),
             Line::from(""),
@@ -1757,6 +1935,7 @@ fn display_engine(engine: &str) -> &'static str {
         "dolphin" => "Dolphin",
         "omnilingual" => "Omnilingual",
         "cohere" => "Cohere",
+        "deepgram" => "Deepgram",
         _ => "Engine",
     }
 }

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -64,7 +64,8 @@ pub fn create_vad(config: &Config) -> Result<Option<Box<dyn VoiceActivityDetecto
                 | TranscriptionEngine::Dolphin
                 | TranscriptionEngine::Omnilingual
                 | TranscriptionEngine::Cohere
-                | TranscriptionEngine::Soniox => VadBackend::Energy,
+                | TranscriptionEngine::Soniox
+                | TranscriptionEngine::Deepgram => VadBackend::Energy,
             }
         }
         explicit => explicit,


### PR DESCRIPTION
## Summary

- add an unconditional Deepgram pre-recorded transcription engine using the existing HTTP and WAV dependencies
- support `nova-3`, BCP-47/auto/multi language configuration, smart formatting, MIP opt-out, request timeouts, and configurable endpoints
- resolve credentials from `DEEPGRAM_API_KEY` before the optional config fallback without displaying or logging secrets
- share 16 kHz mono WAV encoding across remote Whisper, Soniox async, and Deepgram
- expose Deepgram in the configuration schema, TUI, CLI/status surfaces, sample config, and provider docs

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets --no-deps -- -D warnings`
- `cargo test` (all default tests pass; live/download tests remain ignored)
- local mock HTTP tests cover headers, query parameters, WAV bodies, parsing, empty/malformed responses, HTTP errors, and timeout handling
- live 7.3-second dictation smoke test: transcript returned 0.76 seconds after recording stopped and inserted at the cursor

The live test is opt-in and requires both `DEEPGRAM_API_KEY` and `DEEPGRAM_LIVE_TEST_WAV`; CI never needs a real credential.
