### PR TITLE
Voxtype Cloud pilot: OpenAI-compatible STT Worker + remote meeting diarization

### DIFF
--- a/cloud/.gitignore
+++ b/cloud/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+.dev.vars
+worker-configuration.d.ts

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,119 @@
+# Voxtype Cloud (pilot)
+
+An OpenAI-compatible speech-to-text API on Cloudflare Workers, backed by
+Workers AI. Transcription runs on `@cf/deepgram/nova-3` (with optional speaker
+diarization) or `@cf/openai/whisper-large-v3-turbo`. This Worker is the pilot
+for a hosted Voxtype Cloud offering and the seed of the planned local
+OpenAI-compatible STT API (#244) — voxtype's existing remote Whisper client
+speaks this protocol without modification.
+
+## Endpoints
+
+All endpoints require `Authorization: Bearer <key>`.
+
+### `POST /v1/audio/transcriptions`
+
+OpenAI-compatible multipart form:
+
+| Field | Notes |
+|---|---|
+| `file` | required; the audio (WAV/MP3/OGG — content type taken from the part) |
+| `model` | `nova-3` (default) or any `whisper*` name → whisper-large-v3-turbo |
+| `language` | Nova-3 set only (en/es/fr/de/hi/ru/pt/ja/it/nl + regional variants, or `multi`); anything else is omitted |
+| `response_format` | `json` (default) or `verbose_json` |
+| `prompt` | accepted, ignored (keyterm mapping is a follow-up) |
+| `diarize` | `true` → per-speaker-turn segments (voxtype extension; nova-3 only) |
+
+Responses:
+
+```jsonc
+// response_format=json
+{ "text": "full transcript" }
+
+// response_format=verbose_json (speaker/confidence appear when diarize=true)
+{
+  "task": "transcribe", "language": "en", "duration": 8.42,
+  "text": "full transcript",
+  "segments": [ { "id": 0, "start": 0.32, "end": 1.98, "text": "So the deploy failed twice.", "speaker": 0, "confidence": 0.98 } ],
+  "words": [ { "word": "so", "punctuated_word": "So", "start": 0.32, "end": 0.48, "confidence": 0.99, "speaker": 0 } ]
+}
+```
+
+Errors use the OpenAI envelope `{"error":{"message","type","code"}}` with
+401 / 400 / 413 (body > 50 MB) / 502.
+
+### `GET /v1/models`
+
+Static OpenAI-style list. `/v1/chat/completions` and `/v1/realtime` are
+reserved (404 with a "not yet available" message).
+
+## Deploy
+
+```bash
+cd cloud
+npm install
+npx wrangler types        # generates worker-configuration.d.ts (gitignored)
+npm run check && npm test
+npx wrangler secret put VOXTYPE_API_KEY   # the single pilot key
+npm run deploy
+```
+
+The Worker serves on its workers.dev URL until the voxtype.io zone is on
+Cloudflare DNS; then uncomment the `routes` block in `wrangler.jsonc` to claim
+`api.voxtype.io` as a custom domain and redeploy.
+
+## Fixture
+
+All knowledge of the Nova-3 response shape lives in `src/deepgram.ts`, pinned
+by `test/fixtures/nova3-diarized.json`. The committed fixture starts as a
+hand-written placeholder matching Deepgram's documented schema — replace it
+with a live capture before trusting field names:
+
+```bash
+CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... \
+  ./scripts/capture-fixture.sh two-speaker-sample.wav
+npm test
+```
+
+## Try it
+
+```bash
+URL=https://voxtype-cloud.<account>.workers.dev
+curl -sS "$URL/v1/audio/transcriptions" \
+  -H "Authorization: Bearer $VOXTYPE_API_KEY" \
+  -F file=@test.wav -F model=nova-3 \
+  -F response_format=verbose_json -F diarize=true | jq .
+```
+
+Voxtype client config for the pilot:
+
+```toml
+engine = "whisper"
+
+[whisper]
+mode = "remote"
+remote_endpoint = "https://api.voxtype.io"   # or the workers.dev URL
+remote_model = "nova-3"
+remote_api_key = "<pilot key>"               # or VOXTYPE_WHISPER_API_KEY
+remote_timeout_secs = 60
+
+[meeting]
+chunk_duration_secs = 120
+
+[meeting.diarization]
+enabled = true
+backend = "remote"
+```
+
+## Privacy and logging
+
+Audio and transcripts are never logged — only durations, sizes, status, and
+model names. Audio sent here transits Cloudflare and is processed by
+Deepgram's model under Deepgram's terms; this is an explicitly opt-in
+departure from voxtype's local-first default.
+
+## Cost
+
+Nova-3 bills $0.0052 per audio minute (HTTP). A meeting with mic + loopback
+both active costs ≈ $0.62/hour, less whatever silence the client-side VAD
+skips. whisper-large-v3-turbo is $0.0005/min with no diarization.

--- a/cloud/package-lock.json
+++ b/cloud/package-lock.json
@@ -1,0 +1,3204 @@
+{
+	"name": "voxtype-cloud",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "voxtype-cloud",
+			"version": "0.1.0",
+			"devDependencies": {
+				"typescript": "^5.6.0",
+				"vitest": "^3.0.0",
+				"wrangler": "^4.0.0"
+			}
+		},
+		"node_modules/@cloudflare/kv-asset-handler": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+			"integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@cloudflare/unenv-preset": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+			"integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"peerDependencies": {
+				"unenv": "2.0.0-rc.24",
+				"workerd": ">1.20260305.0 <2.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"workerd": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20260831.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260831.1.tgz",
+			"integrity": "sha512-oyZ8xhu+gYTvoxV/sn6NRmTHK95RhEO1Dk54/6oPb0Uu70w7ZeRoCjkJ5aNmfS8Vrkdu6+oL0HNg6EcC61uQ2Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20260831.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260831.1.tgz",
+			"integrity": "sha512-s6Go53KPnoXZ1sTGBZ3en3otfHDuMPJhiwXMYWU21JkJQkpoeRt6HFUwM0GPhK3YhXWm+8baGMvCGZYS/KA9eA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20260831.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260831.1.tgz",
+			"integrity": "sha512-WxNKBgjKgeYTolW3yl1Lt3Lu67UlxdeyzWYi9MIqrKBdyQcz+UNG36RevSBf8rv1sTWapRW234VX2keZ+wXapA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20260831.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260831.1.tgz",
+			"integrity": "sha512-JTF9+9clUT3gaCq7Xnmd+Q/wEMaitpngSTOec/Ffb/r3xexA9XwNJVFSOKfk6q61flHGjAYJ4H9B7Mu5Qur49w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20260831.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260831.1.tgz",
+			"integrity": "sha512-do+KDYw0PABwsrKUQIccWBZB70kqKcADoSnvzJ8pvMaWUVB4qaCspEZYfm97WNdtY1wt8mlKYqIJyYUNOkTvQg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@img/colour": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+			"integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+			"integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+			"integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-freebsd-wasm32": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+			"integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.2"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+			"integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+			"integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+			"integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+			"integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+			"integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+			"integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+			"integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+			"integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+			"integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+			"integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+			"integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+			"integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+			"integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+			"integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-linux-s390x": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+			"integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+			"integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+			"integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+			"integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+			}
+		},
+		"node_modules/@img/sharp-wasm32": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+			"integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.11.1"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-webcontainers-wasm32": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+			"integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.2"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-arm64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+			"integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-ia32": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+			"integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+			"integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+			"integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@napi-rs/lzma-linux-x64-gnu": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+			"integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^22.20 || ^24.12 || >=25"
+			}
+		},
+		"node_modules/@poppinss/colors": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+			"integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"kleur": "^4.1.5"
+			}
+		},
+		"node_modules/@poppinss/dumper": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+			"integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@poppinss/colors": "^4.1.5",
+				"@sindresorhus/is": "^7.0.2",
+				"supports-color": "^10.0.0"
+			}
+		},
+		"node_modules/@poppinss/exception": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+			"integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+			"integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+			"integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+			"integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+			"integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+			"integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+			"integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+			"integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+			"integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+			"integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+			"integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+			"integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+			"integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+			"integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+			"integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+			"integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+			"integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+			"integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+			"integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+			"integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+			"integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+			"integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+			"integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+			"integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+			"integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+			"integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@sindresorhus/is": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+			"integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/@speed-highlight/core": {
+			"version": "1.2.24",
+			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+			"integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+			"integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.7",
+				"@vitest/utils": "3.2.7",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+			"integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.7",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+			"integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+			"integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.7",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+			"integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.7",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+			"integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+			"integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.7",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/blake3-wasm": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+			"integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+			"integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+			"integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/error-stack-parser-es": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+			"integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.2",
+				"@esbuild/android-arm": "0.28.2",
+				"@esbuild/android-arm64": "0.28.2",
+				"@esbuild/android-x64": "0.28.2",
+				"@esbuild/darwin-arm64": "0.28.2",
+				"@esbuild/darwin-x64": "0.28.2",
+				"@esbuild/freebsd-arm64": "0.28.2",
+				"@esbuild/freebsd-x64": "0.28.2",
+				"@esbuild/linux-arm": "0.28.2",
+				"@esbuild/linux-arm64": "0.28.2",
+				"@esbuild/linux-ia32": "0.28.2",
+				"@esbuild/linux-loong64": "0.28.2",
+				"@esbuild/linux-mips64el": "0.28.2",
+				"@esbuild/linux-ppc64": "0.28.2",
+				"@esbuild/linux-riscv64": "0.28.2",
+				"@esbuild/linux-s390x": "0.28.2",
+				"@esbuild/linux-x64": "0.28.2",
+				"@esbuild/netbsd-arm64": "0.28.2",
+				"@esbuild/netbsd-x64": "0.28.2",
+				"@esbuild/openbsd-arm64": "0.28.2",
+				"@esbuild/openbsd-x64": "0.28.2",
+				"@esbuild/openharmony-arm64": "0.28.2",
+				"@esbuild/sunos-x64": "0.28.2",
+				"@esbuild/win32-arm64": "0.28.2",
+				"@esbuild/win32-ia32": "0.28.2",
+				"@esbuild/win32-x64": "0.28.2"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/kleur": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/miniflare": {
+			"version": "5.20260831.0-alpha",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260831.0-alpha.tgz",
+			"integrity": "sha512-Hwgh1VDUiPCPGQKODQfUmy7hRAje1D55icB+9png3ueiM64rlSM87nSrtqpxAD+DlLWI4ehnYBuECaXV43zGmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "0.8.1",
+				"sharp": "0.35.2",
+				"undici": "7.29.0",
+				"workerd": "1.20260831.1",
+				"ws": "8.21.0",
+				"youch": "4.1.0-beta.10"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+			"integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.17",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.63.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+			"integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.9"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+				"@rollup/rollup-android-arm-eabi": "4.63.1",
+				"@rollup/rollup-android-arm64": "4.63.1",
+				"@rollup/rollup-darwin-arm64": "4.63.1",
+				"@rollup/rollup-darwin-x64": "4.63.1",
+				"@rollup/rollup-freebsd-arm64": "4.63.1",
+				"@rollup/rollup-freebsd-x64": "4.63.1",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+				"@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+				"@rollup/rollup-linux-arm64-gnu": "4.63.1",
+				"@rollup/rollup-linux-arm64-musl": "4.63.1",
+				"@rollup/rollup-linux-loong64-gnu": "4.63.1",
+				"@rollup/rollup-linux-loong64-musl": "4.63.1",
+				"@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+				"@rollup/rollup-linux-ppc64-musl": "4.63.1",
+				"@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+				"@rollup/rollup-linux-riscv64-musl": "4.63.1",
+				"@rollup/rollup-linux-s390x-gnu": "4.63.1",
+				"@rollup/rollup-linux-x64-gnu": "4.63.1",
+				"@rollup/rollup-linux-x64-musl": "4.63.1",
+				"@rollup/rollup-openbsd-x64": "4.63.1",
+				"@rollup/rollup-openharmony-arm64": "4.63.1",
+				"@rollup/rollup-win32-arm64-msvc": "4.63.1",
+				"@rollup/rollup-win32-ia32-msvc": "4.63.1",
+				"@rollup/rollup-win32-x64-gnu": "4.63.1",
+				"@rollup/rollup-win32-x64-msvc": "4.63.1",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/sharp": {
+			"version": "0.35.2",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+			"integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@img/colour": "^1.1.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.8.4"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.35.2",
+				"@img/sharp-darwin-x64": "0.35.2",
+				"@img/sharp-freebsd-wasm32": "0.35.2",
+				"@img/sharp-libvips-darwin-arm64": "1.3.1",
+				"@img/sharp-libvips-darwin-x64": "1.3.1",
+				"@img/sharp-libvips-linux-arm": "1.3.1",
+				"@img/sharp-libvips-linux-arm64": "1.3.1",
+				"@img/sharp-libvips-linux-ppc64": "1.3.1",
+				"@img/sharp-libvips-linux-riscv64": "1.3.1",
+				"@img/sharp-libvips-linux-s390x": "1.3.1",
+				"@img/sharp-libvips-linux-x64": "1.3.1",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+				"@img/sharp-linux-arm": "0.35.2",
+				"@img/sharp-linux-arm64": "0.35.2",
+				"@img/sharp-linux-ppc64": "0.35.2",
+				"@img/sharp-linux-riscv64": "0.35.2",
+				"@img/sharp-linux-s390x": "0.35.2",
+				"@img/sharp-linux-x64": "0.35.2",
+				"@img/sharp-linuxmusl-arm64": "0.35.2",
+				"@img/sharp-linuxmusl-x64": "0.35.2",
+				"@img/sharp-webcontainers-wasm32": "0.35.2",
+				"@img/sharp-win32-arm64": "0.35.2",
+				"@img/sharp-win32-ia32": "0.35.2",
+				"@img/sharp-win32-x64": "0.35.2"
+			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/strip-literal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+			"integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/unenv": {
+			"version": "2.0.0-rc.24",
+			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pathe": "^2.0.3"
+			}
+		},
+		"node_modules/vite": {
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+			"integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+			"integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.7",
+				"@vitest/mocker": "3.2.7",
+				"@vitest/pretty-format": "^3.2.7",
+				"@vitest/runner": "3.2.7",
+				"@vitest/snapshot": "3.2.7",
+				"@vitest/spy": "3.2.7",
+				"@vitest/utils": "3.2.7",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.7",
+				"@vitest/ui": "3.2.7",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/workerd": {
+			"version": "1.20260831.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260831.1.tgz",
+			"integrity": "sha512-A2LwrkBel/FnKABPfeBAMiL6v70+rugnunqQRfWsWZjlhsTZoBScWUVunMy/xLCGLjWCQL2zp39AVR6aO0jurQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20260831.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260831.1",
+				"@cloudflare/workerd-linux-64": "1.20260831.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260831.1",
+				"@cloudflare/workerd-windows-64": "1.20260831.1"
+			}
+		},
+		"node_modules/wrangler": {
+			"version": "4.128.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.128.0.tgz",
+			"integrity": "sha512-jNXy9e8/pbx8iqTzXPiuflnitKJZoAfEUSUUDLW87bwyeMvJ7kb3yQMSbxEcfNdfHqJW38KRcKaLljOYV4N/4w==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"@cloudflare/kv-asset-handler": "0.5.0",
+				"@cloudflare/unenv-preset": "2.16.1",
+				"blake3-wasm": "2.1.5",
+				"esbuild": "0.28.1",
+				"miniflare": "5.20260831.0-alpha",
+				"path-to-regexp": "6.3.0",
+				"unenv": "2.0.0-rc.24",
+				"workerd": "1.20260831.1"
+			},
+			"bin": {
+				"cf-wrangler": "bin/cf-wrangler.js",
+				"wrangler": "bin/wrangler.js",
+				"wrangler2": "bin/wrangler.js"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.3"
+			},
+			"peerDependencies": {
+				"@cloudflare/workers-types": "^5.20260831.1"
+			},
+			"peerDependenciesMeta": {
+				"@cloudflare/workers-types": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/wrangler/node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/youch": {
+			"version": "4.1.0-beta.10",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+			"integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@poppinss/colors": "^4.1.5",
+				"@poppinss/dumper": "^0.6.4",
+				"@speed-highlight/core": "^1.2.7",
+				"cookie": "^1.0.2",
+				"youch-core": "^0.3.3"
+			}
+		},
+		"node_modules/youch-core": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+			"integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@poppinss/exception": "^1.2.2",
+				"error-stack-parser-es": "^1.0.5"
+			}
+		}
+	}
+}

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "voxtype-cloud",
+	"version": "0.1.0",
+	"private": true,
+	"description": "Voxtype Cloud pilot: OpenAI-compatible STT API on Cloudflare Workers AI (Deepgram Nova-3)",
+	"scripts": {
+		"dev": "wrangler dev",
+		"deploy": "wrangler deploy",
+		"types": "wrangler types",
+		"check": "tsc --noEmit",
+		"test": "vitest run"
+	},
+	"devDependencies": {
+		"typescript": "^5.6.0",
+		"vitest": "^3.0.0",
+		"wrangler": "^4.0.0"
+	}
+}

--- a/cloud/scripts/capture-fixture.sh
+++ b/cloud/scripts/capture-fixture.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Capture a real diarized Nova-3 response from Workers AI and pin it as the
+# parser fixture. Run once (and again whenever Cloudflare bumps the model),
+# then review the diff against test/fixtures/nova3-diarized.json and re-run
+# the tests — all Deepgram shape assumptions live in src/deepgram.ts.
+#
+# Usage:
+#   CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... \
+#     ./scripts/capture-fixture.sh path/to/two-speaker.wav
+set -euo pipefail
+
+AUDIO="${1:?usage: capture-fixture.sh <two-speaker wav/mp3>}"
+: "${CLOUDFLARE_ACCOUNT_ID:?set CLOUDFLARE_ACCOUNT_ID}"
+: "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN (needs Workers AI read/run permission)}"
+
+OUT="$(dirname "$0")/../test/fixtures/nova3-diarized.json"
+
+case "$AUDIO" in
+  *.wav) CONTENT_TYPE="audio/wav" ;;
+  *.mp3) CONTENT_TYPE="audio/mpeg" ;;
+  *.ogg) CONTENT_TYPE="audio/ogg" ;;
+  *) CONTENT_TYPE="application/octet-stream" ;;
+esac
+
+curl --fail-with-body -sS -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/run/@cf/deepgram/nova-3?diarize=true&punctuate=true&smart_format=true" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: ${CONTENT_TYPE}" \
+  --data-binary "@${AUDIO}" |
+  # The REST API wraps the model output in {result, success, errors}; the AI
+  # binding returns the bare model output, which is what the fixture pins.
+  jq '.result' >"$OUT"
+
+echo "Wrote $OUT"
+jq '{duration: .metadata.duration, words: (.results.channels[0].alternatives[0].words | length), speakers: ([.results.channels[0].alternatives[0].words[]?.speaker] | unique)}' "$OUT"

--- a/cloud/scripts/capture-fixture.sh
+++ b/cloud/scripts/capture-fixture.sh
@@ -1,35 +1,34 @@
 #!/usr/bin/env bash
-# Capture a real diarized Nova-3 response from Workers AI and pin it as the
-# parser fixture. Run once (and again whenever Cloudflare bumps the model),
-# then review the diff against test/fixtures/nova3-diarized.json and re-run
-# the tests — all Deepgram shape assumptions live in src/deepgram.ts.
+# Capture a real diarized Nova-3 response and pin it as the parser fixture.
+# Run once (and again whenever Cloudflare bumps the model), review the diff
+# against test/fixtures/nova3-diarized.json, and re-run the tests — all
+# Deepgram shape assumptions live in src/deepgram.ts.
+#
+# Goes through the deployed Worker's auth-protected raw=true debug field, so
+# the only credential needed is the pilot API key (cloud/.dev.vars).
 #
 # Usage:
-#   CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... \
-#     ./scripts/capture-fixture.sh path/to/two-speaker.wav
+#   VOXTYPE_CLOUD_URL=https://voxtype-cloud.<account>.workers.dev \
+#   VOXTYPE_API_KEY=... ./scripts/capture-fixture.sh path/to/two-speaker.wav
 set -euo pipefail
 
 AUDIO="${1:?usage: capture-fixture.sh <two-speaker wav/mp3>}"
-: "${CLOUDFLARE_ACCOUNT_ID:?set CLOUDFLARE_ACCOUNT_ID}"
-: "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN (needs Workers AI read/run permission)}"
+: "${VOXTYPE_CLOUD_URL:?set VOXTYPE_CLOUD_URL to the deployed Worker URL}"
+
+# Default the key from cloud/.dev.vars when not set in the environment.
+if [ -z "${VOXTYPE_API_KEY:-}" ] && [ -f "$(dirname "$0")/../.dev.vars" ]; then
+  VOXTYPE_API_KEY="$(sed -n 's/^VOXTYPE_API_KEY=//p' "$(dirname "$0")/../.dev.vars")"
+fi
+: "${VOXTYPE_API_KEY:?set VOXTYPE_API_KEY to the pilot key}"
 
 OUT="$(dirname "$0")/../test/fixtures/nova3-diarized.json"
 
-case "$AUDIO" in
-  *.wav) CONTENT_TYPE="audio/wav" ;;
-  *.mp3) CONTENT_TYPE="audio/mpeg" ;;
-  *.ogg) CONTENT_TYPE="audio/ogg" ;;
-  *) CONTENT_TYPE="application/octet-stream" ;;
-esac
-
-curl --fail-with-body -sS -X POST \
-  "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/run/@cf/deepgram/nova-3?diarize=true&punctuate=true&smart_format=true" \
-  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-  -H "Content-Type: ${CONTENT_TYPE}" \
-  --data-binary "@${AUDIO}" |
-  # The REST API wraps the model output in {result, success, errors}; the AI
-  # binding returns the bare model output, which is what the fixture pins.
-  jq '.result' >"$OUT"
+curl --fail-with-body -sS -X POST "${VOXTYPE_CLOUD_URL}/v1/audio/transcriptions" \
+  -H "Authorization: Bearer ${VOXTYPE_API_KEY}" \
+  -F "file=@${AUDIO}" \
+  -F "diarize=true" \
+  -F "raw=true" |
+  jq . >"$OUT"
 
 echo "Wrote $OUT"
-jq '{duration: .metadata.duration, words: (.results.channels[0].alternatives[0].words | length), speakers: ([.results.channels[0].alternatives[0].words[]?.speaker] | unique)}' "$OUT"
+jq '{duration: .metadata?.duration, words: (.results?.channels?[0]?.alternatives?[0]?.words | length), speakers: ([.results?.channels?[0]?.alternatives?[0]?.words[]?.speaker] | unique)}' "$OUT"

--- a/cloud/src/deepgram.ts
+++ b/cloud/src/deepgram.ts
@@ -1,0 +1,178 @@
+/**
+ * Everything that knows the shape of Workers AI ASR model responses lives in
+ * this module — nothing outside it may touch a Deepgram (or Whisper) response
+ * field. The Nova-3 shape is pinned by test/fixtures/nova3-diarized.json,
+ * captured from a live call (scripts/capture-fixture.sh).
+ */
+
+export const NOVA3_MODEL = "@cf/deepgram/nova-3";
+export const WHISPER_MODEL = "@cf/openai/whisper-large-v3-turbo";
+
+/** Languages Nova-3 on Workers AI accepts; anything else is omitted from the call. */
+const NOVA3_LANGUAGES = new Set([
+	"en", "en-US", "en-AU", "en-GB", "en-IN", "en-NZ",
+	"es", "es-419",
+	"fr", "fr-CA",
+	"de", "de-CH",
+	"hi", "ru", "ja", "it", "nl",
+	"pt", "pt-BR", "pt-PT",
+	"multi",
+]);
+
+export function nova3Language(language: string | undefined): string | undefined {
+	return language !== undefined && NOVA3_LANGUAGES.has(language) ? language : undefined;
+}
+
+/** One word from a diarized Nova-3 response (defensively typed — every field may be absent). */
+export interface NovaWord {
+	word?: string;
+	punctuated_word?: string;
+	start?: number;
+	end?: number;
+	confidence?: number;
+	speaker?: number;
+}
+
+/** A speaker turn: contiguous words by one speaker without a long gap. */
+export interface TurnSegment {
+	id: number;
+	start: number;
+	end: number;
+	text: string;
+	speaker?: number;
+	confidence?: number;
+}
+
+export interface TranscriptionResult {
+	text: string;
+	language?: string;
+	duration?: number;
+	segments: TurnSegment[];
+	words: NovaWord[];
+}
+
+export interface TranscribeOptions {
+	diarize: boolean;
+	language?: string;
+	contentType: string;
+}
+
+/** Start a new segment when the speaker changes or the inter-word gap exceeds this. */
+export const MAX_TURN_GAP_SECS = 3.0;
+
+export function groupWordsIntoTurns(words: NovaWord[], maxGapSecs = MAX_TURN_GAP_SECS): TurnSegment[] {
+	const segments: TurnSegment[] = [];
+	let current: { words: NovaWord[]; speaker?: number } | null = null;
+
+	const flush = () => {
+		if (current === null || current.words.length === 0) return;
+		const ws = current.words;
+		const confidences = ws.map((w) => w.confidence).filter((c): c is number => typeof c === "number");
+		segments.push({
+			id: segments.length,
+			start: ws[0].start ?? 0,
+			end: ws[ws.length - 1].end ?? ws[ws.length - 1].start ?? 0,
+			text: ws.map((w) => w.punctuated_word ?? w.word ?? "").join(" ").trim(),
+			...(current.speaker !== undefined ? { speaker: current.speaker } : {}),
+			...(confidences.length > 0
+				? { confidence: confidences.reduce((a, b) => a + b, 0) / confidences.length }
+				: {}),
+		});
+		current = null;
+	};
+
+	for (const w of words) {
+		if (current !== null) {
+			const prev = current.words[current.words.length - 1];
+			const gap = (w.start ?? 0) - (prev.end ?? prev.start ?? 0);
+			const speakerChanged = w.speaker !== undefined && current.speaker !== undefined && w.speaker !== current.speaker;
+			if (speakerChanged || gap > maxGapSecs) flush();
+		}
+		if (current === null) current = { words: [], speaker: w.speaker };
+		current.words.push(w);
+	}
+	flush();
+	return segments;
+}
+
+interface Nova3Response {
+	results?: {
+		channels?: {
+			alternatives?: {
+				transcript?: string;
+				confidence?: number;
+				words?: NovaWord[];
+			}[];
+			detected_language?: string;
+		}[];
+	};
+	metadata?: { duration?: number };
+}
+
+/** Run Nova-3 and normalize its response. All Nova-3 shape assumptions live here. */
+export async function transcribeNova3(ai: Ai, audio: ReadableStream | Uint8Array, opts: TranscribeOptions): Promise<TranscriptionResult> {
+	const input: Record<string, unknown> = {
+		audio: { body: audio, contentType: opts.contentType },
+		punctuate: true,
+		smart_format: true,
+	};
+	if (opts.diarize) input.diarize = true;
+	const language = nova3Language(opts.language);
+	if (language !== undefined) input.language = language;
+
+	// Partner-model input/output schemas aren't covered by the generated Workers
+	// AI types, so the call goes through a narrow local cast and the response is
+	// parsed defensively against the committed fixture.
+	const raw = (await ai.run(NOVA3_MODEL as Parameters<Ai["run"]>[0], input as never)) as Nova3Response;
+
+	const channel = raw.results?.channels?.[0];
+	const alternative = channel?.alternatives?.[0];
+	const text = (alternative?.transcript ?? "").trim();
+	const words = alternative?.words ?? [];
+	const lastWord = words[words.length - 1];
+
+	return {
+		text,
+		language: channel?.detected_language ?? language,
+		duration: raw.metadata?.duration ?? lastWord?.end,
+		segments: words.length > 0
+			? groupWordsIntoTurns(words)
+			: text.length > 0
+				? [{ id: 0, start: 0, end: raw.metadata?.duration ?? 0, text }]
+				: [],
+		words,
+	};
+}
+
+interface WhisperResponse {
+	text?: string;
+}
+
+/** Base64-encode without building one giant intermediate string (stack-safe). */
+function toBase64(bytes: Uint8Array): string {
+	const chunks: string[] = [];
+	const step = 0x8000;
+	for (let i = 0; i < bytes.length; i += step) {
+		chunks.push(String.fromCharCode(...bytes.subarray(i, i + step)));
+	}
+	return btoa(chunks.join(""));
+}
+
+/** Run whisper-large-v3-turbo (no diarization) and normalize. */
+export async function transcribeWhisper(ai: Ai, audio: Uint8Array, language: string | undefined): Promise<TranscriptionResult> {
+	// whisper-large-v3-turbo takes base64 audio.
+	const input: Record<string, unknown> = {
+		audio: toBase64(audio),
+		task: "transcribe",
+	};
+	if (language !== undefined) input.language = language;
+
+	const raw = (await ai.run(WHISPER_MODEL as Parameters<Ai["run"]>[0], input as never)) as WhisperResponse;
+	const text = (raw.text ?? "").trim();
+	return {
+		text,
+		language,
+		segments: text.length > 0 ? [{ id: 0, start: 0, end: 0, text }] : [],
+		words: [],
+	};
+}

--- a/cloud/src/deepgram.ts
+++ b/cloud/src/deepgram.ts
@@ -109,21 +109,88 @@ interface Nova3Response {
 	metadata?: { duration?: number };
 }
 
-/** Run Nova-3 and normalize its response. All Nova-3 shape assumptions live here. */
-export async function transcribeNova3(ai: Ai, audio: ReadableStream | Uint8Array, opts: TranscribeOptions): Promise<TranscriptionResult> {
-	const input: Record<string, unknown> = {
-		audio: { body: audio, contentType: opts.contentType },
-		punctuate: true,
-		smart_format: true,
-	};
-	if (opts.diarize) input.diarize = true;
-	const language = nova3Language(opts.language);
-	if (language !== undefined) input.language = language;
+/** How to reach Nova-3: the AI binding, plus optional REST-fallback credentials. */
+export interface NovaUpstream {
+	ai: Ai;
+	/** Account id + Workers AI token enable the REST fallback for workerd#5082. */
+	accountId?: string;
+	apiToken?: string;
+}
 
-	// Partner-model input/output schemas aren't covered by the generated Workers
-	// AI types, so the call goes through a narrow local cast and the response is
-	// parsed defensively against the committed fixture.
-	const raw = (await ai.run(NOVA3_MODEL as Parameters<Ai["run"]>[0], input as never)) as Nova3Response;
+function novaParams(opts: TranscribeOptions): Record<string, string> {
+	const params: Record<string, string> = { punctuate: "true", smart_format: "true" };
+	if (opts.diarize) params.diarize = "true";
+	const language = nova3Language(opts.language);
+	if (language !== undefined) params.language = language;
+	return params;
+}
+
+/**
+ * Run Nova-3 and return the raw, un-normalized model output. Used by the
+ * fixture-capture path (`raw=true`); everything else goes through
+ * [`transcribeNova3`].
+ *
+ * Tries the AI binding first, but the binding currently rejects every audio
+ * input shape for this model with `5006: required properties at '/audio' are
+ * 'body,contentType'` (github.com/cloudflare/workerd#5082 — verified live
+ * against base64, number-array, and ReadableStream bodies, with options
+ * top-level and nested). On that error it falls back to the documented REST
+ * path (binary body + query params), which works, when credentials are
+ * configured. When Cloudflare fixes the binding, it takes over automatically.
+ */
+export async function runNova3Raw(upstream: NovaUpstream, bytes: Uint8Array, opts: TranscribeOptions): Promise<unknown> {
+	// Multipart clients often stamp file parts application/octet-stream; the
+	// model schema wants a real audio type.
+	const contentType = opts.contentType.startsWith("audio/") ? opts.contentType : "audio/wav";
+	const params = novaParams(opts);
+
+	try {
+		// Same shape Cloudflare's own workers-ai-provider uses for this model.
+		// Partner-model schemas aren't in the generated Workers AI types, so the
+		// call goes through a narrow cast and responses are parsed defensively
+		// against the committed fixture.
+		const input: Record<string, unknown> = {
+			audio: { body: toBase64(bytes), contentType },
+		};
+		for (const [k, v] of Object.entries(params)) input[k] = v === "true" ? true : v;
+		return await upstream.ai.run(NOVA3_MODEL as Parameters<Ai["run"]>[0], input as never);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		const isKnownBindingBug = message.includes("5006");
+		if (!isKnownBindingBug || upstream.accountId === undefined || upstream.apiToken === undefined) {
+			if (isKnownBindingBug) {
+				throw new Error(
+					`${message} (known Workers AI binding bug for nova-3, workerd#5082; set the CLOUDFLARE_API_TOKEN secret to enable the REST fallback)`,
+				);
+			}
+			throw err;
+		}
+		console.log(JSON.stringify({ event: "nova3_binding_bug_rest_fallback" }));
+		const query = new URLSearchParams(params).toString();
+		const url = `https://api.cloudflare.com/client/v4/accounts/${upstream.accountId}/ai/run/${NOVA3_MODEL}?${query}`;
+		const response = await fetch(url, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${upstream.apiToken}`,
+				"Content-Type": contentType,
+			},
+			body: bytes,
+		});
+		const envelope = (await response.json()) as { result?: unknown; success?: boolean; errors?: { message?: string }[] };
+		if (!response.ok || envelope.success === false) {
+			const detail = envelope.errors?.map((e) => e.message).join("; ") ?? `HTTP ${response.status}`;
+			throw new Error(`Workers AI REST call failed: ${detail}`);
+		}
+		// The REST envelope wraps the model output in `result`; the binding
+		// returns it bare. Normalize to bare.
+		return envelope.result;
+	}
+}
+
+/** Run Nova-3 and normalize its response. All Nova-3 shape assumptions live here. */
+export async function transcribeNova3(upstream: NovaUpstream, bytes: Uint8Array, opts: TranscribeOptions): Promise<TranscriptionResult> {
+	const raw = (await runNova3Raw(upstream, bytes, opts)) as Nova3Response;
+	const language = nova3Language(opts.language);
 
 	const channel = raw.results?.channels?.[0];
 	const alternative = channel?.alternatives?.[0];

--- a/cloud/src/env.d.ts
+++ b/cloud/src/env.d.ts
@@ -1,0 +1,5 @@
+// Secrets set via `wrangler secret put` are not visible to `wrangler types`,
+// so they are merged into the generated global Env interface here.
+interface Env {
+	VOXTYPE_API_KEY?: string;
+}

--- a/cloud/src/env.d.ts
+++ b/cloud/src/env.d.ts
@@ -2,4 +2,6 @@
 // so they are merged into the generated global Env interface here.
 interface Env {
 	VOXTYPE_API_KEY?: string;
+	/** Workers AI-scoped token enabling the nova-3 REST fallback (workerd#5082). */
+	CLOUDFLARE_API_TOKEN?: string;
 }

--- a/cloud/src/errors.ts
+++ b/cloud/src/errors.ts
@@ -1,0 +1,29 @@
+/**
+ * OpenAI-style error envelope. voxtype's RemoteTranscriber surfaces the raw
+ * status + body verbatim in its error message, so the message must stand on
+ * its own for a human reading daemon logs.
+ */
+export interface OpenAiError {
+	error: {
+		message: string;
+		type: string;
+		code: string | null;
+	};
+}
+
+export function errorResponse(status: number, message: string, type = "invalid_request_error", code: string | null = null): Response {
+	const body: OpenAiError = { error: { message, type, code } };
+	return Response.json(body, { status });
+}
+
+export function unauthorized(): Response {
+	return errorResponse(401, "Invalid or missing API key. Pass it as 'Authorization: Bearer <key>'.", "authentication_error", "invalid_api_key");
+}
+
+export function notFound(message = "Not found."): Response {
+	return errorResponse(404, message, "invalid_request_error", "not_found");
+}
+
+export function methodNotAllowed(): Response {
+	return errorResponse(405, "Method not allowed.", "invalid_request_error", "method_not_allowed");
+}

--- a/cloud/src/index.ts
+++ b/cloud/src/index.ts
@@ -1,0 +1,67 @@
+import { transcribeNova3 } from "./deepgram";
+import { errorResponse, methodNotAllowed, notFound, unauthorized } from "./errors";
+import { handleModels } from "./models";
+import { handleTranscription } from "./transcriptions";
+
+/**
+ * Look up the set of valid API keys. The pilot has exactly one, from a Worker
+ * secret; this seam is where per-user keys in KV/D1 drop in later without
+ * touching the auth check itself.
+ */
+async function validKeys(env: Env): Promise<string[]> {
+	return env.VOXTYPE_API_KEY !== undefined && env.VOXTYPE_API_KEY !== "" ? [env.VOXTYPE_API_KEY] : [];
+}
+
+/** Constant-time comparison via SHA-256 digests (no length leak). */
+export async function keyMatches(presented: string, valid: string): Promise<boolean> {
+	const encoder = new TextEncoder();
+	const [a, b] = await Promise.all([
+		crypto.subtle.digest("SHA-256", encoder.encode(presented)),
+		crypto.subtle.digest("SHA-256", encoder.encode(valid)),
+	]);
+	return crypto.subtle.timingSafeEqual(a, b);
+}
+
+async function authenticate(request: Request, env: Env): Promise<boolean> {
+	const header = request.headers.get("Authorization") ?? "";
+	if (!header.startsWith("Bearer ")) return false;
+	const presented = header.slice("Bearer ".length).trim();
+	if (presented === "") return false;
+	for (const valid of await validKeys(env)) {
+		if (await keyMatches(presented, valid)) return true;
+	}
+	return false;
+}
+
+export default {
+	async fetch(request, env, _ctx): Promise<Response> {
+		const url = new URL(request.url);
+		try {
+			if (!(await authenticate(request, env))) {
+				return unauthorized();
+			}
+
+			switch (url.pathname) {
+				case "/v1/audio/transcriptions":
+					return request.method === "POST" ? await handleTranscription(request, env) : methodNotAllowed();
+				case "/v1/models":
+					return request.method === "GET" ? handleModels() : methodNotAllowed();
+				// Reserved routes: claimed in the URL space now, built post-pilot.
+				case "/v1/chat/completions":
+					return notFound("Not yet available: summarization is planned for a future Voxtype Cloud release.");
+				case "/v1/realtime":
+					return notFound("Not yet available: realtime transcription is planned for a future Voxtype Cloud release.");
+				default:
+					return notFound(`Unknown path '${url.pathname}'.`);
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.log(JSON.stringify({ event: "unhandled_error", path: url.pathname, message }));
+			return errorResponse(500, "Internal error.", "api_error", "internal_error");
+		}
+	},
+} satisfies ExportedHandler<Env>;
+
+// Re-exported so the fixture-capture script's sibling test can exercise the
+// same code path the Worker uses.
+export { transcribeNova3 };

--- a/cloud/src/models.ts
+++ b/cloud/src/models.ts
@@ -1,0 +1,10 @@
+/** GET /v1/models — static OpenAI-style model list. */
+export function handleModels(): Response {
+	return Response.json({
+		object: "list",
+		data: [
+			{ id: "nova-3", object: "model", created: 1756684800, owned_by: "deepgram" },
+			{ id: "whisper-large-v3-turbo", object: "model", created: 1756684800, owned_by: "openai" },
+		],
+	});
+}

--- a/cloud/src/transcriptions.ts
+++ b/cloud/src/transcriptions.ts
@@ -1,5 +1,10 @@
-import { transcribeNova3, transcribeWhisper, type TranscriptionResult } from "./deepgram";
+import { runNova3Raw, transcribeNova3, transcribeWhisper, type NovaUpstream, type TranscriptionResult } from "./deepgram";
 import { errorResponse } from "./errors";
+
+/** Binding plus optional REST-fallback credentials (workerd#5082). */
+function novaUpstream(env: Env): NovaUpstream {
+	return { ai: env.AI, accountId: env.CLOUDFLARE_ACCOUNT_ID, apiToken: env.CLOUDFLARE_API_TOKEN };
+}
 
 /**
  * formData() buffers the body and the audio bytes are buffered again for the
@@ -51,6 +56,23 @@ export async function handleTranscription(request: Request, env: Env): Promise<R
 		return errorResponse(400, "Diarization requires the nova-3 model; whisper models do not support diarize=true.");
 	}
 
+	// Debug extension: raw=true returns the un-normalized Nova-3 model output.
+	// Used by scripts/capture-fixture.sh to pin the parser fixture.
+	if (str(form.get("raw")) === "true") {
+		if (useWhisper) return errorResponse(400, "raw=true is only supported with the nova-3 model.");
+		try {
+			const raw = await runNova3Raw(novaUpstream(env), new Uint8Array(await file.arrayBuffer()), {
+				diarize,
+				language,
+				contentType: file.type !== "" ? file.type : "audio/wav",
+			});
+			return Response.json(raw);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			return errorResponse(502, `Speech-to-text inference failed: ${message}`, "api_error", "inference_failed");
+		}
+	}
+
 	const started = Date.now();
 	let result: TranscriptionResult;
 	try {
@@ -58,7 +80,7 @@ export async function handleTranscription(request: Request, env: Env): Promise<R
 			result = await transcribeWhisper(env.AI, new Uint8Array(await file.arrayBuffer()), language);
 		} else {
 			const contentType = file.type !== "" ? file.type : "audio/wav";
-			result = await transcribeNova3(env.AI, new Uint8Array(await file.arrayBuffer()), { diarize, language, contentType });
+			result = await transcribeNova3(novaUpstream(env), new Uint8Array(await file.arrayBuffer()), { diarize, language, contentType });
 		}
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);

--- a/cloud/src/transcriptions.ts
+++ b/cloud/src/transcriptions.ts
@@ -1,0 +1,97 @@
+import { transcribeNova3, transcribeWhisper, type TranscriptionResult } from "./deepgram";
+import { errorResponse } from "./errors";
+
+/**
+ * formData() buffers the body and the audio bytes are buffered again for the
+ * AI.run call, so the real ceiling is Worker memory (128 MB), not the 100 MB
+ * request-body limit. 50 MB ≈ 26 min of 16 kHz mono s16 WAV — far above any
+ * meeting chunk (120 s ≈ 3.8 MB).
+ */
+const MAX_BODY_BYTES = 50 * 1024 * 1024;
+
+/**
+ * POST /v1/audio/transcriptions — OpenAI-compatible, with one voxtype
+ * extension: a `diarize=true` form field. Real OpenAI servers ignore unknown
+ * form fields, so clients speaking this dialect stay generic OpenAI clients.
+ *
+ * response_format=json     -> {"text": "..."}            (what voxtype's RemoteTranscriber parses today)
+ * response_format=verbose_json -> OpenAI verbose shape + `speaker`/`confidence`
+ *                             on segments[] and words[] when diarizing.
+ */
+export async function handleTranscription(request: Request, env: Env): Promise<Response> {
+	const contentLength = Number(request.headers.get("Content-Length") ?? "0");
+	if (contentLength > MAX_BODY_BYTES) {
+		return errorResponse(413, `Audio too large: request body must be under ${MAX_BODY_BYTES} bytes.`);
+	}
+
+	let form: FormData;
+	try {
+		form = await request.formData();
+	} catch {
+		return errorResponse(400, "Request body must be multipart/form-data with a 'file' field.");
+	}
+
+	const file = form.get("file");
+	if (!(file instanceof File)) {
+		return errorResponse(400, "Missing required field 'file' (audio to transcribe).");
+	}
+
+	const model = str(form.get("model")) ?? "nova-3";
+	const language = str(form.get("language"));
+	const responseFormat = str(form.get("response_format")) ?? "json";
+	const diarize = str(form.get("diarize")) === "true";
+	// `prompt` is accepted but ignored in the pilot (Nova-3 keyterm mapping is a follow-up).
+
+	if (responseFormat !== "json" && responseFormat !== "verbose_json") {
+		return errorResponse(400, `Unsupported response_format '${responseFormat}': use 'json' or 'verbose_json'.`);
+	}
+
+	const useWhisper = model.startsWith("whisper");
+	if (useWhisper && diarize) {
+		return errorResponse(400, "Diarization requires the nova-3 model; whisper models do not support diarize=true.");
+	}
+
+	const started = Date.now();
+	let result: TranscriptionResult;
+	try {
+		if (useWhisper) {
+			result = await transcribeWhisper(env.AI, new Uint8Array(await file.arrayBuffer()), language);
+		} else {
+			const contentType = file.type !== "" ? file.type : "audio/wav";
+			result = await transcribeNova3(env.AI, new Uint8Array(await file.arrayBuffer()), { diarize, language, contentType });
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(JSON.stringify({ event: "inference_error", model, message }));
+		return errorResponse(502, `Speech-to-text inference failed: ${message}`, "api_error", "inference_failed");
+	}
+
+	// Never log transcript text or audio — durations and sizes only.
+	console.log(
+		JSON.stringify({
+			event: "transcription",
+			model: useWhisper ? "whisper-large-v3-turbo" : "nova-3",
+			diarize,
+			response_format: responseFormat,
+			audio_bytes: file.size,
+			audio_secs: result.duration ?? null,
+			elapsed_ms: Date.now() - started,
+		}),
+	);
+
+	if (responseFormat === "json") {
+		return Response.json({ text: result.text });
+	}
+	return Response.json({
+		task: "transcribe",
+		language: result.language ?? "en",
+		duration: result.duration ?? 0,
+		text: result.text,
+		segments: result.segments,
+		words: result.words,
+	});
+}
+
+function str(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/cloud/test/deepgram.test.ts
+++ b/cloud/test/deepgram.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { groupWordsIntoTurns, nova3Language, transcribeNova3, type NovaWord } from "../src/deepgram";
+import fixture from "./fixtures/nova3-diarized.json";
+
+function word(w: Partial<NovaWord>): NovaWord {
+	return { word: "x", start: 0, end: 0.1, confidence: 0.9, ...w };
+}
+
+describe("groupWordsIntoTurns", () => {
+	it("splits on speaker change", () => {
+		const turns = groupWordsIntoTurns([
+			word({ word: "hello", start: 0, end: 0.5, speaker: 0 }),
+			word({ word: "there", start: 0.5, end: 1.0, speaker: 0 }),
+			word({ word: "hi", start: 1.2, end: 1.5, speaker: 1 }),
+		]);
+		expect(turns).toHaveLength(2);
+		expect(turns[0].speaker).toBe(0);
+		expect(turns[0].text).toBe("hello there");
+		expect(turns[1].speaker).toBe(1);
+		expect(turns[1].text).toBe("hi");
+	});
+
+	it("splits on a gap longer than the max, same speaker", () => {
+		const turns = groupWordsIntoTurns([
+			word({ word: "one", start: 0, end: 0.5, speaker: 0 }),
+			word({ word: "two", start: 4.0, end: 4.5, speaker: 0 }),
+		]);
+		expect(turns).toHaveLength(2);
+		expect(turns.every((t) => t.speaker === 0)).toBe(true);
+	});
+
+	it("does not split on a short gap", () => {
+		const turns = groupWordsIntoTurns([
+			word({ word: "one", start: 0, end: 0.5, speaker: 0 }),
+			word({ word: "two", start: 2.9, end: 3.2, speaker: 0 }),
+		]);
+		expect(turns).toHaveLength(1);
+	});
+
+	it("prefers punctuated_word and averages confidence", () => {
+		const turns = groupWordsIntoTurns([
+			word({ word: "hello", punctuated_word: "Hello,", start: 0, end: 0.4, confidence: 0.8, speaker: 0 }),
+			word({ word: "world", punctuated_word: "world.", start: 0.4, end: 0.9, confidence: 1.0, speaker: 0 }),
+		]);
+		expect(turns[0].text).toBe("Hello, world.");
+		expect(turns[0].confidence).toBeCloseTo(0.9);
+		expect(turns[0].start).toBe(0);
+		expect(turns[0].end).toBe(0.9);
+	});
+
+	it("handles undiarized words (no speaker field) as one turn", () => {
+		const turns = groupWordsIntoTurns([
+			word({ word: "just", start: 0, end: 0.3 }),
+			word({ word: "text", start: 0.3, end: 0.6 }),
+		]);
+		expect(turns).toHaveLength(1);
+		expect(turns[0].speaker).toBeUndefined();
+	});
+
+	it("returns no turns for no words", () => {
+		expect(groupWordsIntoTurns([])).toHaveLength(0);
+	});
+
+	it("ids are sequential", () => {
+		const turns = groupWordsIntoTurns([
+			word({ word: "a", start: 0, end: 0.1, speaker: 0 }),
+			word({ word: "b", start: 0.2, end: 0.3, speaker: 1 }),
+			word({ word: "c", start: 0.4, end: 0.5, speaker: 0 }),
+		]);
+		expect(turns.map((t) => t.id)).toEqual([0, 1, 2]);
+	});
+});
+
+describe("nova3Language", () => {
+	it("passes through supported languages", () => {
+		expect(nova3Language("en")).toBe("en");
+		expect(nova3Language("pt-BR")).toBe("pt-BR");
+		expect(nova3Language("multi")).toBe("multi");
+	});
+	it("omits unsupported languages", () => {
+		expect(nova3Language("zh")).toBeUndefined();
+		expect(nova3Language(undefined)).toBeUndefined();
+	});
+});
+
+describe("transcribeNova3 against the pinned fixture", () => {
+	const stubAi = { run: async () => fixture } as unknown as Ai;
+
+	it("extracts transcript, duration, and speaker turns", async () => {
+		const result = await transcribeNova3(stubAi, new Uint8Array(0), {
+			diarize: true,
+			contentType: "audio/wav",
+		});
+		expect(result.text).toBe("So the deploy failed twice. Yeah, I saw that in the logs.");
+		expect(result.duration).toBeCloseTo(8.42);
+		expect(result.language).toBe("en");
+		expect(result.segments).toHaveLength(2);
+		expect(result.segments[0].speaker).toBe(0);
+		expect(result.segments[0].text).toBe("So the deploy failed twice.");
+		expect(result.segments[1].speaker).toBe(1);
+		expect(result.segments[1].text).toBe("Yeah, I saw that in the logs.");
+	});
+
+	it("falls back to a single segment when words are missing", async () => {
+		const bare = { results: { channels: [{ alternatives: [{ transcript: "hello there" }] }] } };
+		const ai = { run: async () => bare } as unknown as Ai;
+		const result = await transcribeNova3(ai, new Uint8Array(0), { diarize: false, contentType: "audio/wav" });
+		expect(result.text).toBe("hello there");
+		expect(result.segments).toHaveLength(1);
+		expect(result.segments[0].speaker).toBeUndefined();
+	});
+
+	it("returns empty segments for an empty response", async () => {
+		const ai = { run: async () => ({}) } as unknown as Ai;
+		const result = await transcribeNova3(ai, new Uint8Array(0), { diarize: false, contentType: "audio/wav" });
+		expect(result.text).toBe("");
+		expect(result.segments).toHaveLength(0);
+	});
+});

--- a/cloud/test/deepgram.test.ts
+++ b/cloud/test/deepgram.test.ts
@@ -83,28 +83,34 @@ describe("nova3Language", () => {
 	});
 });
 
-describe("transcribeNova3 against the pinned fixture", () => {
+describe("transcribeNova3 against the pinned fixture (live-captured 2026-09-02)", () => {
 	const stubAi = { run: async () => fixture } as unknown as Ai;
 
-	it("extracts transcript, duration, and speaker turns", async () => {
-		const result = await transcribeNova3(stubAi, new Uint8Array(0), {
+	it("extracts transcript, duration, and speaker-tagged turns", async () => {
+		const result = await transcribeNova3({ ai: stubAi }, new Uint8Array(0), {
 			diarize: true,
 			contentType: "audio/wav",
 		});
-		expect(result.text).toBe("So the deploy failed twice. Yeah, I saw that in the logs.");
-		expect(result.duration).toBeCloseTo(8.42);
-		expect(result.language).toBe("en");
-		expect(result.segments).toHaveLength(2);
-		expect(result.segments[0].speaker).toBe(0);
-		expect(result.segments[0].text).toBe("So the deploy failed twice.");
-		expect(result.segments[1].speaker).toBe(1);
-		expect(result.segments[1].text).toBe("Yeah, I saw that in the logs.");
+		expect(result.text).toBe(
+			"So the deploy failed twice last night. I think the migration step is timing out before the database comes up. Yeah. I saw that in the logs this morning. Let's add a health check before the migration runs and try again.",
+		);
+		// The live response carries no metadata.duration; it falls back to the
+		// last word's end time.
+		expect(result.duration).toBeCloseTo(14.96);
+		expect(result.words).toHaveLength(41);
+		expect(result.segments.length).toBeGreaterThanOrEqual(1);
+		// Workers AI's nova-3 currently tags every word speaker 0 even on
+		// multi-speaker audio (upstream diarization defect, observed live on
+		// Deepgram's own two-speaker demo files); the fixture reflects that.
+		// The turn-grouping tests above cover real multi-speaker word arrays.
+		expect(result.segments.every((s) => s.speaker === 0)).toBe(true);
+		expect(result.segments.map((s) => s.text).join(" ")).toBe(result.text);
 	});
 
 	it("falls back to a single segment when words are missing", async () => {
 		const bare = { results: { channels: [{ alternatives: [{ transcript: "hello there" }] }] } };
 		const ai = { run: async () => bare } as unknown as Ai;
-		const result = await transcribeNova3(ai, new Uint8Array(0), { diarize: false, contentType: "audio/wav" });
+		const result = await transcribeNova3({ ai }, new Uint8Array(0), { diarize: false, contentType: "audio/wav" });
 		expect(result.text).toBe("hello there");
 		expect(result.segments).toHaveLength(1);
 		expect(result.segments[0].speaker).toBeUndefined();
@@ -112,8 +118,52 @@ describe("transcribeNova3 against the pinned fixture", () => {
 
 	it("returns empty segments for an empty response", async () => {
 		const ai = { run: async () => ({}) } as unknown as Ai;
-		const result = await transcribeNova3(ai, new Uint8Array(0), { diarize: false, contentType: "audio/wav" });
+		const result = await transcribeNova3({ ai }, new Uint8Array(0), { diarize: false, contentType: "audio/wav" });
 		expect(result.text).toBe("");
 		expect(result.segments).toHaveLength(0);
+	});
+
+	it("falls back to REST on the 5006 binding bug and unwraps the envelope", async () => {
+		const ai = {
+			run: async () => {
+				throw new Error("5006: Error: required properties at '/audio' are 'body,contentType'");
+			},
+		} as unknown as Ai;
+		const calls: { url: string; init: RequestInit }[] = [];
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+			calls.push({ url: String(url), init: init ?? {} });
+			return Response.json({ result: fixture, success: true });
+		}) as typeof fetch;
+		try {
+			const result = await transcribeNova3({ ai, accountId: "acct123", apiToken: "tok" }, new Uint8Array([1, 2, 3]), {
+				diarize: true,
+				language: "en",
+				contentType: "audio/wav",
+			});
+			expect(result.words).toHaveLength(41);
+			expect(calls).toHaveLength(1);
+			const { url, init } = calls[0];
+			// Mirrors the verified-working curl: binary body + query params.
+			expect(url).toBe(
+				"https://api.cloudflare.com/client/v4/accounts/acct123/ai/run/@cf/deepgram/nova-3?punctuate=true&smart_format=true&diarize=true&language=en",
+			);
+			expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok");
+			expect((init.headers as Record<string, string>)["Content-Type"]).toBe("audio/wav");
+			expect(init.body).toBeInstanceOf(Uint8Array);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("surfaces the workerd#5082 hint when the binding rejects and no fallback is configured", async () => {
+		const ai = {
+			run: async () => {
+				throw new Error("5006: Error: required properties at '/audio' are 'body,contentType'");
+			},
+		} as unknown as Ai;
+		await expect(transcribeNova3({ ai }, new Uint8Array(0), { diarize: false, contentType: "audio/wav" })).rejects.toThrow(
+			/workerd#5082/,
+		);
 	});
 });

--- a/cloud/test/fixtures/nova3-diarized.json
+++ b/cloud/test/fixtures/nova3-diarized.json
@@ -1,33 +1,432 @@
 {
-	"_comment": "PLACEHOLDER matching Deepgram's documented response schema. Replace with a live capture via scripts/capture-fixture.sh before trusting field names (plan step 2).",
-	"metadata": {
-		"duration": 8.42
-	},
-	"results": {
-		"channels": [
-			{
-				"detected_language": "en",
-				"alternatives": [
-					{
-						"transcript": "So the deploy failed twice. Yeah, I saw that in the logs.",
-						"confidence": 0.98,
-						"words": [
-							{ "word": "so", "punctuated_word": "So", "start": 0.32, "end": 0.48, "confidence": 0.99, "speaker": 0 },
-							{ "word": "the", "punctuated_word": "the", "start": 0.48, "end": 0.62, "confidence": 0.99, "speaker": 0 },
-							{ "word": "deploy", "punctuated_word": "deploy", "start": 0.62, "end": 1.04, "confidence": 0.98, "speaker": 0 },
-							{ "word": "failed", "punctuated_word": "failed", "start": 1.04, "end": 1.46, "confidence": 0.97, "speaker": 0 },
-							{ "word": "twice", "punctuated_word": "twice.", "start": 1.46, "end": 1.98, "confidence": 0.98, "speaker": 0 },
-							{ "word": "yeah", "punctuated_word": "Yeah,", "start": 3.1, "end": 3.34, "confidence": 0.96, "speaker": 1 },
-							{ "word": "i", "punctuated_word": "I", "start": 3.34, "end": 3.4, "confidence": 0.99, "speaker": 1 },
-							{ "word": "saw", "punctuated_word": "saw", "start": 3.4, "end": 3.66, "confidence": 0.99, "speaker": 1 },
-							{ "word": "that", "punctuated_word": "that", "start": 3.66, "end": 3.86, "confidence": 0.98, "speaker": 1 },
-							{ "word": "in", "punctuated_word": "in", "start": 3.86, "end": 3.98, "confidence": 0.99, "speaker": 1 },
-							{ "word": "the", "punctuated_word": "the", "start": 3.98, "end": 4.1, "confidence": 0.99, "speaker": 1 },
-							{ "word": "logs", "punctuated_word": "logs.", "start": 4.1, "end": 4.52, "confidence": 0.97, "speaker": 1 }
-						]
-					}
-				]
-			}
-		]
-	}
+  "results": {
+    "channels": [
+      {
+        "alternatives": [
+          {
+            "confidence": 1,
+            "paragraphs": {
+              "paragraphs": [
+                {
+                  "end": 14.96,
+                  "num_words": 41,
+                  "sentences": [
+                    {
+                      "end": 3.04,
+                      "start": 0.24,
+                      "text": "So the deploy failed twice last night."
+                    },
+                    {
+                      "end": 7.44,
+                      "start": 3.1999998,
+                      "text": "I think the migration step is timing out before the database comes up."
+                    },
+                    {
+                      "end": 9.36,
+                      "start": 8.88,
+                      "text": "Yeah."
+                    },
+                    {
+                      "end": 11.5199995,
+                      "start": 9.36,
+                      "text": "I saw that in the logs this morning."
+                    },
+                    {
+                      "end": 14.96,
+                      "start": 11.679999,
+                      "text": "Let's add a health check before the migration runs and try again."
+                    }
+                  ],
+                  "speaker": 0,
+                  "start": 0.24
+                }
+              ],
+              "transcript": "\nSpeaker 0: So the deploy failed twice last night. I think the migration step is timing out before the database comes up. Yeah. I saw that in the logs this morning. Let's add a health check before the migration runs and try again."
+            },
+            "transcript": "So the deploy failed twice last night. I think the migration step is timing out before the database comes up. Yeah. I saw that in the logs this morning. Let's add a health check before the migration runs and try again.",
+            "words": [
+              {
+                "confidence": 0.99316406,
+                "end": 0.48,
+                "punctuated_word": "So",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 0.24,
+                "word": "so"
+              },
+              {
+                "confidence": 1,
+                "end": 0.64,
+                "punctuated_word": "the",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 0.48,
+                "word": "the"
+              },
+              {
+                "confidence": 0.9980469,
+                "end": 1.12,
+                "punctuated_word": "deploy",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 0.64,
+                "word": "deploy"
+              },
+              {
+                "confidence": 1,
+                "end": 1.5999999,
+                "punctuated_word": "failed",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 1.12,
+                "word": "failed"
+              },
+              {
+                "confidence": 1,
+                "end": 2,
+                "punctuated_word": "twice",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 1.5999999,
+                "word": "twice"
+              },
+              {
+                "confidence": 1,
+                "end": 2.3999999,
+                "punctuated_word": "last",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 2,
+                "word": "last"
+              },
+              {
+                "confidence": 0.99902344,
+                "end": 3.04,
+                "punctuated_word": "night.",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 2.3999999,
+                "word": "night"
+              },
+              {
+                "confidence": 1,
+                "end": 3.36,
+                "punctuated_word": "I",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 3.1999998,
+                "word": "i"
+              },
+              {
+                "confidence": 1,
+                "end": 3.6,
+                "punctuated_word": "think",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 3.36,
+                "word": "think"
+              },
+              {
+                "confidence": 1,
+                "end": 3.76,
+                "punctuated_word": "the",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 3.6,
+                "word": "the"
+              },
+              {
+                "confidence": 1,
+                "end": 4.24,
+                "punctuated_word": "migration",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 3.76,
+                "word": "migration"
+              },
+              {
+                "confidence": 1,
+                "end": 4.64,
+                "punctuated_word": "step",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 4.24,
+                "word": "step"
+              },
+              {
+                "confidence": 1,
+                "end": 4.88,
+                "punctuated_word": "is",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 4.64,
+                "word": "is"
+              },
+              {
+                "confidence": 0.99902344,
+                "end": 5.2,
+                "punctuated_word": "timing",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 4.88,
+                "word": "timing"
+              },
+              {
+                "confidence": 1,
+                "end": 5.44,
+                "punctuated_word": "out",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 5.2,
+                "word": "out"
+              },
+              {
+                "confidence": 1,
+                "end": 5.8399997,
+                "punctuated_word": "before",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 5.44,
+                "word": "before"
+              },
+              {
+                "confidence": 1,
+                "end": 6,
+                "punctuated_word": "the",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 5.8399997,
+                "word": "the"
+              },
+              {
+                "confidence": 1,
+                "end": 6.56,
+                "punctuated_word": "database",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 6,
+                "word": "database"
+              },
+              {
+                "confidence": 1,
+                "end": 6.8799996,
+                "punctuated_word": "comes",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 6.56,
+                "word": "comes"
+              },
+              {
+                "confidence": 1,
+                "end": 7.44,
+                "punctuated_word": "up.",
+                "speaker": 0,
+                "speaker_confidence": 0.67446744,
+                "start": 6.8799996,
+                "word": "up"
+              },
+              {
+                "confidence": 0.9995117,
+                "end": 9.36,
+                "punctuated_word": "Yeah.",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 8.88,
+                "word": "yeah"
+              },
+              {
+                "confidence": 1,
+                "end": 9.5199995,
+                "punctuated_word": "I",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 9.36,
+                "word": "i"
+              },
+              {
+                "confidence": 1,
+                "end": 9.76,
+                "punctuated_word": "saw",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 9.5199995,
+                "word": "saw"
+              },
+              {
+                "confidence": 1,
+                "end": 9.92,
+                "punctuated_word": "that",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 9.76,
+                "word": "that"
+              },
+              {
+                "confidence": 1,
+                "end": 10.16,
+                "punctuated_word": "in",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 9.92,
+                "word": "in"
+              },
+              {
+                "confidence": 1,
+                "end": 10.24,
+                "punctuated_word": "the",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 10.16,
+                "word": "the"
+              },
+              {
+                "confidence": 1,
+                "end": 10.639999,
+                "punctuated_word": "logs",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 10.24,
+                "word": "logs"
+              },
+              {
+                "confidence": 1,
+                "end": 10.96,
+                "punctuated_word": "this",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 10.639999,
+                "word": "this"
+              },
+              {
+                "confidence": 1,
+                "end": 11.5199995,
+                "punctuated_word": "morning.",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 10.96,
+                "word": "morning"
+              },
+              {
+                "confidence": 1,
+                "end": 12,
+                "punctuated_word": "Let's",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 11.679999,
+                "word": "let's"
+              },
+              {
+                "confidence": 1,
+                "end": 12.16,
+                "punctuated_word": "add",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 12,
+                "word": "add"
+              },
+              {
+                "confidence": 1,
+                "end": 12.32,
+                "punctuated_word": "a",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 12.16,
+                "word": "a"
+              },
+              {
+                "confidence": 1,
+                "end": 12.559999,
+                "punctuated_word": "health",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 12.32,
+                "word": "health"
+              },
+              {
+                "confidence": 1,
+                "end": 12.799999,
+                "punctuated_word": "check",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 12.559999,
+                "word": "check"
+              },
+              {
+                "confidence": 1,
+                "end": 13.2,
+                "punctuated_word": "before",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 12.799999,
+                "word": "before"
+              },
+              {
+                "confidence": 1,
+                "end": 13.36,
+                "punctuated_word": "the",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 13.2,
+                "word": "the"
+              },
+              {
+                "confidence": 1,
+                "end": 13.84,
+                "punctuated_word": "migration",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 13.36,
+                "word": "migration"
+              },
+              {
+                "confidence": 1,
+                "end": 14.24,
+                "punctuated_word": "runs",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 13.84,
+                "word": "runs"
+              },
+              {
+                "confidence": 0.9941406,
+                "end": 14.4,
+                "punctuated_word": "and",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 14.24,
+                "word": "and"
+              },
+              {
+                "confidence": 1,
+                "end": 14.639999,
+                "punctuated_word": "try",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 14.4,
+                "word": "try"
+              },
+              {
+                "confidence": 1,
+                "end": 14.96,
+                "punctuated_word": "again.",
+                "speaker": 0,
+                "speaker_confidence": 0.67446756,
+                "start": 14.639999,
+                "word": "again"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "usage": {
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "total_tokens": 0,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "neurons": 122.909805
+  }
 }

--- a/cloud/test/fixtures/nova3-diarized.json
+++ b/cloud/test/fixtures/nova3-diarized.json
@@ -1,0 +1,33 @@
+{
+	"_comment": "PLACEHOLDER matching Deepgram's documented response schema. Replace with a live capture via scripts/capture-fixture.sh before trusting field names (plan step 2).",
+	"metadata": {
+		"duration": 8.42
+	},
+	"results": {
+		"channels": [
+			{
+				"detected_language": "en",
+				"alternatives": [
+					{
+						"transcript": "So the deploy failed twice. Yeah, I saw that in the logs.",
+						"confidence": 0.98,
+						"words": [
+							{ "word": "so", "punctuated_word": "So", "start": 0.32, "end": 0.48, "confidence": 0.99, "speaker": 0 },
+							{ "word": "the", "punctuated_word": "the", "start": 0.48, "end": 0.62, "confidence": 0.99, "speaker": 0 },
+							{ "word": "deploy", "punctuated_word": "deploy", "start": 0.62, "end": 1.04, "confidence": 0.98, "speaker": 0 },
+							{ "word": "failed", "punctuated_word": "failed", "start": 1.04, "end": 1.46, "confidence": 0.97, "speaker": 0 },
+							{ "word": "twice", "punctuated_word": "twice.", "start": 1.46, "end": 1.98, "confidence": 0.98, "speaker": 0 },
+							{ "word": "yeah", "punctuated_word": "Yeah,", "start": 3.1, "end": 3.34, "confidence": 0.96, "speaker": 1 },
+							{ "word": "i", "punctuated_word": "I", "start": 3.34, "end": 3.4, "confidence": 0.99, "speaker": 1 },
+							{ "word": "saw", "punctuated_word": "saw", "start": 3.4, "end": 3.66, "confidence": 0.99, "speaker": 1 },
+							{ "word": "that", "punctuated_word": "that", "start": 3.66, "end": 3.86, "confidence": 0.98, "speaker": 1 },
+							{ "word": "in", "punctuated_word": "in", "start": 3.86, "end": 3.98, "confidence": 0.99, "speaker": 1 },
+							{ "word": "the", "punctuated_word": "the", "start": 3.98, "end": 4.1, "confidence": 0.99, "speaker": 1 },
+							{ "word": "logs", "punctuated_word": "logs.", "start": 4.1, "end": 4.52, "confidence": 0.97, "speaker": 1 }
+						]
+					}
+				]
+			}
+		]
+	}
+}

--- a/cloud/tsconfig.json
+++ b/cloud/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "es2022",
+		"module": "es2022",
+		"moduleResolution": "bundler",
+		"lib": ["es2022"],
+		"types": ["./worker-configuration.d.ts"],
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"isolatedModules": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true
+	},
+	"include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/cloud/wrangler.jsonc
+++ b/cloud/wrangler.jsonc
@@ -1,0 +1,18 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "voxtype-cloud",
+	"main": "src/index.ts",
+	"compatibility_date": "2026-09-02",
+	"compatibility_flags": ["nodejs_compat"],
+	"ai": {
+		"binding": "AI"
+	},
+	"observability": {
+		"enabled": true,
+		"head_sampling_rate": 1
+	}
+	// Custom domain — enable once the voxtype.io zone is on Cloudflare DNS
+	// (the site itself stays on GitHub Pages; only the `api` subdomain is claimed).
+	// Until then the Worker serves on its workers.dev URL.
+	// "routes": [{ "pattern": "api.voxtype.io", "custom_domain": true }]
+}

--- a/cloud/wrangler.jsonc
+++ b/cloud/wrangler.jsonc
@@ -7,6 +7,11 @@
 	"ai": {
 		"binding": "AI"
 	},
+	"vars": {
+		// Used by the nova-3 REST fallback (workerd#5082) together with the
+		// CLOUDFLARE_API_TOKEN secret (Workers AI Run scope).
+		"CLOUDFLARE_ACCOUNT_ID": "414602f08a782b26293948812b54a9df"
+	},
 	"observability": {
 		"enabled": true,
 		"head_sampling_rate": 1

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3244,7 +3244,7 @@ Diarization backend to use:
 
 - `"simple"` - Uses audio source (mic vs loopback) to attribute speech as "You" or "Remote". No model download required.
 - `"ml"` - ONNX-based speaker embeddings (ECAPA-TDNN) to identify individual remote speakers. The model is downloaded automatically on first use. **Experimental:** speaker clustering works best with longer speech segments; short segments may produce too many unique speaker IDs.
-- `"remote"` - Remote diarization API.
+- `"remote"` - Speaker labels come from the remote transcription server instead of a local model. Requires `engine = "whisper"` with `[whisper] mode = "remote"` pointed at a server that supports voxtype's diarization extension to the OpenAI transcription API (such as a Voxtype Cloud endpoint); with any other engine or mode this backend falls back to `"simple"` with a warning. The microphone channel is always attributed to "You"; loopback speakers get `SPEAKER_NN` IDs that work with `voxtype meeting label`. **Privacy:** meeting audio leaves your machine and is transcribed by the remote service. **Pilot limitation:** speaker numbering is only guaranteed consistent within one chunk, so raising `chunk_duration_secs` (for example to `120`) is recommended; one-on-one calls (a single remote speaker) get fully stable labels.
 
 ### max_speakers
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,6 +15,7 @@ Solutions to common issues when using Voxtype.
   - [Text output not working on X11](#text-output-not-working-on-x11)
   - [Wrong characters on non-US keyboard layouts](#wrong-characters-on-non-us-keyboard-layouts-yz-swapped-qwertz-azerty)
 - [Performance Issues](#performance-issues)
+- [Remote Diarization Issues](#remote-diarization-issues)
 - [Soniox Backend Issues](#soniox-backend-issues)
 - [Media Does Not Pause While Recording (Omarchy Quattro)](#media-does-not-pause-while-recording-omarchy-quattro)
 - [Quickshell OSD Issues](#quickshell-osd-issues)
@@ -1059,6 +1060,45 @@ model = "tiny.en"
 1. Ensure voxtype is running with normal priority
 2. Check for other applications using evdev
 3. Try a different hotkey
+
+---
+
+## Remote Diarization Issues
+
+Applies to `[meeting.diarization] backend = "remote"` (speaker labels from a remote transcription server such as a Voxtype Cloud endpoint).
+
+### "diarization backend \"remote\" requires engine = \"whisper\" with mode = \"remote\"" warning
+
+The remote backend only works when meetings transcribe through the remote Whisper path. Check that your config sets all three of:
+
+```toml
+engine = "whisper"
+
+[whisper]
+mode = "remote"
+remote_endpoint = "https://api.voxtype.io"
+```
+
+Until then, meetings fall back to the `simple` diarizer (mic = "You", loopback = "Remote").
+
+### Transcript has text but every speaker is "Remote" or missing SPEAKER_NN IDs
+
+The server did not return diarized segments, so voxtype degraded to plain transcription. Causes:
+
+- The endpoint is a plain OpenAI-compatible server (whisper.cpp, LocalAI) that ignores voxtype's `diarize` extension field. Point `remote_endpoint` at a server that supports it.
+- The server-side diarization returned a single speaker. Check the daemon log for "Remote server returned no diarized segments".
+
+### "Server returned 401" during meetings
+
+The API key is wrong or missing. Set `[whisper] remote_api_key` or the `VOXTYPE_WHISPER_API_KEY` environment variable.
+
+### Speaker numbers change mid-meeting
+
+Each audio chunk is diarized independently, so speaker numbering restarts per chunk. One-on-one calls (a single remote speaker) are stable. For multi-party calls, raise `[meeting] chunk_duration_secs` (for example to `120` or `300`) so boundaries are rare, and reapply `voxtype meeting label` where needed.
+
+### Meeting has gaps after network hiccups
+
+A chunk whose upload fails is skipped and the meeting continues; the lost interval is not retried. Check the daemon log for "Request failed" entries around the gap.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -2264,6 +2264,29 @@ ollama_model = "llama3.2"
 timeout_secs = 120
 ```
 
+### Remote Diarization
+
+With `backend = "remote"`, speaker identification happens on the transcription server instead of your machine. This requires running meetings against a remote Whisper-compatible server that supports voxtype's diarization extension (such as a Voxtype Cloud endpoint):
+
+```toml
+engine = "whisper"
+
+[whisper]
+mode = "remote"
+remote_endpoint = "https://api.voxtype.io"
+remote_model = "nova-3"
+remote_api_key = "your-key"      # or VOXTYPE_WHISPER_API_KEY
+
+[meeting]
+chunk_duration_secs = 120        # longer chunks keep speaker IDs more stable
+
+[meeting.diarization]
+enabled = true
+backend = "remote"
+```
+
+The server returns one transcript segment per speaker turn. Your microphone is always labeled "You"; remote participants get `SPEAKER_NN` IDs. Because each audio chunk is diarized independently, speaker numbering is only guaranteed consistent within a chunk — one-on-one calls are fully stable, while multi-party calls may need labels reapplied. Meeting audio is sent to the remote service for processing, unlike the local `simple` and `ml` backends.
+
 ### Speaker Labeling
 
 When diarization is enabled, speakers are assigned auto-generated IDs like `SPEAKER_00`, `SPEAKER_01`, etc. Use the `label` command to assign readable names:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -41,7 +41,7 @@ pub const ENGINE_NAMES_CSV: &str =
 /// The authoritative dispatch lives in `src/meeting/diarization/mod.rs`'s
 /// `match backend.as_str()` block; a test in `src/config/meeting.rs` pins
 /// this list against those arms.
-pub(crate) const DIARIZATION_BACKENDS: &[&str] = &["simple", "ml"];
+pub(crate) const DIARIZATION_BACKENDS: &[&str] = &["simple", "ml", "remote"];
 
 /// Values `voxtype setup --progress-format` accepts. `human` is curl's
 /// progress bar and the usual status lines; `json` emits one NDJSON event per

--- a/src/config/meeting.rs
+++ b/src/config/meeting.rs
@@ -101,11 +101,14 @@ pub struct MeetingDiarizationConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
 
-    /// Diarization backend: "simple" or "ml".
-    /// The match arms in `src/meeting/diarization/mod.rs` are the source of
-    /// truth for what the daemon actually dispatches on; the CLI's
-    /// `--diarization` value parser is pinned to the same set via
-    /// `crate::cli::DIARIZATION_BACKENDS` and a test in this file.
+    /// Diarization backend: "simple", "ml", or "remote".
+    /// "simple" and "ml" dispatch through the match arms in
+    /// `src/meeting/diarization/mod.rs`; "remote" runs no local diarizer —
+    /// speaker labels come embedded in the transcription (requires
+    /// engine = "whisper" with mode = "remote" against a voxtype-cloud
+    /// server, see `MeetingDaemon::new`). The CLI's `--diarization` value
+    /// parser is pinned to the same set via `crate::cli::DIARIZATION_BACKENDS`
+    /// and a test in this file.
     #[serde(default = "default_diarization_backend")]
     pub backend: String,
 

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -206,7 +206,31 @@ impl Config {
                 }
             }
         }
+        if self.cloud_diarization_active() {
+            tracing::info!(
+                "Remote diarization meeting mode: requesting speaker-diarized segments from the remote server; dictation path unchanged"
+            );
+            cfg.whisper.remote_diarize = true;
+        }
         cfg
+    }
+
+    /// True when meeting-mode transcription should ask the remote server for
+    /// speaker-diarized segments instead of running a local diarizer: the
+    /// meeting diarization backend is `"remote"`, diarization is enabled, and
+    /// the active engine is Whisper in remote mode (the only transcriber that
+    /// speaks the voxtype-cloud diarization extension).
+    ///
+    /// The dictation path reads the raw config and never sets
+    /// `whisper.remote_diarize`, so this only affects meetings.
+    pub fn cloud_diarization_active(&self) -> bool {
+        self.meeting.diarization.enabled
+            && self.meeting.diarization.backend == "remote"
+            && matches!(self.engine, TranscriptionEngine::Whisper)
+            && matches!(
+                self.whisper.effective_mode(),
+                crate::config::WhisperMode::Remote
+            )
     }
 
     /// System-wide config path used as a fallback when no user config exists.
@@ -480,6 +504,79 @@ mod tests {
     use super::super::hotkey::default_hotkey_key;
     use super::super::{ActivationMode, OutputMode};
     use super::*;
+
+    /// Config with the full remote-diarization gate satisfied: whisper engine
+    /// in remote mode, meeting diarization enabled with backend "remote".
+    fn remote_diarization_config() -> Config {
+        let mut cfg = Config {
+            engine: TranscriptionEngine::Whisper,
+            whisper: WhisperConfig {
+                mode: Some(crate::config::WhisperMode::Remote),
+                remote_endpoint: Some("https://api.voxtype.io".into()),
+                ..WhisperConfig::default()
+            },
+            ..Config::default()
+        };
+        cfg.meeting.diarization.enabled = true;
+        cfg.meeting.diarization.backend = "remote".into();
+        cfg
+    }
+
+    #[test]
+    fn meeting_mode_sets_remote_diarize_when_gate_satisfied() {
+        let cfg = remote_diarization_config();
+        assert!(cfg.cloud_diarization_active());
+        let meeting_cfg = cfg.with_meeting_mode_overrides();
+        assert!(meeting_cfg.whisper.remote_diarize);
+        // Original config untouched — dictation never diarizes.
+        assert!(!cfg.whisper.remote_diarize);
+    }
+
+    #[test]
+    fn remote_diarize_not_set_without_remote_backend() {
+        let mut cfg = remote_diarization_config();
+        cfg.meeting.diarization.backend = "simple".into();
+        assert!(!cfg.cloud_diarization_active());
+        assert!(!cfg.with_meeting_mode_overrides().whisper.remote_diarize);
+    }
+
+    #[test]
+    fn remote_diarize_not_set_when_diarization_disabled() {
+        let mut cfg = remote_diarization_config();
+        cfg.meeting.diarization.enabled = false;
+        assert!(!cfg.cloud_diarization_active());
+        assert!(!cfg.with_meeting_mode_overrides().whisper.remote_diarize);
+    }
+
+    #[test]
+    fn remote_diarize_not_set_for_non_whisper_engine() {
+        let mut cfg = remote_diarization_config();
+        cfg.engine = TranscriptionEngine::Soniox;
+        assert!(!cfg.cloud_diarization_active());
+        assert!(!cfg.with_meeting_mode_overrides().whisper.remote_diarize);
+    }
+
+    #[test]
+    fn remote_diarize_not_set_for_local_whisper_mode() {
+        let mut cfg = remote_diarization_config();
+        cfg.whisper.mode = Some(crate::config::WhisperMode::Local);
+        assert!(!cfg.cloud_diarization_active());
+        assert!(!cfg.with_meeting_mode_overrides().whisper.remote_diarize);
+    }
+
+    #[test]
+    fn remote_diarize_defaults_false_and_old_toml_parses() {
+        // Backwards compatibility: configs written before remote_diarize
+        // existed must parse, with the flag off.
+        let toml_str = r#"
+            engine = "whisper"
+            [whisper]
+            mode = "remote"
+            remote_endpoint = "http://localhost:8080"
+        "#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert!(!cfg.whisper.remote_diarize);
+    }
 
     #[test]
     fn meeting_mode_forces_soniox_async_when_user_had_realtime() {

--- a/src/config/whisper.rs
+++ b/src/config/whisper.rs
@@ -209,6 +209,14 @@ pub struct WhisperConfig {
     #[serde(default)]
     pub remote_timeout_secs: Option<u64>,
 
+    /// Request speaker-diarized segments from the remote server (voxtype-cloud
+    /// extension to the OpenAI transcription API). Not a user-facing knob:
+    /// `Config::with_meeting_mode_overrides()` sets this for meeting-mode
+    /// transcription when `[meeting.diarization] backend = "remote"`. Plain
+    /// OpenAI servers ignore the extra field and voxtype degrades gracefully.
+    #[serde(default, skip_serializing)]
+    pub remote_diarize: bool,
+
     /// Send an explicit `language=auto` field when language = "auto" (default: false)
     /// OpenAI-compatible endpoints treat a missing language field as auto-detect
     /// (and reject non-ISO-639-1 values like "auto"), but whisper.cpp's server
@@ -288,6 +296,7 @@ impl Default for WhisperConfig {
             remote_model: None,
             remote_api_key: None,
             remote_timeout_secs: None,
+            remote_diarize: false,
             remote_send_auto_language: false,
             whisper_cli_path: None,
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1835,10 +1835,18 @@ impl Daemon {
             return Ok(());
         }
 
-        // CLI override (validated against ["simple", "ml"] by clap) wins over config.
+        // CLI override (validated against DIARIZATION_BACKENDS by clap) wins
+        // over config.
         let backend = diarization_override
             .clone()
             .unwrap_or_else(|| self.config.meeting.diarization.backend.clone());
+
+        // MeetingDaemon::new consults app_config.meeting.diarization.backend
+        // (via cloud_diarization_active / with_meeting_mode_overrides), so the
+        // CLI override must be visible there too, not just in the
+        // meeting-module DiarizationConfig built below.
+        let mut app_config = self.config.clone();
+        app_config.meeting.diarization.backend = backend.clone();
 
         // Create meeting config from main config
         tracing::debug!(
@@ -1886,7 +1894,7 @@ impl Daemon {
         self.meeting_event_rx = Some(rx);
 
         // Create meeting daemon
-        match MeetingDaemon::new(meeting_config, &self.config, tx) {
+        match MeetingDaemon::new(meeting_config, &app_config, tx) {
             Ok(mut daemon) => {
                 match daemon.start(title).await {
                     Ok(meeting_id) => {

--- a/src/meeting/chunk.rs
+++ b/src/meeting/chunk.rs
@@ -314,6 +314,20 @@ impl ChunkProcessor {
             );
             segment.source = source;
 
+            // Engines with built-in diarization (remote voxtype-cloud) tag
+            // segments with a speaker index. The echo-cancelled mic channel is
+            // always the local user (same rule as the simple diarizer);
+            // loopback speakers surface as SPEAKER_NN, matching
+            // SpeakerId::Auto rendering so `voxtype meeting label` works
+            // unchanged. When a local diarizer is active it overwrites these.
+            if let Some(speaker) = timed.speaker {
+                segment.speaker_id = Some(match source {
+                    AudioSource::Microphone => "You".to_string(),
+                    _ => format!("SPEAKER_{:02}", speaker),
+                });
+                segment.confidence = timed.confidence;
+            }
+
             segments.push(segment);
         }
 
@@ -401,6 +415,82 @@ mod tests {
         let (start, end) = segments[0];
         assert!(start > 0);
         assert!(end < samples.len());
+    }
+
+    /// Stub transcriber returning fixed speaker-tagged segments, standing in
+    /// for a remote voxtype-cloud server with diarization enabled.
+    struct SpeakerStubTranscriber {
+        segments: Vec<crate::transcribe::TimedSegment>,
+    }
+
+    impl Transcriber for SpeakerStubTranscriber {
+        fn transcribe(&self, _samples: &[f32]) -> Result<String, TranscribeError> {
+            Ok(self
+                .segments
+                .iter()
+                .map(|s| s.text.clone())
+                .collect::<Vec<_>>()
+                .join(" "))
+        }
+
+        fn transcribe_timed(
+            &self,
+            _samples: &[f32],
+        ) -> Result<Vec<crate::transcribe::TimedSegment>, TranscribeError> {
+            Ok(self.segments.clone())
+        }
+    }
+
+    fn speaker_segment(text: &str, speaker: Option<u32>) -> crate::transcribe::TimedSegment {
+        crate::transcribe::TimedSegment {
+            text: text.to_string(),
+            start_secs: 0.0,
+            end_secs: 1.0,
+            speaker,
+            confidence: speaker.map(|_| 0.9),
+        }
+    }
+
+    fn process_with_stub(
+        source: AudioSource,
+        segments: Vec<crate::transcribe::TimedSegment>,
+    ) -> ProcessedChunk {
+        let transcriber = std::sync::Arc::new(SpeakerStubTranscriber { segments });
+        let mut processor = ChunkProcessor::new(ChunkConfig::default(), transcriber);
+        let mut buffer = processor.new_buffer(0, source, 0);
+        buffer.add_samples(&create_test_samples(2.0, 440.0, 0.5));
+        processor.process_chunk(buffer).unwrap()
+    }
+
+    #[test]
+    fn test_speaker_hint_loopback_maps_to_speaker_nn() {
+        let result = process_with_stub(
+            AudioSource::Loopback,
+            vec![
+                speaker_segment("hello", Some(0)),
+                speaker_segment("hi there", Some(1)),
+            ],
+        );
+        assert_eq!(result.segments.len(), 2);
+        assert_eq!(result.segments[0].speaker_id.as_deref(), Some("SPEAKER_00"));
+        assert_eq!(result.segments[1].speaker_id.as_deref(), Some("SPEAKER_01"));
+        assert_eq!(result.segments[0].confidence, Some(0.9));
+    }
+
+    #[test]
+    fn test_speaker_hint_microphone_is_always_you() {
+        let result = process_with_stub(
+            AudioSource::Microphone,
+            vec![speaker_segment("hello", Some(3))],
+        );
+        assert_eq!(result.segments[0].speaker_id.as_deref(), Some("You"));
+    }
+
+    #[test]
+    fn test_no_speaker_hint_leaves_speaker_id_unset() {
+        let result = process_with_stub(AudioSource::Loopback, vec![speaker_segment("hello", None)]);
+        assert_eq!(result.segments[0].speaker_id, None);
+        assert_eq!(result.segments[0].confidence, None);
     }
 
     #[test]

--- a/src/meeting/mod.rs
+++ b/src/meeting/mod.rs
@@ -144,14 +144,33 @@ impl MeetingDaemon {
             PostProcessor::new(cfg)
         });
 
-        // Create diarizer if configured
+        // Create diarizer if configured. The "remote" backend runs no local
+        // diarizer at all: speaker labels arrive embedded in the transcriber's
+        // segments (with_meeting_mode_overrides sets whisper.remote_diarize),
+        // and running a local diarizer would overwrite them in
+        // process_chunk_with_source.
         let diarizer = config.diarization.as_ref().and_then(|diar_config| {
-            if diar_config.enabled {
+            if !diar_config.enabled {
+                None
+            } else if diar_config.backend == "remote" {
+                if app_config.cloud_diarization_active() {
+                    tracing::info!(
+                        "Meeting diarization enabled: remote (speaker labels come from the remote transcription server)"
+                    );
+                    None
+                } else {
+                    tracing::warn!(
+                        "diarization backend \"remote\" requires engine = \"whisper\" with mode = \"remote\"; \
+                         falling back to the simple diarizer"
+                    );
+                    let mut simple_config = diar_config.clone();
+                    simple_config.backend = "simple".to_string();
+                    Some(diarization::create_diarizer(&simple_config))
+                }
+            } else {
                 let d = diarization::create_diarizer(diar_config);
                 tracing::info!("Meeting diarization enabled: {}", d.name());
                 Some(d)
-            } else {
-                None
             }
         });
 

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -95,6 +95,12 @@ pub struct TimedSegment {
     pub start_secs: f32,
     /// End time in seconds relative to the audio input
     pub end_secs: f32,
+    /// Request-local speaker index from engines with built-in diarization
+    /// (e.g. a voxtype-cloud server returning per-turn speakers). `None` for
+    /// engines without speaker awareness.
+    pub speaker: Option<u32>,
+    /// Engine-reported confidence for this segment, when available.
+    pub confidence: Option<f32>,
 }
 
 /// Trait for speech-to-text implementations
@@ -115,6 +121,8 @@ pub trait Transcriber: Send + Sync {
                 text,
                 start_secs: 0.0,
                 end_secs: duration,
+                speaker: None,
+                confidence: None,
             }])
         }
     }

--- a/src/transcribe/parakeet.rs
+++ b/src/transcribe/parakeet.rs
@@ -270,6 +270,8 @@ impl Transcriber for ParakeetTranscriber {
                 text: sentence.clone(),
                 start_secs,
                 end_secs,
+                speaker: None,
+                confidence: None,
             });
 
             token_idx = end_token_idx;

--- a/src/transcribe/remote.rs
+++ b/src/transcribe/remote.rs
@@ -30,6 +30,9 @@ pub struct RemoteTranscriber {
     initial_prompt: Option<String>,
     /// Send an explicit `language=auto` field instead of omitting it
     send_auto_language: bool,
+    /// Request speaker-diarized segments (voxtype-cloud extension). Set via
+    /// `Config::with_meeting_mode_overrides()` for meeting transcription only.
+    diarize: bool,
     /// Request timeout
     timeout: Duration,
 }
@@ -109,6 +112,7 @@ impl RemoteTranscriber {
             api_key,
             initial_prompt,
             send_auto_language: config.remote_send_auto_language,
+            diarize: config.remote_diarize,
             timeout,
         })
     }
@@ -189,15 +193,103 @@ impl RemoteTranscriber {
             body.extend_from_slice(b"\r\n");
         }
 
-        // Add response_format field
+        // Add response_format field. Diarization needs the segment-carrying
+        // verbose_json shape; the plain path keeps requesting json.
         body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
         body.extend_from_slice(b"Content-Disposition: form-data; name=\"response_format\"\r\n\r\n");
-        body.extend_from_slice(b"json\r\n");
+        if self.diarize {
+            body.extend_from_slice(b"verbose_json\r\n");
+        } else {
+            body.extend_from_slice(b"json\r\n");
+        }
+
+        // Add diarize field (voxtype-cloud extension; plain OpenAI servers
+        // ignore unknown form fields)
+        if self.diarize {
+            body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+            body.extend_from_slice(b"Content-Disposition: form-data; name=\"diarize\"\r\n\r\n");
+            body.extend_from_slice(b"true\r\n");
+        }
 
         // End boundary
         body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
 
         (boundary, body)
+    }
+
+    /// Send one transcription request and return the parsed JSON response.
+    fn request_json(&self, samples: &[f32]) -> Result<serde_json::Value, TranscribeError> {
+        let wav_data = self.encode_wav(samples)?;
+        tracing::debug!("Encoded WAV: {} bytes", wav_data.len());
+
+        let (boundary, body) = self.build_multipart_body(&wav_data);
+
+        // Determine the API path based on whether we're doing transcription or translation
+        let path = if self.translate {
+            "/v1/audio/translations"
+        } else {
+            "/v1/audio/transcriptions"
+        };
+
+        let url = format!("{}{}", self.endpoint.trim_end_matches('/'), path);
+
+        let mut request = ureq::post(&url).timeout(self.timeout).set(
+            "Content-Type",
+            &format!("multipart/form-data; boundary={}", boundary),
+        );
+
+        if let Some(ref key) = self.api_key {
+            request = request.set("Authorization", &format!("Bearer {}", key));
+        }
+
+        let response = request.send_bytes(&body).map_err(|e| match e {
+            ureq::Error::Status(code, resp) => {
+                let body = resp.into_string().unwrap_or_default();
+                TranscribeError::RemoteError(format!("Server returned {}: {}", code, body))
+            }
+            ureq::Error::Transport(t) => {
+                TranscribeError::NetworkError(format!("Request failed: {}", t))
+            }
+        })?;
+
+        response
+            .into_json()
+            .map_err(|e| TranscribeError::RemoteError(format!("Failed to parse response: {}", e)))
+    }
+}
+
+/// Parse a verbose_json `segments` array (with the voxtype-cloud
+/// `speaker`/`confidence` extensions) into [`TimedSegment`]s. Returns `None`
+/// when the response has no usable segments array, so callers can degrade to
+/// the whole-buffer single segment.
+fn parse_diarized_segments(json: &serde_json::Value) -> Option<Vec<super::TimedSegment>> {
+    let segments = json.get("segments")?.as_array()?;
+    let parsed: Vec<super::TimedSegment> = segments
+        .iter()
+        .filter_map(|seg| {
+            let text = seg.get("text")?.as_str()?.trim().to_string();
+            if text.is_empty() {
+                return None;
+            }
+            Some(super::TimedSegment {
+                text,
+                start_secs: seg.get("start").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32,
+                end_secs: seg.get("end").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32,
+                speaker: seg
+                    .get("speaker")
+                    .and_then(|v| v.as_u64())
+                    .map(|s| s as u32),
+                confidence: seg
+                    .get("confidence")
+                    .and_then(|v| v.as_f64())
+                    .map(|c| c as f32),
+            })
+        })
+        .collect();
+    if parsed.is_empty() {
+        None
+    } else {
+        Some(parsed)
     }
 }
 
@@ -216,48 +308,7 @@ impl Transcriber for RemoteTranscriber {
 
         let start = std::time::Instant::now();
 
-        // Encode audio to WAV
-        let wav_data = self.encode_wav(samples)?;
-        tracing::debug!("Encoded WAV: {} bytes", wav_data.len());
-
-        // Build multipart form
-        let (boundary, body) = self.build_multipart_body(&wav_data);
-
-        // Determine the API path based on whether we're doing transcription or translation
-        let path = if self.translate {
-            "/v1/audio/translations"
-        } else {
-            "/v1/audio/transcriptions"
-        };
-
-        let url = format!("{}{}", self.endpoint.trim_end_matches('/'), path);
-
-        // Build request
-        let mut request = ureq::post(&url).timeout(self.timeout).set(
-            "Content-Type",
-            &format!("multipart/form-data; boundary={}", boundary),
-        );
-
-        // Add authorization if API key is configured
-        if let Some(ref key) = self.api_key {
-            request = request.set("Authorization", &format!("Bearer {}", key));
-        }
-
-        // Send request
-        let response = request.send_bytes(&body).map_err(|e| match e {
-            ureq::Error::Status(code, resp) => {
-                let body = resp.into_string().unwrap_or_default();
-                TranscribeError::RemoteError(format!("Server returned {}: {}", code, body))
-            }
-            ureq::Error::Transport(t) => {
-                TranscribeError::NetworkError(format!("Request failed: {}", t))
-            }
-        })?;
-
-        // Parse JSON response
-        let json: serde_json::Value = response.into_json().map_err(|e| {
-            TranscribeError::RemoteError(format!("Failed to parse response: {}", e))
-        })?;
+        let json = self.request_json(samples)?;
 
         // Extract text from response
         let text = json
@@ -280,6 +331,81 @@ impl Transcriber for RemoteTranscriber {
         );
 
         Ok(text)
+    }
+
+    /// With `remote_diarize` set (meeting mode against a voxtype-cloud
+    /// server), parse the verbose_json `segments` array into speaker-tagged
+    /// timed segments. Without the flag — or when the server returns no
+    /// segments (an older Worker, or a plain OpenAI server that ignored the
+    /// extension field) — degrade to the whole-buffer single segment.
+    fn transcribe_timed(
+        &self,
+        samples: &[f32],
+    ) -> Result<Vec<super::TimedSegment>, TranscribeError> {
+        if !self.diarize {
+            // Same behavior as the trait's default implementation.
+            let text = self.transcribe(samples)?;
+            let duration = samples.len() as f32 / 16000.0;
+            return Ok(if text.is_empty() {
+                vec![]
+            } else {
+                vec![super::TimedSegment {
+                    text,
+                    start_secs: 0.0,
+                    end_secs: duration,
+                    speaker: None,
+                    confidence: None,
+                }]
+            });
+        }
+
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat("Empty audio buffer".into()));
+        }
+
+        let start = std::time::Instant::now();
+        let json = self.request_json(samples)?;
+
+        if let Some(segments) = parse_diarized_segments(&json) {
+            tracing::info!(
+                "Remote diarized transcription completed in {:.2}s: {} segments, {} speakers",
+                start.elapsed().as_secs_f32(),
+                segments.len(),
+                {
+                    let mut speakers: Vec<u32> =
+                        segments.iter().filter_map(|s| s.speaker).collect();
+                    speakers.sort_unstable();
+                    speakers.dedup();
+                    speakers.len()
+                }
+            );
+            return Ok(segments);
+        }
+
+        // No segments: degrade like the default implementation, from the text
+        // already present in this response.
+        tracing::warn!(
+            "Remote server returned no diarized segments; falling back to a single segment \
+             (server may not support the voxtype-cloud diarize extension)"
+        );
+        let text = json
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let duration = samples.len() as f32 / 16000.0;
+        Ok(if text.is_empty() {
+            vec![]
+        } else {
+            vec![super::TimedSegment {
+                text,
+                start_secs: 0.0,
+                end_secs: duration,
+                speaker: None,
+                confidence: None,
+            }]
+        })
     }
 }
 
@@ -503,6 +629,90 @@ mod tests {
             "/v1/audio/transcriptions"
         };
         assert_eq!(path, "/v1/audio/translations");
+    }
+
+    #[test]
+    fn test_multipart_body_plain_has_no_diarize_and_json_format() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        let (_boundary, body) = transcriber.build_multipart_body(&[0u8; 100]);
+        let body_str = String::from_utf8_lossy(&body);
+
+        assert!(!body_str.contains("name=\"diarize\""));
+        assert!(body_str.contains("name=\"response_format\"\r\n\r\njson\r\n"));
+    }
+
+    #[test]
+    fn test_multipart_body_diarize_requests_verbose_json() {
+        let config = WhisperConfig {
+            mode: Some(crate::config::WhisperMode::Remote),
+            remote_endpoint: Some("http://localhost:8080".to_string()),
+            remote_diarize: true,
+            ..Default::default()
+        };
+
+        let transcriber = RemoteTranscriber::new(&config).unwrap();
+        let (_boundary, body) = transcriber.build_multipart_body(&[0u8; 100]);
+        let body_str = String::from_utf8_lossy(&body);
+
+        assert!(body_str.contains("name=\"diarize\"\r\n\r\ntrue\r\n"));
+        assert!(body_str.contains("name=\"response_format\"\r\n\r\nverbose_json\r\n"));
+    }
+
+    #[test]
+    fn test_parse_diarized_segments() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "text": "Hello there. Hi.",
+                "segments": [
+                    {"id": 0, "start": 0.2, "end": 1.5, "text": "Hello there.", "speaker": 0, "confidence": 0.98},
+                    {"id": 1, "start": 2.0, "end": 2.6, "text": "Hi.", "speaker": 1, "confidence": 0.91}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let segments = parse_diarized_segments(&json).unwrap();
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].text, "Hello there.");
+        assert_eq!(segments[0].speaker, Some(0));
+        assert!((segments[0].start_secs - 0.2).abs() < 1e-6);
+        assert!((segments[0].confidence.unwrap() - 0.98).abs() < 1e-6);
+        assert_eq!(segments[1].speaker, Some(1));
+    }
+
+    #[test]
+    fn test_parse_diarized_segments_without_speaker_fields() {
+        // A plain OpenAI verbose_json response: segments without the
+        // voxtype-cloud speaker extension still parse, with speaker = None.
+        let json: serde_json::Value =
+            serde_json::from_str(r#"{"segments": [{"start": 0.0, "end": 1.0, "text": "Hello."}]}"#)
+                .unwrap();
+
+        let segments = parse_diarized_segments(&json).unwrap();
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].speaker, None);
+        assert_eq!(segments[0].confidence, None);
+    }
+
+    #[test]
+    fn test_parse_diarized_segments_absent_or_empty_is_none() {
+        let no_segments: serde_json::Value = serde_json::from_str(r#"{"text": "hello"}"#).unwrap();
+        assert!(parse_diarized_segments(&no_segments).is_none());
+
+        let empty: serde_json::Value =
+            serde_json::from_str(r#"{"text": "hello", "segments": []}"#).unwrap();
+        assert!(parse_diarized_segments(&empty).is_none());
+
+        let whitespace_only: serde_json::Value =
+            serde_json::from_str(r#"{"segments": [{"start": 0.0, "end": 1.0, "text": "  "}]}"#)
+                .unwrap();
+        assert!(parse_diarized_segments(&whitespace_only).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Pilot for a hosted Voxtype Cloud offering and the protocol seed for #244.

## What's in here

**`cloud/` — a Cloudflare Worker (new wrangler project)** implementing an OpenAI-compatible `POST /v1/audio/transcriptions` (`json` | `verbose_json`) backed by Deepgram Nova-3 on Workers AI, plus `GET /v1/models`. One documented voxtype extension: a `diarize=true` form field returns per-speaker-turn segments (`speaker`/`confidence` on segments and words in `verbose_json`). `whisper*` model names route to whisper-large-v3-turbo (1/10 the price, no diarization). Single-key Bearer auth with constant-time compare; the key-lookup seam is ready for per-user keys. `/v1/chat/completions` and `/v1/realtime` are reserved routes. Audio/transcripts are never logged.

**Client — remote meeting diarization.** `[meeting.diarization] backend = "remote"` (config or `voxtype meeting start --diarization remote`) makes meetings request speaker-diarized segments from the remote whisper server: `with_meeting_mode_overrides()` sets an internal `whisper.remote_diarize` flag, `RemoteTranscriber` gains a `transcribe_timed()` override parsing `segments[]` (graceful degrade against plain OpenAI servers), `TimedSegment` gains optional `speaker`/`confidence`, and `ChunkProcessor` maps them to `speaker_id` (mic → "You", loopback → `SPEAKER_NN`, so `meeting label` and the integer-keyed labels table work unchanged). No local diarizer runs when the gate is satisfied. Dictation is untouched — plain remote mode against the Worker already works with zero client changes (verified with the stock 1.0.0 binary).

## Verified

- Worker: 14 vitest tests (turn grouping, fixture parsing, REST-fallback request shape, error hints); curl matrix against the deployed Worker (auth 401, missing file 400, bad format 400, models list, whisper json transcription, nova-3 502-with-hint).
- Client: `cargo test` (1,075 lib tests incl. 14 new), `clippy -D warnings`, `fmt`. Old TOML without the new field parses; the flag defaults off.
- E2E: stock installed voxtype 1.0.0 **and** this branch's binary both transcribe through the deployed Worker (`--engine whisper --whisper-mode remote`), ~2 s round trip on 15 s audio.

## Upstream blockers (documented, not ours)

1. **Workers AI binding rejects nova-3 audio input** (cloudflare/workerd#5082) — every body encoding fails with error 5006. The Worker falls back to the documented REST path (verified live) when a `CLOUDFLARE_API_TOKEN` secret (Workers AI Run scope) is set; the binding takes over automatically when fixed.
2. **Nova-3 diarization on Workers AI tags every word speaker 0**, including on Deepgram's own two-speaker demo files (`diarize=true` demonstrably engages — speaker fields appear only with it). Until Cloudflare fixes the hosted model, cloud diarization returns a single speaker; the whole pipeline is in place and needs no changes when it's fixed.

## Known pilot limitations

Chunk-local speaker numbering (1:1 calls fully stable; raise `chunk_duration_secs` for multi-party), `prompt` ignored by the Worker, batch only, single shared API key, no retry on failed chunks. The privacy shift (audio leaves the machine) is called out in CONFIGURATION.md, USER_MANUAL.md, and TROUBLESHOOTING.md.