### PR TITLE
Register remote_send_auto_language in the config schema

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -405,6 +405,16 @@ pub const CONFIG_KEYS: &[KeySpec] = &[
         "Model name to request from the remote endpoint (e.g. whisper-1).",
     )
     .for_engine("whisper"),
+    spec(
+        "whisper.remote_send_auto_language",
+        "whisper",
+        "remote_send_auto_language",
+        KeyType::Bool,
+        "Engine",
+        "Send explicit auto language",
+        "Send language=auto instead of omitting the field. Needed by whisper.cpp servers, which otherwise fall back to their own -l setting.",
+    )
+    .for_engine("whisper"),
     // parakeet
     spec(
         "parakeet.model",
@@ -1642,6 +1652,7 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
         "whisper.remote_endpoint" => opt_str(cfg.whisper.remote_endpoint.as_ref()),
         "whisper.remote_api_key" => opt_str(cfg.whisper.remote_api_key.as_ref()),
         "whisper.remote_model" => opt_str(cfg.whisper.remote_model.as_ref()),
+        "whisper.remote_send_auto_language" => json!(cfg.whisper.remote_send_auto_language),
         "whisper.gpu_isolation" => json!(cfg.whisper.gpu_isolation),
         "whisper.on_demand_loading" => json!(cfg.whisper.on_demand_loading),
         "whisper.flash_attention" => json!(cfg.whisper.flash_attention),


### PR DESCRIPTION
## Description

`whisper.remote_send_auto_language` was added to `WhisperConfig` without a matching entry in the config schema (`2228250`, from #620). Without it, `voxtype config get/set whisper.remote_send_auto_language` reports an unknown key and the `voxtype configure` TUI does not show the option, so the only way to set it is editing `config.toml` by hand.

This adds the spec entry next to the other `remote_*` keys and the corresponding arm in the value lookup.

## Related Issue

Follow-up to #619 / #620; no separate issue filed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [x] I have run `cargo test` and all tests pass
- [ ] I have run `cargo clippy -- -D warnings` with no warnings
- [x] I have run `cargo fmt`

`config::schema` tests pass, including `every_key_round_trips_through_the_config_loader`, which now covers the new key. Verified by hand that `voxtype config set whisper.remote_send_auto_language true` followed by `config get` returns `true` and writes the key into the file.

Clippy note: on a macOS host, `dev` already fails `cargo clippy -- -D warnings` with 12 pre-existing errors in macOS-only code, so I could not get a clean run locally. Nothing in this diff adds a warning; Linux CI is unaffected.

## Documentation

- [x] I have updated documentation as needed
- [ ] No documentation changes are needed

`docs/CONFIGURATION.md` already documents the option (added in #620); this only makes it reachable from the CLI and the TUI.

## Pre-merge checklist

- [x] This PR targets the `dev` branch (not `main`)
- [ ] Wait for `ci-success` to pass before marking Ready for Review (draft mode is encouraged while CI is red)

## Additional Notes

While checking this I noticed the schema registry is maintained by hand and no test walks the config structs to catch a missing entry, so a key added without a spec silently disappears from `config set` and the TUI. If a reverse-coverage test would be welcome I am happy to open a separate PR for it.
