### PR TITLE
Allow overriding the remote transcription request path

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1112,6 +1112,26 @@ remote_endpoint = "https://api.openai.com"
 
 **Security note:** Voxtype logs a warning if you use HTTP (unencrypted) for non-localhost endpoints, as your audio would be transmitted in the clear.
 
+### remote_path
+
+**Type:** String
+**Default:** `"/v1/audio/transcriptions"` (`"/v1/audio/translations"` when `translate = true`)
+**Required:** No
+
+The request path appended to `remote_endpoint`. The defaults match the OpenAI API, which most compatible servers implement. A stock whisper.cpp `server` does not: it only serves `/inference`, so a request to the default path returns 404.
+
+When this option is set, the same path is used for both transcription and translation, since servers with a custom path generally do not split the two. A leading `/` is added if you omit it.
+
+**Example:**
+```toml
+[whisper]
+mode = "remote"
+remote_endpoint = "http://192.168.1.100:8080"
+remote_path = "/inference"
+```
+
+If you run whisper.cpp's server with `--inference-path`, set `remote_path` to the same value.
+
 ### remote_model
 
 **Type:** String
@@ -3535,6 +3555,7 @@ Any config file setting can be overridden via environment variable. These are ap
 | `VOXTYPE_GPU_DEVICE` | integer | `whisper.gpu_device` |
 | `VOXTYPE_ON_DEMAND_LOADING` | bool | `whisper.on_demand_loading` |
 | `VOXTYPE_REMOTE_ENDPOINT` | string | `whisper.remote_endpoint` |
+| `VOXTYPE_REMOTE_PATH` | string | `whisper.remote_path` |
 | `VOXTYPE_WHISPER_API_KEY` | string | `whisper.remote_api_key` |
 
 **Audio:**

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -182,6 +182,12 @@ translate = false
 #   - OpenAI API: "https://api.openai.com"
 # remote_endpoint = "http://192.168.1.100:8080"
 #
+# Request path appended to remote_endpoint
+# Defaults to "/v1/audio/transcriptions" ("/v1/audio/translations" when
+# translate = true). A stock whisper.cpp server only serves "/inference";
+# when this is set the same path is used for transcription and translation.
+# remote_path = "/inference"
+#
 # Model name to send to remote server (default: "whisper-1")
 # remote_model = "whisper-1"
 #

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -186,6 +186,9 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
     if let Ok(endpoint) = std::env::var("VOXTYPE_REMOTE_ENDPOINT") {
         config.whisper.remote_endpoint = Some(endpoint);
     }
+    if let Ok(path) = std::env::var("VOXTYPE_REMOTE_PATH") {
+        config.whisper.remote_path = Some(path);
+    }
     if let Ok(key) = std::env::var("VOXTYPE_WHISPER_API_KEY") {
         config.whisper.remote_api_key = Some(key);
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -386,6 +386,16 @@ pub const CONFIG_KEYS: &[KeySpec] = &[
     )
     .for_engine("whisper"),
     spec(
+        "whisper.remote_path",
+        "whisper",
+        "remote_path",
+        KeyType::String,
+        "Engine",
+        "Remote request path",
+        "Request path appended to remote_endpoint. Defaults to the OpenAI paths; set to /inference for a stock whisper.cpp server.",
+    )
+    .for_engine("whisper"),
+    spec(
         "whisper.remote_api_key",
         "whisper",
         "remote_api_key",
@@ -1640,6 +1650,7 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
         },
         "whisper.initial_prompt" => opt_str(cfg.whisper.initial_prompt.as_ref()),
         "whisper.remote_endpoint" => opt_str(cfg.whisper.remote_endpoint.as_ref()),
+        "whisper.remote_path" => opt_str(cfg.whisper.remote_path.as_ref()),
         "whisper.remote_api_key" => opt_str(cfg.whisper.remote_api_key.as_ref()),
         "whisper.remote_model" => opt_str(cfg.whisper.remote_model.as_ref()),
         "whisper.gpu_isolation" => json!(cfg.whisper.gpu_isolation),

--- a/src/config/whisper.rs
+++ b/src/config/whisper.rs
@@ -218,6 +218,15 @@ pub struct WhisperConfig {
     #[serde(default)]
     pub remote_send_auto_language: bool,
 
+    /// Request path appended to `remote_endpoint` (default: the OpenAI paths
+    /// `/v1/audio/transcriptions`, or `/v1/audio/translations` when translating)
+    /// Set this for servers that expose a different path, such as a stock
+    /// whisper.cpp server, which only serves `/inference`. When set, the same
+    /// path is used for transcription and translation, since servers with a
+    /// custom path generally do not split the two.
+    #[serde(default)]
+    pub remote_path: Option<String>,
+
     // --- CLI backend settings ---
     /// Path to whisper-cli binary (optional, searches PATH if not set)
     /// Used when mode = "cli"
@@ -289,6 +298,7 @@ impl Default for WhisperConfig {
             remote_api_key: None,
             remote_timeout_secs: None,
             remote_send_auto_language: false,
+            remote_path: None,
             whisper_cli_path: None,
         }
     }

--- a/src/transcribe/remote.rs
+++ b/src/transcribe/remote.rs
@@ -30,6 +30,8 @@ pub struct RemoteTranscriber {
     initial_prompt: Option<String>,
     /// Send an explicit `language=auto` field instead of omitting it
     send_auto_language: bool,
+    /// Request path override for servers that don't use the OpenAI paths
+    path: Option<String>,
     /// Request timeout
     timeout: Duration,
 }
@@ -109,8 +111,24 @@ impl RemoteTranscriber {
             api_key,
             initial_prompt,
             send_auto_language: config.remote_send_auto_language,
+            path: config.remote_path.as_ref().map(|p| {
+                if p.starts_with('/') {
+                    p.clone()
+                } else {
+                    format!("/{}", p)
+                }
+            }),
             timeout,
         })
+    }
+
+    /// Path to request on the remote server
+    fn request_path(&self) -> &str {
+        match self.path {
+            Some(ref path) => path,
+            None if self.translate => "/v1/audio/translations",
+            None => "/v1/audio/transcriptions",
+        }
     }
 
     /// Encode f32 samples to WAV format
@@ -223,14 +241,11 @@ impl Transcriber for RemoteTranscriber {
         // Build multipart form
         let (boundary, body) = self.build_multipart_body(&wav_data);
 
-        // Determine the API path based on whether we're doing transcription or translation
-        let path = if self.translate {
-            "/v1/audio/translations"
-        } else {
-            "/v1/audio/transcriptions"
-        };
-
-        let url = format!("{}{}", self.endpoint.trim_end_matches('/'), path);
+        let url = format!(
+            "{}{}",
+            self.endpoint.trim_end_matches('/'),
+            self.request_path()
+        );
 
         // Build request
         let mut request = ureq::post(&url).timeout(self.timeout).set(
@@ -472,14 +487,7 @@ mod tests {
 
         // Verify translate flag is stored correctly
         assert!(!transcriber.translate);
-
-        // The endpoint path logic: if !translate, use /v1/audio/transcriptions
-        let path = if transcriber.translate {
-            "/v1/audio/translations"
-        } else {
-            "/v1/audio/transcriptions"
-        };
-        assert_eq!(path, "/v1/audio/transcriptions");
+        assert_eq!(transcriber.request_path(), "/v1/audio/transcriptions");
     }
 
     #[test]
@@ -495,14 +503,36 @@ mod tests {
 
         // Verify translate flag is stored correctly
         assert!(transcriber.translate);
+        assert_eq!(transcriber.request_path(), "/v1/audio/translations");
+    }
 
-        // The endpoint path logic: if translate, use /v1/audio/translations
-        let path = if transcriber.translate {
-            "/v1/audio/translations"
-        } else {
-            "/v1/audio/transcriptions"
+    #[test]
+    fn test_remote_path_overrides_openai_paths() {
+        for translate in [false, true] {
+            let config = WhisperConfig {
+                mode: Some(crate::config::WhisperMode::Remote),
+                translate,
+                remote_endpoint: Some("http://localhost:8080".to_string()),
+                remote_path: Some("/inference".to_string()),
+                ..Default::default()
+            };
+
+            let transcriber = RemoteTranscriber::new(&config).unwrap();
+            assert_eq!(transcriber.request_path(), "/inference");
+        }
+    }
+
+    #[test]
+    fn test_remote_path_gets_leading_slash() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            remote_path: Some("inference".to_string()),
+            ..Default::default()
         };
-        assert_eq!(path, "/v1/audio/translations");
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        assert_eq!(transcriber.request_path(), "/inference");
     }
 
     #[test]


### PR DESCRIPTION
## Description

The remote backend hardcodes the OpenAI paths `/v1/audio/transcriptions` and `/v1/audio/translations`. A stock whisper.cpp server serves only `/inference` (its `--inference-path` default), so the documented "point voxtype at a whisper.cpp server" setup returns 404 unless the operator happens to have started the server with `--inference-path /v1/audio/transcriptions`.

This adds an optional `[whisper] remote_path` that overrides the path. Default behavior is unchanged: with the option unset, the existing OpenAI paths are used, including the transcribe/translate switch.

Changes:

- `whisper.remote_path` config key (`Option<String>`, unset by default), registered in the config schema and overridable via `VOXTYPE_REMOTE_PATH`
- `RemoteTranscriber::request_path()` centralizes the path choice; a missing leading `/` is added
- Documentation: `docs/CONFIGURATION.md` section plus env-var table entry, and a commented example in the default config

When `remote_path` is set, the same path serves transcription and translation, since servers with a custom path generally do not split the two. That is stated in the doc comment and in `CONFIGURATION.md`.

## Related Issue

Fixes #701

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

Verified end to end against a real whisper.cpp server: the released v1.0.1 binary fails with `Server returned 404: File Not Found (/v1/audio/transcriptions)`, and a build with `remote_path = "/inference"` transcribes the same audio correctly, including through the daemon's normal record/transcribe/type path. Also exercised `VOXTYPE_REMOTE_PATH` and `voxtype config get/set whisper.remote_path`.

New tests cover `remote_path` overriding both the transcribe and translate paths and the leading-slash normalization. The two existing path tests duplicated the path logic inline instead of calling into the transcriber; they now assert on `request_path()`.

Clippy note: on a macOS host, `dev` already fails `cargo clippy -- -D warnings` with 12 pre-existing errors in macOS-only code (verified on a clean `dev` checkout), so I could not get a clean run locally. No new warnings come from the files this PR touches; Linux CI is unaffected.

## Documentation

- [x] I have updated documentation as needed
- [ ] No documentation changes are needed

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [ ] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

Related: #603 reports the mirror-image problem, an endpoint ending in `/v1` producing a duplicate `/v1`. `remote_path` gives those users a way out but does not implement the endpoint normalization requested there; happy to follow up on that separately if you want it.
