### PR TITLE
Wait for OpenVINO NPU compilation during model setup

### DIFF
--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -640,6 +640,14 @@ pub async fn run_setup(
                 model_path.exists() && model::validate_openvino_model(&model_path).is_ok();
 
             if model_valid {
+                // A failed first compile leaves valid downloaded IR files in
+                // place. A retry with --download must retry NPU preparation
+                // instead of treating those files alone as complete setup.
+                if download {
+                    let mut openvino = config.openvino.clone().unwrap_or_default();
+                    openvino.model = model_name.to_string();
+                    model::prepare_openvino_model_for_config(model_name, &openvino)?;
+                }
                 if !quiet {
                     let size = std::fs::read_dir(&model_path)
                         .map(|entries| {
@@ -662,7 +670,9 @@ pub async fn run_setup(
                     }
                 }
             } else if download {
-                model::download_openvino_model(model_name)?;
+                let mut openvino = config.openvino.clone().unwrap_or_default();
+                openvino.model = model_name.to_string();
+                model::download_openvino_model_with_config(model_name, &openvino)?;
                 if activate {
                     model::set_openvino_config(model_name)?;
                     if !quiet {

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -3,7 +3,7 @@
 use super::manifest::{ExpectedFile, ModelArtifact};
 use super::progress::{self, FileProgress};
 use super::{print_failure, print_info, print_success, print_warning};
-use crate::config::{Config, TranscriptionEngine};
+use crate::config::{Config, OpenVinoConfig, TranscriptionEngine};
 use crate::transcribe::whisper::{get_model_filename, get_model_url};
 use std::io::{self, Write};
 use std::path::Path;
@@ -1826,7 +1826,7 @@ pub async fn interactive_select() -> anyhow::Result<()> {
         handle_cohere_selection(idx).await
     } else if openvino_available && selection <= openvino_offset + openvino_count {
         let idx = selection - openvino_offset;
-        handle_openvino_selection(idx).await
+        handle_openvino_selection(idx, &config).await
     } else {
         println!("\nInvalid selection.");
         Ok(())
@@ -3467,7 +3467,7 @@ fn validate_onnx_ctc_model(path: &Path) -> anyhow::Result<()> {
 }
 
 /// Handle OpenVINO model selection (download/config).
-async fn handle_openvino_selection(selection: usize) -> anyhow::Result<()> {
+async fn handle_openvino_selection(selection: usize, config: &Config) -> anyhow::Result<()> {
     let models_dir = Config::models_dir();
 
     if selection == 0 || selection > OPENVINO_MODELS.len() {
@@ -3490,6 +3490,9 @@ async fn handle_openvino_selection(selection: usize) -> anyhow::Result<()> {
         io::stdin().read_line(&mut choice)?;
         match choice.trim() {
             "" | "1" => {
+                let mut openvino = config.openvino.clone().unwrap_or_default();
+                openvino.model = model.name.to_string();
+                prepare_openvino_model_for_config(model.name, &openvino)?;
                 update_config_openvino(model.name)?;
                 restart_daemon_if_running().await;
                 return Ok(());
@@ -3502,7 +3505,9 @@ async fn handle_openvino_selection(selection: usize) -> anyhow::Result<()> {
         }
     }
 
-    download_openvino_model(model.name)?;
+    let mut openvino = config.openvino.clone().unwrap_or_default();
+    openvino.model = model.name.to_string();
+    download_openvino_model_with_config(model.name, &openvino)?;
     update_config_openvino(model.name)?;
     restart_daemon_if_running().await;
     Ok(())
@@ -4035,8 +4040,75 @@ const OPENVINO_MODELS: &[OpenVinoModelInfo] = &[
     },
 ];
 
-/// Download an OpenVINO Whisper model by name
+/// Download an OpenVINO Whisper model using the user's configured device.
+/// NPU downloads do not return until the compiled cache blob is ready.
 pub fn download_openvino_model(model_name: &str) -> anyhow::Result<()> {
+    let config = crate::config::load_config(None).unwrap_or_default();
+    let mut openvino = config.openvino.unwrap_or_default();
+    openvino.model = model_name.to_string();
+    download_openvino_model_with_config(model_name, &openvino)
+}
+
+/// Download an OpenVINO model and eagerly compile it when NPU is selected.
+pub fn download_openvino_model_with_config(
+    model_name: &str,
+    config: &OpenVinoConfig,
+) -> anyhow::Result<()> {
+    download_openvino_model_files(model_name)?;
+
+    if openvino_download_needs_precompile(&config.device) {
+        prepare_openvino_model_for_config(model_name, config)?;
+    } else {
+        print_success(&format!("OpenVINO model '{}' downloaded", model_name));
+    }
+
+    Ok(())
+}
+
+fn openvino_download_needs_precompile(device: &str) -> bool {
+    device.trim().eq_ignore_ascii_case("NPU")
+}
+
+/// Ensure setup has synchronously compiled an NPU model into OpenVINO's cache.
+/// This is also usable when retrying setup after a previous compile failed but
+/// left the fully downloaded IR files in place.
+pub fn prepare_openvino_model_for_config(
+    model_name: &str,
+    config: &OpenVinoConfig,
+) -> anyhow::Result<()> {
+    if !openvino_download_needs_precompile(&config.device) {
+        return Ok(());
+    }
+
+    #[cfg(not(feature = "openvino-whisper"))]
+    {
+        let _ = model_name;
+        anyhow::bail!("NPU cache compilation requires the 'openvino-whisper' feature");
+    }
+
+    #[cfg(feature = "openvino-whisper")]
+    {
+        println!(
+            "\nCompiling '{}' for Intel NPU and creating its cache blob...",
+            model_name
+        );
+        println!("  This can take several minutes for large models. Please wait.");
+        io::stdout().flush()?;
+
+        let mut compile_config = config.clone();
+        compile_config.model = model_name.to_string();
+        let cache_dir = crate::transcribe::openvino_whisper::precompile_npu_model(&compile_config)
+            .map_err(|error| anyhow::anyhow!(error))?;
+        print_success(&format!(
+            "OpenVINO model '{}' compiled for NPU and cached in {}",
+            model_name,
+            cache_dir.display()
+        ));
+        Ok(())
+    }
+}
+
+fn download_openvino_model_files(model_name: &str) -> anyhow::Result<()> {
     let model = OPENVINO_MODELS
         .iter()
         .find(|m| m.name == model_name)
@@ -4099,8 +4171,8 @@ pub fn download_openvino_model(model_name: &str) -> anyhow::Result<()> {
         print_failure("Model download incomplete. Missing required files.");
     })?;
 
-    print_success(&format!(
-        "OpenVINO model '{}' downloaded to {:?}",
+    print_info(&format!(
+        "OpenVINO model '{}' download complete at {:?}",
         model.name, model_path
     ));
 
@@ -4229,6 +4301,15 @@ fn update_openvino_in_config(config: &str, model_name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn only_npu_downloads_require_eager_openvino_compilation() {
+        assert!(openvino_download_needs_precompile("NPU"));
+        assert!(openvino_download_needs_precompile(" npu "));
+        assert!(!openvino_download_needs_precompile("GPU"));
+        assert!(!openvino_download_needs_precompile("CPU"));
+        assert!(!openvino_download_needs_precompile("AUTO"));
+    }
 
     #[test]
     fn openvino_download_manifest_covers_every_required_runtime_file() {

--- a/src/setup/npu.rs
+++ b/src/setup/npu.rs
@@ -169,7 +169,11 @@ pub fn enable() -> anyhow::Result<()> {
         // Download default model if needed
         if !has_openvino_model() {
             println!();
-            super::model::download_openvino_model(DEFAULT_OPENVINO_MODEL)?;
+            let loaded = crate::config::load_config(None).unwrap_or_default();
+            let mut openvino = loaded.openvino.unwrap_or_default();
+            openvino.device = "NPU".to_string();
+            openvino.model = DEFAULT_OPENVINO_MODEL.to_string();
+            super::model::download_openvino_model_with_config(DEFAULT_OPENVINO_MODEL, &openvino)?;
         } else {
             super::print_success(&format!(
                 "OpenVINO model '{}' already installed",

--- a/src/transcribe/openvino_whisper.rs
+++ b/src/transcribe/openvino_whisper.rs
@@ -12,7 +12,7 @@ use crate::config::OpenVinoConfig;
 use crate::error::TranscribeError;
 use openvino_genai::WhisperPipeline;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 /// Directory OpenVINO persists compiled device blobs to (`CACHE_DIR`
@@ -24,6 +24,79 @@ fn openvino_cache_dir() -> PathBuf {
         .unwrap_or_else(std::env::temp_dir)
         .join("voxtype")
         .join("openvino")
+}
+
+/// Compile one downloaded model specifically for the NPU and wait until
+/// OpenVINO has persisted its compiled blob.
+///
+/// Setup deliberately uses a strict NPU initialization here. The normal
+/// transcription path falls back to GPU and CPU when an accelerator is not
+/// available, but that would let `voxtype setup model` claim that NPU setup
+/// succeeded without ever producing an NPU cache entry.
+pub fn precompile_npu_model(config: &OpenVinoConfig) -> Result<PathBuf, TranscribeError> {
+    let model_dir = resolve_model_path(&config.model, config.quantized)?;
+    let encoder_xml = model_dir.join("openvino_encoder_model.xml");
+    if !encoder_xml.exists() {
+        return Err(TranscribeError::ModelNotFound(format!(
+            "OpenVINO Whisper encoder model not found: {}",
+            encoder_xml.display()
+        )));
+    }
+    OpenVinoTranscriber::require_preprocessor_config(&model_dir, &config.model)?;
+
+    OpenVinoTranscriber::load_library(config)?;
+    let model_path_str = model_dir.to_str().ok_or_else(|| {
+        TranscribeError::InitFailed("Model path contains invalid UTF-8".to_string())
+    })?;
+
+    let cache_dir = openvino_cache_dir();
+    fs::create_dir_all(&cache_dir).map_err(|error| {
+        TranscribeError::InitFailed(format!(
+            "Failed to create OpenVINO cache directory {}: {}",
+            cache_dir.display(),
+            error
+        ))
+    })?;
+    let cache_dir_str = cache_dir.to_string_lossy();
+    let props: &[(&str, &str)] = &[("CACHE_DIR", &cache_dir_str)];
+
+    // WhisperPipeline construction is synchronous: it returns only after the
+    // NPU compiler has finished (or failed) and CACHE_DIR has been serviced.
+    let _pipeline =
+        WhisperPipeline::with_properties(model_path_str, "NPU", props).map_err(|error| {
+            TranscribeError::InitFailed(format!(
+                "Failed to compile OpenVINO Whisper model '{}' for NPU: {}\n\n{}",
+                config.model,
+                error,
+                config.installation_guidance(),
+            ))
+        })?;
+
+    if !contains_compiled_blob(&cache_dir) {
+        return Err(TranscribeError::InitFailed(format!(
+            "OpenVINO finished compiling '{}' for NPU but did not create a cache blob in {}",
+            config.model,
+            cache_dir.display()
+        )));
+    }
+
+    Ok(cache_dir)
+}
+
+fn contains_compiled_blob(dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let path = entry.path();
+        if path.is_dir() {
+            contains_compiled_blob(&path)
+        } else {
+            path.extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("blob"))
+        }
+    })
 }
 
 /// OpenVINO GenAI Whisper transcriber for Intel NPU/CPU/GPU.
@@ -601,6 +674,17 @@ mod tests {
         assert_eq!(device_candidates("GPU"), ["GPU", "CPU"]);
         assert_eq!(device_candidates("gpu"), ["gpu", "CPU"]);
         assert_eq!(device_candidates("CPU"), ["CPU", "GPU"]);
+    }
+
+    #[test]
+    fn compiled_blob_detection_checks_nested_cache_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let nested = temp.path().join("NPU").join("model");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert!(!contains_compiled_blob(temp.path()));
+
+        std::fs::write(nested.join("compiled.BLOB"), b"cache").unwrap();
+        assert!(contains_compiled_blob(temp.path()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- eagerly compile downloaded OpenVINO models when the configured device is NPU
- block setup until strict NPU pipeline initialization succeeds and a cache blob exists
- avoid GPU/CPU fallback masking an NPU compilation failure
- retry NPU preparation when model files remain after an earlier failed compile
- show users that first-time compilation may take several minutes

## Verification

- `cargo check`
- `cargo check --features openvino-whisper`
- focused NPU precompile decision and cache-blob detection tests