### PR TITLE
Add Nemotron 3.5 streaming transcription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4022,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "parakeet-rs"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c54ec33ff53d2078cc6a48dcdd9c50c229905e392743375e29652a2b9a369e"
+checksum = "63f887c35960ee3e101563a384021d9555ad9d693fe696f85119fa39537669df"
 dependencies = [
  "eyre",
  "hound",
@@ -4033,7 +4039,7 @@ dependencies = [
  "realfft",
  "serde",
  "serde_json",
- "tokenizers 0.22.2",
+ "tokenizers 0.23.1",
 ]
 
 [[package]]
@@ -5486,13 +5492,13 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str 0.9.0",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1273,7 +1273,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1309,7 +1309,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1514,7 +1514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2082,7 +2082,7 @@ dependencies = [
  "gobject-sys 0.22.6",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3477,21 +3477,6 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "ndarray"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7c9125e8f6f10c9da3aad044cc918cf8784fa34de857b1aa68038eb05a50a9"
@@ -3612,7 +3597,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3953,13 +3938,13 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
  "half",
  "libloading 0.9.0",
- "ndarray 0.17.1",
+ "ndarray",
  "ort-sys",
  "smallvec",
  "tracing",
@@ -3968,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
@@ -4028,13 +4013,13 @@ dependencies = [
 
 [[package]]
 name = "parakeet-rs"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f887c35960ee3e101563a384021d9555ad9d693fe696f85119fa39537669df"
+checksum = "65e81a1a402d3084d30ed835d848e06168c37565738a0aba490785502c22a30a"
 dependencies = [
  "eyre",
  "hound",
- "ndarray 0.17.1",
+ "ndarray",
  "ort",
  "realfft",
  "serde",
@@ -4790,7 +4775,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5363,7 +5348,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5888,7 +5873,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6131,7 +6116,7 @@ dependencies = [
  "inotify 0.10.2",
  "libc",
  "mac-notification-sys",
- "ndarray 0.16.1",
+ "ndarray",
  "nix",
  "notify",
  "num_cpus",
@@ -6682,7 +6667,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ rodio = { version = "0.19", default-features = false, features = ["wav"] }
 whisper-rs = "0.16.0"
 
 # Parakeet speech-to-text (optional, ONNX-based)
-parakeet-rs = { version = "0.3.5", optional = true }
+parakeet-rs = { version = "0.3.6", optional = true }
 
 # ONNX-based ASR engines (Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual)
 ort = { version = "2.0.0-rc.12", optional = true, default-features = false, features = ["std", "ndarray", "api-24", "half"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,11 +83,11 @@ rodio = { version = "0.19", default-features = false, features = ["wav"] }
 whisper-rs = "0.16.0"
 
 # Parakeet speech-to-text (optional, ONNX-based)
-parakeet-rs = { version = "0.3.6", optional = true }
+parakeet-rs = { version = "0.3.7", optional = true, default-features = false, features = ["cpu", "ort-defaults", "api-24"] }
 
 # ONNX-based ASR engines (Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual)
-ort = { version = "2.0.0-rc.12", optional = true, default-features = false, features = ["std", "ndarray", "api-24", "half"] }
-ndarray = { version = "0.16", optional = true }
+ort = { version = "2.0.0-rc.13", optional = true, default-features = false, features = ["std", "ndarray", "api-24", "half"] }
+ndarray = { version = "0.17", optional = true }
 half = { version = "2", optional = true }
 tokenizers = { version = "0.20", optional = true, default-features = false, features = ["onig"] }
 rustfft = { version = "6", optional = true }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1308,6 +1308,7 @@ The model architecture type. Usually auto-detected based on files present in the
 **Values:**
 - `tdt` - Token-Duration-Transducer (recommended, proper punctuation)
 - `ctc` - Connectionist Temporal Classification (faster, character-level)
+- `nemotron` - Cache-aware RNNT streaming model. Registered Nemotron models are detected automatically.
 
 **Example:**
 ```toml
@@ -1315,6 +1316,16 @@ The model architecture type. Usually auto-detected based on files present in the
 model = "parakeet-tdt-0.6b-v3"
 model_type = "tdt"
 ```
+
+### language
+
+**Type:** String
+**Default:** `"auto"`
+**Required:** No
+
+Target locale for multilingual Nemotron models. A specific locale such as
+`"en-US"` gives better accuracy than automatic language detection. This setting
+is ignored by TDT, CTC, and English-only Nemotron models.
 
 ### on_demand_loading
 
@@ -1338,10 +1349,12 @@ on_demand_loading = true  # Free memory when not transcribing
 **Required:** No
 
 When `true`, voxtype types text incrementally while you are still speaking
-instead of waiting for hotkey release. Uses the parakeet-rs cache-aware
-streaming pipeline and a TDT v3 family model with `tokenizer.model` — a
-different mechanism from the shared `[streaming]` section used by
-`[whisper] streaming` and `[openvino] streaming`, and not configured by it.
+instead of waiting for hotkey release. Uses a cache-aware Parakeet Unified or
+Nemotron model with `tokenizer.model`. This is separate from the shared
+`[streaming]` section used by `[whisper] streaming` and `[openvino] streaming`.
+
+Streaming requires `on_demand_loading = false` so the model is already loaded
+when recording starts.
 
 **Requires toggle activation.** Streaming output types characters at the
 cursor while you dictate. On Wayland compositors backed by libinput
@@ -1358,7 +1371,8 @@ a warning to the log.
 engine = "parakeet"
 
 [parakeet]
-model = "parakeet-tdt-0.6b-v3"
+model = "nemotron-3.5-asr-streaming-0.6b-int8"
+language = "en-US"
 streaming = true
 
 [hotkey]

--- a/docs/MODEL_SELECTION_GUIDE.md
+++ b/docs/MODEL_SELECTION_GUIDE.md
@@ -180,6 +180,7 @@ NVIDIA's FastConformer model via the parakeet-rs crate. State-of-the-art accurac
 |-------|------|-------------|
 | parakeet-tdt-0.6b-v3 | 2.6 GB | TDT with punctuation (recommended) |
 | parakeet-tdt-0.6b-v3-int8 | 670 MB | Quantized, smaller and faster |
+| nemotron-3.5-asr-streaming-0.6b-int8 | 651 MB | Multilingual cache-aware streaming, punctuation |
 
 **TDT vs CTC:** The TDT model includes punctuation and capitalization. The CTC variant is slightly faster but outputs raw text without punctuation. Use TDT unless you have a specific reason not to.
 
@@ -207,7 +208,7 @@ model = "parakeet-tdt-0.6b-v3-int8"
 - GPU acceleration via CUDA, MIGraphX, or TensorRT
 
 **Cons:**
-- Limited to 25 European languages (no CJK, Arabic, Hindi, etc.)
+- TDT models are limited to 25 European languages; Nemotron 3.5 adds 40 locales
 - Requires ONNX binary
 - Only one model size (0.6B parameters)
 

--- a/docs/PARAKEET.md
+++ b/docs/PARAKEET.md
@@ -11,6 +11,9 @@ Parakeet is NVIDIA's FastConformer-based speech recognition model. The TDT (Toke
 - Good accuracy for English dictation
 - No GPU required (though CUDA acceleration is available)
 
+Voxtype also supports Nemotron 3.5 through the same ONNX/parakeet-rs backend.
+Nemotron adds cache-aware streaming, native punctuation, and 40 language locales.
+
 ## Requirements
 
 - An ONNX-enabled voxtype binary (see below)
@@ -98,6 +101,20 @@ model = "parakeet-tdt-0.6b-v3"
 # model_path = "/path/to/parakeet-tdt-0.6b-v3"
 ```
 
+For Nemotron streaming:
+
+```toml
+engine = "parakeet"
+
+[parakeet]
+model = "nemotron-3.5-asr-streaming-0.6b-int8"
+language = "en-US" # or "auto"
+streaming = true
+
+[hotkey]
+mode = "toggle"
+```
+
 Restart the daemon:
 
 ```bash
@@ -146,9 +163,11 @@ Uncommon names and technical terms may be substituted with phonetically similar 
 - "Krzyzewski" → "Krasiewski"
 - "Nguyen" → "Gwen"
 
-### English Only
+### Language Support
 
-Parakeet TDT models are English-only. For multilingual support, use Whisper.
+Parakeet TDT v3 supports 25 languages. Nemotron 3.5 supports 40 locales,
+including CJK, Arabic, and Hindi. Whisper remains the broadest multilingual
+option.
 
 ### Model Size
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -906,6 +906,16 @@ so a held PTT key never fires its release event. The daemon auto-promotes
 push-to-talk to toggle at startup when streaming is enabled and logs a
 warning.
 
+For multilingual streaming with native punctuation, select the quantized
+Nemotron 3.5 model:
+
+```toml
+[parakeet]
+model = "nemotron-3.5-asr-streaming-0.6b-int8"
+language = "en-US" # or "auto"
+streaming = true
+```
+
 See [PARAKEET.md](PARAKEET.md) for detailed setup instructions.
 
 ### Moonshine

--- a/src/app/config_show.rs
+++ b/src/app/config_show.rs
@@ -112,6 +112,7 @@ pub(crate) async fn show_config(config: &config::Config) -> anyhow::Result<()> {
     println!("\n[parakeet]");
     if let Some(ref parakeet_config) = config.parakeet {
         println!("  model = {:?}", parakeet_config.model);
+        println!("  language = {:?}", parakeet_config.language);
         if let Some(ref model_type) = parakeet_config.model_type {
             println!("  model_type = {:?}", model_type);
         }

--- a/src/app/overrides.rs
+++ b/src/app/overrides.rs
@@ -132,9 +132,13 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
         config.whisper.initial_prompt = Some(prompt.clone());
     }
     if let Some(ref lang) = cli.language {
-        config.whisper.language = config::LanguageConfig::from_comma_separated(lang);
-        if let Some(parakeet) = config.parakeet.as_mut() {
-            parakeet.language = lang.clone();
+        if config.engine == config::TranscriptionEngine::Parakeet {
+            config
+                .parakeet
+                .get_or_insert_with(config::ParakeetConfig::default)
+                .language = lang.clone();
+        } else {
+            config.whisper.language = config::LanguageConfig::from_comma_separated(lang);
         }
     }
     if cli.translate {

--- a/src/app/overrides.rs
+++ b/src/app/overrides.rs
@@ -50,10 +50,30 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
         config.output.restore_clipboard_delay_ms = delay;
     }
     if let Some(ref model) = cli.model {
-        if setup::model::is_valid_model(model) {
+        let selected_engine = cli
+            .engine
+            .as_deref()
+            .and_then(|engine| engine.parse::<config::TranscriptionEngine>().ok())
+            .unwrap_or(config.engine);
+        if selected_engine == config::TranscriptionEngine::Parakeet
+            && (setup::model::is_parakeet_model(model) || std::path::Path::new(model).exists())
+        {
+            let parakeet = config
+                .parakeet
+                .get_or_insert_with(config::ParakeetConfig::default);
+            parakeet.model = model.clone();
+        } else if setup::model::is_valid_model(model) {
             config.whisper.model = model.clone();
         } else {
-            let default_model = &config.whisper.model;
+            let default_model = if selected_engine == config::TranscriptionEngine::Parakeet {
+                config
+                    .parakeet
+                    .as_ref()
+                    .map(|p| p.model.as_str())
+                    .unwrap_or("parakeet-tdt-0.6b-v3")
+            } else {
+                &config.whisper.model
+            };
             tracing::warn!(
                 "Unknown model '{}', using default model '{}'",
                 model,
@@ -113,6 +133,9 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
     }
     if let Some(ref lang) = cli.language {
         config.whisper.language = config::LanguageConfig::from_comma_separated(lang);
+        if let Some(parakeet) = config.parakeet.as_mut() {
+            parakeet.language = lang.clone();
+        }
     }
     if cli.translate {
         config.whisper.translate = true;
@@ -130,7 +153,14 @@ pub(crate) fn apply_cli_overrides(config: &mut config::Config, cli: &Cli) -> Opt
         config.whisper.flash_attention = true;
     }
     if cli.on_demand_loading {
-        config.whisper.on_demand_loading = true;
+        if config.engine == config::TranscriptionEngine::Parakeet {
+            config
+                .parakeet
+                .get_or_insert_with(config::ParakeetConfig::default)
+                .on_demand_loading = true;
+        } else {
+            config.whisper.on_demand_loading = true;
+        }
     }
     if let Some(ref mode) = cli.whisper_mode {
         match mode.to_lowercase().as_str() {

--- a/src/app/record.rs
+++ b/src/app/record.rs
@@ -33,6 +33,21 @@ pub(crate) fn send_record_command(
         return Ok(());
     }
 
+    // Streaming uses a model preloaded by the daemon, so a model supplied on
+    // this one record command cannot take effect without restarting it. Reject
+    // before writing any other override files that could leak into the next
+    // recording after this command fails.
+    let model_override = action.model_override().or(top_level_model);
+    if model_override.is_some()
+        && config.engine == config::TranscriptionEngine::Parakeet
+        && config.streaming_active()
+    {
+        anyhow::bail!(
+            "Per-record model overrides are not supported during Parakeet streaming. \
+             Set [parakeet] model in config.toml and restart the daemon instead."
+        );
+    }
+
     // Write output mode override file if specified
     // For file mode, format is "file" or "file:/path/to/file"
     if let Some(mode_override) = action.output_mode_override() {
@@ -54,7 +69,6 @@ pub(crate) fn send_record_command(
     }
 
     // Write model override file if specified (subcommand --model takes priority over top-level --model)
-    let model_override = action.model_override().or(top_level_model);
     if let Some(model) = model_override {
         let override_file = config::Config::runtime_dir().join("model_override");
         std::fs::write(&override_file, model)

--- a/src/app/record.rs
+++ b/src/app/record.rs
@@ -33,17 +33,13 @@ pub(crate) fn send_record_command(
         return Ok(());
     }
 
-    // Streaming uses a model preloaded by the daemon, so a model supplied on
-    // this one record command cannot take effect without restarting it. Reject
-    // before writing any other override files that could leak into the next
-    // recording after this command fails.
+    // Parakeet uses the model loaded by the daemon, so a model supplied on one
+    // record command cannot take effect without restarting it. Reject before
+    // writing override files that could leak into the next recording.
     let model_override = action.model_override().or(top_level_model);
-    if model_override.is_some()
-        && config.engine == config::TranscriptionEngine::Parakeet
-        && config.streaming_active()
-    {
+    if model_override.is_some() && config.engine == config::TranscriptionEngine::Parakeet {
         anyhow::bail!(
-            "Per-record model overrides are not supported during Parakeet streaming. \
+            "Per-record model overrides are not supported for Parakeet. \
              Set [parakeet] model in config.toml and restart the daemon instead."
         );
     }

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -81,8 +81,14 @@ pub struct Cli {
     )]
     pub engine: Option<String>,
 
-    /// Language for transcription (e.g., en, fr, auto, or comma-separated: en,fr,de)
-    #[arg(long, value_name = "LANG", help_heading = "Transcription")]
+    #[arg(
+        long,
+        value_name = "LANG",
+        help_heading = "Transcription",
+        long_help = "Language for transcription.\n\
+        Whisper accepts a language code, auto, or a comma-separated detection set.\n\
+        Nemotron accepts auto or a locale such as en-US, de-DE, or pt-BR."
+    )]
     pub language: Option<String>,
 
     /// Translate non-English speech to English

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -67,7 +67,8 @@ pub struct Cli {
         help_heading = "Transcription",
         long_help = "Override model for transcription.\n\
         Whisper: tiny, base, small, medium, large-v3, large-v3-turbo (and .en variants).\n\
-        Parakeet: parakeet-tdt-0.6b-v3, parakeet-tdt-0.6b-v3-int8"
+        Parakeet: parakeet-tdt-0.6b-v3, parakeet-tdt-0.6b-v3-int8, \
+        nemotron-3.5-asr-streaming-0.6b-int8, or an absolute model directory"
     )]
     pub model: Option<String>,
 

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -18,7 +18,7 @@ pub use moonshine::MoonshineConfig;
 pub use omnilingual::OmnilingualConfig;
 pub use openvino::OpenVinoConfig;
 pub use paraformer::ParaformerConfig;
-pub use parakeet::{ParakeetConfig, ParakeetModelType};
+pub use parakeet::{ParakeetConfig, ParakeetModelType, NEMOTRON_LANGUAGE_CHOICES};
 pub use sensevoice::SenseVoiceConfig;
 pub use soniox::SonioxConfig;
 

--- a/src/config/engines/parakeet.rs
+++ b/src/config/engines/parakeet.rs
@@ -13,6 +13,8 @@ pub enum ParakeetModelType {
     /// TDT (Token-Duration-Transducer) - recommended, proper punctuation and word boundaries
     #[default]
     Tdt,
+    /// Nemotron cache-aware RNNT streaming model
+    Nemotron,
 }
 
 /// Parakeet speech-to-text configuration (ONNX-based, alternative to Whisper)
@@ -24,10 +26,15 @@ pub struct ParakeetConfig {
     /// For CTC: model.onnx, tokenizer.json
     pub model: String,
 
-    /// Model architecture type: "tdt" (default, recommended) or "ctc"
+    /// Model architecture type: "tdt", "ctc", or "nemotron"
     /// Auto-detected from model directory structure if not specified
     #[serde(default)]
     pub model_type: Option<ParakeetModelType>,
+
+    /// Target language for multilingual Nemotron models.
+    /// Use "auto" for automatic language detection.
+    #[serde(default = "default_language")]
+    pub language: String,
 
     /// Load model on-demand when recording starts (true) or keep loaded (false)
     #[serde(default = "default_on_demand_loading")]
@@ -62,6 +69,10 @@ fn default_streaming_chunk_secs() -> f32 {
     0.5
 }
 
+fn default_language() -> String {
+    "auto".to_string()
+}
+
 fn default_streaming_left_context_secs() -> f32 {
     1.5
 }
@@ -75,6 +86,7 @@ impl Default for ParakeetConfig {
         Self {
             model: "parakeet-tdt-0.6b-v3".to_string(),
             model_type: None, // Auto-detect
+            language: default_language(),
             on_demand_loading: false,
             streaming: false,
             streaming_chunk_secs: default_streaming_chunk_secs(),
@@ -152,6 +164,25 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_nemotron_language() {
+        let toml_str = r#"
+            engine = "parakeet"
+
+            [parakeet]
+            model = "nemotron-3.5-asr-streaming-0.6b-int8"
+            model_type = "nemotron"
+            language = "en-US"
+            streaming = true
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let parakeet = config.parakeet.unwrap();
+        assert_eq!(parakeet.model_type, Some(ParakeetModelType::Nemotron));
+        assert_eq!(parakeet.language, "en-US");
+        assert!(parakeet.streaming);
+    }
+
+    #[test]
     fn test_parakeet_model_type_defaults_to_none_for_auto_detection() {
         let toml_str = r#"
             engine = "parakeet"
@@ -186,6 +217,7 @@ mod tests {
         let config = ParakeetConfig::default();
         assert_eq!(config.model, "parakeet-tdt-0.6b-v3");
         assert!(config.model_type.is_none());
+        assert_eq!(config.language, "auto");
         assert!(!config.on_demand_loading);
     }
 

--- a/src/config/engines/parakeet.rs
+++ b/src/config/engines/parakeet.rs
@@ -4,6 +4,15 @@ use serde::{Deserialize, Serialize};
 
 use super::super::default_on_demand_loading;
 
+/// Nemotron 3.5 locales documented by NVIDIA, plus automatic detection.
+pub const NEMOTRON_LANGUAGE_CHOICES: &[&str] = &[
+    "auto", "en-US", "en-GB", "es-US", "es-ES", "fr-FR", "fr-CA", "it-IT", "pt-BR", "pt-PT",
+    "nl-NL", "de-DE", "tr-TR", "ru-RU", "ar-AR", "hi-IN", "ja-JP", "ko-KR", "vi-VN", "uk-UA",
+    "pl-PL", "sv-SE", "cs-CZ", "nb-NO", "da-DK", "bg-BG", "fi-FI", "hr-HR", "sk-SK", "zh-CN",
+    "hu-HU", "ro-RO", "et-EE", "el-GR", "lt-LT", "lv-LV", "mt-MT", "sl-SI", "he-IL", "th-TH",
+    "nn-NO",
+];
+
 /// Parakeet model architecture type
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -56,17 +56,27 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     }
 
     // Whisper / engine
-    if let Ok(model) = std::env::var("VOXTYPE_MODEL") {
-        config.whisper.model = model;
-    }
     if let Ok(engine) = std::env::var("VOXTYPE_ENGINE") {
         match engine.parse::<TranscriptionEngine>() {
             Ok(e) => config.engine = e,
             Err(_) => tracing::warn!("Unknown VOXTYPE_ENGINE value: {}", engine),
         }
     }
+    if let Ok(model) = std::env::var("VOXTYPE_MODEL") {
+        if config.engine == TranscriptionEngine::Parakeet {
+            let parakeet = config
+                .parakeet
+                .get_or_insert_with(super::ParakeetConfig::default);
+            parakeet.model = model;
+        } else {
+            config.whisper.model = model;
+        }
+    }
     if let Ok(lang) = std::env::var("VOXTYPE_LANGUAGE") {
         config.whisper.language = LanguageConfig::from_comma_separated(&lang);
+        if let Some(parakeet) = config.parakeet.as_mut() {
+            parakeet.language = lang;
+        }
     }
     if let Ok(val) = std::env::var("VOXTYPE_TRANSLATE") {
         config.whisper.translate = parse_bool_env(&val);
@@ -88,7 +98,15 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         config.whisper.flash_attention = parse_bool_env(&val);
     }
     if let Ok(val) = std::env::var("VOXTYPE_ON_DEMAND_LOADING") {
-        config.whisper.on_demand_loading = parse_bool_env(&val);
+        let enabled = parse_bool_env(&val);
+        if config.engine == TranscriptionEngine::Parakeet {
+            config
+                .parakeet
+                .get_or_insert_with(super::ParakeetConfig::default)
+                .on_demand_loading = enabled;
+        } else {
+            config.whisper.on_demand_loading = enabled;
+        }
     }
     if let Ok(dir) = std::env::var("VOXTYPE_OPENVINO_DIR") {
         config

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -73,9 +73,13 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
         }
     }
     if let Ok(lang) = std::env::var("VOXTYPE_LANGUAGE") {
-        config.whisper.language = LanguageConfig::from_comma_separated(&lang);
-        if let Some(parakeet) = config.parakeet.as_mut() {
-            parakeet.language = lang;
+        if config.engine == TranscriptionEngine::Parakeet {
+            config
+                .parakeet
+                .get_or_insert_with(super::ParakeetConfig::default)
+                .language = lang;
+        } else {
+            config.whisper.language = LanguageConfig::from_comma_separated(&lang);
         }
     }
     if let Ok(val) = std::env::var("VOXTYPE_TRANSLATE") {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,7 +30,7 @@ pub use default_config::{default_config_content, DEFAULT_CONFIG};
 pub use engines::{
     CohereConfig, DolphinConfig, MoonshineConfig, OmnilingualConfig, OpenVinoConfig,
     ParaformerConfig, ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig,
-    TranscriptionEngine,
+    TranscriptionEngine, NEMOTRON_LANGUAGE_CHOICES,
 };
 pub use hotkey::{ActivationMode, HotkeyConfig};
 pub use language::LanguageConfig;

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -1,8 +1,8 @@
 use super::{
     AudioConfig, CohereConfig, DolphinConfig, HotkeyConfig, MeetingConfig, MoonshineConfig,
-    OmnilingualConfig, OpenVinoConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile,
-    SenseVoiceConfig, SonioxConfig, StatusConfig, StreamingConfig, TextConfig, TranscriptionEngine,
-    VadConfig, WhisperConfig,
+    OmnilingualConfig, OpenVinoConfig, OutputConfig, ParaformerConfig, ParakeetConfig,
+    ParakeetModelType, Profile, SenseVoiceConfig, SonioxConfig, StatusConfig, StreamingConfig,
+    TextConfig, TranscriptionEngine, VadConfig, WhisperConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -400,8 +400,22 @@ impl Config {
             TranscriptionEngine::SenseVoice => {
                 self.sensevoice.as_ref().map(|s| s.language.as_str())?
             }
-            // Parakeet, Moonshine, Paraformer, Dolphin, Omnilingual and Soniox
-            // either detect the language or are fixed to one.
+            TranscriptionEngine::Parakeet => {
+                let parakeet = self.parakeet.as_ref()?;
+                let is_nemotron = match parakeet.model_type {
+                    Some(ParakeetModelType::Nemotron) => true,
+                    Some(_) => false,
+                    None => {
+                        crate::setup::model::is_configured_nemotron_parakeet_model(&parakeet.model)
+                    }
+                };
+                if !is_nemotron {
+                    return None;
+                }
+                parakeet.language.as_str()
+            }
+            // Moonshine, Paraformer, Dolphin, Omnilingual and Soniox either
+            // detect the language or are fixed to one.
             _ => return None,
         };
 
@@ -531,6 +545,33 @@ mod tests {
         assert_eq!(config.whisper.model, "base.en");
         assert_eq!(config.output.mode, OutputMode::Type);
         assert!(!config.output.auto_submit);
+    }
+
+    #[test]
+    fn active_language_uses_nemotron_locale() {
+        let config = Config {
+            engine: TranscriptionEngine::Parakeet,
+            parakeet: Some(ParakeetConfig {
+                model: "nemotron-3.5-asr-streaming-0.6b-int8".to_string(),
+                language: "de-DE".to_string(),
+                ..ParakeetConfig::default()
+            }),
+            ..Config::default()
+        };
+        assert_eq!(config.active_language(), Some("de-DE"));
+    }
+
+    #[test]
+    fn active_language_ignores_non_nemotron_parakeet_language() {
+        let config = Config {
+            engine: TranscriptionEngine::Parakeet,
+            parakeet: Some(ParakeetConfig {
+                language: "de-DE".to_string(),
+                ..ParakeetConfig::default()
+            }),
+            ..Config::default()
+        };
+        assert_eq!(config.active_language(), None);
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -25,7 +25,7 @@ use std::path::Path;
 
 use serde_json::{json, Map, Value as Json};
 
-use super::{ActivationMode, Config, LanguageConfig};
+use super::{ActivationMode, Config, LanguageConfig, NEMOTRON_LANGUAGE_CHOICES};
 use crate::tui::ConfigEditor;
 
 /// Version of the `voxtype config schema --json` document shape. Bump when
@@ -211,7 +211,7 @@ const COHERE_LANG_CHOICES: &[&str] = &[
     "ar", "de", "en", "es", "fr", "hi", "it", "ja", "ko", "nl", "pt", "ru", "tr", "zh",
 ];
 const OPENVINO_DEVICE_CHOICES: &[&str] = &["NPU", "GPU", "CPU", "AUTO"];
-const PARAKEET_MODEL_TYPE_CHOICES: &[&str] = &["tdt", "ctc"];
+const PARAKEET_MODEL_TYPE_CHOICES: &[&str] = &["tdt", "ctc", "nemotron"];
 
 const HOTKEY_MODE_CHOICES: &[&str] = &["push_to_talk", "toggle"];
 const HOTKEY_KEY_CHOICES: &[&str] = &[
@@ -424,6 +424,16 @@ pub const CONFIG_KEYS: &[KeySpec] = &[
         "Engine",
         "Decoder type",
         "Force the decoder family instead of auto-detecting it from the model directory.",
+    )
+    .for_onnx_engine("parakeet"),
+    spec(
+        "parakeet.language",
+        "parakeet",
+        "language",
+        closed(NEMOTRON_LANGUAGE_CHOICES),
+        "Engine",
+        "Nemotron language",
+        "Target locale for multilingual Nemotron models, or auto for language detection.",
     )
     .for_onnx_engine("parakeet"),
     spec(
@@ -1656,6 +1666,7 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
             Some(t) => serde_json::to_value(t).ok()?,
             None => Json::Null,
         },
+        "parakeet.language" => json!(pk().language),
         "parakeet.on_demand_loading" => json!(pk().on_demand_loading),
         "parakeet.streaming" => json!(pk().streaming),
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1611,8 +1611,12 @@ impl Daemon {
         streaming_chain: &mut Option<Vec<Box<dyn TextOutput>>>,
         notification_body: &str,
     ) {
-        let backend_task = streaming_handle.take().map(|h| {
+        let backend_task = streaming_handle.take().map(|mut h| {
             let _ = h.cancel.send(());
+            // Cutting the audio pump only closes the backend's input side.
+            // Close its output receiver too so a saturated event channel
+            // cannot keep the backend task blocked during cancellation.
+            h.events.close();
             h.task
         });
         self.cut_streaming_audio();
@@ -3429,14 +3433,8 @@ impl Daemon {
                         (HotkeyEvent::Released, ActivationMode::PushToTalk) => {
                             tracing::debug!("Received HotkeyEvent::Released (push-to-talk), state.is_recording() = {}", state.is_recording());
                             if state.is_streaming() {
-                                tracing::debug!("Streaming push-to-talk released; closing audio capture and disowning session");
+                                tracing::debug!("Streaming push-to-talk released; closing audio capture and draining final events");
                                 self.stop_streaming_capture(&mut audio_capture).await;
-                                // Drop session/chain so the backend's
-                                // post-stop flush emission is dropped at
-                                // the event pump instead of typed.
-                                // Matches the SIGUSR2 stop path.
-                                streaming_session = None;
-                                streaming_chain = None;
                             } else if let State::Recording { model_override, .. } = &state {
                                 let model_override = model_override.clone();
 
@@ -3790,6 +3788,19 @@ impl Daemon {
                     // Check for cancel request first
                     if check_cancel_requested() {
                         tracing::info!("Recording cancelled");
+
+                        if state.is_streaming() {
+                            self.cancel_streaming_to_idle(
+                                &mut state,
+                                &mut audio_capture,
+                                &mut streaming_handle,
+                                &mut streaming_session,
+                                &mut streaming_chain,
+                                "Recording discarded",
+                            )
+                            .await;
+                            continue;
+                        }
 
                         // Stop recording and discard audio
                         if let Some(mut capture) = audio_capture.take() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1611,6 +1611,7 @@ impl Daemon {
         streaming_chain: &mut Option<Vec<Box<dyn TextOutput>>>,
         notification_body: &str,
     ) {
+        self.end_external_session(state.is_recording()).await;
         let backend_task = streaming_handle.take().map(|mut h| {
             let _ = h.cancel.send(());
             // Cutting the audio pump only closes the backend's input side.
@@ -4514,8 +4515,9 @@ impl Daemon {
 
         // Stop any active dictation capture before shutting down and always
         // restore media that this daemon suppressed for the session.
-        let streaming_task = streaming_handle.take().map(|handle| {
+        let streaming_task = streaming_handle.take().map(|mut handle| {
             let _ = handle.cancel.send(());
+            handle.events.close();
             handle.task
         });
         self.cut_streaming_audio();

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -263,6 +263,27 @@ pub fn is_nemotron_parakeet_model(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Returns true when a configured Parakeet model resolves to Nemotron.
+///
+/// Relative model names are checked both against the registry and under the
+/// standard models directory, matching the path resolution used by the
+/// transcriber factory.
+pub fn is_configured_nemotron_parakeet_model(name: &str) -> bool {
+    is_nemotron_parakeet_model_in(name, &Config::models_dir())
+}
+
+fn is_nemotron_parakeet_model_in(name: &str, models_dir: &Path) -> bool {
+    if is_nemotron_parakeet_model(name) {
+        return true;
+    }
+    if Path::new(name).is_absolute() {
+        return false;
+    }
+
+    let resolved = models_dir.join(name);
+    is_nemotron_parakeet_model(resolved.to_string_lossy().as_ref())
+}
+
 /// Canonical Parakeet model name that the TUI auto-switches to when the user
 /// enables streaming on top of an incompatible model. Stable string identifier
 /// rather than a struct lookup so config writers and feedback messages can
@@ -4559,6 +4580,23 @@ language = "en"
         .unwrap();
 
         assert!(is_nemotron_parakeet_model(tmp.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn test_detects_custom_nemotron_under_models_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let model_path = tmp.path().join("custom-nemotron");
+        std::fs::create_dir(&model_path).unwrap();
+        std::fs::write(model_path.join("encoder.onnx"), []).unwrap();
+        std::fs::write(model_path.join("decoder_joint.onnx"), []).unwrap();
+        std::fs::write(model_path.join("tokenizer.model"), []).unwrap();
+        std::fs::write(
+            model_path.join("config.json"),
+            r#"{"model_name":"nemotron-3.5-asr-streaming-0.6b"}"#,
+        )
+        .unwrap();
+
+        assert!(is_nemotron_parakeet_model_in("custom-nemotron", tmp.path()));
     }
 
     #[test]

--- a/src/setup/model.rs
+++ b/src/setup/model.rs
@@ -113,6 +113,8 @@ struct ParakeetModelInfo {
     /// handler auto-switches the configured model to one of these when the
     /// user enables streaming on top of an incompatible model. See #423.
     streaming_compatible: bool,
+    /// Whether this entry uses the Nemotron cache-aware RNNT architecture.
+    nemotron: bool,
 }
 
 const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
@@ -129,6 +131,7 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
         ],
         huggingface_repo: "istupakov/parakeet-tdt-0.6b-v2-onnx",
         streaming_compatible: false,
+        nemotron: false,
     },
     ParakeetModelInfo {
         name: "parakeet-tdt-0.6b-v2-int8",
@@ -142,6 +145,7 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
         ],
         huggingface_repo: "istupakov/parakeet-tdt-0.6b-v2-onnx",
         streaming_compatible: false,
+        nemotron: false,
     },
     ParakeetModelInfo {
         name: "parakeet-tdt-0.6b-v3",
@@ -156,6 +160,7 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
         ],
         huggingface_repo: "istupakov/parakeet-tdt-0.6b-v3-onnx",
         streaming_compatible: false,
+        nemotron: false,
     },
     ParakeetModelInfo {
         name: "parakeet-tdt-0.6b-v3-int8",
@@ -169,6 +174,7 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
         ],
         huggingface_repo: "istupakov/parakeet-tdt-0.6b-v3-onnx",
         streaming_compatible: false,
+        nemotron: false,
     },
     // Streaming-capable Parakeet model. Ships `tokenizer.model` alongside the
     // encoder/decoder, which `parakeet-rs::ParakeetUnified::load` requires for
@@ -189,6 +195,22 @@ const PARAKEET_MODELS: &[ParakeetModelInfo] = &[
         ],
         huggingface_repo: "bobNight/parakeet-unified-en-0.6b-onnx",
         streaming_compatible: true,
+        nemotron: false,
+    },
+    ParakeetModelInfo {
+        name: "nemotron-3.5-asr-streaming-0.6b-int8",
+        size_mb: 651,
+        description: "Nemotron 3.5 multilingual streaming, int8 (40 locales)",
+        files: &[
+            ("encoder.onnx", 42_963_073),
+            ("encoder.onnx.data", 614_649_600),
+            ("decoder_joint.onnx", 24_483_962),
+            ("tokenizer.model", 406_554),
+            ("config.json", 2_970),
+        ],
+        huggingface_repo: "smcleod/nemotron-3.5-asr-streaming-0.6b-int8",
+        streaming_compatible: true,
+        nemotron: true,
     },
 ];
 
@@ -209,6 +231,36 @@ pub fn is_streaming_compatible_parakeet(name: &str) -> bool {
 /// gating the streaming pipeline at load time.
 pub fn is_known_parakeet_model(name: &str) -> bool {
     PARAKEET_MODELS.iter().any(|m| m.name == name)
+}
+
+/// Returns true when the named registry model uses the Nemotron backend, or a
+/// custom directory contains Nemotron model metadata. Custom exports without
+/// `config.json` can select the backend explicitly with
+/// `[parakeet] model_type = "nemotron"`.
+pub fn is_nemotron_parakeet_model(name: &str) -> bool {
+    if PARAKEET_MODELS.iter().any(|m| m.name == name && m.nemotron) {
+        return true;
+    }
+
+    let path = Path::new(name);
+    if !path.is_dir()
+        || !path.join("encoder.onnx").exists()
+        || !path.join("decoder_joint.onnx").exists()
+        || !path.join("tokenizer.model").exists()
+    {
+        return false;
+    }
+
+    std::fs::read_to_string(path.join("config.json"))
+        .ok()
+        .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+        .and_then(|config| {
+            config
+                .get("model_name")
+                .and_then(serde_json::Value::as_str)
+                .map(|name| name.to_ascii_lowercase().contains("nemotron"))
+        })
+        .unwrap_or(false)
 }
 
 /// Canonical Parakeet model name that the TUI auto-switches to when the user
@@ -2532,7 +2584,7 @@ pub fn validate_parakeet_model(path: &Path) -> anyhow::Result<()> {
     let has_decoder = path.join("decoder_joint-model.onnx").exists()
         || path.join("decoder_joint-model.int8.onnx").exists()
         || path.join("decoder_joint.onnx").exists();
-    let has_vocab = path.join("vocab.txt").exists();
+    let has_vocab = path.join("vocab.txt").exists() || path.join("tokenizer.model").exists();
 
     if has_encoder && has_decoder && has_vocab {
         Ok(())
@@ -2545,7 +2597,7 @@ pub fn validate_parakeet_model(path: &Path) -> anyhow::Result<()> {
             missing.push("decoder model");
         }
         if !has_vocab {
-            missing.push("vocab.txt");
+            missing.push("vocab.txt or tokenizer.model");
         }
         anyhow::bail!("Incomplete Parakeet model, missing: {}", missing.join(", "))
     }
@@ -4439,6 +4491,7 @@ language = "en"
         let model_names: Vec<&str> = PARAKEET_MODELS.iter().map(|m| m.name).collect();
         assert!(model_names.contains(&"parakeet-tdt-0.6b-v3"));
         assert!(model_names.contains(&"parakeet-tdt-0.6b-v3-int8"));
+        assert!(model_names.contains(&"nemotron-3.5-asr-streaming-0.6b-int8"));
     }
 
     #[test]
@@ -4464,10 +4517,13 @@ language = "en"
                 "Model {} should have file definitions",
                 model.name
             );
-            // All TDT models should have vocab.txt
+            // Every model needs either the TDT vocabulary or SentencePiece tokenizer.
             assert!(
-                model.files.iter().any(|(f, _)| *f == "vocab.txt"),
-                "Model {} should have vocab.txt",
+                model
+                    .files
+                    .iter()
+                    .any(|(f, _)| matches!(*f, "vocab.txt" | "tokenizer.model")),
+                "Model {} should have a tokenizer",
                 model.name
             );
         }
@@ -4478,6 +4534,10 @@ language = "en"
         // Valid Parakeet models
         assert!(is_parakeet_model("parakeet-tdt-0.6b-v3"));
         assert!(is_parakeet_model("parakeet-tdt-0.6b-v3-int8"));
+        assert!(is_parakeet_model("nemotron-3.5-asr-streaming-0.6b-int8"));
+        assert!(is_nemotron_parakeet_model(
+            "nemotron-3.5-asr-streaming-0.6b-int8"
+        ));
 
         // Invalid models
         assert!(!is_parakeet_model("base.en"));
@@ -4487,10 +4547,41 @@ language = "en"
     }
 
     #[test]
+    fn test_detects_custom_nemotron_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("encoder.onnx"), []).unwrap();
+        std::fs::write(tmp.path().join("decoder_joint.onnx"), []).unwrap();
+        std::fs::write(tmp.path().join("tokenizer.model"), []).unwrap();
+        std::fs::write(
+            tmp.path().join("config.json"),
+            r#"{"model_name":"nemotron-3.5-asr-streaming-0.6b"}"#,
+        )
+        .unwrap();
+
+        assert!(is_nemotron_parakeet_model(tmp.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn test_does_not_misdetect_custom_unified_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("encoder.onnx"), []).unwrap();
+        std::fs::write(tmp.path().join("decoder_joint.onnx"), []).unwrap();
+        std::fs::write(tmp.path().join("tokenizer.model"), []).unwrap();
+        std::fs::write(
+            tmp.path().join("config.json"),
+            r#"{"model_name":"parakeet-unified-en-0.6b"}"#,
+        )
+        .unwrap();
+
+        assert!(!is_nemotron_parakeet_model(tmp.path().to_str().unwrap()));
+    }
+
+    #[test]
     fn test_valid_parakeet_model_names() {
         let names = valid_parakeet_model_names();
         assert!(names.contains(&"parakeet-tdt-0.6b-v3"));
         assert!(names.contains(&"parakeet-tdt-0.6b-v3-int8"));
+        assert!(names.contains(&"nemotron-3.5-asr-streaming-0.6b-int8"));
         assert_eq!(names.len(), PARAKEET_MODELS.len());
     }
 

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -15,6 +15,8 @@
 
 pub mod cli;
 #[cfg(feature = "parakeet")]
+pub mod nemotron_streaming;
+#[cfg(feature = "parakeet")]
 pub mod parakeet_streaming;
 pub mod remote;
 pub mod sliding_window;
@@ -186,7 +188,27 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
                     "Parakeet engine selected but [parakeet] config section is missing".to_string(),
                 )
             })?;
-            if parakeet_config.streaming {
+            let model_path = if std::path::Path::new(&parakeet_config.model).is_absolute() {
+                parakeet_config.model.clone()
+            } else {
+                Config::models_dir()
+                    .join(&parakeet_config.model)
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            let is_nemotron = match parakeet_config.model_type {
+                Some(crate::config::ParakeetModelType::Nemotron) => true,
+                Some(_) => false,
+                None => {
+                    crate::setup::model::is_nemotron_parakeet_model(&parakeet_config.model)
+                        || crate::setup::model::is_nemotron_parakeet_model(&model_path)
+                }
+            };
+            if is_nemotron {
+                Ok(Box::new(
+                    nemotron_streaming::NemotronStreamingTranscriber::new(parakeet_config)?,
+                ))
+            } else if parakeet_config.streaming {
                 Ok(Box::new(
                     parakeet_streaming::ParakeetStreamingTranscriber::new(parakeet_config)?,
                 ))

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -188,21 +188,12 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
                     "Parakeet engine selected but [parakeet] config section is missing".to_string(),
                 )
             })?;
-            let model_path = if std::path::Path::new(&parakeet_config.model).is_absolute() {
-                parakeet_config.model.clone()
-            } else {
-                Config::models_dir()
-                    .join(&parakeet_config.model)
-                    .to_string_lossy()
-                    .into_owned()
-            };
             let is_nemotron = match parakeet_config.model_type {
                 Some(crate::config::ParakeetModelType::Nemotron) => true,
                 Some(_) => false,
-                None => {
-                    crate::setup::model::is_nemotron_parakeet_model(&parakeet_config.model)
-                        || crate::setup::model::is_nemotron_parakeet_model(&model_path)
-                }
+                None => crate::setup::model::is_configured_nemotron_parakeet_model(
+                    &parakeet_config.model,
+                ),
             };
             if is_nemotron {
                 Ok(Box::new(

--- a/src/transcribe/nemotron_streaming.rs
+++ b/src/transcribe/nemotron_streaming.rs
@@ -1,0 +1,370 @@
+//! Nemotron cache-aware streaming transcription via `parakeet-rs`.
+
+use super::parakeet::{build_execution_config, resolve_model_path};
+use super::streaming::{StreamHandle, StreamingEvent, StreamingTranscriber};
+use super::{TimedSegment, Transcriber};
+use crate::config::ParakeetConfig;
+use crate::error::TranscribeError;
+use parakeet_rs::{Nemotron, NemotronHandle, NemotronMode};
+use std::sync::Mutex;
+use tokio::sync::{mpsc, oneshot};
+
+const NEMOTRON_CHUNK_SAMPLES: usize = 8_960;
+const NEMOTRON_FLUSH_CHUNKS: usize = 3;
+
+/// Streaming-capable Nemotron transcriber with shared model weights.
+pub struct NemotronStreamingTranscriber {
+    handle: NemotronHandle,
+    language: String,
+    streaming: bool,
+    batch: Mutex<Nemotron>,
+}
+
+impl NemotronStreamingTranscriber {
+    pub fn new(config: &ParakeetConfig) -> Result<Self, TranscribeError> {
+        if config.streaming && config.on_demand_loading {
+            return Err(TranscribeError::InitFailed(
+                "Nemotron streaming requires [parakeet] on_demand_loading = false so the model is ready when recording starts."
+                    .to_string(),
+            ));
+        }
+        let model_path = resolve_model_path(&config.model)?;
+        let start = std::time::Instant::now();
+        tracing::info!(
+            model = %config.model,
+            language = %config.language,
+            "Loading Nemotron streaming model from {:?}",
+            model_path
+        );
+
+        let handle = NemotronHandle::load(&model_path, build_execution_config()).map_err(|e| {
+            TranscribeError::InitFailed(format!(
+                "Nemotron init failed: {e}\n\n\
+                 Expected encoder.onnx, decoder_joint.onnx, and tokenizer.model \
+                 in {}.",
+                model_path.display()
+            ))
+        })?;
+
+        let mut batch = Nemotron::from_shared(&handle);
+        configure_language(&mut batch, &config.language)?;
+
+        tracing::info!(
+            "Nemotron model loaded in {:.2}s ({:?}, language={})",
+            start.elapsed().as_secs_f32(),
+            handle.mode(),
+            config.language
+        );
+
+        Ok(Self {
+            handle,
+            language: config.language.clone(),
+            streaming: config.streaming,
+            batch: Mutex::new(batch),
+        })
+    }
+}
+
+fn configure_language(model: &mut Nemotron, language: &str) -> Result<(), TranscribeError> {
+    if model.mode() == NemotronMode::Multilingual {
+        model.set_target_lang(language).map_err(|e| {
+            TranscribeError::InitFailed(format!("Invalid Nemotron language '{language}': {e}"))
+        })?;
+    } else if !matches!(language, "auto" | "en" | "en-US") {
+        tracing::warn!(
+            language,
+            "Ignoring target language for English-only Nemotron model"
+        );
+    }
+    Ok(())
+}
+
+impl Transcriber for NemotronStreamingTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat(
+                "Empty audio buffer".to_string(),
+            ));
+        }
+
+        let mut model = self.batch.lock().map_err(|e| {
+            TranscribeError::InferenceFailed(format!("Failed to lock Nemotron mutex: {e}"))
+        })?;
+        model
+            .transcribe_audio(samples)
+            .map(|text| text.trim().to_string())
+            .map_err(|e| {
+                TranscribeError::InferenceFailed(format!("Nemotron inference failed: {e}"))
+            })
+    }
+
+    fn transcribe_timed(&self, _samples: &[f32]) -> Result<Vec<TimedSegment>, TranscribeError> {
+        Err(TranscribeError::InferenceFailed(
+            "Timed segments are not supported by Nemotron streaming models.".to_string(),
+        ))
+    }
+
+    fn as_streaming(&self) -> Option<&dyn StreamingTranscriber> {
+        self.streaming.then_some(self)
+    }
+
+    fn last_detected_language(&self) -> Option<String> {
+        (self.language != "auto").then(|| {
+            self.language
+                .split('-')
+                .next()
+                .unwrap_or(&self.language)
+                .to_string()
+        })
+    }
+}
+
+enum StreamInput {
+    Audio(Option<Vec<f32>>),
+    Cancel,
+}
+
+impl StreamingTranscriber for NemotronStreamingTranscriber {
+    fn start_stream(
+        &self,
+        mut samples_rx: mpsc::Receiver<Vec<f32>>,
+    ) -> Result<StreamHandle, TranscribeError> {
+        let mut model = Nemotron::from_shared(&self.handle);
+        configure_language(&mut model, &self.language)?;
+
+        let (events_tx, events_rx) = mpsc::channel::<StreamingEvent>(64);
+        let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+
+        let task = tokio::task::spawn_blocking(move || -> Result<(), TranscribeError> {
+            let runtime = tokio::runtime::Handle::current();
+            let segment_id = 0;
+            let mut cancelled = false;
+            let mut total_samples = 0usize;
+            let mut pending_partial = String::new();
+
+            loop {
+                let input = runtime.block_on(async {
+                    tokio::select! {
+                        _ = &mut cancel_rx => StreamInput::Cancel,
+                        chunk = samples_rx.recv() => StreamInput::Audio(chunk),
+                    }
+                });
+
+                let chunk = match input {
+                    StreamInput::Audio(Some(chunk)) => chunk,
+                    StreamInput::Audio(None) => break,
+                    StreamInput::Cancel => {
+                        cancelled = true;
+                        break;
+                    }
+                };
+                if chunk.is_empty() {
+                    continue;
+                }
+                total_samples += chunk.len();
+
+                match model.transcribe_chunk(&chunk) {
+                    Ok(text) if !text.is_empty() => {
+                        pending_partial.push_str(&text);
+                        match events_tx.try_send(StreamingEvent::Partial {
+                            text: pending_partial.clone(),
+                            segment_id,
+                        }) {
+                            Ok(()) => pending_partial.clear(),
+                            Err(mpsc::error::TrySendError::Full(_)) => {}
+                            Err(mpsc::error::TrySendError::Closed(_)) => return Ok(()),
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        let err = TranscribeError::InferenceFailed(format!(
+                            "Nemotron::transcribe_chunk failed: {e}"
+                        ));
+                        let _ = runtime.block_on(events_tx.send(StreamingEvent::Error(err)));
+                        let _ = runtime.block_on(events_tx.send(StreamingEvent::Ended));
+                        return Ok(());
+                    }
+                }
+            }
+
+            if cancelled {
+                return Ok(());
+            }
+
+            if !pending_partial.is_empty()
+                && runtime
+                    .block_on(events_tx.send(StreamingEvent::Partial {
+                        text: std::mem::take(&mut pending_partial),
+                        segment_id,
+                    }))
+                    .is_err()
+            {
+                return Ok(());
+            }
+
+            {
+                let mut final_text = String::new();
+                let remainder = total_samples % NEMOTRON_CHUNK_SAMPLES;
+                if remainder != 0 {
+                    match model.transcribe_chunk(&vec![0.0; NEMOTRON_CHUNK_SAMPLES - remainder]) {
+                        Ok(text) => final_text.push_str(&text),
+                        Err(e) => {
+                            let err = TranscribeError::InferenceFailed(format!(
+                                "Nemotron final-chunk padding failed: {e}"
+                            ));
+                            let _ = runtime.block_on(events_tx.send(StreamingEvent::Error(err)));
+                            let _ = runtime.block_on(events_tx.send(StreamingEvent::Ended));
+                            return Ok(());
+                        }
+                    }
+                }
+
+                // Silence drains the RNNT right context, matching the
+                // parakeet-rs reference example.
+                for _ in 0..NEMOTRON_FLUSH_CHUNKS {
+                    match model.transcribe_chunk(&vec![0.0; NEMOTRON_CHUNK_SAMPLES]) {
+                        Ok(text) => final_text.push_str(&text),
+                        Err(e) => {
+                            let err = TranscribeError::InferenceFailed(format!(
+                                "Nemotron flush failed: {e}"
+                            ));
+                            let _ = runtime.block_on(events_tx.send(StreamingEvent::Error(err)));
+                            let _ = runtime.block_on(events_tx.send(StreamingEvent::Ended));
+                            return Ok(());
+                        }
+                    }
+                }
+                let _ = runtime.block_on(events_tx.send(StreamingEvent::Final {
+                    text: final_text,
+                    segment_id,
+                }));
+            }
+
+            let _ = runtime.block_on(events_tx.send(StreamingEvent::Ended));
+            Ok(())
+        });
+
+        let task = tokio::spawn(async move {
+            match task.await {
+                Ok(result) => result,
+                Err(e) => Err(TranscribeError::InferenceFailed(format!(
+                    "Nemotron streaming task panicked: {e}"
+                ))),
+            }
+        });
+
+        Ok(StreamHandle {
+            events: events_rx,
+            cancel: cancel_tx,
+            task,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ParakeetModelType;
+    use crate::transcribe::StreamingEvent;
+
+    #[test]
+    fn nemotron_uses_560ms_chunks() {
+        assert_eq!(NEMOTRON_CHUNK_SAMPLES, 16_000 * 560 / 1_000);
+    }
+
+    #[test]
+    fn streaming_rejects_on_demand_loading_before_model_lookup() {
+        let config = ParakeetConfig {
+            model: "/does/not/exist".to_string(),
+            model_type: Some(ParakeetModelType::Nemotron),
+            streaming: true,
+            on_demand_loading: true,
+            ..ParakeetConfig::default()
+        };
+        let error = match NemotronStreamingTranscriber::new(&config) {
+            Ok(_) => panic!("streaming and on-demand loading must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("on_demand_loading = false"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires VOXTYPE_NEMOTRON_MODEL and downloaded model weights"]
+    async fn real_model_streams_and_flushes() {
+        let model = std::env::var("VOXTYPE_NEMOTRON_MODEL")
+            .expect("set VOXTYPE_NEMOTRON_MODEL to a compatible model directory");
+        let config = ParakeetConfig {
+            model,
+            model_type: Some(ParakeetModelType::Nemotron),
+            language: "en-US".to_string(),
+            streaming: true,
+            ..ParakeetConfig::default()
+        };
+        let transcriber = NemotronStreamingTranscriber::new(&config).unwrap();
+        let (samples_tx, samples_rx) = mpsc::channel(16);
+        let mut handle = transcriber.start_stream(samples_rx).unwrap();
+
+        let mut reader = hound::WavReader::open("tests/fixtures/vad/speech_long.wav").unwrap();
+        let samples: Vec<f32> = reader
+            .samples::<i16>()
+            .map(|sample| sample.unwrap() as f32 / i16::MAX as f32)
+            .collect();
+        for chunk in samples.chunks(1_600) {
+            samples_tx.send(chunk.to_vec()).await.unwrap();
+        }
+        drop(samples_tx);
+
+        let mut transcript = String::new();
+        let mut final_events = 0;
+        while let Some(event) = handle.events.recv().await {
+            match event {
+                StreamingEvent::Partial { text, .. } => transcript.push_str(&text),
+                StreamingEvent::Final { text, .. } => {
+                    final_events += 1;
+                    transcript.push_str(&text);
+                }
+                StreamingEvent::Ended => break,
+                StreamingEvent::Error(error) => panic!("streaming failed: {error}"),
+                StreamingEvent::Replace { .. } => panic!("Nemotron must not revise deltas"),
+            }
+        }
+        handle.task.await.unwrap().unwrap();
+
+        assert_eq!(final_events, 1);
+        assert!(transcript
+            .to_lowercase()
+            .contains("voice activity detection"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires VOXTYPE_NEMOTRON_MODEL and downloaded model weights"]
+    async fn real_model_cancels_with_saturated_event_channel() {
+        let model = std::env::var("VOXTYPE_NEMOTRON_MODEL")
+            .expect("set VOXTYPE_NEMOTRON_MODEL to a compatible model directory");
+        let config = ParakeetConfig {
+            model,
+            model_type: Some(ParakeetModelType::Nemotron),
+            language: "en-US".to_string(),
+            streaming: true,
+            ..ParakeetConfig::default()
+        };
+        let transcriber = NemotronStreamingTranscriber::new(&config).unwrap();
+        let (samples_tx, samples_rx) = mpsc::channel(128);
+        let mut handle = transcriber.start_stream(samples_rx).unwrap();
+
+        for _ in 0..96 {
+            samples_tx
+                .send(vec![0.25; NEMOTRON_CHUNK_SAMPLES])
+                .await
+                .unwrap();
+        }
+        let _ = handle.cancel.send(());
+        handle.events.close();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle.task)
+            .await
+            .expect("cancelled stream must not block on a full event channel")
+            .unwrap()
+            .unwrap();
+    }
+}

--- a/src/transcribe/nemotron_streaming.rs
+++ b/src/transcribe/nemotron_streaming.rs
@@ -9,7 +9,6 @@ use parakeet_rs::{Nemotron, NemotronHandle, NemotronMode};
 use std::sync::Mutex;
 use tokio::sync::{mpsc, oneshot};
 
-const NEMOTRON_CHUNK_SAMPLES: usize = 8_960;
 const NEMOTRON_FLUSH_CHUNKS: usize = 3;
 
 /// Streaming-capable Nemotron transcriber with shared model weights.
@@ -131,6 +130,7 @@ impl StreamingTranscriber for NemotronStreamingTranscriber {
     ) -> Result<StreamHandle, TranscribeError> {
         let mut model = Nemotron::from_shared(&self.handle);
         configure_language(&mut model, &self.language)?;
+        let chunk_samples = self.handle.chunk_samples();
 
         let (events_tx, events_rx) = mpsc::channel::<StreamingEvent>(64);
         let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
@@ -204,9 +204,9 @@ impl StreamingTranscriber for NemotronStreamingTranscriber {
 
             {
                 let mut final_text = String::new();
-                let remainder = total_samples % NEMOTRON_CHUNK_SAMPLES;
+                let remainder = total_samples % chunk_samples;
                 if remainder != 0 {
-                    match model.transcribe_chunk(&vec![0.0; NEMOTRON_CHUNK_SAMPLES - remainder]) {
+                    match model.transcribe_chunk(&vec![0.0; chunk_samples - remainder]) {
                         Ok(text) => final_text.push_str(&text),
                         Err(e) => {
                             let err = TranscribeError::InferenceFailed(format!(
@@ -222,7 +222,7 @@ impl StreamingTranscriber for NemotronStreamingTranscriber {
                 // Silence drains the RNNT right context, matching the
                 // parakeet-rs reference example.
                 for _ in 0..NEMOTRON_FLUSH_CHUNKS {
-                    match model.transcribe_chunk(&vec![0.0; NEMOTRON_CHUNK_SAMPLES]) {
+                    match model.transcribe_chunk(&vec![0.0; chunk_samples]) {
                         Ok(text) => final_text.push_str(&text),
                         Err(e) => {
                             let err = TranscribeError::InferenceFailed(format!(
@@ -266,11 +266,6 @@ mod tests {
     use super::*;
     use crate::config::ParakeetModelType;
     use crate::transcribe::StreamingEvent;
-
-    #[test]
-    fn nemotron_uses_560ms_chunks() {
-        assert_eq!(NEMOTRON_CHUNK_SAMPLES, 16_000 * 560 / 1_000);
-    }
 
     #[test]
     fn streaming_rejects_on_demand_loading_before_model_lookup() {
@@ -349,14 +344,12 @@ mod tests {
             ..ParakeetConfig::default()
         };
         let transcriber = NemotronStreamingTranscriber::new(&config).unwrap();
+        let chunk_samples = transcriber.handle.chunk_samples();
         let (samples_tx, samples_rx) = mpsc::channel(128);
         let mut handle = transcriber.start_stream(samples_rx).unwrap();
 
         for _ in 0..96 {
-            samples_tx
-                .send(vec![0.25; NEMOTRON_CHUNK_SAMPLES])
-                .await
-                .unwrap();
+            samples_tx.send(vec![0.25; chunk_samples]).await.unwrap();
         }
         let _ = handle.cancel.send(());
         handle.events.close();

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -73,6 +73,11 @@ impl ParakeetTranscriber {
                     })?;
                 ParakeetModel::Tdt(Mutex::new(parakeet))
             }
+            ParakeetModelType::Nemotron => {
+                return Err(TranscribeError::InitFailed(
+                    "Nemotron models must use the Nemotron transcriber".to_string(),
+                ));
+            }
         };
 
         tracing::info!(

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -70,7 +70,8 @@ pub struct AllFields {
 
     // Parakeet
     pub pk_model: String,
-    pub pk_model_type: Option<String>, // "tdt", "ctc", or None for auto-detect
+    pub pk_model_type: Option<String>, // "tdt", "ctc", "nemotron", or auto-detect
+    pub pk_language: String,
     pub pk_on_demand_loading: bool,
     /// True if the [parakeet] table existed in the config at load time. We
     /// only write back to it on save if either this is true or parakeet is
@@ -159,6 +160,7 @@ pub enum FieldId {
     // Parakeet
     PkModel,
     PkModelType,
+    PkLanguage,
     PkOnDemandLoading,
 
     // Moonshine
@@ -215,7 +217,13 @@ const LANG_CHOICES: &[&str] = &[
     "auto", "en", "fr", "de", "it", "es", "pt", "nl", "pl", "zh", "ja", "ko", "ru", "ar",
 ];
 const SV_LANG_CHOICES: &[&str] = &["auto", "zh", "en", "ja", "ko", "yue"];
-const PARAKEET_MODEL_TYPES: &[Option<&str>] = &[None, Some("tdt"), Some("ctc")];
+const PARAKEET_MODEL_TYPES: &[Option<&str>] =
+    &[None, Some("tdt"), Some("ctc"), Some("nemotron")];
+const NEMOTRON_LANG_CHOICES: &[&str] = &[
+    "auto", "en-US", "en-GB", "es-US", "es-ES", "fr-FR", "fr-CA", "de-DE", "it-IT", "pt-BR",
+    "pt-PT", "nl-NL", "pl-PL", "tr-TR", "ru-RU", "uk-UA", "ar-AR", "hi-IN", "ja-JP", "ko-KR",
+    "vi-VN", "zh-CN",
+];
 /// Inference device OpenVINO GenAI tries first; falls back to CPU if the
 /// requested device fails to initialize (see `OpenVinoTranscriber::new`).
 /// AUTO is a real OpenVINO device value too (see `installation_guidance`'s
@@ -248,6 +256,7 @@ fn rows_for_engine_with_mode(engine: &str, whisper_mode: &str) -> Vec<FieldId> {
         "parakeet" => rows.extend_from_slice(&[
             FieldId::PkModel,
             FieldId::PkModelType,
+            FieldId::PkLanguage,
             FieldId::PkOnDemandLoading,
         ]),
         "moonshine" => rows.extend_from_slice(&[
@@ -328,6 +337,9 @@ impl EngineState {
                 .get_string("parakeet", "model")
                 .unwrap_or_else(|| default_model("parakeet").to_string()),
             pk_model_type: ed.get_string("parakeet", "model_type"),
+            pk_language: ed
+                .get_string("parakeet", "language")
+                .unwrap_or_else(|| "auto".to_string()),
             pk_on_demand_loading: ed
                 .get_bool("parakeet", "on_demand_loading")
                 .unwrap_or(false),
@@ -575,6 +587,7 @@ impl EngineState {
                 Some(m) => ed.set_string("parakeet", "model_type", m),
                 None => ed.unset("parakeet", "model_type"),
             }
+            ed.set_string("parakeet", "language", &f.pk_language);
             ed.set_bool("parakeet", "on_demand_loading", f.pk_on_demand_loading);
         }
 
@@ -861,6 +874,9 @@ impl EngineState {
                     .unwrap_or(0);
                 let n = (idx + delta).rem_euclid(PARAKEET_MODEL_TYPES.len() as i32);
                 f.pk_model_type = PARAKEET_MODEL_TYPES[n as usize].map(|s| s.to_string());
+            }
+            FieldId::PkLanguage => {
+                f.pk_language = cycle_str(NEMOTRON_LANG_CHOICES, &f.pk_language, delta)
             }
             FieldId::PkOnDemandLoading => f.pk_on_demand_loading = !f.pk_on_demand_loading,
 
@@ -1213,6 +1229,7 @@ fn field_label_value(state: &EngineState, fid: FieldId) -> (&'static str, String
                 .unwrap_or("auto-detect")
                 .to_string(),
         ),
+        FieldId::PkLanguage => ("Parakeet · Nemotron language", f.pk_language.clone()),
         FieldId::PkOnDemandLoading => (
             "Parakeet · on-demand model load",
             yesno(f.pk_on_demand_loading),
@@ -1630,9 +1647,28 @@ fn guidance(state: &EngineState) -> Vec<Line<'_>> {
             ),
             Line::from(""),
             Line::from(Span::styled(
+                "nemotron: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            )),
+            Line::from(
+                "Cache-aware RNNT model for native streaming. Registered \
+                 Nemotron models are detected automatically.",
+            ),
+            Line::from(""),
+            Line::from(Span::styled(
                 "Leave at auto-detect unless you have reason to override.",
                 Style::default().fg(Color::Gray),
             )),
+        ],
+        FieldId::PkLanguage => vec![
+            heading("Parakeet · Nemotron language"),
+            Line::from(""),
+            Line::from(
+                "Target locale for multilingual Nemotron models. A specific \
+                 locale is more accurate; `auto` enables language detection.",
+            ),
+            Line::from(""),
+            Line::from("Ignored by TDT, CTC, and English-only Nemotron models."),
         ],
         FieldId::PkOnDemandLoading => vec![
             heading("Parakeet · on-demand model loading"),

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -19,7 +19,7 @@ use super::common::{
     self, FeedbackLevel as CommonFeedback, FormRowSpec, TextInput, TextInputResult,
 };
 use super::config_editor::{ConfigEditor, EditorError};
-use crate::config::TranscriptionEngine;
+use crate::config::{TranscriptionEngine, NEMOTRON_LANGUAGE_CHOICES};
 use crate::model_catalog::{default_model, installed_models_for, model_catalog};
 use crate::setup::binary::{self, EngineFamily, InstallKind, Variant};
 use crate::setup::model;
@@ -217,13 +217,7 @@ const LANG_CHOICES: &[&str] = &[
     "auto", "en", "fr", "de", "it", "es", "pt", "nl", "pl", "zh", "ja", "ko", "ru", "ar",
 ];
 const SV_LANG_CHOICES: &[&str] = &["auto", "zh", "en", "ja", "ko", "yue"];
-const PARAKEET_MODEL_TYPES: &[Option<&str>] =
-    &[None, Some("tdt"), Some("ctc"), Some("nemotron")];
-const NEMOTRON_LANG_CHOICES: &[&str] = &[
-    "auto", "en-US", "en-GB", "es-US", "es-ES", "fr-FR", "fr-CA", "de-DE", "it-IT", "pt-BR",
-    "pt-PT", "nl-NL", "pl-PL", "tr-TR", "ru-RU", "uk-UA", "ar-AR", "hi-IN", "ja-JP", "ko-KR",
-    "vi-VN", "zh-CN",
-];
+const PARAKEET_MODEL_TYPES: &[Option<&str>] = &[None, Some("tdt"), Some("ctc"), Some("nemotron")];
 /// Inference device OpenVINO GenAI tries first; falls back to CPU if the
 /// requested device fails to initialize (see `OpenVinoTranscriber::new`).
 /// AUTO is a real OpenVINO device value too (see `installation_guidance`'s
@@ -876,7 +870,7 @@ impl EngineState {
                 f.pk_model_type = PARAKEET_MODEL_TYPES[n as usize].map(|s| s.to_string());
             }
             FieldId::PkLanguage => {
-                f.pk_language = cycle_str(NEMOTRON_LANG_CHOICES, &f.pk_language, delta)
+                f.pk_language = cycle_str(NEMOTRON_LANGUAGE_CHOICES, &f.pk_language, delta)
             }
             FieldId::PkOnDemandLoading => f.pk_on_demand_loading = !f.pk_on_demand_loading,
 


### PR DESCRIPTION
## Summary

Adds NVIDIA Nemotron 3.5 ASR through the existing Parakeet/ONNX engine using `parakeet-rs` 0.3.7.

- Adds a `NemotronStreamingTranscriber` backed by shared `NemotronHandle` weights
- Supports batch transcription and optional live cache-aware streaming
- Reads the streaming chunk size from model metadata (560 ms for the registered model)
- Supports automatic detection or any of the 40 documented target locales
- Registers the multilingual INT8 model on the Voxtype model CDN (~651 MB)
- Detects registered and custom Nemotron models consistently
- Preserves final RNNT tokens by draining padding and right context before ending
- Integrates with the current `dev` streaming stop, cancel, file-output, and rewind lifecycle
- Prevents saturated event channels from deadlocking cancellation or daemon shutdown
- Exposes the model type and language through config, CLI, environment, schema, TUI, and documentation
- Keeps ORT API 24 compatibility for packaged ONNX Runtime 1.24 builds

This supersedes #533. It is rebased onto current `dev` and incorporates the maintainer feedback from that PR, including the updated streaming cancellation path and `parakeet-rs` 0.3.7.

Closes #47.

## Configuration

```toml
engine = "parakeet"

[parakeet]
model = "nemotron-3.5-asr-streaming-0.6b-int8"
language = "en-US" # or "auto"
streaming = true
on_demand_loading = false

[hotkey]
mode = "toggle"
```

Download the model with:

```bash
voxtype setup --download --model nemotron-3.5-asr-streaming-0.6b-int8
```

## Validation

- `cargo fmt --all --check`
- `cargo test --lib --features parakeet`
- `cargo clippy --all-targets --features parakeet --no-deps -- -D warnings -A clippy::needless-return -A clippy::large-enum-variant -A clippy::manual-checked-ops`
- `cargo check --features parakeet,moonshine,sensevoice,paraformer,dolphin,omnilingual,cohere,openvino-whisper,ml-diarization`
- Confirmed the dependency graph enables `ort/api-24` and not `ort/api-28`
- Downloaded the registered model from `models.voxtype.io`
- Loaded the multilingual INT8 model with the dev daemon
- Confirmed live streaming dictation through the existing GNOME `Super+H` toggle shortcut
- Confirmed rollback to the packaged Voxtype daemon

The three allowed clippy lints are pre-existing on `dev` and are unchanged by this branch.

## Credit

Builds on Loki Coyote's original Nemotron prototype in #155, Enes Altun's `parakeet-rs` Nemotron implementation, Sam McLeod's compatible multilingual INT8 export, and Pete Jackson's review and integration guidance on #533.

Please also consider reviewing #491 and #502
