### PR TITLE
fix: fall back to CPU when the GPU cannot serve a transcription

### DIFF
--- a/src/transcribe/whisper.rs
+++ b/src/transcribe/whisper.rs
@@ -18,6 +18,37 @@ use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextPar
 pub struct WhisperTranscriber {
     /// Whisper context (holds the model)
     ctx: WhisperContext,
+    /// CPU fallback context, built lazily on the first GPU failure.
+    ///
+    /// Why this exists: the GPU context holds the model persistently, but every
+    /// transcription re-creates a *state* (KV cache + compute buffers) and that
+    /// allocation can fail when another process has taken the VRAM. Measured on a
+    /// RTX 3070 Laptop (8 GiB) shared with a batch indexer:
+    ///
+    /// ```text
+    /// ggml_vulkan: Device memory allocation of size 18874368 failed.
+    /// ggml_vulkan: vk::Device::allocateMemory: ErrorOutOfDeviceMemory
+    /// whisper_kv_cache_init: failed to allocate memory for the kv cache
+    /// ERROR Transcription failed: Failed to create a new whisper context.
+    /// ```
+    ///
+    /// The model itself was still resident on the card — only the 18 MB of
+    /// per-transcription scratch could not be found. The user loses the sentence
+    /// they just spoke, which no amount of retrying afterwards can give back.
+    ///
+    /// `None` inside the mutex means "not built yet"; a build failure is not cached,
+    /// so a transient condition (page cache pressure while reading the model) does
+    /// not poison the fallback for the rest of the process lifetime.
+    ///
+    /// Cost when nothing ever fails: zero. Nothing is loaded until the first failure.
+    cpu_fallback: Mutex<Option<WhisperContext>>,
+    /// Model path, kept to build the CPU fallback without re-resolving.
+    model_path: PathBuf,
+    /// Flash attention setting, mirrored onto the fallback context.
+    flash_attention: bool,
+    /// Whether the primary context was asked to use a GPU. When false there is
+    /// nothing to fall back *from*, and the fallback is never attempted.
+    gpu_requested: bool,
     /// Language configuration (single, auto, or array)
     language: LanguageConfig,
     /// Whether to translate to English
@@ -68,6 +99,10 @@ impl WhisperTranscriber {
 
         Ok(Self {
             ctx,
+            cpu_fallback: Mutex::new(None),
+            model_path,
+            flash_attention: config.flash_attention,
+            gpu_requested: config.gpu_device.is_some(),
             language: config.language.clone(),
             translate: config.translate,
             threads,
@@ -144,13 +179,13 @@ impl WhisperTranscriber {
 
     fn run_full(
         &self,
+        ctx: &WhisperContext,
         samples: &[f32],
         selected_language: Option<&str>,
         duration_secs: f32,
         retry: bool,
     ) -> Result<String, TranscribeError> {
-        let mut state = self
-            .ctx
+        let mut state = ctx
             .create_state()
             .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?;
         let params = self.build_params(selected_language, duration_secs, retry);
@@ -232,15 +267,19 @@ impl WhisperTranscriber {
     }
 }
 
-impl Transcriber for WhisperTranscriber {
-    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
-        if samples.is_empty() {
-            return Err(TranscribeError::AudioFormat(
-                "Empty audio buffer".to_string(),
-            ));
-        }
-
-        let duration_secs = samples.len() as f32 / 16000.0;
+impl WhisperTranscriber {
+    /// Run one full transcription on the given context.
+    ///
+    /// Split out of `transcribe()` so that the *entire* run can be retried on the
+    /// CPU fallback, not just the state creation. `state.full()` allocates its own
+    /// compute buffers and can fail the same way `create_state()` does; wrapping
+    /// only the latter would leave that path uncovered for the same amount of code.
+    fn transcribe_on(
+        &self,
+        ctx: &WhisperContext,
+        samples: &[f32],
+        duration_secs: f32,
+    ) -> Result<String, TranscribeError> {
         tracing::debug!(
             "Transcribing {:.2}s of audio ({} samples)",
             duration_secs,
@@ -249,13 +288,13 @@ impl Transcriber for WhisperTranscriber {
 
         let start = std::time::Instant::now();
 
-        // Create state for this transcription
-        let mut state = self
-            .ctx
-            .create_state()
-            .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?;
-
-        // Determine language based on configuration mode
+        // Determine language based on configuration mode.
+        //
+        // The state is created INSIDE the branch that needs it. It used to be created
+        // unconditionally here, and in single-language mode — the common case — it was
+        // then dropped without a single call being made on it. That is a full KV-cache
+        // allocation (18 MB of VRAM, measured) per transcription, for nothing, and it
+        // doubled the number of chances to hit an out-of-memory condition on a busy card.
         let selected_language: Option<String> = if self.language.is_auto() {
             // Unconstrained auto-detection: let Whisper detect from all languages
             tracing::debug!("Using unconstrained language auto-detection");
@@ -264,6 +303,9 @@ impl Transcriber for WhisperTranscriber {
             // Constrained auto-detection: detect from allowed set only
             let allowed = self.language.as_vec();
             tracing::debug!("Using constrained language detection from: {:?}", allowed);
+            let mut state = ctx
+                .create_state()
+                .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?;
             Some(self.select_language_from_allowed(&mut state, samples, &allowed)?)
         } else {
             // Single language: use it directly
@@ -281,8 +323,13 @@ impl Transcriber for WhisperTranscriber {
             *guard = selected_language.clone();
         }
 
-        let mut result =
-            self.run_full(samples, selected_language.as_deref(), duration_secs, false)?;
+        let mut result = self.run_full(
+            ctx,
+            samples,
+            selected_language.as_deref(),
+            duration_secs,
+            false,
+        )?;
 
         if duration_secs >= 1.0 && is_degenerate_transcript(&result) {
             tracing::warn!(
@@ -290,8 +337,13 @@ impl Transcriber for WhisperTranscriber {
                 result,
                 duration_secs
             );
-            let retry_result =
-                self.run_full(samples, selected_language.as_deref(), duration_secs, true)?;
+            let retry_result = self.run_full(
+                ctx,
+                samples,
+                selected_language.as_deref(),
+                duration_secs,
+                true,
+            )?;
             if is_degenerate_transcript(&retry_result) {
                 tracing::warn!(
                     "Whisper retry also returned degenerate transcript {:?}; treating as empty",
@@ -315,6 +367,118 @@ impl Transcriber for WhisperTranscriber {
         );
 
         Ok(result)
+    }
+
+    /// Build the CPU fallback context on first use.
+    ///
+    /// Deliberately NOT cached on failure: if loading the model fails once because the
+    /// machine was momentarily out of page cache, the next dictation should try again
+    /// rather than inherit a permanent "no fallback" verdict.
+    fn with_cpu_fallback<R>(
+        &self,
+        f: impl FnOnce(&WhisperContext) -> R,
+    ) -> Result<R, TranscribeError> {
+        let mut guard = self
+            .cpu_fallback
+            .lock()
+            .map_err(|_| TranscribeError::InitFailed("CPU fallback mutex poisoned".to_string()))?;
+
+        if guard.is_none() {
+            tracing::warn!(
+                "Building CPU fallback context from {:?} — the GPU could not serve this transcription",
+                self.model_path
+            );
+            let start = std::time::Instant::now();
+
+            let mut params = WhisperContextParameters::default();
+            params.use_gpu(false);
+            params.flash_attn(self.flash_attention);
+
+            let ctx = WhisperContext::new_with_params(
+                self.model_path
+                    .to_str()
+                    .ok_or_else(|| TranscribeError::ModelNotFound("Invalid path".to_string()))?,
+                params,
+            )
+            .map_err(|e| TranscribeError::InitFailed(e.to_string()))?;
+
+            tracing::info!(
+                "CPU fallback context ready in {:.2}s",
+                start.elapsed().as_secs_f32()
+            );
+            *guard = Some(ctx);
+        }
+
+        let ctx = guard
+            .as_ref()
+            .expect("CPU fallback context was just built or already present");
+        Ok(f(ctx))
+    }
+}
+
+impl Transcriber for WhisperTranscriber {
+    /// Transcribe, and do not fail because the GPU is busy.
+    ///
+    /// The GPU holds the model persistently, but each transcription allocates a fresh
+    /// state on the card. On a shared GPU that allocation can fail at any moment —
+    /// measured here with a batch indexer holding 6.1 GB of an 8 GB card. When it does,
+    /// the sentence the user just spoke is gone, and no later retry can recover it:
+    /// the audio buffer is not kept, and the user has already stopped talking.
+    ///
+    /// So the CPU is the guaranteed floor and the GPU is an optimisation that is never
+    /// allowed to carry the load. A CPU transcription is slower — seconds instead of
+    /// tenths — but slow is a different category of outcome from lost.
+    ///
+    /// ANY inference error triggers the fallback, not just a recognised out-of-memory
+    /// string. Matching on driver messages would mean a new ggml release, a different
+    /// backend, or a reworded error silently turning "never fails" back into "fails".
+    /// The cost of falling back when it was not strictly needed is one slow dictation;
+    /// the cost of not falling back is a lost one.
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat(
+                "Empty audio buffer".to_string(),
+            ));
+        }
+
+        let duration_secs = samples.len() as f32 / 16000.0;
+
+        let gpu_error = match self.transcribe_on(&self.ctx, samples, duration_secs) {
+            Ok(text) => return Ok(text),
+            Err(e) => e,
+        };
+
+        // No GPU was requested: the primary context IS the CPU one, and there is
+        // nothing to fall back to. Report the real error rather than loading the
+        // model a second time to fail identically.
+        if !self.gpu_requested {
+            return Err(gpu_error);
+        }
+
+        tracing::warn!(
+            "GPU transcription failed ({}), falling back to CPU for this {:.2}s clip",
+            gpu_error,
+            duration_secs
+        );
+
+        match self.with_cpu_fallback(|ctx| self.transcribe_on(ctx, samples, duration_secs)) {
+            Ok(Ok(text)) => {
+                tracing::info!("CPU fallback transcribed the clip the GPU could not");
+                Ok(text)
+            }
+            // The fallback ran and still failed: report ITS error, which describes what
+            // actually stopped the transcription, not the GPU condition that led here.
+            Ok(Err(cpu_error)) => {
+                tracing::error!("CPU fallback also failed: {}", cpu_error);
+                Err(cpu_error)
+            }
+            // The fallback could not even be built. The GPU error is the one worth
+            // reporting — it is the cause; this is a consequence.
+            Err(build_error) => {
+                tracing::error!("Could not build the CPU fallback: {}", build_error);
+                Err(gpu_error)
+            }
+        }
     }
 
     fn last_detected_language(&self) -> Option<String> {


### PR DESCRIPTION
Fixes #723.

## The problem

A transient Vulkan VRAM shortage loses the dictation.

The model itself is fine — it is loaded once and stays resident on the card
(`Vulkan1 total size = 487.01 MB`). What fails is the **state**, which is re-created on
**every single transcription**: 18.87 MB of self-attention KV cache, 56.62 MB of
cross-attention, plus ~185 MB of compute buffers. When another process has taken the
VRAM, that allocation fails and the sentence the user just spoke is gone:

```
whisper_backend_init_gpu: using Vulkan1 backend
whisper_init_state: kv self size  =   18.87 MB
ggml_vulkan: Device memory allocation of size 56623104 failed.
ggml_vulkan: vk::Device::allocateMemory: ErrorOutOfDeviceMemory
whisper_kv_cache_init: failed to allocate memory for the kv cache
ERROR Transcription failed: Transcription failed: Failed to create a new whisper context.
```

6 dictations lost in 7 days on my machine with stock 0.7.5, same daemon PID throughout.
Speech is the one input that cannot be replayed: by the time the error appears, the user
has already stopped talking and the audio buffer is gone.

## What this changes

**A CPU fallback context, built lazily on the first GPU failure.** Zero cost while
everything works — nothing is loaded until something actually fails. A build failure is
deliberately *not* cached, so a transient condition (page-cache pressure while reading
the model) does not poison the fallback for the rest of the process lifetime.

**The whole run is replayed on CPU, not just `create_state()`.** `state.full()` allocates
its own compute buffers and can fail exactly the same way. Wrapping only state creation
would leave that path uncovered for the same amount of code, so `transcribe_on(ctx, ...)`
takes the context as a parameter and the fallback re-runs all of it.

**Any inference error triggers the fallback — no string matching on driver messages.**
Matching on `ErrorOutOfDeviceMemory` or similar would mean that a new ggml release, a
different backend, or a reworded error silently turns "never loses a dictation" back into
"loses a dictation". The cost of falling back when it was not strictly necessary is one
slow dictation; the cost of not falling back is a lost one.

**When no GPU was requested, there is nothing to fall back *from*.** `gpu_requested`
short-circuits the whole thing and the real error is returned, rather than loading the
model a second time to fail identically.

**Bonus: removal of an unused `create_state()`.** `transcribe()` created a `WhisperState`
for language detection *before* the branch that decides whether detection is needed. With
`language = "fr"` (any single language) that state was allocated and dropped without a
single call being made on it — a full KV cache, ~18 MB of VRAM, on every transcription,
and one extra chance to hit the failure above. It now lives inside the
`is_multiple()` branch that actually uses it. This one helps every Vulkan/CUDA user
regardless of the fallback.

## How it was verified

I could not write a unit test for this. Reproducing it requires a GPU that refuses an
allocation, and the existing tests in `whisper.rs` cover pure functions only
(`calculate_audio_ctx`, `is_degenerate_transcript`). Rather than add a test that asserts
nothing, here is what was actually measured.

A small Vulkan filler holds VRAM in a second process — binding and writing its buffers,
since `vkAllocateMemory` alone commits nothing and `nvidia-smi` does not move. 7072 MiB
taken on an 8 GiB card, 16 MiB free, daemon model still resident.

Same daemon, same clip, before and after releasing the VRAM:

```
# GPU starved
whisper_backend_init_gpu: using Vulkan1 backend
whisper_init_state: kv self size  =   18.87 MB
ggml_vulkan: vk::Device::allocateMemory: ErrorOutOfDeviceMemory
whisper_kv_cache_init: failed to allocate memory for the kv cache
WARN  GPU transcription failed (...), falling back to CPU for this 3.63s clip
WARN  Building CPU fallback context from ".../ggml-small.bin"
INFO  CPU fallback context ready in 6.39s
INFO  Transcription completed in 12.97s: "Hello, welcome in Switzerland. Show me your hands."
INFO  CPU fallback transcribed the clip the GPU could not

# VRAM released — no fallback, straight back to the GPU
whisper_backend_init_gpu: using Vulkan1 backend
INFO  Transcription completed in 7.90s
```

12.97s on CPU instead of 7.90s on GPU for a 3.63s clip: slower, but slow is a different
category of outcome from lost.

Pre-push checks (`CONTRIBUTING.md`), on `dev` + this patch:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --no-deps -- -D warnings` — clean
- `cargo test` — passing

Environment: Ubuntu 26.04, GNOME/Wayland, RTX 3070 Laptop (8 GiB, driver 595.84) with a
second Vulkan device (AMD RENOIR iGPU), `gpu_device = 1`, model `small`, `language = "fr"`.
The patched binary has been running as my daily driver since.

https://claude.ai/code/session_01Ha9NkiRdnCxAj4MLVwTHzz
