### PR TITLE
fix: skip unused WhisperState allocation in single-language mode

### DIFF
--- a/src/transcribe/whisper.rs
+++ b/src/transcribe/whisper.rs
@@ -249,12 +249,6 @@ impl Transcriber for WhisperTranscriber {
 
         let start = std::time::Instant::now();
 
-        // Create state for this transcription
-        let mut state = self
-            .ctx
-            .create_state()
-            .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?;
-
         // Determine language based on configuration mode
         let selected_language: Option<String> = if self.language.is_auto() {
             // Unconstrained auto-detection: let Whisper detect from all languages
@@ -264,6 +258,14 @@ impl Transcriber for WhisperTranscriber {
             // Constrained auto-detection: detect from allowed set only
             let allowed = self.language.as_vec();
             tracing::debug!("Using constrained language detection from: {:?}", allowed);
+            // Only this branch needs a state (for pcm_to_mel/lang_detect below);
+            // run_full() creates its own state for the actual decode, so a state
+            // created unconditionally above this match was wasted GPU buffer
+            // allocation on every single-language/auto-detect transcription.
+            let mut state = self
+                .ctx
+                .create_state()
+                .map_err(|e| TranscribeError::InferenceFailed(e.to_string()))?;
             Some(self.select_language_from_allowed(&mut state, samples, &allowed)?)
         } else {
             // Single language: use it directly

--- a/src/transcribe/whisper.rs
+++ b/src/transcribe/whisper.rs
@@ -258,10 +258,8 @@ impl Transcriber for WhisperTranscriber {
             // Constrained auto-detection: detect from allowed set only
             let allowed = self.language.as_vec();
             tracing::debug!("Using constrained language detection from: {:?}", allowed);
-            // Only this branch needs a state (for pcm_to_mel/lang_detect below);
-            // run_full() creates its own state for the actual decode, so a state
-            // created unconditionally above this match was wasted GPU buffer
-            // allocation on every single-language/auto-detect transcription.
+            // State needed only for pcm_to_mel/lang_detect below; run_full()
+            // creates its own separate state for the actual decode.
             let mut state = self
                 .ctx
                 .create_state()


### PR DESCRIPTION
Fixes #721.

`transcribe()` in `src/transcribe/whisper.rs` created a `WhisperState` before branching on language mode, but that state is only used inside the `is_multiple()` branch (constrained auto-detect), for `pcm_to_mel`/`lang_detect`. The `is_auto()` and single-language branches, which cover the common case including the default `language = "en"`, left it created and unused. `run_full()` right after creates its own separate state for the actual decode.

So every single-language or auto-detect transcription paid for two full `WhisperState` allocations (KV cache plus compute buffers) instead of one. You can see it in the logs as duplicate `whisper_init_state` blocks per recording.

The fix moves `create_state()` inside the `is_multiple()` branch, the only place that uses it. No behavior change for any language mode, since the removed state was never read.

## Testing

Ran the full local pre-push smoke from CONTRIBUTING.md against the Vulkan build (large-v3 model):

- `cargo fmt --check`: clean
- `cargo clippy --all-targets --no-deps -- -D warnings`: clean
- `cargo test`: 1061 passed, 0 failed, including `transcribe::whisper::tests` and the VAD integration suite

Also confirmed on real hardware (NixOS, RTX 4050, Vulkan backend) that the duplicate `whisper_init_state` log blocks are gone after the fix, with no change in transcription output.