### PR TITLE
fix: smooth waveform scrolling in GTK4 and egui OSDs

### DIFF
--- a/src/bin/voxtype_osd_gtk4.rs
+++ b/src/bin/voxtype_osd_gtk4.rs
@@ -5,9 +5,8 @@
 //! scrolling waveform plus a segmented peak meter. Audio frames arrive on
 //! the daemon's audio Unix socket via [`voxtype::osd::ipc::run_ipc_loop`],
 //! decoded into [`AudioFrame`]s by a tokio runtime on a worker thread, and
-//! pushed into a shared [`FrameRing`] + [`PeakHold`]. The GTK side polls a
-//! ~60 Hz `glib::timeout_add_local` callback that redraws the
-//! `DrawingArea` whenever new frames have arrived.
+//! pushed into a shared [`FrameRing`] + [`PeakHold`]. The GTK frame clock
+//! redraws the `DrawingArea` while visible, including between audio arrivals.
 //!
 //! When the IPC socket is silent for `idle_timeout_secs` (Idle proxy) the
 //! window is hidden so the binary does no rendering work and consumes
@@ -30,7 +29,7 @@ use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use voxtype::audio::levels::{AudioFrame, FRAME_HZ};
 use voxtype::config::Config as VoxtypeConfig;
 use voxtype::osd::config::{OsdConfig, OsdPosition};
-use voxtype::osd::ipc::{resolve_socket_path, run_ipc_loop, FrameRing, DEFAULT_RING_DEPTH};
+use voxtype::osd::ipc::{resolve_socket_path, run_ipc_loop, FrameRing};
 use voxtype::osd::theme::ThemeWatcher;
 use voxtype::osd::visual::{peak_meter_fraction, project_envelope, MeterZone, Palette, PeakHold};
 
@@ -69,8 +68,7 @@ fn load_osd_config_from_file(explicit: Option<&std::path::Path>) -> OsdConfig {
 /// Application id for the GTK4 frontend.
 const APP_ID: &str = "io.voxtype.OsdGtk4";
 
-/// Render tick period (~60 Hz). The redraw is gated on whether new frames
-/// have arrived since the last paint, so this is a cheap upper bound.
+/// Visibility polling period. Drawing follows the GTK frame clock.
 const RENDER_TICK_MS: u32 = 16;
 
 /// How long we wait without frames before treating the daemon as idle and
@@ -149,15 +147,18 @@ struct Args {
 /// State shared between the IPC worker and the GTK redraw timer.
 struct SharedState {
     ring: Mutex<FrameRing>,
+    window_frames: f64,
     peak: Mutex<PeakHold>,
     last_seq: Mutex<u64>,
     last_frame_at: Mutex<Instant>,
 }
 
 impl SharedState {
-    fn new(decay_db_per_sec: f32) -> Self {
+    fn new(decay_db_per_sec: f32, window_secs: f32) -> Self {
+        let window_frames = window_secs.max(0.01) as f64 * FRAME_HZ as f64;
         Self {
-            ring: Mutex::new(FrameRing::new(DEFAULT_RING_DEPTH)),
+            ring: Mutex::new(FrameRing::for_window(window_secs)),
+            window_frames,
             peak: Mutex::new(PeakHold::new(decay_db_per_sec)),
             last_seq: Mutex::new(0),
             last_frame_at: Mutex::new(Instant::now() - Duration::from_secs(3600)),
@@ -207,7 +208,10 @@ fn main() -> anyhow::Result<()> {
     let theme = ThemeWatcher::new();
     let palette = theme.palette();
 
-    let state = Arc::new(SharedState::new(osd_cfg.peak_decay_db_per_sec));
+    let state = Arc::new(SharedState::new(
+        osd_cfg.peak_decay_db_per_sec,
+        osd_cfg.waveform_window_secs,
+    ));
 
     // Spawn the tokio IPC worker on a side thread.
     spawn_ipc_worker(
@@ -428,12 +432,17 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
         });
     }
 
-    // Redraw timer. We only call queue_draw() when the IPC has produced a
-    // newer seq than the last paint, so this is cheap when idle.
+    // GTK pauses tick callbacks while the widget is hidden. While visible,
+    // redraw even between audio deliveries so fractional scrolling continues.
+    drawing_area.add_tick_callback(|area, _clock| {
+        area.queue_draw();
+        glib::ControlFlow::Continue
+    });
+
+    // Visibility must be polled separately: a hidden widget has no frame clock
+    // ticks with which to notice the next recording.
     let redraw_state = state.clone();
-    let redraw_area = drawing_area.clone();
     let redraw_window = window.clone();
-    let last_drawn_seq = Cell::new(0u64);
     // Tracks GTK visibility. Starts true because `window.present()` below maps
     // the surface, the first tick's idle check then hides it.
     let visible = Cell::new(true);
@@ -486,10 +495,6 @@ fn build_window(app: &Application, cfg: &OsdConfig, palette: Palette, state: Arc
             }
         }
 
-        if cur_seq != last_drawn_seq.get() {
-            redraw_area.queue_draw();
-            last_drawn_seq.set(cur_seq);
-        }
         glib::ControlFlow::Continue
     });
 
@@ -546,6 +551,7 @@ fn draw(
     draw_peak_meter(cr, wave_width + gap, 0.0, meter_width, h, palette, state);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_waveform(
     cr: &Context,
     x: f64,
@@ -564,12 +570,18 @@ fn draw_waveform(
         return;
     }
 
-    // Collect frames as a Vec snapshot under the lock, then drop.
-    let frames: Vec<AudioFrame> = match state.ring.lock() {
-        Ok(r) => r.iter().collect(),
+    let cols = match state.ring.lock() {
+        Ok(r) => {
+            let frames: Vec<AudioFrame> = r.iter().collect();
+            project_envelope(
+                &frames,
+                n_columns,
+                state.window_frames,
+                r.scroll_offset(Instant::now()),
+            )
+        }
         Err(_) => return,
     };
-    let cols = project_envelope(&frames, n_columns);
 
     let mid = y + h * 0.5;
     let half = h * 0.5;
@@ -617,9 +629,7 @@ fn draw_waveform(
 }
 
 fn sample_to_pixels(sample: f32, half_height: f64, gain: f64) -> f64 {
-    // Apply visual gain, then clamp to -1.0..=1.0, then scale to half_height.
-    let s = (sample as f64 * gain).clamp(-1.0, 1.0);
-    s * half_height
+    (sample as f64 * gain).clamp(-1.0, 1.0) * half_height
 }
 
 fn draw_peak_meter(

--- a/src/bin/voxtype_osd_native/app.rs
+++ b/src/bin/voxtype_osd_native/app.rs
@@ -68,9 +68,8 @@ pub struct SharedState {
 /// second as "instant," and 0.5s is well above the recording boundary
 /// gaps the daemon naturally produces.
 const IDLE_TEARDOWN_SECS: f32 = 0.5;
-/// Target render rate. 60 Hz is enough for a smooth scrolling waveform; we
-/// can't render faster than the underlying frame rate (100 Hz IPC) gains us.
-const REDRAW_INTERVAL_MS: u64 = 16;
+/// Idle/recovery checks only; animation is paced by Wayland frame callbacks.
+const IDLE_CHECK_INTERVAL_MS: u64 = 50;
 
 /// Outer state owned by the calloop event loop. Implements the SCTK delegate
 /// traits via `delegate_*` macros.
@@ -99,6 +98,7 @@ struct RenderSurface {
     height: u32,
     /// Whether we've received the first configure (and thus may render).
     configured: bool,
+    frame_pending: bool,
 
     // wgpu plumbing.
     _instance: wgpu::Instance,
@@ -157,12 +157,12 @@ pub fn run(
         })
         .map_err(|e| anyhow!("insert ping source: {}", e))?;
 
-    // Periodic redraw timer + idle teardown. Re-arms each fire.
-    let timer = calloop::timer::Timer::from_duration(Duration::from_millis(REDRAW_INTERVAL_MS));
+    // Periodic idle teardown and recovery after a skipped surface acquisition.
+    let timer = calloop::timer::Timer::from_duration(Duration::from_millis(IDLE_CHECK_INTERVAL_MS));
     loop_handle
         .insert_source(timer, |_deadline, _, app: &mut App| {
             app.tick();
-            calloop::timer::TimeoutAction::ToDuration(Duration::from_millis(REDRAW_INTERVAL_MS))
+            calloop::timer::TimeoutAction::ToDuration(Duration::from_millis(IDLE_CHECK_INTERVAL_MS))
         })
         .map_err(|e| anyhow!("insert redraw timer: {}", e))?;
 
@@ -313,6 +313,7 @@ impl App {
             width: cfg.width_px,
             height: cfg.height_px,
             configured: false,
+            frame_pending: false,
             _instance: instance,
             surface,
             device,
@@ -351,7 +352,7 @@ impl App {
 
     fn render_frame(&mut self) -> anyhow::Result<()> {
         let rs = match self.surface.as_mut() {
-            Some(s) if s.configured => s,
+            Some(s) if s.configured && !s.frame_pending => s,
             _ => return Ok(()),
         };
 
@@ -390,14 +391,13 @@ impl App {
 
         let envelope_cols = {
             let ring = self.shared.ring.lock().expect("ring poisoned");
-            let frames_in_window =
-                (waveform_window_secs * voxtype::audio::levels::FRAME_HZ as f32) as usize;
-            let mut buf: Vec<AudioFrame> = ring.iter().collect();
-            if buf.len() > frames_in_window {
-                let skip = buf.len() - frames_in_window;
-                buf = buf.split_off(skip);
-            }
-            project_envelope(&buf, n_columns)
+            let buf: Vec<AudioFrame> = ring.iter().collect();
+            project_envelope(
+                &buf,
+                n_columns,
+                waveform_window_secs as f64 * voxtype::audio::levels::FRAME_HZ as f64,
+                ring.scroll_offset(Instant::now()),
+            )
         };
 
         let (peak_dbfs, held_dbfs) = {
@@ -492,6 +492,7 @@ impl App {
 
         rs.queue.submit(Some(encoder.finish()));
         rs.wl_surface.frame(&self.qh, rs.wl_surface.clone());
+        rs.frame_pending = true;
         surface_texture.present();
         Ok(())
     }
@@ -525,6 +526,7 @@ fn position_to_anchor_and_margins(pos: OsdPosition, margin: i32) -> (Anchor, i32
 
 /// Render the egui UI: scrolling waveform on the left, segmented vertical
 /// peak meter on the right.
+#[allow(clippy::too_many_arguments)]
 fn draw_ui(
     ui: &mut egui::Ui,
     width: u32,
@@ -564,32 +566,37 @@ fn draw_waveform(
     let mid_y = rect.center().y;
     let half_h = rect.height() * 0.45;
 
-    let mut top_pts = Vec::with_capacity(n);
-    let mut bot_pts = Vec::with_capacity(n);
+    // A waveform is concave. Triangulate each strip explicitly instead of
+    // passing the whole outline to egui's convex-polygon tessellator.
+    let mut mesh = egui::Mesh::default();
+    let fill = color_to_egui(palette.accent);
+    let mut top_edge = Vec::with_capacity(n);
+    let mut bottom_edge = Vec::with_capacity(n);
     for (i, col) in envelope.iter().enumerate() {
         let x = rect.left() + (i as f32 + 0.5) * col_w;
-        // Apply visual gain, then clamp to -1.0..=1.0, then map to pixel y.
-        // y grows downward so we subtract from mid_y for the top edge.
         let top = mid_y - (col.max * gain).clamp(-1.0, 1.0) * half_h;
         let bot = mid_y - (col.min * gain).clamp(-1.0, 1.0) * half_h;
-        top_pts.push(pos2(x, top));
-        bot_pts.push(pos2(x, bot));
+        mesh.colored_vertex(pos2(x, top), fill);
+        mesh.colored_vertex(pos2(x, bot), fill);
+        top_edge.push(pos2(x, top));
+        bottom_edge.push(pos2(x, bot));
+        if i > 0 {
+            let v = (i * 2) as u32;
+            mesh.add_triangle(v - 2, v - 1, v);
+            mesh.add_triangle(v, v - 1, v + 1);
+        }
     }
-
-    // Build a closed polygon: top points left-to-right, bottom right-to-left.
-    let mut polygon = top_pts;
-    for p in bot_pts.iter().rev() {
-        polygon.push(*p);
-    }
-
-    let fill = color_to_egui(palette.accent);
-    painter.add(Shape::convex_polygon(polygon, fill, egui::Stroke::NONE));
+    painter.add(Shape::mesh(mesh));
+    // Mesh edges are not antialiased by egui. Its stroked paths keep the
+    // silhouette smooth as it moves through fractional pixel positions.
+    painter.add(Shape::line(top_edge, egui::Stroke::new(1.0_f32, fill)));
+    painter.add(Shape::line(bottom_edge, egui::Stroke::new(1.0_f32, fill)));
 
     // Centerline tick for visual reference at low levels.
     let line_color = color_to_egui(palette.foreground.with_alpha(0.25));
     painter.line_segment(
         [pos2(rect.left(), mid_y), pos2(rect.right(), mid_y)],
-        egui::Stroke::new(1.0, line_color),
+        egui::Stroke::new(1.0_f32, line_color),
     );
 }
 
@@ -679,9 +686,16 @@ impl CompositorHandler for App {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        _surface: &WlSurface,
+        surface: &WlSurface,
         _time: u32,
     ) {
+        if let Some(rs) = self.surface.as_mut() {
+            if rs.wl_surface != *surface {
+                return;
+            }
+            rs.frame_pending = false;
+            self.tick();
+        }
     }
 
     fn surface_enter(

--- a/src/bin/voxtype_osd_native/main.rs
+++ b/src/bin/voxtype_osd_native/main.rs
@@ -10,7 +10,7 @@
 //! - The main thread runs the Wayland event loop (calloop + SCTK), creates
 //!   the wlr-layer-shell surface on demand when frames start arriving, and
 //!   destroys it after a configurable idle timeout. While the surface is
-//!   alive, a calloop timer drives ~60 Hz redraws.
+//!   alive, Wayland frame callbacks pace redraws at the display refresh rate.
 //! - When no daemon is running, the IPC thread sleeps in its reconnect loop
 //!   and the main thread sleeps in `EventLoop::run`. Idle CPU is essentially
 //!   zero rendering work.
@@ -31,7 +31,7 @@ use clap::Parser;
 
 use voxtype::audio::levels::{AudioFrame, FRAME_HZ};
 use voxtype::osd::config::OsdConfig;
-use voxtype::osd::ipc::{resolve_socket_path, run_ipc_loop, FrameRing, DEFAULT_RING_DEPTH};
+use voxtype::osd::ipc::{resolve_socket_path, run_ipc_loop, FrameRing};
 use voxtype::osd::theme::ThemeWatcher;
 use voxtype::osd::visual::PeakHold;
 
@@ -157,7 +157,9 @@ fn main() -> anyhow::Result<()> {
     let palette = theme.palette();
 
     let shared = SharedState {
-        ring: Arc::new(Mutex::new(FrameRing::new(DEFAULT_RING_DEPTH))),
+        ring: Arc::new(Mutex::new(FrameRing::for_window(
+            osd_config.waveform_window_secs,
+        ))),
         peak_hold: Arc::new(Mutex::new(PeakHold::new(osd_config.peak_decay_db_per_sec))),
         last_frame_at: Arc::new(Mutex::new(None)),
         palette,

--- a/src/osd/ipc.rs
+++ b/src/osd/ipc.rs
@@ -14,16 +14,20 @@
 
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::io::AsyncReadExt;
 use tokio::net::UnixStream;
 use tokio::time::sleep;
 
-use crate::audio::levels::{default_socket_path, AudioFrame, FRAME_BYTES};
+use crate::audio::levels::{default_socket_path, AudioFrame, FRAME_BYTES, FRAME_HZ};
 
 /// Default ring buffer depth: 3 seconds at 100 Hz.
 pub const DEFAULT_RING_DEPTH: usize = 300;
+
+// Hold back 50 ms of audio so ordinary 10–40 ms capture batches can be
+// interpolated at display refresh rate without stopping between arrivals.
+const PLAYOUT_DELAY_FRAMES: f64 = FRAME_HZ as f64 * 0.05;
 
 /// Fixed-capacity ring buffer of audio frames.
 ///
@@ -33,19 +37,56 @@ pub struct FrameRing {
     buf: Vec<Option<AudioFrame>>,
     head: usize,
     len: usize,
+    clock_origin: Option<Instant>,
+    received: u64,
 }
 
 impl FrameRing {
+    /// Keep the visible window plus interpolation history for a capture batch
+    /// on either side of the delayed right edge.
+    pub fn for_window(window_secs: f32) -> Self {
+        let visible = (window_secs.max(0.01) as f64 * FRAME_HZ as f64).ceil() as usize;
+        Self::new(visible + (PLAYOUT_DELAY_FRAMES * 2.0) as usize + 2)
+    }
+
     pub fn new(capacity: usize) -> Self {
         assert!(capacity > 0, "FrameRing capacity must be > 0");
         Self {
             buf: vec![None; capacity],
             head: 0,
             len: 0,
+            clock_origin: None,
+            received: 0,
         }
     }
 
     pub fn push(&mut self, frame: AudioFrame) {
+        self.push_at(frame, Instant::now());
+    }
+
+    fn push_at(&mut self, frame: AudioFrame, now: Instant) {
+        // A new recording (or a discontinuity after reconnecting) must not
+        // animate the previous recording's history. wrapping_add also handles
+        // the wire counter rolling over during a long capture.
+        if self
+            .latest()
+            .is_some_and(|last| frame.seq != last.seq.wrapping_add(1))
+        {
+            self.clear();
+        }
+        let origin = self.clock_origin.get_or_insert(now);
+        // Re-anchor after an underrun, rather than jumping through a late
+        // batch at socket-read speed. Normal batch arrivals never move this
+        // clock: scrolling follows elapsed time, not delivery timing.
+        let elapsed = now.duration_since(*origin).as_secs_f64() * FRAME_HZ as f64;
+        if elapsed > self.received as f64 + PLAYOUT_DELAY_FRAMES {
+            // Resume where the display stopped, without rewinding history to
+            // refill the delay buffer or jumping straight to the late data.
+            let stopped_at = self.received.saturating_sub(1) as f64;
+            *origin = now
+                - Duration::from_secs_f64((stopped_at + PLAYOUT_DELAY_FRAMES) / FRAME_HZ as f64);
+        }
+        self.received += 1;
         let cap = self.buf.len();
         self.buf[self.head] = Some(frame);
         self.head = (self.head + 1) % cap;
@@ -75,6 +116,19 @@ impl FrameRing {
         self.buf.len()
     }
 
+    /// Fractional position of the scrolling right edge relative to the newest
+    /// frame. Negative values keep a small interpolation buffer; zero means
+    /// the display caught up and waits for audio rather than inventing samples.
+    pub fn scroll_offset(&self, now: Instant) -> f64 {
+        let Some(origin) = self.clock_origin else {
+            return 0.0;
+        };
+        (now.saturating_duration_since(origin).as_secs_f64() * FRAME_HZ as f64
+            - self.received.saturating_sub(1) as f64
+            - PLAYOUT_DELAY_FRAMES)
+            .min(0.0)
+    }
+
     /// Iterate over the buffered frames in oldest-first order.
     pub fn iter(&self) -> impl Iterator<Item = AudioFrame> + '_ {
         let cap = self.buf.len();
@@ -93,6 +147,8 @@ impl FrameRing {
         }
         self.head = 0;
         self.len = 0;
+        self.clock_origin = None;
+        self.received = 0;
     }
 }
 
@@ -239,5 +295,63 @@ mod tests {
         assert!(r.latest().is_none());
         r.push(frame(99));
         assert_eq!(r.latest().unwrap().seq, 99);
+    }
+
+    #[test]
+    fn scroll_clock_is_continuous_across_capture_batches_and_ring_wrap() {
+        // At 60, 144 and 240 Hz, each displayed frame must advance by elapsed
+        // time even though four audio frames arrive together every 40 ms.
+        for refresh_hz in [60, 144, 240] {
+            let mut ring = FrameRing::new(20);
+            let start = Instant::now();
+            let mut received = 0;
+            for tick in 0..refresh_hz * 2 {
+                let seconds = tick as f64 / refresh_hz as f64;
+                let now = start + Duration::from_secs_f64(seconds);
+                let available = (seconds / 0.04).floor() as u32 * 4 + 4;
+                while received < available {
+                    ring.push_at(frame(received), now);
+                    received += 1;
+                }
+                let position = received as f64 - 1.0 + ring.scroll_offset(now);
+                let expected = seconds * FRAME_HZ as f64 - PLAYOUT_DELAY_FRAMES;
+                assert!(
+                    (position - expected).abs() < 1e-5,
+                    "{refresh_hz} Hz, tick {tick}: {position} != {expected}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn recording_restart_clears_history_and_clock() {
+        let start = Instant::now();
+        let mut ring = FrameRing::new(10);
+        ring.push_at(frame(4), start);
+        ring.push_at(frame(5), start + Duration::from_millis(10));
+        let restart = start + Duration::from_secs(1);
+        ring.push_at(frame(0), restart);
+        assert_eq!(ring.len(), 1);
+        assert_eq!(ring.scroll_offset(restart), -PLAYOUT_DELAY_FRAMES);
+    }
+
+    #[test]
+    fn wire_sequence_wrap_keeps_history() {
+        let start = Instant::now();
+        let mut ring = FrameRing::new(10);
+        ring.push_at(frame(u32::MAX), start);
+        ring.push_at(frame(0), start + Duration::from_millis(10));
+        assert_eq!(ring.len(), 2);
+    }
+
+    #[test]
+    fn stalled_input_stops_at_latest_sample_and_recovers() {
+        let start = Instant::now();
+        let mut ring = FrameRing::new(10);
+        ring.push_at(frame(0), start);
+        let later = start + Duration::from_secs(1);
+        assert_eq!(ring.scroll_offset(later), 0.0);
+        ring.push_at(frame(1), later);
+        assert_eq!(ring.scroll_offset(later), -1.0);
     }
 }

--- a/src/osd/visual.rs
+++ b/src/osd/visual.rs
@@ -158,65 +158,59 @@ impl EnvelopeColumn {
     pub const SILENT: Self = Self { min: 0.0, max: 0.0 };
 }
 
-/// Project the most recent `frames.len()` audio frames onto `n_columns`
-/// pixel columns by aggregating min/max over the frames that map to each
-/// column. Columns are oldest-on-left, newest-on-right.
+/// Project a fixed time window onto pixel columns, oldest on the left.
 ///
-/// Every column is mapped proportionally to the available frame range,
-/// which means the waveform always fills the entire display width. When
-/// the ring contains fewer frames than columns, frames stretch to cover
-/// the extra columns (one frame may map to several adjacent columns) —
-/// preferable to leaving a permanent dead zone on the left edge that
-/// never receives data.
-pub fn project_envelope(frames: &[AudioFrame], n_columns: usize) -> Vec<EnvelopeColumn> {
+/// `right_offset` is the fractional frame position relative to the newest
+/// sample. Interpolation lets the window scroll between audio deliveries.
+/// Missing history is silence, so starting a recording does not stretch or
+/// rescale the time axis. When zoomed out, retain every peak within a column.
+pub fn project_envelope(
+    frames: &[AudioFrame],
+    n_columns: usize,
+    window_frames: f64,
+    right_offset: f64,
+) -> Vec<EnvelopeColumn> {
     let mut out = vec![EnvelopeColumn::SILENT; n_columns];
     if frames.is_empty() || n_columns == 0 {
         return out;
     }
-
-    let n_frames = frames.len();
-    // Index-based loop: `col` is needed both to compute the bucket bounds and
-    // to write into `out[col]`. Suggested `iter_mut().enumerate()` would still
-    // need the index, so the index form reads more cleanly.
-    #[allow(clippy::needless_range_loop)]
-    for col in 0..n_columns {
-        // Bucket-map column index to a half-open frame range. When
-        // n_frames >= n_columns, each bucket covers >=1 frame and we
-        // aggregate min/max over the bucket. When n_frames < n_columns,
-        // start..end ends up empty for some buckets (start == end);
-        // we sample-and-hold the previous column's value so the
-        // waveform stretches across the full width instead of leaving
-        // gaps.
-        let start = (col * n_frames) / n_columns;
-        let end = ((col + 1) * n_frames) / n_columns;
-        let mut min = 0.0_f32;
-        let mut max = 0.0_f32;
-        let mut any = false;
-        for f in &frames[start..end] {
-            if !any {
-                min = f.min;
-                max = f.max;
-                any = true;
-            } else {
-                if f.min < min {
-                    min = f.min;
-                }
-                if f.max > max {
-                    max = f.max;
-                }
+    let right = (frames.len() - 1) as f64 + right_offset;
+    let step = window_frames.max(1.0) / n_columns.saturating_sub(1).max(1) as f64;
+    let sample = |index: isize| {
+        usize::try_from(index)
+            .ok()
+            .and_then(|i| frames.get(i))
+            .map(|f| EnvelopeColumn {
+                min: f.min,
+                max: f.max,
+            })
+            .unwrap_or(EnvelopeColumn::SILENT)
+    };
+    let interpolate = |position: f64| {
+        let index = position.floor() as isize;
+        let fraction = (position - position.floor()) as f32;
+        let a = sample(index);
+        let b = sample(index + 1);
+        EnvelopeColumn {
+            min: a.min + (b.min - a.min) * fraction,
+            max: a.max + (b.max - a.max) * fraction,
+        }
+    };
+    for (col, out) in out.iter_mut().enumerate() {
+        let position = right - (n_columns - 1 - col) as f64 * step;
+        *out = interpolate(position);
+        if step > 1.0 {
+            let start = position - step;
+            let edge = interpolate(start);
+            out.min = out.min.min(edge.min);
+            out.max = out.max.max(edge.max);
+            let first = (start.ceil().max(0.0) as usize).min(frames.len());
+            let end = ((position.floor() + 1.0).max(0.0) as usize).min(frames.len());
+            for f in &frames[first..end] {
+                out.min = out.min.min(f.min);
+                out.max = out.max.max(f.max);
             }
         }
-        out[col] = if any {
-            EnvelopeColumn { min, max }
-        } else {
-            // Empty bucket: sample-and-hold the nearest frame so the
-            // visualization stretches rather than going silent.
-            let idx = ((col * n_frames) / n_columns).min(n_frames - 1);
-            EnvelopeColumn {
-                min: frames[idx].min,
-                max: frames[idx].max,
-            }
-        };
     }
     out
 }
@@ -300,55 +294,39 @@ mod tests {
     }
 
     #[test]
-    fn envelope_partial_stretches_to_fill() {
-        // 2 frames into 5 columns: every column must be populated (no
-        // silent left edge). Frames stretch via sample-and-hold.
+    fn envelope_partial_preserves_time_scale() {
         let frames = vec![frame(0, -0.1, 0.1, -20.0), frame(1, -0.2, 0.2, -14.0)];
-        let cols = project_envelope(&frames, 5);
-        assert_eq!(cols.len(), 5);
-        for (i, c) in cols.iter().enumerate() {
-            assert_ne!(*c, EnvelopeColumn::SILENT, "column {i} was silent");
-        }
-        // The newest frame should appear in the last column.
-        assert_eq!(
-            cols[4],
-            EnvelopeColumn {
-                min: -0.2,
-                max: 0.2
-            }
-        );
-        // The oldest frame should appear in the first column.
-        assert_eq!(
-            cols[0],
-            EnvelopeColumn {
-                min: -0.1,
-                max: 0.1
-            }
-        );
+        let cols = project_envelope(&frames, 5, 4.0, 0.0);
+        assert_eq!(&cols[..3], &[EnvelopeColumn::SILENT; 3]);
+        assert_eq!(cols[3].max, 0.1);
+        assert_eq!(cols[4].max, 0.2);
     }
 
     #[test]
-    fn envelope_aggregates_when_full() {
-        // 10 frames into 5 columns: each column covers 2 frames.
-        let frames: Vec<AudioFrame> = (0..10)
-            .map(|i| frame(i, -(i as f32) * 0.1, (i as f32) * 0.1, -20.0))
-            .collect();
-        let cols = project_envelope(&frames, 5);
-        assert_eq!(cols.len(), 5);
-        // First column: frames 0..=1 -> min = -0.1, max = 0.1
-        assert!((cols[0].min - -0.1).abs() < 1e-6);
-        assert!((cols[0].max - 0.1).abs() < 1e-6);
-        // Last column: frames 8..=9 -> min = -0.9, max = 0.9
-        assert!((cols[4].min - -0.9).abs() < 1e-6);
-        assert!((cols[4].max - 0.9).abs() < 1e-6);
+    fn envelope_interpolates_fractional_scroll() {
+        let frames = vec![frame(0, -0.2, 0.4, -8.0), frame(1, -0.6, 0.8, -2.0)];
+        let cols = project_envelope(&frames, 3, 1.0, -0.25);
+        assert!((cols[2].max - 0.7).abs() < 1e-6);
+        assert!((cols[2].min + 0.5).abs() < 1e-6);
+        assert!((cols[1].max - 0.5).abs() < 1e-6);
     }
 
     #[test]
-    fn envelope_empty_input_yields_silence() {
-        let cols = project_envelope(&[], 4);
-        assert_eq!(cols.len(), 4);
-        for c in cols {
-            assert_eq!(c, EnvelopeColumn::SILENT);
-        }
+    fn envelope_preserves_transients_when_zoomed_out() {
+        let mut frames = vec![frame(0, 0.0, 0.0, -120.0); 101];
+        frames[47] = frame(47, -0.9, 1.0, 0.0);
+        let cols = project_envelope(&frames, 5, 100.0, -0.5);
+        assert!(cols.iter().any(|c| c.max == 1.0 && c.min == -0.9));
+    }
+
+    #[test]
+    fn envelope_handles_empty_and_single_column() {
+        assert_eq!(
+            project_envelope(&[], 4, 300.0, 0.0),
+            vec![EnvelopeColumn::SILENT; 4]
+        );
+        let frames = [frame(0, -0.1, 0.2, -14.0)];
+        assert!(project_envelope(&frames, 0, 300.0, 0.0).is_empty());
+        assert_eq!(project_envelope(&frames, 1, 300.0, 0.0)[0].max, 0.2);
     }
 }


### PR DESCRIPTION
Hey Pete!

I've been working on some new DJ software that I'll announce at some point, and learned a lot getting its waveform display really smooth. I applied those lessons to VoxType's OSD, and both the GTK4 and native egui versions now scroll smoothly with my normal dictation keybinding.

The native frontend requested Wayland frame callbacks but ignored them, redrawing on a separate 16 ms timer. GTK4 also used a timer and only redrew when new audio had arrived. Both moved through the audio history in whole-frame steps, so capture batches showed up as jumps in the waveform.

This change:

- Paces native redraws with Wayland frame callbacks and GTK4 redraws with its frame clock, including between audio arrivals.
- Scrolls a fixed time window using elapsed time and fractional interpolation, with a 50 ms buffer to absorb ordinary capture batches. The window fills with silence at the start instead of stretching the available history across its width.
- Keeps enough history for the configured window, resets it when the audio sequence restarts, and preserves transients when several audio frames fall into one pixel column.
- Draws the egui waveform with triangle strips and antialiased edges, fixing the use of a convex-polygon fill for a concave waveform.

Tested both frontends on my 144 Hz display, including repeated recordings through the usual keybinding. A synthetic test with audio arriving in 40 ms batches measured 7 ms median and 95th-percentile frame-callback intervals in both frontends, and confirmed idle hiding and restart. Unit tests cover timing at 60, 144, and 240 Hz, interpolation, transient preservation, counter wrap, and input stalls.

Please try it. It's smooooth.

Validation: `cargo fmt --check`, default and OSD-feature Clippy with `-D warnings`, builds of both frontends, and `cargo test` (1,120 passed, 2 ignored).
