### PR TITLE
hotkey: min_hold_ms, discard sub-threshold push-to-talk taps

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -177,6 +177,34 @@ key = "SCROLLLOCK"
 mode = "toggle"  # Press to start, press again to stop
 ```
 
+### min_hold_ms
+
+**Type:** Integer (milliseconds)
+**Default:** `0` (every release transcribes)
+**Required:** No
+
+Minimum hold time for a push-to-talk press to count as dictation. When the
+hotkey is released before this duration, the recording is discarded instead
+of transcribed, so accidental short taps of the hotkey produce no transcript
+and no output. (Streaming/eager engines may still have shipped audio while
+the key was held; the tap only suppresses the result.) A too-short tap never
+aborts an in-flight transcription of a previous dictation, unlike the cancel
+key. Only applies in `push_to_talk` mode; in `toggle` mode a short press is
+the intended start action and the setting is ignored. Like the other evdev
+hotkey options, this only applies when using evdev hotkey detection (Linux);
+the macOS listener always treats a release as a transcription trigger.
+
+Useful when the hotkey is a key that also gets tapped incidentally, e.g. a
+repurposed CapsLock (paired with an xkb option like `caps:none`) or a shared
+modifier key.
+
+**Example:**
+```toml
+[hotkey]
+key = "CAPSLOCK"
+min_hold_ms = 1500  # taps shorter than 1.5s are discarded
+```
+
 ### enabled
 
 **Type:** Boolean

--- a/src/config/hotkey.rs
+++ b/src/config/hotkey.rs
@@ -34,6 +34,15 @@ pub struct HotkeyConfig {
     #[serde(default)]
     pub mode: ActivationMode,
 
+    /// Minimum hold time in milliseconds for a push-to-talk press to count as
+    /// dictation. Releasing the hotkey earlier sends a TooShort (discard)
+    /// instead of a Released, so the recording is discarded rather than
+    /// transcribed: short accidental taps of the hotkey produce no text. Only
+    /// applies in push_to_talk mode. 0 (default) keeps the previous behavior
+    /// where every release transcribes.
+    #[serde(default)]
+    pub min_hold_ms: u64,
+
     /// Enable built-in hotkey detection (default: true)
     /// Set to false when using compositor keybindings (Hyprland, Sway) instead
     /// When disabled, use `voxtype record start/stop/toggle` to control recording
@@ -65,6 +74,7 @@ impl Default for HotkeyConfig {
             key: default_hotkey_key(),
             modifiers: Vec::new(),
             mode: ActivationMode::default(),
+            min_hold_ms: 0,
             enabled: true,
             cancel_key: None,
             model_modifier: None,
@@ -146,6 +156,53 @@ mod tests {
         assert!(config.audio.feedback.enabled);
         assert_eq!(config.audio.feedback.theme, "subtle");
         assert_eq!(config.audio.feedback.volume, 0.5);
+    }
+
+    #[test]
+    fn test_parse_min_hold_ms() {
+        let toml_str = r#"
+            [hotkey]
+            key = "CAPSLOCK"
+            min_hold_ms = 1500
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = "en"
+
+            [output]
+            mode = "type"
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.hotkey.min_hold_ms, 1500);
+    }
+
+    #[test]
+    fn test_min_hold_ms_defaults_to_zero() {
+        let toml_str = r#"
+            [hotkey]
+            key = "SCROLLLOCK"
+
+            [audio]
+            device = "default"
+            sample_rate = 16000
+            max_duration_secs = 60
+
+            [whisper]
+            model = "base.en"
+            language = "en"
+
+            [output]
+            mode = "type"
+        "#;
+
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.hotkey.min_hold_ms, 0);
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -782,6 +782,15 @@ pub const CONFIG_KEYS: &[KeySpec] = &[
         "push_to_talk records while the key is held; toggle starts and stops on separate taps.",
     ),
     spec(
+        "hotkey.min_hold_ms",
+        "hotkey",
+        "min_hold_ms",
+        KeyType::Int { min: 0, max: 10_000 },
+        "Hotkey",
+        "Min hold time",
+        "Push-to-talk only: releases before this many milliseconds cancel the recording, so short accidental taps produce no text.",
+    ),
+    spec(
         "hotkey.cancel_key",
         "hotkey",
         "cancel_key",
@@ -1724,6 +1733,7 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
             ActivationMode::PushToTalk => "push_to_talk",
             ActivationMode::Toggle => "toggle",
         }),
+        "hotkey.min_hold_ms" => json!(cfg.hotkey.min_hold_ms),
         "hotkey.cancel_key" => opt_str(cfg.hotkey.cancel_key.as_ref()),
         "hotkey.model_modifier" => opt_str(cfg.hotkey.model_modifier.as_ref()),
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3697,9 +3697,21 @@ impl Daemon {
                             tracing::trace!("Ignoring HotkeyEvent::Released in toggle mode");
                         }
 
-                        // === CANCEL KEY (works in both modes) ===
-                        (HotkeyEvent::Cancel, _) => {
-                            tracing::debug!("Received HotkeyEvent::Cancel");
+                        // === CANCEL KEY (both modes) and min_hold tap ===
+                        // A too-short tap discards a recording like the cancel
+                        // key, but must NOT abort an in-flight transcription of
+                        // a previous dictation; the guard arm above swallows it.
+                        (HotkeyEvent::TooShort, _)
+                            if matches!(state, State::Transcribing { .. }) =>
+                        {
+                            tracing::trace!(
+                                "Too-short tap during transcription: ignored \
+                                 (does not abort the in-flight result)"
+                            );
+                        }
+
+                        (cancel_or_tap @ (HotkeyEvent::Cancel | HotkeyEvent::TooShort), _) => {
+                            tracing::debug!("Received hotkey event: {:?}", cancel_or_tap);
 
                             if state.is_streaming() {
                                 tracing::info!("Streaming cancelled via hotkey");

--- a/src/hotkey/evdev_listener.rs
+++ b/src/hotkey/evdev_listener.rs
@@ -33,6 +33,9 @@ pub struct EvdevListener {
     secondary_model: Option<String>,
     /// Modifier keys that activate named profiles for post-processing
     profile_modifiers: HashMap<Key, String>,
+    /// Minimum hold time before a release counts as dictation (push-to-talk
+    /// only); earlier releases send TooShort (discard) instead. Zero disables.
+    min_hold: Duration,
     /// Signal to stop the listener task
     stop_signal: Option<oneshot::Sender<()>>,
 }
@@ -93,6 +96,24 @@ impl EvdevListener {
         std::fs::read_dir("/dev/input")
             .map_err(|e| HotkeyError::DeviceAccess(format!("/dev/input: {}", e)))?;
 
+        // min_hold only makes sense in push-to-talk mode: in toggle mode a
+        // short press IS the intended action (start recording).
+        let min_hold = if config.mode == crate::config::ActivationMode::PushToTalk {
+            Duration::from_millis(config.min_hold_ms)
+        } else {
+            if config.min_hold_ms > 0 {
+                tracing::warn!("hotkey.min_hold_ms is ignored in toggle mode");
+            }
+            Duration::ZERO
+        };
+        if !min_hold.is_zero() {
+            tracing::info!(
+                "Hotkey releases before {:?} will cancel the recording (min_hold_ms = {})",
+                min_hold,
+                config.min_hold_ms
+            );
+        }
+
         Ok(Self {
             target_key,
             modifier_keys,
@@ -100,6 +121,7 @@ impl EvdevListener {
             model_modifier,
             secondary_model: None, // Set later via set_secondary_model
             profile_modifiers,
+            min_hold,
             stop_signal: None,
         })
     }
@@ -122,6 +144,7 @@ impl HotkeyListener for EvdevListener {
         let model_modifier = self.model_modifier;
         let secondary_model = self.secondary_model.clone();
         let profile_modifiers = self.profile_modifiers.clone();
+        let min_hold = self.min_hold;
 
         // Spawn the listener task
         tokio::task::spawn_blocking(move || {
@@ -132,6 +155,7 @@ impl HotkeyListener for EvdevListener {
                 model_modifier,
                 secondary_model,
                 profile_modifiers,
+                min_hold,
                 tx,
                 stop_rx,
             ) {
@@ -440,6 +464,22 @@ fn reset_for_device_change(
     was_pressed.then_some(HotkeyEvent::Released)
 }
 
+/// Decide what a hotkey release means given how long it was held.
+///
+/// Held for at least `min_hold` (or `min_hold` disabled): a normal release,
+/// transcribe. Shorter: the press was not dictation intent, so the daemon
+/// should discard the recording (if any) without aborting an in-flight
+/// transcription of a previous dictation (hence TooShort, not Cancel).
+/// Exactly `min_hold` counts as long enough: the doc promises cancellation
+/// only for releases *before* the duration.
+fn release_event_for(held_for: Duration, min_hold: Duration) -> HotkeyEvent {
+    if held_for < min_hold {
+        HotkeyEvent::TooShort
+    } else {
+        HotkeyEvent::Released
+    }
+}
+
 /// Main listener loop running in a blocking task
 #[allow(clippy::too_many_arguments)]
 fn evdev_listener_loop(
@@ -449,6 +489,7 @@ fn evdev_listener_loop(
     model_modifier: Option<Key>,
     secondary_model: Option<String>,
     profile_modifiers: HashMap<Key, String>,
+    min_hold: Duration,
     tx: mpsc::Sender<HotkeyEvent>,
     mut stop_rx: oneshot::Receiver<()>,
 ) -> Result<(), HotkeyError> {
@@ -466,6 +507,9 @@ fn evdev_listener_loop(
 
     // Track if we're currently "pressed" (to handle repeat events)
     let mut is_pressed = false;
+
+    // When the current press started (for min_hold tap filtering)
+    let mut pressed_at: Option<Instant> = None;
 
     if let Some(cancel) = cancel_key {
         tracing::info!(
@@ -506,6 +550,7 @@ fn evdev_listener_loop(
 
         // Check inotify for device changes
         if manager.check_for_device_changes() {
+            pressed_at = None; // keep the invariant explicit beside is_pressed
             if let Some(event) = reset_for_device_change(
                 &mut is_pressed,
                 &mut active_modifiers,
@@ -533,6 +578,7 @@ fn evdev_listener_loop(
                 held_profile_modifiers.clear();
                 last_pressed_profile = None;
                 is_pressed = false;
+                pressed_at = None;
                 tracing::debug!("Stale devices removed during validation");
             }
             manager.last_validation = Instant::now();
@@ -613,6 +659,7 @@ fn evdev_listener_loop(
                         1 if !is_pressed => {
                             // Key press (not repeat)
                             is_pressed = true;
+                            pressed_at = Some(Instant::now());
 
                             // Determine model override based on model_modifier state
                             let model_override = if model_modifier_held {
@@ -648,8 +695,13 @@ fn evdev_listener_loop(
                         0 if is_pressed => {
                             // Key release
                             is_pressed = false;
-                            tracing::debug!("Hotkey released");
-                            if tx.blocking_send(HotkeyEvent::Released).is_err() {
+                            let held_for = pressed_at
+                                .take()
+                                .map(|at| at.elapsed())
+                                .unwrap_or(Duration::ZERO);
+                            let event = release_event_for(held_for, min_hold);
+                            tracing::debug!("Hotkey released after {:?}: {:?}", held_for, event);
+                            if tx.blocking_send(event).is_err() {
                                 return Ok(()); // Channel closed
                             }
                         }
@@ -874,6 +926,39 @@ fn fd_is_hung_up(fd: RawFd) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn release_before_min_hold_is_too_short() {
+        assert_eq!(
+            release_event_for(Duration::from_millis(400), Duration::from_millis(1500)),
+            HotkeyEvent::TooShort
+        );
+    }
+
+    #[test]
+    fn release_at_exactly_min_hold_transcribes() {
+        // The doc promises cancellation only for releases BEFORE the duration.
+        assert_eq!(
+            release_event_for(Duration::from_millis(1500), Duration::from_millis(1500)),
+            HotkeyEvent::Released
+        );
+    }
+
+    #[test]
+    fn release_after_min_hold_transcribes() {
+        assert_eq!(
+            release_event_for(Duration::from_secs(4), Duration::from_millis(1500)),
+            HotkeyEvent::Released
+        );
+    }
+
+    #[test]
+    fn min_hold_disabled_keeps_previous_behavior() {
+        assert_eq!(
+            release_event_for(Duration::from_millis(1), Duration::ZERO),
+            HotkeyEvent::Released
+        );
+    }
 
     /// #556: a device change while the hotkey is held must synthesize a
     /// release. Without it the real key-up is dropped by the `0 if is_pressed`

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -24,6 +24,10 @@ pub enum HotkeyEvent {
     },
     /// The hotkey was released
     Released,
+    /// The hotkey was released before min_hold_ms elapsed: discard the
+    /// recording (if any), but do NOT abort an in-flight transcription the
+    /// way the cancel key does.
+    TooShort,
     /// The cancel key was pressed (abort recording/transcription)
     Cancel,
 }


### PR DESCRIPTION
## What

Two changes in the evdev hotkey listener:

1. New optional `[hotkey] min_hold_ms` (default 0, behavior unchanged). In push_to_talk mode, releasing the hotkey before the threshold sends a new `HotkeyEvent::TooShort` and the daemon discards the recording instead of transcribing it. A short tap never aborts an in-flight transcription of a previous dictation; only the cancel key does that.

2. After any input device change (inotify CREATE or DELETE on /dev/input), the listener now closes and reopens ALL keyboards instead of just enumerating new ones. Re-enumeration alone left the same fds in place, and after a uinput device was created or destroyed in rapid succession, an existing keyboard fd could go stale: technically open, poll() reported it readable, but fetch_events() silently stopped delivering key events. The daemon logged "Listening for hotkey" and "N keyboard(s) active" while deaf, and only a full restart recovered.

## Why

I use a repurposed CapsLock as my push-to-talk hotkey (paired with the xkb `caps:none` option) on a ThinkPad that has no Scroll Lock and no F13 and up. Without a threshold, every accidental tap runs a full recording cycle and sends a request to the transcription backend, which in a remote setup means a wasted round trip and typed garbage at the cursor.

The deaf-listener problem showed up in production: after ydotoold restarted (creating and destroying its uinput virtual keyboard), the AT keyboard's fd went stale and every subsequent keypress was silently ignored. The daemon reported it was listening, the state file said "idle", but no key event ever reached the hotkey logic.

## How

### min_hold_ms

- `release_event_for(held_for, min_hold)` classifies each release. Below the threshold it returns `TooShort`, at or above it returns `Released`. Unit tests cover both sides of the boundary and the disabled case.
- In the daemon, `TooShort` shares the cancel key's discard path for the recording and streaming states through a merged arm. A guard arm in front of it swallows `TooShort` while a previous dictation is still transcribing, which is the one place the two events must differ.
- Toggle mode ignores the setting, since a short press there is the intended start action, and logs a warning when it is set to a nonzero value.
- The key is registered in the config schema (`spec` plus `resolve`), so `voxtype config set/unset/get` and the JSON schema pick it up and the existing invariant tests cover the round trip. CONFIGURATION.md documents it next to `mode`, with the evdev-only scope noted since the macOS listener always treats a release as a transcription trigger.

### Device-change re-attach

- `handle_device_changes()` now clears the device map (dropping all open fds) before calling `enumerate_devices()`, so every keyboard is opened fresh after any topology change.
- `reset_for_device_change()` (the #556 synthetic-release path) is unchanged: it still emits a `Released` if the hotkey was held when devices changed, preserving that fix.
- The injection-keyboard skip (#445) is also unchanged: ydotoold's virtual device is still filtered out during re-enumeration.

## Compatibility

- `min_hold_ms` is a plain `u64` with `#[serde(default)]` and the config structs do not use `deny_unknown_fields`, so older binaries ignore the key and new binaries default it to 0.
- The device-change re-attach change is internal to `handle_device_changes()` and `reset_for_device_change()`; no API changes outside the listener module.
- All 1067 lib tests pass with the change.
