### PR TITLE
Fix stalled Seed-ASR live text after a provisional revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6116,6 +6116,7 @@ dependencies = [
  "egui",
  "egui-wgpu",
  "evdev",
+ "flate2",
  "futures-util",
  "glib 0.22.7",
  "gtk4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,10 @@ hound = "3"  # WAV file reading/writing
 # HTTP client for remote transcription
 ureq = { version = "2", features = ["json"] }
 
-# WebSocket client for Soniox streaming backend
+# WebSocket client for cloud streaming backends
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"
+flate2 = "1"
 # Async HTTP client for Soniox async transcription API (multipart upload + poll)
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -143,6 +143,22 @@ on_demand_loading = false
 #
 # on_demand_loading = false
 
+# [seedasr]
+# Volcengine Seed-ASR cloud WebSocket engine (engine = "seedasr").
+# Use either api_key or the legacy app_id + access_token pair.
+# api_key = "your-api-key"             # Or SEEDASR_API_KEY
+# app_id = "your-app-id"               # Or SEEDASR_APP_ID
+# access_token = "your-access-token"   # Or SEEDASR_ACCESS_TOKEN
+# resource_id = "volc.seedasr.sauc.duration"
+# url = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async"
+# streaming = true
+# type_partials = false
+# language = "auto"
+# enable_itn = true
+# enable_punc = true
+# enable_ddc = false
+# end_window_ms = 800
+
 [output]
 # Primary output mode: "type", "clipboard", or "paste"
 # - type: Simulates keyboard input at cursor position (requires wtype or ydotool)

--- a/config/default.toml
+++ b/config/default.toml
@@ -3,7 +3,8 @@
 # Location: ~/.config/voxtype/config.toml
 # All settings can be overridden via CLI flags
 
-# Transcription engine: "whisper" (default) or "parakeet"
+# Transcription engine: "whisper" (default), "parakeet", or another engine
+# reported by `voxtype info engines`, including the cloud-hosted "seedasr".
 # Whisper: whisper.cpp via whisper-rs (most compatible)
 # Parakeet: NVIDIA FastConformer via ONNX Runtime (requires --features parakeet)
 # engine = "whisper"

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
             { text: "Model Selection", link: "/MODEL_SELECTION_GUIDE" },
             { text: "Waybar Integration", link: "/WAYBAR" },
             { text: "Parakeet ASR", link: "/PARAKEET" },
+            { text: "Seed-ASR", link: "/SEEDASR" },
             { text: "CI Setup", link: "/CI-SETUP" },
           ],
         },

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -76,10 +76,11 @@ config changes; restart it with `systemctl --user restart voxtype` for the
 new engine to take effect.
 
 **Notes:**
-- Whisper, Remote Whisper, and Soniox run in every binary. The other engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) require an ONNX-enabled binary (`voxtype-*-onnx-*`)
+- Whisper, Remote Whisper, Soniox, and Seed-ASR run in every binary. The other engines (Parakeet, Moonshine, SenseVoice, Paraformer, Dolphin, Omnilingual, Cohere) require an ONNX-enabled binary (`voxtype-*-onnx-*`)
 - Each ONNX engine reads its own `[<engine>]` section (e.g. `[parakeet]`, `[cohere]`)
 - See [PARAKEET.md](PARAKEET.md) for detailed Parakeet setup instructions
 - See [MOONSHINE.md](MOONSHINE.md) for detailed Moonshine setup instructions
+- See [SEEDASR.md](SEEDASR.md) for Seed-ASR authentication, configuration, and protocol details
 - Cohere Transcribe is the largest model voxtype ships (~3 GB int8); use `voxtype setup model` to download it
 
 ---

--- a/docs/SEEDASR.md
+++ b/docs/SEEDASR.md
@@ -37,6 +37,18 @@ feature.
 
 ## Quick start
 
+Run `voxtype configure`, choose `seedasr` in the Engine section, select an
+authentication mode, and enter its credentials. The form masks API keys and
+access tokens.
+
+The same setup can be performed non-interactively:
+
+```bash
+voxtype config set engine seedasr
+voxtype config set seedasr.api_key "$SEEDASR_API_KEY"
+voxtype config set seedasr.resource_id volc.seedasr.sauc.duration
+```
+
 ### New-console credentials
 
 ```toml

--- a/docs/SEEDASR.md
+++ b/docs/SEEDASR.md
@@ -1,0 +1,207 @@
+# Volcengine Seed-ASR Integration
+
+This document describes voxtype's native Volcengine Seed-ASR engine. It covers
+configuration, authentication, streaming behavior, and the WebSocket protocol
+boundary implemented by `transcribe::seedasr`.
+
+## Overview
+
+Seed-ASR is a cloud speech-recognition engine. Voxtype sends 16 kHz mono PCM
+audio to Volcengine over WebSocket and maps cumulative recognition results to
+its existing streaming events.
+
+The initial implementation supports:
+
+- Seed-ASR 2.0 bidirectional streaming
+- New-console API key authentication
+- Legacy-console App ID and access token authentication
+- Native live streaming and buffered one-shot transcription
+- Stable final results, optional partial typing, and tail correction
+- A configurable resource ID and WebSocket URL
+
+OSD transcript snapshots are deliberately outside this implementation. The
+engine only emits the existing `StreamingEvent` variants consumed by the daemon.
+
+Seed-ASR is a third-party paid service. Audio leaves the local machine and is
+subject to the account's Volcengine billing, retention, and regional policies.
+Use a local engine when dictated audio cannot be sent off-device.
+
+## Requirements
+
+1. A Volcengine account with Seed-ASR enabled.
+2. Either a new-console API key or legacy-console credentials.
+3. Network access to the configured WebSocket endpoint.
+
+Seed-ASR is compiled into every voxtype binary and does not require a Cargo
+feature.
+
+## Quick start
+
+### New-console credentials
+
+```toml
+engine = "seedasr"
+
+[hotkey]
+mode = "toggle"
+
+[seedasr]
+api_key = "your-api-key"
+resource_id = "volc.seedasr.sauc.duration"
+```
+
+The API key can be kept out of the configuration file:
+
+```bash
+export SEEDASR_API_KEY="your-api-key"
+```
+
+### Legacy-console credentials
+
+```toml
+engine = "seedasr"
+
+[hotkey]
+mode = "toggle"
+
+[seedasr]
+app_id = "your-app-id"
+access_token = "your-access-token"
+resource_id = "volc.seedasr.sauc.duration"
+```
+
+Equivalent environment variables are `SEEDASR_APP_ID` and
+`SEEDASR_ACCESS_TOKEN`.
+
+## Authentication
+
+Voxtype accepts exactly one authentication mode per configuration.
+
+| Mode | Configuration | WebSocket headers |
+|---|---|---|
+| New console | `api_key` | `X-Api-Key` |
+| Legacy console | `app_id` and `access_token` | `X-Api-App-Key` and `X-Api-Access-Key` |
+
+Both modes also send a generated UUID in `X-Api-Request-Id` and the configured
+value in `X-Api-Resource-Id`.
+
+Configuring both `api_key` and any legacy credential is an error. Legacy mode
+requires both `app_id` and `access_token`.
+
+## Streaming and buffered modes
+
+### Native streaming
+
+`streaming = true` is the default. Voxtype opens the bidirectional WebSocket at
+recording start and sends audio in 200 ms gzip-compressed PCM16 frames. The
+daemon automatically treats this as a streaming engine and promotes an
+incompatible push-to-talk hotkey to toggle mode through the existing streaming
+gate.
+
+The request enables `enable_nonstream` so the service can return its second-pass
+stable result for each finalized utterance. This is distinct from voxtype's
+`streaming` setting: the former is a Seed-ASR two-pass recognition option, while
+the latter selects voxtype's live pipeline.
+
+### Buffered one-shot mode
+
+Set `streaming = false` to keep push-to-talk behavior. Voxtype buffers the
+recording, opens the configured WebSocket after release, sends the complete
+audio stream, and returns the last cumulative transcript.
+
+Both modes use `url`. The default endpoint is:
+
+```text
+wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async
+```
+
+## Result reconciliation
+
+Seed-ASR returns cumulative transcript snapshots. Text in the current utterance
+can change until its `definite` flag becomes true. Voxtype converts those
+snapshots to cursor-oriented deltas:
+
+| Seed-ASR state | Voxtype event | Purpose |
+|---|---|---|
+| Stable prefix extends committed text | `Final` | Types and commits only the new stable suffix |
+| Optional provisional prefix extends the typed tail | `Partial` | Types only the new provisional suffix |
+| Stable text revises a typed provisional tail | `Replace` | Backspaces the divergent Unicode characters and commits the replacement |
+| Final response package | `Ended` after reconciliation | Closes the session cleanly |
+| Protocol, server, or network failure | `Error`, then `Ended` | Surfaces the failure and resets daemon state |
+
+`type_partials = false` is the default. This emits stable text only and avoids
+visible corrections. When enabled, voxtype types only monotonic extensions of a
+partial result; it suppresses provisional revisions until Seed-ASR finalizes the
+utterance.
+
+If the service revises text already marked definite and committed, voxtype ends
+the session with an error. The existing streaming contract can revise the active
+partial tail but intentionally cannot rewrite arbitrary older output.
+
+## Wire protocol
+
+The engine implements Volcengine's binary WebSocket framing directly:
+
+1. A full client request (`0x1`) contains gzip-compressed JSON.
+2. Audio-only requests (`0x2`) contain gzip-compressed raw PCM16.
+3. The last audio request uses the protocol's last-packet flag.
+4. Full server responses (`0x9`) are decompressed and parsed as JSON.
+5. Server error frames (`0xF`) are converted to `TranscribeError`.
+
+The response parser accepts both the direct recognition payload and the
+`payload_msg` wrapper used by newer protocol examples. A negative response
+sequence, the binary last-packet flag, or `is_last_package = true` terminates
+the recognition stream.
+
+Official protocol references:
+
+- [Seed-ASR bidirectional streaming API](https://docs.volcengine.com/docs/6561/2630027?lang=zh)
+- [Seed-ASR binary WebSocket protocol](https://docs.volcengine.com/docs/6561/1354869?lang=zh)
+- [Legacy credential FAQ](https://docs.volcengine.com/docs/6561/196768)
+
+## Configuration reference
+
+| Option | Environment variable | Default | Description |
+|---|---|---|---|
+| `api_key` | `SEEDASR_API_KEY` | unset | New-console API key |
+| `app_id` | `SEEDASR_APP_ID` | unset | Legacy-console App ID |
+| `access_token` | `SEEDASR_ACCESS_TOKEN` | unset | Legacy-console access token |
+| `resource_id` | `SEEDASR_RESOURCE_ID` | `volc.seedasr.sauc.duration` | Service/resource identifier |
+| `url` | `SEEDASR_URL` | Seed-ASR 2.0 bidirectional endpoint | WebSocket endpoint |
+| `streaming` | - | `true` | Use native live streaming |
+| `type_partials` | - | `false` | Type monotonic provisional text |
+| `language` | - | unset | Recognition language; unset or `auto` enables detection |
+| `enable_itn` | - | `true` | Enable inverse text normalization |
+| `enable_punc` | - | `true` | Enable punctuation |
+| `enable_ddc` | - | `false` | Enable semantic smoothing and filler-word removal |
+| `end_window_ms` | - | `800` | Silence window used to finalize utterances; valid range 300-5000 ms |
+
+Common alternative resource IDs include
+`volc.seedasr.sauc.concurrent` for concurrency-based Seed-ASR 2.0 plans. Keep
+this value configurable because account entitlements and product generations
+can require a different resource ID.
+
+## Security and diagnostics
+
+API keys and access tokens are never included in voxtype logs. Startup logging
+records only the authentication mode.
+Volcengine's `X-Tt-Logid` response header is logged at debug level to help
+support teams trace failed requests.
+
+Use protocol trace logging only when needed:
+
+```bash
+RUST_LOG=voxtype::seedasr=debug,voxtype::seedasr::wire=trace voxtype daemon
+```
+
+Wire logs include recognized text but not request headers. Treat them as
+sensitive if dictated content is private.
+
+## Current limitations
+
+- The engine sends 16 kHz mono PCM16 input only.
+- Hotwords, contextual prompts, speaker diarization, and unidirectional
+  high-accuracy mode are not exposed in the initial implementation.
+- Live service integration tests require user credentials and are not part of
+  the offline test suite.
+- No OSD transcript-snapshot event is introduced by this change.

--- a/src/app/config_show.rs
+++ b/src/app/config_show.rs
@@ -108,6 +108,38 @@ pub(crate) async fn show_config(config: &config::Config) -> anyhow::Result<()> {
         println!("  gpu_device = {}", gpu_device);
     }
 
+    println!("\n[seedasr]");
+    if let Some(ref seedasr) = config.seedasr {
+        println!(
+            "  api_key = {}",
+            if seedasr.api_key.is_some() {
+                "(set)"
+            } else {
+                "(unset)"
+            }
+        );
+        println!("  app_id = {:?}", seedasr.app_id);
+        println!(
+            "  access_token = {}",
+            if seedasr.access_token.is_some() {
+                "(set)"
+            } else {
+                "(unset)"
+            }
+        );
+        println!("  resource_id = {:?}", seedasr.resource_id);
+        println!("  url = {:?}", seedasr.url);
+        println!("  streaming = {}", seedasr.streaming);
+        println!("  type_partials = {}", seedasr.type_partials);
+        println!("  language = {:?}", seedasr.language);
+        println!("  enable_itn = {}", seedasr.enable_itn);
+        println!("  enable_punc = {}", seedasr.enable_punc);
+        println!("  enable_ddc = {}", seedasr.enable_ddc);
+        println!("  end_window_ms = {}", seedasr.end_window_ms);
+    } else {
+        println!("  (not configured)");
+    }
+
     // Show Parakeet status
     println!("\n[parakeet]");
     if let Some(ref parakeet_config) = config.parakeet {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,7 @@ pub use setup::{CompositorType, SetupAction};
 /// `src/config/engines/mod.rs` so a new engine variant forces this string
 /// to update or the build breaks.
 pub const ENGINE_NAMES_CSV: &str =
-    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, openvino, soniox";
+    "whisper, parakeet, moonshine, sensevoice, paraformer, dolphin, omnilingual, cohere, openvino, soniox, seedasr";
 
 /// Diarization backends the daemon dispatches on. Used by the CLI's
 /// `value_parser` for `--diarization` so unknown values are rejected at

--- a/src/config/default_config.rs
+++ b/src/config/default_config.rs
@@ -13,6 +13,13 @@ pub const DEFAULT_CONFIG: &str = r#"# Voxtype Configuration
 # Required for `voxtype record toggle` and `voxtype status` commands.
 state_file = "auto"
 
+# Volcengine Seed-ASR example (uncomment and set engine = "seedasr"):
+# [seedasr]
+# api_key = "your-api-key" # Or use SEEDASR_API_KEY
+# resource_id = "volc.seedasr.sauc.duration"
+# streaming = true
+# type_partials = false
+
 [hotkey]
 # Key to hold for push-to-talk
 # Common choices: SCROLLLOCK, PAUSE, RIGHTALT, F13-F24

--- a/src/config/engines/mod.rs
+++ b/src/config/engines/mod.rs
@@ -9,6 +9,7 @@ mod omnilingual;
 mod openvino;
 mod paraformer;
 mod parakeet;
+mod seedasr;
 mod sensevoice;
 mod soniox;
 
@@ -19,6 +20,7 @@ pub use omnilingual::OmnilingualConfig;
 pub use openvino::OpenVinoConfig;
 pub use paraformer::ParaformerConfig;
 pub use parakeet::{ParakeetConfig, ParakeetModelType};
+pub use seedasr::{SeedAsrConfig, DEFAULT_SEEDASR_RESOURCE_ID, DEFAULT_SEEDASR_URL};
 pub use sensevoice::SenseVoiceConfig;
 pub use soniox::SonioxConfig;
 
@@ -70,6 +72,8 @@ pub enum TranscriptionEngine {
     OpenVino,
     /// Use Soniox (cloud streaming WebSocket STT).
     Soniox,
+    /// Use Volcengine Seed-ASR (cloud streaming WebSocket STT).
+    SeedAsr,
 }
 
 impl TranscriptionEngine {

--- a/src/config/engines/seedasr.rs
+++ b/src/config/engines/seedasr.rs
@@ -1,0 +1,137 @@
+//! Volcengine Seed-ASR engine configuration.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::default_true;
+
+/// Default Seed-ASR 2.0 bidirectional streaming endpoint.
+pub const DEFAULT_SEEDASR_URL: &str = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async";
+
+/// Default duration-based Seed-ASR 2.0 resource identifier.
+pub const DEFAULT_SEEDASR_RESOURCE_ID: &str = "volc.seedasr.sauc.duration";
+
+/// Volcengine Seed-ASR WebSocket configuration.
+///
+/// New-console credentials use `api_key`. Legacy-console credentials use
+/// `app_id` and `access_token`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SeedAsrConfig {
+    /// New-console API key. Falls back to `SEEDASR_API_KEY`.
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Legacy-console application ID. Falls back to `SEEDASR_APP_ID`.
+    #[serde(default)]
+    pub app_id: Option<String>,
+
+    /// Legacy-console access token. Falls back to `SEEDASR_ACCESS_TOKEN`.
+    #[serde(default)]
+    pub access_token: Option<String>,
+
+    /// Volcengine service resource ID.
+    #[serde(default = "default_resource_id")]
+    pub resource_id: String,
+
+    /// WebSocket endpoint. Override this for a compatible regional endpoint
+    /// or a local protocol test server.
+    #[serde(default = "default_url")]
+    pub url: String,
+
+    /// Use the native bidirectional streaming pipeline. When false, voxtype
+    /// buffers the recording and uses the same endpoint as a one-shot request.
+    #[serde(default = "default_true")]
+    pub streaming: bool,
+
+    /// Type stable partial results while recording. Disabled by default to
+    /// avoid visible cursor churn when the model revises its current sentence.
+    #[serde(default)]
+    pub type_partials: bool,
+
+    /// Optional recognition language code. Omit for automatic detection.
+    #[serde(default)]
+    pub language: Option<String>,
+
+    /// Enable inverse text normalization.
+    #[serde(default = "default_true")]
+    pub enable_itn: bool,
+
+    /// Enable punctuation.
+    #[serde(default = "default_true")]
+    pub enable_punc: bool,
+
+    /// Enable semantic smoothing and filler-word removal.
+    #[serde(default)]
+    pub enable_ddc: bool,
+
+    /// Server-side silence window in milliseconds used to finalize an
+    /// utterance. Volcengine recommends 800-1000 ms for realtime dictation.
+    #[serde(default = "default_end_window_ms")]
+    pub end_window_ms: u32,
+}
+
+fn default_resource_id() -> String {
+    DEFAULT_SEEDASR_RESOURCE_ID.to_string()
+}
+
+fn default_url() -> String {
+    DEFAULT_SEEDASR_URL.to_string()
+}
+
+fn default_end_window_ms() -> u32 {
+    800
+}
+
+impl Default for SeedAsrConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            app_id: None,
+            access_token: None,
+            resource_id: default_resource_id(),
+            url: default_url(),
+            streaming: true,
+            type_partials: false,
+            language: None,
+            enable_itn: true,
+            enable_punc: true,
+            enable_ddc: false,
+            end_window_ms: default_end_window_ms(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, TranscriptionEngine};
+
+    #[test]
+    fn defaults_target_seedasr_2_bidirectional_streaming() {
+        let cfg = SeedAsrConfig::default();
+        assert_eq!(cfg.url, DEFAULT_SEEDASR_URL);
+        assert_eq!(cfg.resource_id, DEFAULT_SEEDASR_RESOURCE_ID);
+        assert!(cfg.streaming);
+        assert!(!cfg.type_partials);
+        assert_eq!(cfg.end_window_ms, 800);
+    }
+
+    #[test]
+    fn parses_legacy_configuration_and_enables_streaming_gate() {
+        let cfg: Config = toml::from_str(
+            r#"
+                engine = "seedasr"
+
+                [seedasr]
+                app_id = "app"
+                access_token = "token"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.engine, TranscriptionEngine::SeedAsr);
+        assert!(cfg.streaming_active());
+        let seedasr = cfg.seedasr.unwrap();
+        assert_eq!(seedasr.resource_id, DEFAULT_SEEDASR_RESOURCE_ID);
+        assert_eq!(seedasr.url, DEFAULT_SEEDASR_URL);
+    }
+}

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1,6 +1,7 @@
 use super::parse::parse_config_with_defaults;
 use super::{
-    Config, LanguageConfig, OpenVinoConfig, OutputMode, SonioxConfig, TranscriptionEngine,
+    Config, LanguageConfig, OpenVinoConfig, OutputMode, SeedAsrConfig, SonioxConfig,
+    TranscriptionEngine,
 };
 use crate::error::VoxtypeError;
 use std::path::{Path, PathBuf};
@@ -196,6 +197,38 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, VoxtypeError> {
             .soniox
             .get_or_insert_with(SonioxConfig::default)
             .api_key = Some(key);
+    }
+
+    // Volcengine Seed-ASR
+    if let Ok(key) = std::env::var("SEEDASR_API_KEY") {
+        config
+            .seedasr
+            .get_or_insert_with(SeedAsrConfig::default)
+            .api_key = Some(key);
+    }
+    if let Ok(app_id) = std::env::var("SEEDASR_APP_ID") {
+        config
+            .seedasr
+            .get_or_insert_with(SeedAsrConfig::default)
+            .app_id = Some(app_id);
+    }
+    if let Ok(token) = std::env::var("SEEDASR_ACCESS_TOKEN") {
+        config
+            .seedasr
+            .get_or_insert_with(SeedAsrConfig::default)
+            .access_token = Some(token);
+    }
+    if let Ok(resource_id) = std::env::var("SEEDASR_RESOURCE_ID") {
+        config
+            .seedasr
+            .get_or_insert_with(SeedAsrConfig::default)
+            .resource_id = resource_id;
+    }
+    if let Ok(url) = std::env::var("SEEDASR_URL") {
+        config
+            .seedasr
+            .get_or_insert_with(SeedAsrConfig::default)
+            .url = url;
     }
     if let Ok(val) = std::env::var("VOXTYPE_RESTORE_CLIPBOARD") {
         config.output.restore_clipboard = parse_bool_env(&val);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,8 +29,8 @@ pub use audio::{AudioConfig, AudioFeedbackConfig};
 pub use default_config::{default_config_content, DEFAULT_CONFIG};
 pub use engines::{
     CohereConfig, DolphinConfig, MoonshineConfig, OmnilingualConfig, OpenVinoConfig,
-    ParaformerConfig, ParakeetConfig, ParakeetModelType, SenseVoiceConfig, SonioxConfig,
-    TranscriptionEngine,
+    ParaformerConfig, ParakeetConfig, ParakeetModelType, SeedAsrConfig, SenseVoiceConfig,
+    SonioxConfig, TranscriptionEngine, DEFAULT_SEEDASR_RESOURCE_ID, DEFAULT_SEEDASR_URL,
 };
 pub use hotkey::{ActivationMode, HotkeyConfig};
 pub use language::LanguageConfig;

--- a/src/config/root.rs
+++ b/src/config/root.rs
@@ -1,8 +1,8 @@
 use super::{
     AudioConfig, CohereConfig, DolphinConfig, HotkeyConfig, MeetingConfig, MoonshineConfig,
     OmnilingualConfig, OpenVinoConfig, OutputConfig, ParaformerConfig, ParakeetConfig, Profile,
-    SenseVoiceConfig, SonioxConfig, StatusConfig, StreamingConfig, TextConfig, TranscriptionEngine,
-    VadConfig, WhisperConfig,
+    SeedAsrConfig, SenseVoiceConfig, SonioxConfig, StatusConfig, StreamingConfig, TextConfig,
+    TranscriptionEngine, VadConfig, WhisperConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -24,8 +24,8 @@ pub struct Config {
     #[serde(default)]
     pub output: OutputConfig,
 
-    /// Transcription engine: "whisper" (default) or "parakeet"
-    /// Parakeet requires: cargo build --features parakeet
+    /// Active transcription engine. Local optional engines may require a
+    /// matching Cargo feature; cloud engines are always compiled.
     #[serde(default)]
     pub engine: TranscriptionEngine,
 
@@ -65,6 +65,11 @@ pub struct Config {
     /// (optional, only used when engine = "soniox")
     #[serde(default)]
     pub soniox: Option<SonioxConfig>,
+
+    /// Volcengine Seed-ASR streaming WebSocket STT configuration
+    /// (optional, only used when engine = "seedasr")
+    #[serde(default)]
+    pub seedasr: Option<SeedAsrConfig>,
 
     /// Shared sliding-window streaming engine tuning, used by every batch
     /// backend wrapped in `transcribe::sliding_window` (currently `whisper`
@@ -127,6 +132,7 @@ impl Default for Config {
             cohere: None,
             openvino: None,
             soniox: None,
+            seedasr: None,
             streaming: None,
             text: TextConfig::default(),
             vad: VadConfig::default(),
@@ -167,6 +173,9 @@ impl Config {
                 .as_ref()
                 .map(|s| s.streaming && !s.async_api)
                 .unwrap_or(false),
+            TranscriptionEngine::SeedAsr => {
+                self.seedasr.as_ref().map(|s| s.streaming).unwrap_or(false)
+            }
             // Same reasoning as Parakeet/Soniox: an absent [openvino] section
             // means the transcriber can't initialize anyway, so don't
             // auto-promote push-to-talk to toggle for a config that can't
@@ -375,7 +384,7 @@ impl Config {
                 .map(|o| o.on_demand_loading)
                 .unwrap_or(false),
             // Soniox is a cloud backend; nothing to load on demand.
-            TranscriptionEngine::Soniox => false,
+            TranscriptionEngine::Soniox | TranscriptionEngine::SeedAsr => false,
         }
     }
 
@@ -400,6 +409,7 @@ impl Config {
             TranscriptionEngine::SenseVoice => {
                 self.sensevoice.as_ref().map(|s| s.language.as_str())?
             }
+            TranscriptionEngine::SeedAsr => self.seedasr.as_ref()?.language.as_deref()?,
             // Parakeet, Moonshine, Paraformer, Dolphin, Omnilingual and Soniox
             // either detect the language or are fixed to one.
             _ => return None,
@@ -460,6 +470,11 @@ impl Config {
                 .as_ref()
                 .map(|s| s.model.as_str())
                 .unwrap_or("soniox (not configured)"),
+            TranscriptionEngine::SeedAsr => self
+                .seedasr
+                .as_ref()
+                .map(|_| "bigmodel")
+                .unwrap_or("seedasr (not configured)"),
         }
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -198,8 +198,7 @@ pub fn feature_compiled(feature: &str) -> bool {
 /// Engines `voxtype config set engine` accepts. Mirrors `ENGINE_CHOICES` in
 /// `src/tui/engine.rs` and [`crate::config_set::ENGINE_NAMES`]. Note this is
 /// deliberately narrower than [`super::TranscriptionEngine`], which also has
-/// a `Soniox` variant that neither the TUI picker nor `config set engine`
-/// offers today.
+/// cloud-engine variants configured through their own tables.
 const ENGINE_CHOICES: &[&str] = crate::config_set::ENGINE_NAMES;
 
 const WHISPER_MODE_CHOICES: &[&str] = &["local", "remote", "cli"];

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -195,11 +195,20 @@ pub fn feature_compiled(feature: &str) -> bool {
 // Choice lists. Each mirrors the corresponding `*_CHOICES` const in src/tui/.
 // ---------------------------------------------------------------------------
 
-/// Engines `voxtype config set engine` accepts. Mirrors `ENGINE_CHOICES` in
-/// `src/tui/engine.rs` and [`crate::config_set::ENGINE_NAMES`]. Note this is
-/// deliberately narrower than [`super::TranscriptionEngine`], which also has
-/// cloud-engine variants configured through their own tables.
-const ENGINE_CHOICES: &[&str] = crate::config_set::ENGINE_NAMES;
+/// Engines exposed by config settings surfaces. Soniox still requires manual
+/// table configuration; Seed-ASR has a complete schema and TUI form.
+const ENGINE_CHOICES: &[&str] = &[
+    "whisper",
+    "parakeet",
+    "moonshine",
+    "sensevoice",
+    "paraformer",
+    "dolphin",
+    "omnilingual",
+    "cohere",
+    "openvino",
+    "seedasr",
+];
 
 const WHISPER_MODE_CHOICES: &[&str] = &["local", "remote", "cli"];
 const WHISPER_LANG_CHOICES: &[&str] = &[
@@ -211,6 +220,9 @@ const COHERE_LANG_CHOICES: &[&str] = &[
 ];
 const OPENVINO_DEVICE_CHOICES: &[&str] = &["NPU", "GPU", "CPU", "AUTO"];
 const PARAKEET_MODEL_TYPE_CHOICES: &[&str] = &["tdt", "ctc"];
+const SEEDASR_RESOURCE_ID_CHOICES: &[&str] =
+    &["volc.seedasr.sauc.duration", "volc.seedasr.sauc.concurrent"];
+const SEEDASR_LANGUAGE_CHOICES: &[&str] = &["auto", "zh", "en"];
 
 const HOTKEY_MODE_CHOICES: &[&str] = &["push_to_talk", "toggle"];
 const HOTKEY_KEY_CHOICES: &[&str] = &[
@@ -752,6 +764,130 @@ pub const CONFIG_KEYS: &[KeySpec] = &[
         "Enable live transcription through the shared sliding-window engine.",
     )
     .for_onnx_engine("openvino"),
+    // Seed-ASR
+    spec(
+        "seedasr.api_key",
+        "seedasr",
+        "api_key",
+        KeyType::String,
+        "Engine",
+        "API key",
+        "New-console Volcengine API key. Mutually exclusive with the legacy app_id and access_token credentials.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.app_id",
+        "seedasr",
+        "app_id",
+        KeyType::String,
+        "Engine",
+        "App ID",
+        "Legacy-console Volcengine application ID.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.access_token",
+        "seedasr",
+        "access_token",
+        KeyType::String,
+        "Engine",
+        "Access token",
+        "Legacy-console Volcengine access token. Used together with app_id.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.resource_id",
+        "seedasr",
+        "resource_id",
+        open(SEEDASR_RESOURCE_ID_CHOICES),
+        "Engine",
+        "Resource ID",
+        "Volcengine Seed-ASR service resource identifier.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.url",
+        "seedasr",
+        "url",
+        KeyType::String,
+        "Engine",
+        "WebSocket URL",
+        "Seed-ASR WebSocket endpoint. Use wss:// for production connections.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.streaming",
+        "seedasr",
+        "streaming",
+        KeyType::Bool,
+        "Engine",
+        "Streaming",
+        "Stream microphone audio to Seed-ASR while recording instead of buffering the full recording first.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.type_partials",
+        "seedasr",
+        "type_partials",
+        KeyType::Bool,
+        "Engine",
+        "Type partials",
+        "Type stable partial results while recording. Revised text may cause visible cursor edits.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.language",
+        "seedasr",
+        "language",
+        open(SEEDASR_LANGUAGE_CHOICES),
+        "Engine",
+        "Language",
+        "Recognition language code, or auto for automatic detection.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.enable_itn",
+        "seedasr",
+        "enable_itn",
+        KeyType::Bool,
+        "Engine",
+        "Inverse text normalization",
+        "Convert spoken numbers, dates, and similar expressions into written form.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.enable_punc",
+        "seedasr",
+        "enable_punc",
+        KeyType::Bool,
+        "Engine",
+        "Punctuation",
+        "Ask Seed-ASR to add punctuation to recognition results.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.enable_ddc",
+        "seedasr",
+        "enable_ddc",
+        KeyType::Bool,
+        "Engine",
+        "Semantic smoothing",
+        "Enable semantic smoothing and filler-word removal.",
+    )
+    .for_engine("seedasr"),
+    spec(
+        "seedasr.end_window_ms",
+        "seedasr",
+        "end_window_ms",
+        KeyType::Int {
+            min: 300,
+            max: 5_000,
+        },
+        "Engine",
+        "End window",
+        "Server-side silence window in milliseconds used to finalize an utterance.",
+    )
+    .for_engine("seedasr"),
     // -- Hotkey -------------------------------------------------------------
     spec(
         "hotkey.enabled",
@@ -1548,7 +1684,7 @@ pub fn validate_value(spec: &KeySpec, raw: &str) -> Result<TypedValue, ValueErro
 fn ensure_required_siblings(editor: &mut ConfigEditor, spec: &KeySpec) {
     let Some(engine) = spec.engine else { return };
     // Whisper's table is not optional and its `model` has a serde default.
-    if engine == "whisper" || spec.field == "model" {
+    if matches!(engine, "whisper" | "seedasr") || spec.field == "model" {
         return;
     }
     if editor.get_string(spec.table, "model").is_none() {
@@ -1568,6 +1704,16 @@ fn ensure_required_siblings(editor: &mut ConfigEditor, spec: &KeySpec) {
 /// refuse to load the config it had just written.
 pub fn apply(editor: &mut ConfigEditor, found: &Found, value: &TypedValue) {
     ensure_required_siblings(editor, found.spec());
+    match found.spec().key {
+        "seedasr.api_key" => {
+            editor.unset("seedasr", "app_id");
+            editor.unset("seedasr", "access_token");
+        }
+        "seedasr.app_id" | "seedasr.access_token" => {
+            editor.unset("seedasr", "api_key");
+        }
+        _ => {}
+    }
     let (table, field) = found.target();
     match value {
         TypedValue::Bool(b) => editor.set_bool(table, field, *b),
@@ -1621,6 +1767,7 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
     let om = || cfg.omnilingual.clone().unwrap_or_default();
     let co = || cfg.cohere.clone().unwrap_or_default();
     let ov = || cfg.openvino.clone().unwrap_or_default();
+    let seed = || cfg.seedasr.clone().unwrap_or_default();
 
     let v = match key {
         "engine" => json!(cfg.engine.name()),
@@ -1716,6 +1863,22 @@ pub fn resolve(key: &str, cfg: &Config) -> Option<Json> {
         "openvino.on_demand_loading" => json!(ov().on_demand_loading),
         "openvino.openvino_dir" => opt_str(ov().openvino_dir.as_ref()),
         "openvino.streaming" => json!(ov().streaming),
+
+        "seedasr.api_key" => opt_str(seed().api_key.as_ref()),
+        "seedasr.app_id" => opt_str(seed().app_id.as_ref()),
+        "seedasr.access_token" => opt_str(seed().access_token.as_ref()),
+        "seedasr.resource_id" => json!(seed().resource_id),
+        "seedasr.url" => json!(seed().url),
+        "seedasr.streaming" => json!(seed().streaming),
+        "seedasr.type_partials" => json!(seed().type_partials),
+        "seedasr.language" => match seed().language {
+            Some(language) => json!(language),
+            None => json!("auto"),
+        },
+        "seedasr.enable_itn" => json!(seed().enable_itn),
+        "seedasr.enable_punc" => json!(seed().enable_punc),
+        "seedasr.enable_ddc" => json!(seed().enable_ddc),
+        "seedasr.end_window_ms" => json!(seed().end_window_ms),
 
         "hotkey.enabled" => json!(cfg.hotkey.enabled),
         "hotkey.key" => json!(cfg.hotkey.key),
@@ -2267,8 +2430,8 @@ mod tests {
     #[test]
     fn feature_gate_agrees_with_config_set() {
         for name in config_set::ENGINE_NAMES {
-            if *name == "whisper" {
-                continue; // always available, so it has no feature entry
+            if matches!(*name, "whisper" | "seedasr") {
+                continue; // unconditional engines have no Cargo feature entry
             }
             assert_eq!(
                 feature_compiled(name),
@@ -2285,11 +2448,12 @@ mod tests {
     fn onnx_engine_keys_are_feature_gated() {
         for s in CONFIG_KEYS {
             let Some(engine) = s.engine else { continue };
-            if engine == "whisper" {
+            if matches!(engine, "whisper" | "seedasr") {
                 assert!(
                     s.requires_feature.is_none(),
-                    "{} should not be feature-gated; whisper is always compiled in",
-                    s.key
+                    "{} should not be feature-gated; {} is always compiled in",
+                    s.key,
+                    engine
                 );
             } else {
                 assert_eq!(
@@ -2328,12 +2492,37 @@ mod tests {
 
     #[test]
     fn engine_choices_match_config_set() {
-        assert_eq!(ENGINE_CHOICES, config_set::ENGINE_NAMES);
+        assert!(config_set::ENGINE_NAMES
+            .iter()
+            .all(|name| ENGINE_CHOICES.contains(name)));
+        let schema_only: Vec<_> = ENGINE_CHOICES
+            .iter()
+            .filter(|name| !config_set::ENGINE_NAMES.contains(name))
+            .copied()
+            .collect();
+        assert_eq!(schema_only, ["seedasr"]);
         let spec = scalar_keys().find(|s| s.key == "engine").unwrap();
         for name in ENGINE_CHOICES {
             assert!(validate_value(spec, name).is_ok(), "engine '{}'", name);
         }
         assert!(validate_value(spec, "nope").is_err());
+    }
+
+    #[test]
+    fn setting_a_seedasr_credential_scheme_removes_the_other_one() {
+        let (_dir, path) = temp_config();
+        let mut ed = ConfigEditor::load_from_path(path).unwrap();
+        ed.set_string("seedasr", "app_id", "legacy-app");
+        ed.set_string("seedasr", "access_token", "legacy-token");
+
+        let api = find_key("seedasr.api_key").unwrap();
+        apply(&mut ed, &api, &TypedValue::Str("new-api-key".to_string()));
+        assert_eq!(
+            ed.get_string("seedasr", "api_key").as_deref(),
+            Some("new-api-key")
+        );
+        assert!(ed.get_string("seedasr", "app_id").is_none());
+        assert!(ed.get_string("seedasr", "access_token").is_none());
     }
 
     #[test]

--- a/src/config_set.rs
+++ b/src/config_set.rs
@@ -85,10 +85,10 @@ impl ConfigSetError {
     }
 }
 
-/// Engines `config set engine` and the settings UIs offer, in
-/// [`TranscriptionEngine`] declaration order. Deliberately narrower than the
-/// enum: `soniox` is configured through its own `[soniox]` table and is not
-/// offered by the TUI picker or `config set engine`, so it is excluded here.
+/// Engines offered by the model/settings UIs, in [`TranscriptionEngine`]
+/// declaration order. Deliberately narrower than the enum: cloud engines are
+/// configured through their own tables and have no downloadable model, so they
+/// are excluded here.
 /// The `engine_names_track_the_enum` test pins this list against the enum so
 /// a new variant can't be silently forgotten.
 pub const ENGINE_NAMES: &[&str] = &[
@@ -116,8 +116,8 @@ pub fn parse_engine(name: &str) -> Option<TranscriptionEngine> {
 
 /// Was this binary compiled with the feature needed to run the given engine?
 ///
-/// Whisper and Soniox are unconditional (Soniox was un-feature-gated in
-/// #441); every other engine is gated on the corresponding Cargo feature.
+/// Whisper, Soniox, and Seed-ASR are unconditional cloud/core engines; every
+/// other engine is gated on the corresponding Cargo feature.
 /// This is the source-of-truth check that matches what the TUI shows on
 /// source builds (see `EngineState::refresh_binary_match` in
 /// `src/tui/engine.rs`). The TUI's `compiled_features()` list in
@@ -133,7 +133,7 @@ pub fn engine_feature_compiled(name: &str) -> bool {
     };
     match engine {
         TranscriptionEngine::Whisper => true,
-        TranscriptionEngine::Soniox => true,
+        TranscriptionEngine::Soniox | TranscriptionEngine::SeedAsr => true,
         TranscriptionEngine::Parakeet => cfg!(feature = "parakeet"),
         TranscriptionEngine::Moonshine => cfg!(feature = "moonshine"),
         TranscriptionEngine::SenseVoice => cfg!(feature = "sensevoice"),
@@ -266,7 +266,7 @@ mod tests {
             .collect();
         assert_eq!(
             excluded,
-            [&"soniox"],
+            [&"soniox", &"seedasr"],
             "new engine variants must be added to ENGINE_NAMES or documented as excluded"
         );
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1779,7 +1779,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
                 | crate::config::TranscriptionEngine::OpenVino
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::SeedAsr => {
                     if let Some(ref t) = transcriber_preloaded {
                         Ok(t.clone())
                     } else {
@@ -3201,9 +3202,10 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
                 | crate::config::TranscriptionEngine::OpenVino
-                | crate::config::TranscriptionEngine::Soniox => {
-                    // Non-Whisper engines do their own setup; Soniox just validates
-                    // API key + endpoint at construction (no model to download).
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::SeedAsr => {
+                    // Non-Whisper engines do their own setup; cloud engines only
+                    // validate credentials and endpoints at construction.
                     transcriber_preloaded = Some(Arc::from(crate::transcribe::create_transcriber(
                         &self.config,
                     )?));
@@ -3322,7 +3324,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
                 | crate::config::TranscriptionEngine::OpenVino
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::SeedAsr => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -3353,7 +3356,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
                 | crate::config::TranscriptionEngine::OpenVino
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::SeedAsr => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -3536,7 +3540,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
                 | crate::config::TranscriptionEngine::OpenVino
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::SeedAsr => {
                                             let config = self.config.clone();
                                             self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                                 crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -3567,7 +3572,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
                 | crate::config::TranscriptionEngine::OpenVino
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::SeedAsr => {
                                             if let Some(ref t) = transcriber_preloaded {
                                                 let transcriber = t.clone();
                                                 tokio::task::spawn_blocking(move || {
@@ -4058,7 +4064,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
                 | crate::config::TranscriptionEngine::OpenVino
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::SeedAsr => {
                                     let config = self.config.clone();
                                     self.model_load_task = Some(tokio::task::spawn_blocking(move || {
                                         crate::transcribe::create_transcriber(&config).map(Arc::from)
@@ -4088,7 +4095,8 @@ impl Daemon {
                 | crate::config::TranscriptionEngine::Omnilingual
                 | crate::config::TranscriptionEngine::Cohere
                 | crate::config::TranscriptionEngine::OpenVino
-                | crate::config::TranscriptionEngine::Soniox => {
+                | crate::config::TranscriptionEngine::Soniox
+                | crate::config::TranscriptionEngine::SeedAsr => {
                                     if let Some(ref t) = transcriber_preloaded {
                                         let transcriber = t.clone();
                                         tokio::task::spawn_blocking(move || {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1567,6 +1567,12 @@ impl Daemon {
                         FileMode::Append => "appended",
                     };
                     tracing::info!("{} streamed transcription to {:?}", mode_str, output_path);
+                    let outcome = if final_text.trim().is_empty() {
+                        TranscriptOutcome::empty()
+                    } else {
+                        TranscriptOutcome::ok(final_text.chars().count())
+                    };
+                    write_result_sidecar(&output_path, &outcome);
                     self.play_feedback(SoundEvent::TranscriptionComplete);
                 }
                 Err(e) => {
@@ -1575,6 +1581,7 @@ impl Daemon {
                         output_path,
                         e
                     );
+                    write_result_sidecar(&output_path, &TranscriptOutcome::error(&e.to_string()));
                 }
             }
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -290,6 +290,7 @@ fn send_macos_native(title: &str, body: &str, engine: Option<TranscriptionEngine
         | TranscriptionEngine::Omnilingual
         | TranscriptionEngine::Cohere
         | TranscriptionEngine::Soniox
+        | TranscriptionEngine::SeedAsr
         | TranscriptionEngine::OpenVino => None,
     });
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -179,6 +179,7 @@ pub fn engine_icon(engine: crate::config::TranscriptionEngine) -> &'static str {
         crate::config::TranscriptionEngine::Omnilingual => "\u{1F30D}", // 🌍
         crate::config::TranscriptionEngine::Cohere => "\u{1F4DD}",   // 📝
         crate::config::TranscriptionEngine::Soniox => "\u{2601}\u{FE0F}", // ☁️
+        crate::config::TranscriptionEngine::SeedAsr => "\u{1F331}",  // 🌱
         crate::config::TranscriptionEngine::OpenVino => "\u{1F9E0}", // 🧠
     }
 }

--- a/src/output/streaming.rs
+++ b/src/output/streaming.rs
@@ -179,6 +179,10 @@ impl StreamingSession {
         post_output_command: Option<&str>,
     ) -> Result<(), OutputError> {
         if text.is_empty() {
+            // An empty Final can still promote an already-typed partial.
+            // Snapshot-based providers use this when the final text exactly
+            // matches the visible provisional text.
+            self.finalized_text.push_str(&self.partial);
             self.clear_partial();
             return Ok(());
         }
@@ -233,6 +237,7 @@ impl StreamingSession {
     /// is a file.
     pub fn commit_segment_silent(&mut self, text: &str) {
         if text.is_empty() {
+            self.finalized_text.push_str(&self.partial);
             self.clear_partial();
             return;
         }
@@ -290,11 +295,12 @@ impl StreamingSession {
             };
             output_with_fallback(chain, text, opts).await?;
             self.typed_chars += text.chars().count();
-            // Treat the (now-truncated) partial + new text as committed,
-            // matching commit_segment's accounting.
-            let finalized_tail = format!("{}{}", self.partial, text);
-            self.finalized_text.push_str(&finalized_tail);
         }
+        // Treat the (now-truncated) partial plus any replacement as
+        // committed. The replacement may be empty when finalization only
+        // removes a provisional suffix.
+        let finalized_tail = format!("{}{}", self.partial, text);
+        self.finalized_text.push_str(&finalized_tail);
         self.clear_partial();
         Ok(())
     }
@@ -318,10 +324,8 @@ impl StreamingSession {
             let new_partial_len = self.partial.chars().count().saturating_sub(backspace);
             self.partial = self.partial.chars().take(new_partial_len).collect();
         }
-        if !text.is_empty() {
-            let finalized_tail = format!("{}{}", self.partial, text);
-            self.finalized_text.push_str(&finalized_tail);
-        }
+        let finalized_tail = format!("{}{}", self.partial, text);
+        self.finalized_text.push_str(&finalized_tail);
         self.clear_partial();
     }
 
@@ -538,6 +542,32 @@ mod tests {
             .unwrap();
         assert!(rec.typed().is_empty());
         assert_eq!(session.typed_chars(), 0);
+    }
+
+    #[tokio::test]
+    async fn empty_final_promotes_an_existing_partial() {
+        let rec = std::sync::Arc::new(RecordingOutput::new());
+        let chain = chain_with(rec.clone());
+        let mut session = StreamingSession::new();
+        session.observe_partial_delta("hello");
+
+        session
+            .commit_segment(&chain, "", None, None, None)
+            .await
+            .unwrap();
+
+        assert!(rec.typed().is_empty());
+        assert_eq!(session.finalized_text(), "hello");
+        assert!(session.partial().is_empty());
+    }
+
+    #[test]
+    fn empty_silent_final_promotes_an_existing_partial() {
+        let mut session = StreamingSession::new();
+        session.observe_partial_delta("hello");
+        session.commit_segment_silent("");
+        assert_eq!(session.finalized_text(), "hello");
+        assert!(session.partial().is_empty());
     }
 
     #[tokio::test]

--- a/src/setup/variant_check.rs
+++ b/src/setup/variant_check.rs
@@ -57,13 +57,13 @@ pub enum Remediation {
 /// Map a `TranscriptionEngine` to its required Cargo feature, or `None`
 /// for engines that have no compile-time gate.
 ///
-/// Whisper is unconditional in every variant (the engine itself is the
-/// reason whisper-rs is a non-optional dependency). Every other engine is
-/// behind a feature flag of the same name — so once Whisper is excluded
-/// the feature name is just the engine's canonical name.
+/// Whisper and the cloud engines are unconditional in every variant. Local
+/// optional engines are behind a Cargo feature of the same name.
 pub fn required_feature(engine: TranscriptionEngine) -> Option<&'static str> {
     match engine {
-        TranscriptionEngine::Whisper => None,
+        TranscriptionEngine::Whisper
+        | TranscriptionEngine::Soniox
+        | TranscriptionEngine::SeedAsr => None,
         other => Some(other.name()),
     }
 }
@@ -222,10 +222,8 @@ mod tests {
     }
 
     #[test]
-    fn every_non_whisper_engine_has_a_required_feature() {
-        // Regression guard: if a new engine is added to TranscriptionEngine
-        // without updating required_feature, this catches it before it
-        // ships as a silent always-passes mismatch check.
+    fn every_optional_engine_has_a_required_feature() {
+        // Regression guard for every locally compiled optional engine.
         let engines = [
             TranscriptionEngine::Parakeet,
             TranscriptionEngine::Moonshine,
@@ -234,7 +232,6 @@ mod tests {
             TranscriptionEngine::Dolphin,
             TranscriptionEngine::Omnilingual,
             TranscriptionEngine::Cohere,
-            TranscriptionEngine::Soniox,
         ];
         for e in engines {
             assert!(
@@ -244,5 +241,7 @@ mod tests {
             );
         }
         assert_eq!(required_feature(TranscriptionEngine::Whisper), None);
+        assert_eq!(required_feature(TranscriptionEngine::Soniox), None);
+        assert_eq!(required_feature(TranscriptionEngine::SeedAsr), None);
     }
 }

--- a/src/transcribe/mod.rs
+++ b/src/transcribe/mod.rs
@@ -17,6 +17,7 @@ pub mod cli;
 #[cfg(feature = "parakeet")]
 pub mod parakeet_streaming;
 pub mod remote;
+pub mod seedasr;
 pub mod sliding_window;
 pub mod soniox;
 pub mod streaming;
@@ -300,6 +301,14 @@ pub fn create_transcriber(config: &Config) -> Result<Box<dyn Transcriber>, Trans
                 )
             })?;
             Ok(Box::new(soniox::SonioxTranscriber::new(cfg.clone())?))
+        }
+        TranscriptionEngine::SeedAsr => {
+            let cfg = config.seedasr.as_ref().ok_or_else(|| {
+                TranscribeError::InitFailed(
+                    "Seed-ASR engine selected but [seedasr] config section is missing".to_string(),
+                )
+            })?;
+            Ok(Box::new(seedasr::SeedAsrTranscriber::new(cfg.clone())?))
         }
         #[cfg(feature = "openvino-whisper")]
         TranscriptionEngine::OpenVino => {

--- a/src/transcribe/seedasr.rs
+++ b/src/transcribe/seedasr.rs
@@ -761,18 +761,8 @@ fn stable_prefix(result: &Value, text: &str) -> String {
         return String::new();
     };
 
-    let definite: String = utterances
-        .iter()
-        .take_while(|utterance| {
-            utterance
-                .get("definite")
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-        })
-        .filter_map(|utterance| utterance.get("text").and_then(Value::as_str))
-        .collect();
-    if !definite.is_empty() && text.starts_with(&definite) {
-        return definite;
+    if let Some(definite) = align_definite_prefix(utterances, text) {
+        return definite.to_string();
     }
 
     utterances
@@ -787,6 +777,57 @@ fn stable_prefix(result: &Value, text: &str) -> String {
         .max_by_key(|prefix| prefix.len())
         .unwrap_or_default()
         .to_string()
+}
+
+/// Align the leading definite utterances with the cumulative transcript and
+/// return the exact prefix from `text` that they cover.
+///
+/// Seed-ASR can insert whitespace between utterances in `result.text` even
+/// though that whitespace is absent from the individual `utterance.text`
+/// values. Concatenating utterance strings directly therefore turns
+/// `"hello"` + `"world"` into `"helloworld"`, which does not match the
+/// authoritative cumulative transcript `"hello world"`. Match each utterance
+/// in sequence instead, allowing only whitespace between them, and retain the
+/// exact separator chosen by the service in the returned prefix.
+fn align_definite_prefix<'a>(utterances: &[Value], text: &'a str) -> Option<&'a str> {
+    let mut offset = 0;
+    let mut matched_any = false;
+
+    for utterance in utterances.iter().take_while(|utterance| {
+        utterance
+            .get("definite")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }) {
+        let utterance_text = utterance.get("text").and_then(Value::as_str)?;
+        if utterance_text.is_empty() {
+            continue;
+        }
+
+        let remaining = &text[offset..];
+        if remaining.starts_with(utterance_text) {
+            // The utterance text already contains exactly the separator used
+            // by the cumulative transcript, so consume it verbatim.
+            offset += utterance_text.len();
+        } else if matched_any {
+            // Some responses keep inter-utterance whitespace only in the
+            // cumulative transcript. Skip that separator and try again.
+            let candidate = remaining.trim_start_matches(char::is_whitespace);
+            if !candidate.starts_with(utterance_text) {
+                // Stability metadata for later utterances can be temporarily
+                // inconsistent. Keep the prefix aligned so far instead of
+                // regressing the entire stable prefix to empty.
+                break;
+            }
+            let separator_len = remaining.len() - candidate.len();
+            offset += separator_len + utterance_text.len();
+        } else {
+            return None;
+        }
+        matched_any = true;
+    }
+
+    matched_any.then(|| &text[..offset])
 }
 
 #[derive(Debug, Default)]
@@ -810,14 +851,29 @@ impl Reconciler {
                 "server revised text that was already finalized",
             ));
         }
-        if !snapshot.stable_text.starts_with(&self.committed) {
+
+        // `utterances` stability metadata is not monotonic: intermediate
+        // responses can temporarily omit it or report a shorter prefix. The
+        // cumulative transcript is authoritative for protecting text already
+        // committed to the output, so retain that prefix while the transcript
+        // itself still extends it.
+        let stable_text = if snapshot.stable_text.starts_with(&self.committed) {
+            snapshot.stable_text
+        } else if self.committed.starts_with(&snapshot.stable_text) {
+            tracing::debug!(
+                reported = %snapshot.stable_text,
+                committed = %self.committed,
+                "Seed-ASR stable prefix regressed; retaining committed text"
+            );
+            self.committed.clone()
+        } else {
             return Err(inference_error(
                 "server stable prefix does not extend finalized text",
             ));
-        }
+        };
 
-        if snapshot.stable_text.len() > self.committed.len() {
-            let stable_tail = &snapshot.stable_text[self.committed.len()..];
+        if stable_text.len() > self.committed.len() {
+            let stable_tail = &stable_text[self.committed.len()..];
             let segment_id = self.next_segment_id;
             self.next_segment_id += 1;
 
@@ -835,7 +891,7 @@ impl Reconciler {
                     segment_id,
                 });
             }
-            self.committed = snapshot.stable_text.clone();
+            self.committed = stable_text;
             self.typed_partial.clear();
         }
 
@@ -1014,6 +1070,81 @@ mod tests {
     }
 
     #[test]
+    fn stable_prefix_preserves_whitespace_between_definite_utterances() {
+        let snapshot = parse_recognition_payload(
+            br#"{"result":{"text":"hello world","utterances":[{"text":"hello","definite":true},{"text":"world","definite":true}]}}"#,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.stable_text, "hello world");
+    }
+
+    #[test]
+    fn stable_prefix_accepts_whitespace_already_present_in_utterance_text() {
+        let snapshot = parse_recognition_payload(
+            br#"{"result":{"text":"hello world","utterances":[{"text":"hello","definite":true},{"text":" world","definite":true}]}}"#,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.stable_text, "hello world");
+    }
+
+    #[test]
+    fn stable_prefix_keeps_the_last_aligned_utterance_on_a_later_mismatch() {
+        let snapshot = parse_recognition_payload(
+            br#"{"result":{"text":"hello world","utterances":[{"text":"hello","definite":true},{"text":"there","definite":true}]}}"#,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.stable_text, "hello");
+    }
+
+    #[test]
+    fn stable_prefix_stops_before_a_provisional_utterance_and_its_separator() {
+        let snapshot = parse_recognition_payload(
+            br#"{"result":{"text":"hello world","utterances":[{"text":"hello","definite":true},{"text":"world","definite":false}]}}"#,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.stable_text, "hello");
+    }
+
+    #[test]
+    fn reconciler_commits_a_whitespace_separated_definite_utterance() {
+        let mut reconciler = Reconciler::default();
+        let first = reconciler
+            .process(
+                RecognitionSnapshot {
+                    text: "hello".into(),
+                    stable_text: "hello".into(),
+                    is_last: false,
+                },
+                false,
+            )
+            .unwrap();
+        assert!(matches!(
+            &first[0],
+            StreamingEvent::Final { text, .. } if text == "hello"
+        ));
+
+        let snapshot = parse_recognition_payload(
+            br#"{"result":{"text":"hello world","utterances":[{"text":"hello","definite":true},{"text":"world","definite":true}]}}"#,
+            false,
+        )
+        .unwrap();
+        let second = reconciler.process(snapshot, false).unwrap();
+
+        assert!(matches!(
+            &second[0],
+            StreamingEvent::Final { text, .. } if text == " world"
+        ));
+    }
+
+    #[test]
     fn reconciler_emits_deltas_and_final_promotion() {
         let mut reconciler = Reconciler::default();
         let partial = reconciler
@@ -1073,6 +1204,72 @@ mod tests {
                 ..
             } if text == "。"
         ));
+    }
+
+    #[test]
+    fn reconciler_tolerates_regressed_stability_metadata() {
+        let mut reconciler = Reconciler::default();
+        reconciler
+            .process(
+                RecognitionSnapshot {
+                    text: "hello".into(),
+                    stable_text: "hello".into(),
+                    is_last: false,
+                },
+                false,
+            )
+            .unwrap();
+
+        let regressed = reconciler
+            .process(
+                RecognitionSnapshot {
+                    text: "hello world".into(),
+                    stable_text: String::new(),
+                    is_last: false,
+                },
+                false,
+            )
+            .unwrap();
+        assert!(regressed.is_empty());
+        assert_eq!(reconciler.committed, "hello");
+
+        let recovered = reconciler
+            .process(
+                RecognitionSnapshot {
+                    text: "hello world".into(),
+                    stable_text: "hello world".into(),
+                    is_last: true,
+                },
+                false,
+            )
+            .unwrap();
+        assert!(matches!(
+            &recovered[0],
+            StreamingEvent::Final { text, .. } if text == " world"
+        ));
+        assert!(reconciler.finished);
+    }
+
+    #[test]
+    fn reconciler_still_rejects_revision_of_committed_text() {
+        let mut reconciler = Reconciler {
+            committed: "hello".into(),
+            ..Reconciler::default()
+        };
+        let error = reconciler
+            .process(
+                RecognitionSnapshot {
+                    text: "hullo".into(),
+                    stable_text: "hullo".into(),
+                    is_last: false,
+                },
+                false,
+            )
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("server revised text that was already finalized"));
     }
 
     #[test]

--- a/src/transcribe/seedasr.rs
+++ b/src/transcribe/seedasr.rs
@@ -1,0 +1,1150 @@
+//! Volcengine Seed-ASR bidirectional streaming WebSocket backend.
+//!
+//! Seed-ASR uses a compact binary framing protocol over WebSocket. The first
+//! client frame contains a gzip-compressed JSON request; subsequent frames
+//! contain gzip-compressed PCM16 audio. Server responses contain cumulative,
+//! revisable transcript snapshots, which are converted into voxtype's delta
+//! oriented [`StreamingEvent`] contract by [`Reconciler`].
+
+use crate::config::SeedAsrConfig;
+use crate::error::TranscribeError;
+use crate::transcribe::streaming::{SegmentId, StreamHandle, StreamingEvent, StreamingTranscriber};
+use crate::transcribe::Transcriber;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::{HeaderName, HeaderValue};
+use tokio_tungstenite::tungstenite::Message;
+use uuid::Uuid;
+
+const SAMPLE_RATE: u32 = 16_000;
+const AUDIO_FRAME_SAMPLES: usize = 3_200; // 200 ms at 16 kHz.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const BATCH_TIMEOUT: Duration = Duration::from_secs(60);
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
+
+const PROTOCOL_VERSION: u8 = 1;
+const HEADER_SIZE_WORDS: u8 = 1;
+const MESSAGE_FULL_CLIENT_REQUEST: u8 = 0x1;
+const MESSAGE_AUDIO_ONLY_REQUEST: u8 = 0x2;
+const MESSAGE_FULL_SERVER_RESPONSE: u8 = 0x9;
+const MESSAGE_SERVER_ERROR: u8 = 0xf;
+const FLAG_NONE: u8 = 0x0;
+const FLAG_SEQUENCE: u8 = 0x1;
+const FLAG_LAST: u8 = 0x2;
+const FLAG_LAST_WITH_SEQUENCE: u8 = 0x3;
+const SERIALIZATION_NONE: u8 = 0x0;
+const SERIALIZATION_JSON: u8 = 0x1;
+const COMPRESSION_NONE: u8 = 0x0;
+const COMPRESSION_GZIP: u8 = 0x1;
+
+#[derive(Debug, Clone)]
+enum Authentication {
+    ApiKey(String),
+    Legacy {
+        app_id: String,
+        access_token: String,
+    },
+}
+
+impl Authentication {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::ApiKey(_) => "api_key",
+            Self::Legacy { .. } => "legacy",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ConnectionConfig {
+    url: String,
+    resource_id: String,
+    auth: Authentication,
+    request_payload: Vec<u8>,
+    type_partials: bool,
+}
+
+/// Volcengine Seed-ASR transcriber.
+#[derive(Debug)]
+pub struct SeedAsrTranscriber {
+    config: SeedAsrConfig,
+    auth: Authentication,
+}
+
+impl SeedAsrTranscriber {
+    pub fn new(mut config: SeedAsrConfig) -> Result<Self, TranscribeError> {
+        fill_credential_from_env(&mut config.api_key, "SEEDASR_API_KEY");
+        fill_credential_from_env(&mut config.app_id, "SEEDASR_APP_ID");
+        fill_credential_from_env(&mut config.access_token, "SEEDASR_ACCESS_TOKEN");
+        if let Ok(value) = std::env::var("SEEDASR_RESOURCE_ID") {
+            if !value.trim().is_empty() {
+                config.resource_id = value;
+            }
+        }
+        if let Ok(value) = std::env::var("SEEDASR_URL") {
+            if !value.trim().is_empty() {
+                config.url = value;
+            }
+        }
+
+        normalize_optional(&mut config.api_key);
+        normalize_optional(&mut config.app_id);
+        normalize_optional(&mut config.access_token);
+
+        let auth = resolve_authentication(&config)?;
+        if config.resource_id.trim().is_empty() {
+            return Err(TranscribeError::ConfigError(
+                "Seed-ASR resource_id cannot be empty".into(),
+            ));
+        }
+        if config.url.trim().is_empty() {
+            return Err(TranscribeError::ConfigError(
+                "Seed-ASR url cannot be empty".into(),
+            ));
+        }
+        if !(300..=5_000).contains(&config.end_window_ms) {
+            return Err(TranscribeError::ConfigError(
+                "Seed-ASR end_window_ms must be between 300 and 5000".into(),
+            ));
+        }
+
+        tracing::info!(
+            "Seed-ASR backend configured: streaming={}, type_partials={}, auth={}, resource_id={}, url={}",
+            config.streaming,
+            config.type_partials,
+            auth.kind(),
+            config.resource_id,
+            config.url,
+        );
+
+        Ok(Self { config, auth })
+    }
+
+    fn connection_config(&self) -> Result<ConnectionConfig, TranscribeError> {
+        Ok(ConnectionConfig {
+            url: self.config.url.clone(),
+            resource_id: self.config.resource_id.clone(),
+            auth: self.auth.clone(),
+            request_payload: encode_full_client_request(&self.request_json())?,
+            type_partials: self.config.type_partials,
+        })
+    }
+
+    fn request_json(&self) -> Value {
+        let mut request = json!({
+            "model_name": "bigmodel",
+            "enable_nonstream": true,
+            "enable_itn": self.config.enable_itn,
+            "enable_punc": self.config.enable_punc,
+            "enable_ddc": self.config.enable_ddc,
+            "show_utterances": true,
+            "result_type": "full",
+            "end_window_size": self.config.end_window_ms,
+        });
+        if let Some(language) = self
+            .config
+            .language
+            .as_ref()
+            .filter(|value| !value.trim().is_empty() && value.as_str() != "auto")
+        {
+            request["language"] = Value::String(language.clone());
+        }
+
+        json!({
+            "user": {
+                "uid": "voxtype"
+            },
+            "audio": {
+                "format": "pcm",
+                "codec": "raw",
+                "rate": SAMPLE_RATE,
+                "bits": 16,
+                "channel": 1
+            },
+            "request": request
+        })
+    }
+
+    async fn transcribe_async(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        let connection = self.connection_config()?;
+        let (stream, _) = connect(&connection).await?;
+        let (mut write, mut read) = stream.split();
+
+        write
+            .send(Message::Binary(connection.request_payload.clone()))
+            .await
+            .map_err(|e| inference_error(format!("send request failed: {e}")))?;
+
+        let pcm = f32_to_s16le_bytes(samples);
+        let frame_bytes = AUDIO_FRAME_SAMPLES * 2;
+        let mut chunks = pcm.chunks(frame_bytes).peekable();
+        while let Some(chunk) = chunks.next() {
+            let last = chunks.peek().is_none();
+            write
+                .send(Message::Binary(encode_audio_request(chunk, last)?))
+                .await
+                .map_err(|e| inference_error(format!("send audio failed: {e}")))?;
+        }
+
+        let deadline = tokio::time::Instant::now() + BATCH_TIMEOUT;
+        let mut transcript = String::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(inference_error("batch response timeout"));
+            }
+
+            let message = match tokio::time::timeout(remaining, read.next()).await {
+                Ok(Some(Ok(message))) => message,
+                Ok(Some(Err(error))) => {
+                    return Err(inference_error(format!("WebSocket error: {error}")))
+                }
+                Ok(None) => break,
+                Err(_) => return Err(inference_error("batch response timeout")),
+            };
+
+            match message {
+                Message::Binary(bytes) => {
+                    let frame = decode_server_frame(&bytes)?;
+                    match frame {
+                        ServerFrame::Response { payload, is_last } => {
+                            let snapshot = parse_recognition_payload(&payload, is_last)?;
+                            if !snapshot.text.is_empty() {
+                                transcript = snapshot.text;
+                            }
+                            if snapshot.is_last {
+                                break;
+                            }
+                        }
+                        ServerFrame::Error { code, message } => {
+                            return Err(inference_error(format!("server error {code}: {message}")))
+                        }
+                    }
+                }
+                Message::Text(text) => {
+                    let snapshot = parse_recognition_payload(text.as_bytes(), false)?;
+                    if !snapshot.text.is_empty() {
+                        transcript = snapshot.text;
+                    }
+                    if snapshot.is_last {
+                        break;
+                    }
+                }
+                Message::Close(_) => break,
+                Message::Ping(payload) => {
+                    write
+                        .send(Message::Pong(payload))
+                        .await
+                        .map_err(|e| inference_error(format!("send pong failed: {e}")))?;
+                }
+                _ => {}
+            }
+        }
+
+        let _ = write.send(Message::Close(None)).await;
+        Ok(transcript.trim().to_string())
+    }
+}
+
+impl Transcriber for SeedAsrTranscriber {
+    fn transcribe(&self, samples: &[f32]) -> Result<String, TranscribeError> {
+        if samples.is_empty() {
+            return Err(TranscribeError::AudioFormat("Empty audio buffer".into()));
+        }
+
+        let future = self.transcribe_async(samples);
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => tokio::task::block_in_place(|| handle.block_on(future)),
+            Err(_) => {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| inference_error(format!("create runtime failed: {e}")))?;
+                runtime.block_on(future)
+            }
+        }
+    }
+
+    fn as_streaming(&self) -> Option<&dyn StreamingTranscriber> {
+        self.config.streaming.then_some(self as _)
+    }
+}
+
+impl StreamingTranscriber for SeedAsrTranscriber {
+    fn start_stream(
+        &self,
+        samples_rx: mpsc::Receiver<Vec<f32>>,
+    ) -> Result<StreamHandle, TranscribeError> {
+        let connection = self.connection_config()?;
+        let (events_tx, events_rx) = mpsc::channel(64);
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+
+        let task = tokio::spawn(async move {
+            if let Err(error) =
+                run_streaming_session(connection, samples_rx, &events_tx, cancel_rx).await
+            {
+                let _ = events_tx.send(StreamingEvent::Error(error)).await;
+            }
+            let _ = events_tx.send(StreamingEvent::Ended).await;
+            Ok(())
+        });
+
+        Ok(StreamHandle {
+            events: events_rx,
+            cancel: cancel_tx,
+            task,
+        })
+    }
+}
+
+async fn run_streaming_session(
+    connection: ConnectionConfig,
+    mut samples_rx: mpsc::Receiver<Vec<f32>>,
+    events_tx: &mpsc::Sender<StreamingEvent>,
+    mut cancel_rx: oneshot::Receiver<()>,
+) -> Result<(), TranscribeError> {
+    let (stream, _) = connect(&connection).await?;
+    let (mut write, mut read) = stream.split();
+    write
+        .send(Message::Binary(connection.request_payload))
+        .await
+        .map_err(|e| inference_error(format!("send request failed: {e}")))?;
+
+    let mut reconciler = Reconciler::default();
+    let mut audio_buffer = Vec::with_capacity(AUDIO_FRAME_SAMPLES * 4);
+    let mut input_closed = false;
+    let mut last_packet_sent = false;
+    let mut drain_deadline = None;
+
+    loop {
+        let drain_timer = async {
+            match drain_deadline {
+                Some(deadline) => tokio::time::sleep_until(deadline).await,
+                None => std::future::pending::<()>().await,
+            }
+        };
+
+        tokio::select! {
+            biased;
+
+            _ = &mut cancel_rx => {
+                tracing::debug!("Seed-ASR streaming session cancelled");
+                break;
+            }
+
+            _ = drain_timer, if drain_deadline.is_some() => {
+                return Err(inference_error("drain timeout after end of audio"));
+            }
+
+            chunk = samples_rx.recv(), if !input_closed => {
+                match chunk {
+                    Some(samples) => {
+                        append_pcm_s16le(&mut audio_buffer, &samples);
+                        let frame_bytes = AUDIO_FRAME_SAMPLES * 2;
+                        while audio_buffer.len() >= frame_bytes {
+                            let remainder = audio_buffer.split_off(frame_bytes);
+                            let frame = std::mem::replace(&mut audio_buffer, remainder);
+                            write
+                                .send(Message::Binary(encode_audio_request(&frame, false)?))
+                                .await
+                                .map_err(|e| inference_error(format!("send audio failed: {e}")))?;
+                        }
+                    }
+                    None => {
+                        input_closed = true;
+                        write
+                            .send(Message::Binary(encode_audio_request(&audio_buffer, true)?))
+                            .await
+                            .map_err(|e| inference_error(format!("send final audio failed: {e}")))?;
+                        audio_buffer.clear();
+                        last_packet_sent = true;
+                        drain_deadline = Some(tokio::time::Instant::now() + DRAIN_TIMEOUT);
+                    }
+                }
+            }
+
+            message = read.next() => {
+                let message = match message {
+                    Some(Ok(message)) => message,
+                    Some(Err(error)) => return Err(inference_error(format!("WebSocket error: {error}"))),
+                    None if last_packet_sent => break,
+                    None => return Err(inference_error("WebSocket closed before end of audio")),
+                };
+
+                let snapshot = match message {
+                    Message::Binary(bytes) => match decode_server_frame(&bytes)? {
+                        ServerFrame::Response { payload, is_last } => {
+                            parse_recognition_payload(&payload, is_last)?
+                        }
+                        ServerFrame::Error { code, message } => {
+                            return Err(inference_error(format!("server error {code}: {message}")))
+                        }
+                    },
+                    Message::Text(text) => parse_recognition_payload(text.as_bytes(), false)?,
+                    Message::Close(_) if last_packet_sent => break,
+                    Message::Close(_) => return Err(inference_error("server closed the stream early")),
+                    Message::Ping(payload) => {
+                        write
+                            .send(Message::Pong(payload))
+                            .await
+                            .map_err(|e| inference_error(format!("send pong failed: {e}")))?;
+                        continue;
+                    }
+                    _ => continue,
+                };
+
+                tracing::trace!(
+                    target: "voxtype::seedasr::wire",
+                    text = %snapshot.text,
+                    stable = %snapshot.stable_text,
+                    is_last = snapshot.is_last,
+                    "Seed-ASR transcript snapshot"
+                );
+                for event in reconciler.process(snapshot, connection.type_partials)? {
+                    if events_tx.send(event).await.is_err() {
+                        return Ok(());
+                    }
+                }
+                if reconciler.finished {
+                    break;
+                }
+            }
+        }
+    }
+
+    let _ = write.send(Message::Close(None)).await;
+    Ok(())
+}
+
+async fn connect(
+    connection: &ConnectionConfig,
+) -> Result<
+    (
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        tokio_tungstenite::tungstenite::http::Response<Option<Vec<u8>>>,
+    ),
+    TranscribeError,
+> {
+    let request = websocket_request(connection)?;
+
+    let connected =
+        tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(request))
+            .await
+            .map_err(|_| inference_error("connect timeout"))?
+            .map_err(|e| inference_error(format!("WebSocket connect failed: {e}")))?;
+
+    if let Some(log_id) = connected.1.headers().get("x-tt-logid") {
+        tracing::debug!(
+            "Seed-ASR connected: log_id={}",
+            log_id.to_str().unwrap_or("<invalid>")
+        );
+    }
+    Ok(connected)
+}
+
+fn websocket_request(
+    connection: &ConnectionConfig,
+) -> Result<tokio_tungstenite::tungstenite::http::Request<()>, TranscribeError> {
+    let mut request = connection
+        .url
+        .as_str()
+        .into_client_request()
+        .map_err(|e| TranscribeError::ConfigError(format!("Invalid Seed-ASR url: {e}")))?;
+
+    match &connection.auth {
+        Authentication::ApiKey(api_key) => {
+            insert_header(request.headers_mut(), "x-api-key", api_key)?;
+        }
+        Authentication::Legacy {
+            app_id,
+            access_token,
+            ..
+        } => {
+            insert_header(request.headers_mut(), "x-api-app-key", app_id)?;
+            insert_header(request.headers_mut(), "x-api-access-key", access_token)?;
+        }
+    }
+    insert_header(
+        request.headers_mut(),
+        "x-api-resource-id",
+        &connection.resource_id,
+    )?;
+    insert_header(
+        request.headers_mut(),
+        "x-api-request-id",
+        &Uuid::new_v4().to_string(),
+    )?;
+    Ok(request)
+}
+
+fn insert_header(
+    headers: &mut tokio_tungstenite::tungstenite::http::HeaderMap,
+    name: &'static str,
+    value: &str,
+) -> Result<(), TranscribeError> {
+    let value = HeaderValue::from_str(value).map_err(|e| {
+        TranscribeError::ConfigError(format!("Invalid value for Seed-ASR header {name}: {e}"))
+    })?;
+    headers.insert(HeaderName::from_static(name), value);
+    Ok(())
+}
+
+fn fill_credential_from_env(target: &mut Option<String>, variable: &str) {
+    if target.as_ref().is_none_or(|value| value.trim().is_empty()) {
+        if let Ok(value) = std::env::var(variable) {
+            *target = Some(value);
+        }
+    }
+}
+
+fn normalize_optional(value: &mut Option<String>) {
+    *value = value.take().and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    });
+}
+
+fn resolve_authentication(config: &SeedAsrConfig) -> Result<Authentication, TranscribeError> {
+    let has_legacy = config.app_id.is_some() || config.access_token.is_some();
+    if config.api_key.is_some() && has_legacy {
+        return Err(TranscribeError::ConfigError(
+            "Seed-ASR credentials are ambiguous: configure api_key or legacy app_id/access_token, not both"
+                .into(),
+        ));
+    }
+
+    if let Some(api_key) = &config.api_key {
+        return Ok(Authentication::ApiKey(api_key.clone()));
+    }
+
+    match (&config.app_id, &config.access_token) {
+        (Some(app_id), Some(access_token)) => Ok(Authentication::Legacy {
+            app_id: app_id.clone(),
+            access_token: access_token.clone(),
+        }),
+        (Some(_), None) => Err(TranscribeError::ConfigError(
+            "Seed-ASR legacy authentication requires access_token".into(),
+        )),
+        (None, Some(_)) => Err(TranscribeError::ConfigError(
+            "Seed-ASR legacy authentication requires app_id".into(),
+        )),
+        (None, None) => Err(TranscribeError::ConfigError(
+            "Seed-ASR credentials required: set api_key, or app_id and access_token, in [seedasr] or SEEDASR_* environment variables"
+                .into(),
+        )),
+    }
+}
+
+fn inference_error(message: impl Into<String>) -> TranscribeError {
+    TranscribeError::InferenceFailed(format!("Seed-ASR: {}", message.into()))
+}
+
+fn encode_full_client_request(request: &Value) -> Result<Vec<u8>, TranscribeError> {
+    let json = serde_json::to_vec(request)
+        .map_err(|e| inference_error(format!("serialize request failed: {e}")))?;
+    encode_client_frame(
+        MESSAGE_FULL_CLIENT_REQUEST,
+        FLAG_NONE,
+        SERIALIZATION_JSON,
+        &json,
+    )
+}
+
+fn encode_audio_request(pcm: &[u8], last: bool) -> Result<Vec<u8>, TranscribeError> {
+    encode_client_frame(
+        MESSAGE_AUDIO_ONLY_REQUEST,
+        if last { FLAG_LAST } else { FLAG_NONE },
+        SERIALIZATION_NONE,
+        pcm,
+    )
+}
+
+fn encode_client_frame(
+    message_type: u8,
+    flags: u8,
+    serialization: u8,
+    payload: &[u8],
+) -> Result<Vec<u8>, TranscribeError> {
+    let compressed = gzip(payload)?;
+    let payload_len = u32::try_from(compressed.len())
+        .map_err(|_| inference_error("request payload is too large"))?;
+    let mut frame = Vec::with_capacity(8 + compressed.len());
+    frame.push((PROTOCOL_VERSION << 4) | HEADER_SIZE_WORDS);
+    frame.push((message_type << 4) | flags);
+    frame.push((serialization << 4) | COMPRESSION_GZIP);
+    frame.push(0);
+    frame.extend_from_slice(&payload_len.to_be_bytes());
+    frame.extend_from_slice(&compressed);
+    Ok(frame)
+}
+
+fn gzip(payload: &[u8]) -> Result<Vec<u8>, TranscribeError> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(payload)
+        .map_err(|e| inference_error(format!("gzip encode failed: {e}")))?;
+    encoder
+        .finish()
+        .map_err(|e| inference_error(format!("gzip encode failed: {e}")))
+}
+
+fn gunzip(payload: &[u8]) -> Result<Vec<u8>, TranscribeError> {
+    let mut decoder = GzDecoder::new(payload);
+    let mut decoded = Vec::new();
+    decoder
+        .read_to_end(&mut decoded)
+        .map_err(|e| inference_error(format!("gzip decode failed: {e}")))?;
+    Ok(decoded)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ServerFrame {
+    Response { payload: Vec<u8>, is_last: bool },
+    Error { code: u32, message: String },
+}
+
+fn decode_server_frame(frame: &[u8]) -> Result<ServerFrame, TranscribeError> {
+    if frame.len() < 4 {
+        return Err(inference_error("server frame is shorter than its header"));
+    }
+    let version = frame[0] >> 4;
+    if version != PROTOCOL_VERSION {
+        return Err(inference_error(format!(
+            "unsupported protocol version {version}"
+        )));
+    }
+    let header_len = usize::from(frame[0] & 0x0f) * 4;
+    if header_len < 4 || frame.len() < header_len {
+        return Err(inference_error("invalid server header size"));
+    }
+
+    let message_type = frame[1] >> 4;
+    let flags = frame[1] & 0x0f;
+    let compression = frame[2] & 0x0f;
+    let mut cursor = header_len;
+
+    match message_type {
+        MESSAGE_FULL_SERVER_RESPONSE => {
+            let mut sequence = None;
+            if matches!(flags, FLAG_SEQUENCE | FLAG_LAST_WITH_SEQUENCE) {
+                sequence = Some(read_i32(frame, &mut cursor)?);
+            }
+            let payload_len = read_u32(frame, &mut cursor)? as usize;
+            let payload = read_payload(frame, cursor, payload_len)?;
+            let payload = decode_compression(payload, compression)?;
+            let is_last = matches!(flags, FLAG_LAST | FLAG_LAST_WITH_SEQUENCE)
+                || sequence.is_some_and(|value| value < 0);
+            Ok(ServerFrame::Response { payload, is_last })
+        }
+        MESSAGE_SERVER_ERROR => {
+            let code = read_u32(frame, &mut cursor)?;
+            let payload_len = read_u32(frame, &mut cursor)? as usize;
+            let payload = read_payload(frame, cursor, payload_len)?;
+            let payload = decode_compression(payload, compression)?;
+            Ok(ServerFrame::Error {
+                code,
+                message: String::from_utf8_lossy(&payload).into_owned(),
+            })
+        }
+        other => Err(inference_error(format!(
+            "unsupported server message type 0x{other:x}"
+        ))),
+    }
+}
+
+fn read_u32(frame: &[u8], cursor: &mut usize) -> Result<u32, TranscribeError> {
+    let bytes = frame
+        .get(*cursor..*cursor + 4)
+        .ok_or_else(|| inference_error("truncated server frame"))?;
+    *cursor += 4;
+    Ok(u32::from_be_bytes(
+        bytes.try_into().expect("four-byte slice"),
+    ))
+}
+
+fn read_i32(frame: &[u8], cursor: &mut usize) -> Result<i32, TranscribeError> {
+    let bytes = frame
+        .get(*cursor..*cursor + 4)
+        .ok_or_else(|| inference_error("truncated server frame"))?;
+    *cursor += 4;
+    Ok(i32::from_be_bytes(
+        bytes.try_into().expect("four-byte slice"),
+    ))
+}
+
+fn read_payload(frame: &[u8], cursor: usize, len: usize) -> Result<&[u8], TranscribeError> {
+    let end = cursor
+        .checked_add(len)
+        .ok_or_else(|| inference_error("invalid server payload length"))?;
+    frame
+        .get(cursor..end)
+        .ok_or_else(|| inference_error("truncated server payload"))
+}
+
+fn decode_compression(payload: &[u8], compression: u8) -> Result<Vec<u8>, TranscribeError> {
+    match compression {
+        COMPRESSION_NONE => Ok(payload.to_vec()),
+        COMPRESSION_GZIP => gunzip(payload),
+        other => Err(inference_error(format!(
+            "unsupported server compression 0x{other:x}"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecognitionSnapshot {
+    text: String,
+    stable_text: String,
+    is_last: bool,
+}
+
+fn parse_recognition_payload(
+    payload: &[u8],
+    frame_is_last: bool,
+) -> Result<RecognitionSnapshot, TranscribeError> {
+    let root: Value = serde_json::from_slice(payload)
+        .map_err(|e| inference_error(format!("parse response JSON failed: {e}")))?;
+
+    if let Some(code) = root.get("code").and_then(Value::as_i64) {
+        if code != 0 {
+            let message = root
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown error");
+            return Err(inference_error(format!("server error {code}: {message}")));
+        }
+    }
+
+    let wrapper_is_last = root
+        .get("is_last_package")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let body = match root.get("payload_msg") {
+        Some(Value::Object(_)) => root.get("payload_msg").expect("checked above"),
+        Some(Value::String(encoded)) => {
+            return parse_recognition_payload(encoded.as_bytes(), frame_is_last || wrapper_is_last)
+        }
+        _ => &root,
+    };
+    let result = body.get("result").unwrap_or(body);
+    let text = result
+        .get("text")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let is_last = frame_is_last || wrapper_is_last;
+
+    let stable_text = if is_last {
+        text.clone()
+    } else {
+        stable_prefix(result, &text)
+    };
+
+    Ok(RecognitionSnapshot {
+        text,
+        stable_text,
+        is_last,
+    })
+}
+
+fn stable_prefix(result: &Value, text: &str) -> String {
+    let Some(utterances) = result.get("utterances").and_then(Value::as_array) else {
+        return String::new();
+    };
+
+    let definite: String = utterances
+        .iter()
+        .take_while(|utterance| {
+            utterance
+                .get("definite")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .filter_map(|utterance| utterance.get("text").and_then(Value::as_str))
+        .collect();
+    if !definite.is_empty() && text.starts_with(&definite) {
+        return definite;
+    }
+
+    utterances
+        .iter()
+        .filter_map(|utterance| {
+            utterance
+                .get("additions")
+                .and_then(|value| value.get("fixed_prefix_result"))
+                .and_then(Value::as_str)
+        })
+        .filter(|prefix| !prefix.is_empty() && text.starts_with(prefix))
+        .max_by_key(|prefix| prefix.len())
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[derive(Debug, Default)]
+struct Reconciler {
+    committed: String,
+    typed_partial: String,
+    next_segment_id: SegmentId,
+    finished: bool,
+}
+
+impl Reconciler {
+    fn process(
+        &mut self,
+        snapshot: RecognitionSnapshot,
+        type_partials: bool,
+    ) -> Result<Vec<StreamingEvent>, TranscribeError> {
+        let mut events = Vec::new();
+
+        if !snapshot.text.starts_with(&self.committed) {
+            return Err(inference_error(
+                "server revised text that was already finalized",
+            ));
+        }
+        if !snapshot.stable_text.starts_with(&self.committed) {
+            return Err(inference_error(
+                "server stable prefix does not extend finalized text",
+            ));
+        }
+
+        if snapshot.stable_text.len() > self.committed.len() {
+            let stable_tail = &snapshot.stable_text[self.committed.len()..];
+            let segment_id = self.next_segment_id;
+            self.next_segment_id += 1;
+
+            if stable_tail.starts_with(&self.typed_partial) {
+                events.push(StreamingEvent::Final {
+                    text: stable_tail[self.typed_partial.len()..].to_string(),
+                    segment_id,
+                });
+            } else {
+                let common_chars = common_prefix_char_count(&self.typed_partial, stable_tail);
+                let replacement: String = stable_tail.chars().skip(common_chars).collect();
+                events.push(StreamingEvent::Replace {
+                    backspace: self.typed_partial.chars().count() - common_chars,
+                    text: replacement,
+                    segment_id,
+                });
+            }
+            self.committed = snapshot.stable_text.clone();
+            self.typed_partial.clear();
+        }
+
+        let candidate_tail = &snapshot.text[self.committed.len()..];
+        if type_partials && candidate_tail.starts_with(&self.typed_partial) {
+            let delta = &candidate_tail[self.typed_partial.len()..];
+            if !delta.is_empty() {
+                events.push(StreamingEvent::Partial {
+                    text: delta.to_string(),
+                    segment_id: self.next_segment_id,
+                });
+                self.typed_partial = candidate_tail.to_string();
+            }
+        }
+
+        self.finished = snapshot.is_last;
+        Ok(events)
+    }
+}
+
+fn common_prefix_char_count(a: &str, b: &str) -> usize {
+    a.chars()
+        .zip(b.chars())
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn append_pcm_s16le(output: &mut Vec<u8>, samples: &[f32]) {
+    output.reserve(samples.len() * 2);
+    for sample in samples {
+        let pcm = (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+        output.extend_from_slice(&pcm.to_le_bytes());
+    }
+}
+
+fn f32_to_s16le_bytes(samples: &[f32]) -> Vec<u8> {
+    let mut output = Vec::with_capacity(samples.len() * 2);
+    append_pcm_s16le(&mut output, samples);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_tungstenite::tungstenite::handshake::server::{
+        Callback, ErrorResponse, Request, Response,
+    };
+
+    struct AssertAuthenticationHeaders;
+
+    impl Callback for AssertAuthenticationHeaders {
+        fn on_request(
+            self,
+            request: &Request,
+            response: Response,
+        ) -> Result<Response, ErrorResponse> {
+            assert_eq!(request.headers()["x-api-key"], "test-api-key");
+            assert_eq!(
+                request.headers()["x-api-resource-id"],
+                "volc.seedasr.sauc.duration"
+            );
+            Ok(response)
+        }
+    }
+
+    fn config() -> SeedAsrConfig {
+        SeedAsrConfig {
+            api_key: Some("test-api-key".into()),
+            ..SeedAsrConfig::default()
+        }
+    }
+
+    #[test]
+    fn accepts_new_console_api_key() {
+        let transcriber = SeedAsrTranscriber::new(config()).unwrap();
+        assert!(matches!(transcriber.auth, Authentication::ApiKey(_)));
+    }
+
+    #[test]
+    fn accepts_legacy_credentials() {
+        let cfg = SeedAsrConfig {
+            api_key: None,
+            app_id: Some("app".into()),
+            access_token: Some("token".into()),
+            ..SeedAsrConfig::default()
+        };
+        let transcriber = SeedAsrTranscriber::new(cfg).unwrap();
+        assert!(matches!(transcriber.auth, Authentication::Legacy { .. }));
+    }
+
+    #[test]
+    fn rejects_mixed_authentication_modes() {
+        let mut cfg = config();
+        cfg.app_id = Some("app".into());
+        cfg.access_token = Some("token".into());
+        let error = SeedAsrTranscriber::new(cfg).unwrap_err().to_string();
+        assert!(error.contains("ambiguous"));
+    }
+
+    #[test]
+    fn builds_new_console_authentication_headers() {
+        let transcriber = SeedAsrTranscriber::new(config()).unwrap();
+        let connection = transcriber.connection_config().unwrap();
+        let request = websocket_request(&connection).unwrap();
+        assert_eq!(request.headers()["x-api-key"], "test-api-key");
+        assert_eq!(
+            request.headers()["x-api-resource-id"],
+            "volc.seedasr.sauc.duration"
+        );
+        assert!(request.headers().get("x-api-app-key").is_none());
+        assert!(Uuid::parse_str(request.headers()["x-api-request-id"].to_str().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn builds_legacy_authentication_headers() {
+        let cfg = SeedAsrConfig {
+            api_key: None,
+            app_id: Some("legacy-app".into()),
+            access_token: Some("legacy-token".into()),
+            ..SeedAsrConfig::default()
+        };
+        let transcriber = SeedAsrTranscriber::new(cfg).unwrap();
+        let connection = transcriber.connection_config().unwrap();
+        let request = websocket_request(&connection).unwrap();
+        assert_eq!(request.headers()["x-api-app-key"], "legacy-app");
+        assert_eq!(request.headers()["x-api-access-key"], "legacy-token");
+        assert!(request.headers().get("x-api-key").is_none());
+    }
+
+    #[test]
+    fn encodes_expected_client_headers() {
+        let full = encode_full_client_request(&json!({"request": {}})).unwrap();
+        assert_eq!(&full[..4], &[0x11, 0x10, 0x11, 0x00]);
+
+        let audio = encode_audio_request(&[1, 2], false).unwrap();
+        assert_eq!(&audio[..4], &[0x11, 0x20, 0x01, 0x00]);
+
+        let last = encode_audio_request(&[], true).unwrap();
+        assert_eq!(&last[..4], &[0x11, 0x22, 0x01, 0x00]);
+    }
+
+    #[test]
+    fn decodes_gzip_server_response_with_negative_sequence() {
+        let payload = br#"{"result":{"text":"hello"}}"#;
+        let compressed = gzip(payload).unwrap();
+        let mut frame = vec![0x11, 0x93, 0x11, 0x00];
+        frame.extend_from_slice(&(-7_i32).to_be_bytes());
+        frame.extend_from_slice(&(compressed.len() as u32).to_be_bytes());
+        frame.extend_from_slice(&compressed);
+
+        assert_eq!(
+            decode_server_frame(&frame).unwrap(),
+            ServerFrame::Response {
+                payload: payload.to_vec(),
+                is_last: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_direct_and_wrapped_response_shapes() {
+        let direct = parse_recognition_payload(
+            br#"{"result":{"text":"hello","utterances":[{"text":"hello","definite":true}]}}"#,
+            false,
+        )
+        .unwrap();
+        assert_eq!(direct.stable_text, "hello");
+
+        let wrapped = parse_recognition_payload(
+            br#"{"code":0,"is_last_package":true,"payload_msg":{"result":{"text":"hello"}}}"#,
+            false,
+        )
+        .unwrap();
+        assert!(wrapped.is_last);
+        assert_eq!(wrapped.stable_text, "hello");
+    }
+
+    #[test]
+    fn reconciler_emits_deltas_and_final_promotion() {
+        let mut reconciler = Reconciler::default();
+        let partial = reconciler
+            .process(
+                RecognitionSnapshot {
+                    text: "hello".into(),
+                    stable_text: String::new(),
+                    is_last: false,
+                },
+                true,
+            )
+            .unwrap();
+        assert!(matches!(
+            &partial[0],
+            StreamingEvent::Partial { text, .. } if text == "hello"
+        ));
+
+        let final_events = reconciler
+            .process(
+                RecognitionSnapshot {
+                    text: "hello world".into(),
+                    stable_text: "hello world".into(),
+                    is_last: true,
+                },
+                true,
+            )
+            .unwrap();
+        assert!(matches!(
+            &final_events[0],
+            StreamingEvent::Final { text, .. } if text == " world"
+        ));
+        assert!(reconciler.finished);
+    }
+
+    #[test]
+    fn reconciler_replaces_revised_unicode_partial() {
+        let mut reconciler = Reconciler {
+            typed_partial: "你好呀".into(),
+            ..Reconciler::default()
+        };
+        let events = reconciler
+            .process(
+                RecognitionSnapshot {
+                    text: "你好。".into(),
+                    stable_text: "你好。".into(),
+                    is_last: true,
+                },
+                true,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            &events[0],
+            StreamingEvent::Replace {
+                backspace: 1,
+                text,
+                ..
+            } if text == "。"
+        ));
+    }
+
+    #[test]
+    fn pcm_conversion_clamps_samples() {
+        let bytes = f32_to_s16le_bytes(&[-2.0, 0.0, 2.0]);
+        assert_eq!(i16::from_le_bytes([bytes[0], bytes[1]]), -32767);
+        assert_eq!(i16::from_le_bytes([bytes[2], bytes[3]]), 0);
+        assert_eq!(i16::from_le_bytes([bytes[4], bytes[5]]), 32767);
+    }
+
+    #[tokio::test]
+    async fn streaming_round_trip_with_local_websocket_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut stream =
+                tokio_tungstenite::accept_hdr_async(socket, AssertAuthenticationHeaders)
+                    .await
+                    .unwrap();
+
+            let request = stream.next().await.unwrap().unwrap();
+            let Message::Binary(request) = request else {
+                panic!("expected full client request");
+            };
+            assert_eq!(&request[..4], &[0x11, 0x10, 0x11, 0x00]);
+
+            loop {
+                let message = stream.next().await.unwrap().unwrap();
+                let Message::Binary(audio) = message else {
+                    continue;
+                };
+                if audio[1] & 0x0f == FLAG_LAST {
+                    break;
+                }
+            }
+
+            let payload =
+                br#"{"result":{"text":"hello","utterances":[{"text":"hello","definite":true}]}}"#;
+            let compressed = gzip(payload).unwrap();
+            let mut response = vec![0x11, 0x93, 0x11, 0x00];
+            response.extend_from_slice(&(-1_i32).to_be_bytes());
+            response.extend_from_slice(&(compressed.len() as u32).to_be_bytes());
+            response.extend_from_slice(&compressed);
+            stream.send(Message::Binary(response)).await.unwrap();
+        });
+
+        let transcriber = SeedAsrTranscriber::new(SeedAsrConfig {
+            url: format!("ws://{address}"),
+            type_partials: false,
+            ..config()
+        })
+        .unwrap();
+        let (samples_tx, samples_rx) = mpsc::channel(2);
+        let mut handle = transcriber.start_stream(samples_rx).unwrap();
+        samples_tx.send(vec![0.1; 400]).await.unwrap();
+        drop(samples_tx);
+
+        let event = tokio::time::timeout(Duration::from_secs(2), handle.events.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            event,
+            StreamingEvent::Final { text, .. } if text == "hello"
+        ));
+        let ended = tokio::time::timeout(Duration::from_secs(2), handle.events.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(ended, StreamingEvent::Ended));
+        handle.task.await.unwrap().unwrap();
+        server.await.unwrap();
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -533,8 +533,8 @@ fn detect_missing_model() -> Option<MissingModel> {
         // Cohere — checked but model layout differs by rc/0.7.0; skip the
         // disk probe rather than emit a false-positive missing warning.
         config::TranscriptionEngine::Cohere => return None,
-        // Soniox is cloud-only, no local model to probe.
-        config::TranscriptionEngine::Soniox => return None,
+        // Cloud engines have no local model to probe.
+        config::TranscriptionEngine::Soniox | config::TranscriptionEngine::SeedAsr => return None,
         // OpenVINO models are stored as multi-file IR directories; skip the
         // generic probe here until the TUI grows engine-specific validation.
         config::TranscriptionEngine::OpenVino => return None,

--- a/src/tui/engine.rs
+++ b/src/tui/engine.rs
@@ -19,7 +19,7 @@ use super::common::{
     self, FeedbackLevel as CommonFeedback, FormRowSpec, TextInput, TextInputResult,
 };
 use super::config_editor::{ConfigEditor, EditorError};
-use crate::config::TranscriptionEngine;
+use crate::config::{TranscriptionEngine, DEFAULT_SEEDASR_RESOURCE_ID, DEFAULT_SEEDASR_URL};
 use crate::model_catalog::{default_model, installed_models_for, model_catalog};
 use crate::setup::binary::{self, EngineFamily, InstallKind, Variant};
 use crate::setup::model;
@@ -125,6 +125,22 @@ pub struct AllFields {
     pub ov_threads: Option<i64>,
     pub ov_on_demand_loading: bool,
     pub ov_section_existed: bool,
+
+    // Volcengine Seed-ASR
+    pub seed_auth_mode: String,
+    pub seed_api_key: Option<String>,
+    pub seed_app_id: Option<String>,
+    pub seed_access_token: Option<String>,
+    pub seed_resource_id: String,
+    pub seed_url: String,
+    pub seed_streaming: bool,
+    pub seed_type_partials: bool,
+    pub seed_language: String,
+    pub seed_enable_itn: bool,
+    pub seed_enable_punc: bool,
+    pub seed_enable_ddc: bool,
+    pub seed_end_window_ms: i64,
+    pub seed_section_existed: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -201,6 +217,21 @@ pub enum FieldId {
     OvLanguage,
     OvThreads,
     OvOnDemandLoading,
+
+    // Seed-ASR
+    SeedAuthMode,
+    SeedApiKey,
+    SeedAppId,
+    SeedAccessToken,
+    SeedResourceId,
+    SeedUrl,
+    SeedStreaming,
+    SeedTypePartials,
+    SeedLanguage,
+    SeedEnableItn,
+    SeedEnablePunc,
+    SeedEnableDdc,
+    SeedEndWindowMs,
 }
 
 /// Cohere Transcribe officially supports these 14 languages. Token IDs are
@@ -221,8 +252,13 @@ const PARAKEET_MODEL_TYPES: &[Option<&str>] = &[None, Some("tdt"), Some("ctc")];
 /// AUTO is a real OpenVINO device value too (see `installation_guidance`'s
 /// own AUTO arm) — included here so it's reachable from the picker.
 const OV_DEVICE_CHOICES: &[&str] = &["NPU", "GPU", "CPU", "AUTO"];
+const SEED_AUTH_MODE_CHOICES: &[&str] = &["api_key", "legacy"];
 
-fn rows_for_engine_with_mode(engine: &str, whisper_mode: &str) -> Vec<FieldId> {
+fn rows_for_engine_with_mode(
+    engine: &str,
+    whisper_mode: &str,
+    seed_auth_mode: &str,
+) -> Vec<FieldId> {
     let mut rows = vec![FieldId::Engine];
     match engine {
         "whisper" => {
@@ -291,6 +327,25 @@ fn rows_for_engine_with_mode(engine: &str, whisper_mode: &str) -> Vec<FieldId> {
             FieldId::OvThreads,
             FieldId::OvOnDemandLoading,
         ]),
+        "seedasr" => {
+            rows.push(FieldId::SeedAuthMode);
+            if seed_auth_mode == "legacy" {
+                rows.extend_from_slice(&[FieldId::SeedAppId, FieldId::SeedAccessToken]);
+            } else {
+                rows.push(FieldId::SeedApiKey);
+            }
+            rows.extend_from_slice(&[
+                FieldId::SeedResourceId,
+                FieldId::SeedUrl,
+                FieldId::SeedStreaming,
+                FieldId::SeedTypePartials,
+                FieldId::SeedLanguage,
+                FieldId::SeedEnableItn,
+                FieldId::SeedEnablePunc,
+                FieldId::SeedEnableDdc,
+                FieldId::SeedEndWindowMs,
+            ]);
+        }
         _ => {}
     }
     rows
@@ -302,6 +357,15 @@ impl EngineState {
         let engine = ed
             .get_string("", "engine")
             .unwrap_or_else(|| "whisper".to_string());
+        let seed_api_key = ed.get_string("seedasr", "api_key");
+        let seed_app_id = ed.get_string("seedasr", "app_id");
+        let seed_access_token = ed.get_string("seedasr", "access_token");
+        let seed_auth_mode =
+            if seed_api_key.is_none() && (seed_app_id.is_some() || seed_access_token.is_some()) {
+                "legacy"
+            } else {
+                "api_key"
+            };
         let fields = AllFields {
             // Whisper
             w_model: ed
@@ -412,6 +476,28 @@ impl EngineState {
                 .get_bool("openvino", "on_demand_loading")
                 .unwrap_or(false),
             ov_section_existed: ed.get_string("openvino", "model").is_some(),
+
+            // Seed-ASR
+            seed_auth_mode: seed_auth_mode.to_string(),
+            seed_api_key,
+            seed_app_id,
+            seed_access_token,
+            seed_resource_id: ed
+                .get_string("seedasr", "resource_id")
+                .unwrap_or_else(|| DEFAULT_SEEDASR_RESOURCE_ID.to_string()),
+            seed_url: ed
+                .get_string("seedasr", "url")
+                .unwrap_or_else(|| DEFAULT_SEEDASR_URL.to_string()),
+            seed_streaming: ed.get_bool("seedasr", "streaming").unwrap_or(true),
+            seed_type_partials: ed.get_bool("seedasr", "type_partials").unwrap_or(false),
+            seed_language: ed
+                .get_string("seedasr", "language")
+                .unwrap_or_else(|| "auto".to_string()),
+            seed_enable_itn: ed.get_bool("seedasr", "enable_itn").unwrap_or(true),
+            seed_enable_punc: ed.get_bool("seedasr", "enable_punc").unwrap_or(true),
+            seed_enable_ddc: ed.get_bool("seedasr", "enable_ddc").unwrap_or(false),
+            seed_end_window_ms: ed.get_int("seedasr", "end_window_ms").unwrap_or(800),
+            seed_section_existed: ed.raw_table("seedasr").is_some(),
         };
         let mut state = Self {
             engine,
@@ -442,6 +528,12 @@ impl EngineState {
     fn refresh_binary_match(&mut self) {
         self.pending_variant_switch = None;
         self.binary_switch_blocked = None;
+
+        // Seed-ASR is a cloud engine compiled into every binary family. It
+        // has no local model and never requires a binary variant switch.
+        if self.engine == "seedasr" {
+            return;
+        }
 
         let inv = binary::inventory();
 
@@ -520,6 +612,51 @@ impl EngineState {
     }
 
     pub fn save(&mut self) -> Action {
+        if self.engine == "seedasr" {
+            let f = &self.fields;
+            let env_present =
+                |env: &str| std::env::var(env).is_ok_and(|value| !value.trim().is_empty());
+            let present = |value: Option<&String>, env: &str| {
+                value.is_some_and(|v| !v.trim().is_empty()) || env_present(env)
+            };
+            let api_key = present(f.seed_api_key.as_ref(), "SEEDASR_API_KEY");
+            let app_id = present(f.seed_app_id.as_ref(), "SEEDASR_APP_ID");
+            let access_token = present(f.seed_access_token.as_ref(), "SEEDASR_ACCESS_TOKEN");
+            let incompatible_environment = if f.seed_auth_mode == "legacy" {
+                env_present("SEEDASR_API_KEY")
+            } else {
+                env_present("SEEDASR_APP_ID") || env_present("SEEDASR_ACCESS_TOKEN")
+            };
+            let error = if incompatible_environment {
+                Some(
+                    "Seed-ASR environment variables conflict with the selected authentication mode."
+                        .to_string(),
+                )
+            } else if f.seed_auth_mode == "api_key" && !api_key {
+                Some("Enter a Seed-ASR API key or set SEEDASR_API_KEY.".to_string())
+            } else if f.seed_auth_mode == "legacy" && (!app_id || !access_token) {
+                Some(
+                    "Legacy Seed-ASR authentication requires both App ID and access token."
+                        .to_string(),
+                )
+            } else if f.seed_resource_id.trim().is_empty() {
+                Some("Seed-ASR resource ID cannot be empty.".to_string())
+            } else if !(f.seed_url.starts_with("ws://") || f.seed_url.starts_with("wss://")) {
+                Some("Seed-ASR URL must start with ws:// or wss://.".to_string())
+            } else if !(300..=5_000).contains(&f.seed_end_window_ms) {
+                Some("Seed-ASR end window must be between 300 and 5000 ms.".to_string())
+            } else {
+                None
+            };
+            if let Some(message) = error {
+                self.feedback = Some(Feedback {
+                    level: FeedbackLevel::Err,
+                    message,
+                });
+                return Action::None;
+            }
+        }
+
         let mut ed = match ConfigEditor::load() {
             Ok(e) => e,
             Err(e) => {
@@ -654,6 +791,48 @@ impl EngineState {
             ed.set_bool("openvino", "on_demand_loading", f.ov_on_demand_loading);
         }
 
+        // Seed-ASR. Keep exactly one credential scheme in the file so the
+        // runtime cannot accidentally combine stale credentials.
+        if self.engine == "seedasr" || f.seed_section_existed {
+            if f.seed_auth_mode == "legacy" {
+                ed.unset("seedasr", "api_key");
+                match &f.seed_app_id {
+                    Some(value) if !value.trim().is_empty() => {
+                        ed.set_string("seedasr", "app_id", value)
+                    }
+                    _ => ed.unset("seedasr", "app_id"),
+                }
+                match &f.seed_access_token {
+                    Some(value) if !value.trim().is_empty() => {
+                        ed.set_string("seedasr", "access_token", value)
+                    }
+                    _ => ed.unset("seedasr", "access_token"),
+                }
+            } else {
+                ed.unset("seedasr", "app_id");
+                ed.unset("seedasr", "access_token");
+                match &f.seed_api_key {
+                    Some(value) if !value.trim().is_empty() => {
+                        ed.set_string("seedasr", "api_key", value)
+                    }
+                    _ => ed.unset("seedasr", "api_key"),
+                }
+            }
+            ed.set_string("seedasr", "resource_id", &f.seed_resource_id);
+            ed.set_string("seedasr", "url", &f.seed_url);
+            ed.set_bool("seedasr", "streaming", f.seed_streaming);
+            ed.set_bool("seedasr", "type_partials", f.seed_type_partials);
+            if f.seed_language == "auto" || f.seed_language.trim().is_empty() {
+                ed.unset("seedasr", "language");
+            } else {
+                ed.set_string("seedasr", "language", &f.seed_language);
+            }
+            ed.set_bool("seedasr", "enable_itn", f.seed_enable_itn);
+            ed.set_bool("seedasr", "enable_punc", f.seed_enable_punc);
+            ed.set_bool("seedasr", "enable_ddc", f.seed_enable_ddc);
+            ed.set_int("seedasr", "end_window_ms", f.seed_end_window_ms);
+        }
+
         match ed.save() {
             Ok(()) => {
                 self.dirty_since_load = false;
@@ -743,7 +922,11 @@ impl EngineState {
     /// Visible rows for the current engine. Whisper has extra rows when
     /// running in remote mode; everything else is constant per engine.
     fn rows(&self) -> Vec<FieldId> {
-        rows_for_engine_with_mode(&self.engine, &self.fields.w_mode)
+        rows_for_engine_with_mode(
+            &self.engine,
+            &self.fields.w_mode,
+            &self.fields.seed_auth_mode,
+        )
     }
 
     fn current_field(&self) -> FieldId {
@@ -760,6 +943,12 @@ impl EngineState {
                 | FieldId::WRemoteEndpoint
                 | FieldId::WRemoteApiKey
                 | FieldId::WRemoteModel
+                | FieldId::SeedApiKey
+                | FieldId::SeedAppId
+                | FieldId::SeedAccessToken
+                | FieldId::SeedResourceId
+                | FieldId::SeedUrl
+                | FieldId::SeedLanguage
         )
     }
 
@@ -773,6 +962,12 @@ impl EngineState {
             FieldId::WRemoteEndpoint => self.fields.w_remote_endpoint.clone().unwrap_or_default(),
             FieldId::WRemoteApiKey => self.fields.w_remote_api_key.clone().unwrap_or_default(),
             FieldId::WRemoteModel => self.fields.w_remote_model.clone().unwrap_or_default(),
+            FieldId::SeedApiKey => self.fields.seed_api_key.clone().unwrap_or_default(),
+            FieldId::SeedAppId => self.fields.seed_app_id.clone().unwrap_or_default(),
+            FieldId::SeedAccessToken => self.fields.seed_access_token.clone().unwrap_or_default(),
+            FieldId::SeedResourceId => self.fields.seed_resource_id.clone(),
+            FieldId::SeedUrl => self.fields.seed_url.clone(),
+            FieldId::SeedLanguage => self.fields.seed_language.clone(),
             _ => String::new(),
         };
         self.editing = Some(TextEdit {
@@ -794,6 +989,18 @@ impl EngineState {
             FieldId::WRemoteEndpoint => self.fields.w_remote_endpoint = opt,
             FieldId::WRemoteApiKey => self.fields.w_remote_api_key = opt,
             FieldId::WRemoteModel => self.fields.w_remote_model = opt,
+            FieldId::SeedApiKey => self.fields.seed_api_key = opt,
+            FieldId::SeedAppId => self.fields.seed_app_id = opt,
+            FieldId::SeedAccessToken => self.fields.seed_access_token = opt,
+            FieldId::SeedResourceId => self.fields.seed_resource_id = buffer.trim().to_string(),
+            FieldId::SeedUrl => self.fields.seed_url = buffer.trim().to_string(),
+            FieldId::SeedLanguage => {
+                self.fields.seed_language = if trimmed.is_empty() {
+                    "auto".to_string()
+                } else {
+                    buffer.trim().to_string()
+                }
+            }
             _ => {}
         }
         self.dirty_since_load = true;
@@ -901,6 +1108,27 @@ impl EngineState {
             FieldId::OvLanguage => f.ov_language = cycle_str(LANG_CHOICES, &f.ov_language, delta),
             FieldId::OvThreads => f.ov_threads = cycle_threads(f.ov_threads, delta),
             FieldId::OvOnDemandLoading => f.ov_on_demand_loading = !f.ov_on_demand_loading,
+
+            FieldId::SeedAuthMode => {
+                f.seed_auth_mode = cycle_str(SEED_AUTH_MODE_CHOICES, &f.seed_auth_mode, delta)
+            }
+            FieldId::SeedApiKey
+            | FieldId::SeedAppId
+            | FieldId::SeedAccessToken
+            | FieldId::SeedResourceId
+            | FieldId::SeedUrl
+            | FieldId::SeedLanguage => {
+                self.start_edit_if_text_field();
+                return;
+            }
+            FieldId::SeedStreaming => f.seed_streaming = !f.seed_streaming,
+            FieldId::SeedTypePartials => f.seed_type_partials = !f.seed_type_partials,
+            FieldId::SeedEnableItn => f.seed_enable_itn = !f.seed_enable_itn,
+            FieldId::SeedEnablePunc => f.seed_enable_punc = !f.seed_enable_punc,
+            FieldId::SeedEnableDdc => f.seed_enable_ddc = !f.seed_enable_ddc,
+            FieldId::SeedEndWindowMs => {
+                f.seed_end_window_ms = (f.seed_end_window_ms + delta as i64 * 100).clamp(300, 5_000)
+            }
         }
         self.dirty_since_load = true;
         self.feedback = None;
@@ -973,6 +1201,7 @@ fn installed_engine_choices() -> std::collections::HashSet<&'static str> {
     // Whisper is always present.
     let inv = binary::inventory();
     out.insert("whisper");
+    out.insert("seedasr");
     for f in &inv.compiled_features {
         for engine in [
             "parakeet",
@@ -1310,6 +1539,81 @@ fn field_label_value(state: &EngineState, fid: FieldId) -> (&'static str, String
             "OpenVINO · on-demand model load",
             yesno(f.ov_on_demand_loading),
         ),
+
+        FieldId::SeedAuthMode => (
+            "Seed-ASR · authentication",
+            if f.seed_auth_mode == "legacy" {
+                "legacy App ID + access token".to_string()
+            } else {
+                "API key".to_string()
+            },
+        ),
+        FieldId::SeedApiKey => (
+            "Seed-ASR · API key",
+            match state.editing.as_ref() {
+                Some(e) if e.field == FieldId::SeedApiKey => mask(&e.input.caret_string()),
+                _ => match f.seed_api_key.as_deref() {
+                    None | Some("") => "(unset)".to_string(),
+                    Some(_) => "•••••• (set; press Enter to edit)".to_string(),
+                },
+            },
+        ),
+        FieldId::SeedAppId => (
+            "Seed-ASR · App ID",
+            match state.editing.as_ref() {
+                Some(e) if e.field == FieldId::SeedAppId => e.input.caret_string(),
+                _ => f
+                    .seed_app_id
+                    .clone()
+                    .unwrap_or_else(|| "(unset)".to_string()),
+            },
+        ),
+        FieldId::SeedAccessToken => (
+            "Seed-ASR · access token",
+            match state.editing.as_ref() {
+                Some(e) if e.field == FieldId::SeedAccessToken => mask(&e.input.caret_string()),
+                _ => match f.seed_access_token.as_deref() {
+                    None | Some("") => "(unset)".to_string(),
+                    Some(_) => "•••••• (set; press Enter to edit)".to_string(),
+                },
+            },
+        ),
+        FieldId::SeedResourceId => (
+            "Seed-ASR · resource ID",
+            match state.editing.as_ref() {
+                Some(e) if e.field == FieldId::SeedResourceId => e.input.caret_string(),
+                _ => f.seed_resource_id.clone(),
+            },
+        ),
+        FieldId::SeedUrl => (
+            "Seed-ASR · WebSocket URL",
+            match state.editing.as_ref() {
+                Some(e) if e.field == FieldId::SeedUrl => e.input.caret_string(),
+                _ => f.seed_url.clone(),
+            },
+        ),
+        FieldId::SeedStreaming => ("Seed-ASR · streaming", yesno(f.seed_streaming)),
+        FieldId::SeedTypePartials => (
+            "Seed-ASR · type partial results",
+            yesno(f.seed_type_partials),
+        ),
+        FieldId::SeedLanguage => (
+            "Seed-ASR · language",
+            match state.editing.as_ref() {
+                Some(e) if e.field == FieldId::SeedLanguage => e.input.caret_string(),
+                _ => f.seed_language.clone(),
+            },
+        ),
+        FieldId::SeedEnableItn => (
+            "Seed-ASR · inverse text normalization",
+            yesno(f.seed_enable_itn),
+        ),
+        FieldId::SeedEnablePunc => ("Seed-ASR · punctuation", yesno(f.seed_enable_punc)),
+        FieldId::SeedEnableDdc => ("Seed-ASR · semantic smoothing", yesno(f.seed_enable_ddc)),
+        FieldId::SeedEndWindowMs => (
+            "Seed-ASR · end window",
+            format!("{} ms", f.seed_end_window_ms),
+        ),
     }
 }
 
@@ -1410,6 +1714,10 @@ fn engine_guidance(state: &EngineState) -> Vec<Line<'static>> {
             "OpenVINO GenAI Whisper (Intel NPU/GPU/CPU). Included in the \
              x86_64 ONNX release binaries; its runtime and device drivers \
              are loaded only when this engine is selected.",
+        ),
+        (
+            "seedasr",
+            "Volcengine Seed-ASR over WebSocket. Native streaming, cloud-hosted, and optimized for low-latency dictation.",
         ),
     ] {
         lines.push(Line::from(Span::styled(
@@ -1809,10 +2117,101 @@ fn guidance(state: &EngineState) -> Vec<Line<'_>> {
             Line::from(
                 "Common values: whisper-1 (OpenAI), whisper-large-v3 \
                  (Groq, Together), whisper.cpp (whisper.cpp server). Check \
-                 your provider's docs.",
+                your provider's docs.",
             ),
         ],
+        FieldId::SeedAuthMode
+        | FieldId::SeedApiKey
+        | FieldId::SeedAppId
+        | FieldId::SeedAccessToken
+        | FieldId::SeedResourceId
+        | FieldId::SeedUrl
+        | FieldId::SeedStreaming
+        | FieldId::SeedTypePartials
+        | FieldId::SeedLanguage
+        | FieldId::SeedEnableItn
+        | FieldId::SeedEnablePunc
+        | FieldId::SeedEnableDdc
+        | FieldId::SeedEndWindowMs => seedasr_guidance(state.current_field()),
     }
+}
+
+fn seedasr_guidance(field: FieldId) -> Vec<Line<'static>> {
+    let (title, body, note) = match field {
+        FieldId::SeedAuthMode => (
+            "Seed-ASR · authentication",
+            "Choose API key for credentials from the current Volcengine console, or legacy for an App ID and access token.",
+            "The two credential schemes cannot be combined, including through SEEDASR_* environment variables.",
+        ),
+        FieldId::SeedApiKey => (
+            "Seed-ASR · API key",
+            "API key issued by the current Volcengine console. The value is masked on screen and in config command output.",
+            "Set SEEDASR_API_KEY instead if you do not want the credential stored in config.toml.",
+        ),
+        FieldId::SeedAppId => (
+            "Seed-ASR · App ID",
+            "Application ID used by the legacy Volcengine authentication scheme.",
+            "Legacy authentication also requires an access token.",
+        ),
+        FieldId::SeedAccessToken => (
+            "Seed-ASR · access token",
+            "Access token used with the legacy App ID. The value is masked on screen and in config command output.",
+            "Set SEEDASR_ACCESS_TOKEN instead if you do not want the token stored in config.toml.",
+        ),
+        FieldId::SeedResourceId => (
+            "Seed-ASR · resource ID",
+            "Service resource identifier assigned by Volcengine. The duration-based Seed-ASR resource is the default.",
+            "Press Enter to enter a different resource ID from your subscription.",
+        ),
+        FieldId::SeedUrl => (
+            "Seed-ASR · WebSocket URL",
+            "Bidirectional Seed-ASR WebSocket endpoint. Production connections should use wss://.",
+            "Override this only for a regional endpoint or a compatible protocol test server.",
+        ),
+        FieldId::SeedStreaming => (
+            "Seed-ASR · streaming",
+            "Send audio while recording and consume partial and final recognition events in real time.",
+            "When off, voxtype buffers the recording and sends it as a one-shot WebSocket request.",
+        ),
+        FieldId::SeedTypePartials => (
+            "Seed-ASR · type partial results",
+            "Type stable partial text before the server finalizes the utterance.",
+            "Keep this off if the target application does not handle cursor-based text revisions well.",
+        ),
+        FieldId::SeedLanguage => (
+            "Seed-ASR · language",
+            "Recognition language code. Use auto to let Seed-ASR detect the language.",
+            "Press Enter to enter a service-supported language code.",
+        ),
+        FieldId::SeedEnableItn => (
+            "Seed-ASR · inverse text normalization",
+            "Convert spoken numbers, dates, and similar expressions into written form.",
+            "Recommended for ordinary dictation.",
+        ),
+        FieldId::SeedEnablePunc => (
+            "Seed-ASR · punctuation",
+            "Ask Seed-ASR to add punctuation to recognition results.",
+            "Recommended for ordinary dictation.",
+        ),
+        FieldId::SeedEnableDdc => (
+            "Seed-ASR · semantic smoothing",
+            "Enable semantic smoothing and filler-word removal in the service.",
+            "Leave off when you need a more literal transcript.",
+        ),
+        FieldId::SeedEndWindowMs => (
+            "Seed-ASR · end window",
+            "Silence window used by the server to finalize an utterance. Use Left/Right to change it in 100 ms steps.",
+            "Valid range: 300-5000 ms. The default is 800 ms.",
+        ),
+        _ => unreachable!("seedasr_guidance called for a non-Seed-ASR field"),
+    };
+    vec![
+        heading(title),
+        Line::from(""),
+        Line::from(body),
+        Line::from(""),
+        Line::from(Span::styled(note, Style::default().fg(Color::Gray))),
+    ]
 }
 
 fn openvino_device_guidance(device: &str) -> Vec<Line<'static>> {
@@ -1934,6 +2333,7 @@ fn display_engine(engine: &str) -> &'static str {
         "omnilingual" => "Omnilingual",
         "cohere" => "Cohere",
         "openvino" => "OpenVINO",
+        "seedasr" => "Seed-ASR",
         _ => "Engine",
     }
 }
@@ -2049,11 +2449,24 @@ mod tests {
 
     #[test]
     fn openvino_engine_exposes_device_configuration() {
-        let rows = rows_for_engine_with_mode("openvino", "local");
+        let rows = rows_for_engine_with_mode("openvino", "local", "api_key");
         assert!(rows.contains(&FieldId::OvModel));
         assert!(rows.contains(&FieldId::OvDevice));
         assert!(rows.contains(&FieldId::OvLanguage));
         assert!(rows.contains(&FieldId::OvOnDemandLoading));
+    }
+
+    #[test]
+    fn seedasr_engine_exposes_the_selected_credential_scheme() {
+        let api_rows = rows_for_engine_with_mode("seedasr", "local", "api_key");
+        assert!(api_rows.contains(&FieldId::SeedApiKey));
+        assert!(!api_rows.contains(&FieldId::SeedAppId));
+        assert!(api_rows.contains(&FieldId::SeedStreaming));
+
+        let legacy_rows = rows_for_engine_with_mode("seedasr", "local", "legacy");
+        assert!(!legacy_rows.contains(&FieldId::SeedApiKey));
+        assert!(legacy_rows.contains(&FieldId::SeedAppId));
+        assert!(legacy_rows.contains(&FieldId::SeedAccessToken));
     }
 
     #[test]

--- a/src/tui/hotkey.rs
+++ b/src/tui/hotkey.rs
@@ -488,7 +488,7 @@ fn guidance_enabled<'a>(state: &'a HotkeyState) -> Vec<Line<'a>> {
 
     // Streaming dictation requires toggle activation; if the user has it
     // enabled, suppress PTT-pair suggestions in favor of a toggle binding.
-    // Covers all streaming-capable backends (Parakeet, Soniox, future).
+    // Covers all native streaming backends.
     let streaming = {
         let ed = ConfigEditor::load().ok();
         let engine = ed
@@ -503,6 +503,10 @@ fn guidance_enabled<'a>(state: &'a HotkeyState) -> Vec<Line<'a>> {
             "soniox" => ed
                 .as_ref()
                 .and_then(|e| e.get_bool("soniox", "streaming"))
+                .unwrap_or(true),
+            "seedasr" => ed
+                .as_ref()
+                .and_then(|e| e.get_bool("seedasr", "streaming"))
                 .unwrap_or(true),
             _ => false,
         }

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -65,6 +65,7 @@ pub fn create_vad(config: &Config) -> Result<Option<Box<dyn VoiceActivityDetecto
                 | TranscriptionEngine::Omnilingual
                 | TranscriptionEngine::Cohere
                 | TranscriptionEngine::Soniox
+                | TranscriptionEngine::SeedAsr
                 | TranscriptionEngine::OpenVino => VadBackend::Energy,
             }
         }


### PR DESCRIPTION
## Description

This is a follow-up to #713. Thanks to @erning for the native Seed-ASR engine; I've been using it for Chinese dictation on Hyprland, and it has made a real difference to my setup.

With `type_partials = true`, a correction such as `这个云书法` → `这个语音输入法` can leave the first version on screen until the utterance becomes definite. The recognizer has already corrected itself, but the new hypothesis no longer extends the old one, so the reconciler suppresses it. A later correction to an already-definite prefix can end the session altogether.

This patch gives live mode a full-transcript `Snapshot` event. The output session compares each snapshot with the text it has rendered, keeps the common prefix, and replaces only the divergent suffix. Empty acknowledgement/final packets retain the last nonempty hypothesis. File output replaces its accumulated text without counting it as keyboard input.

The default stable-only mode is unchanged. Existing output hooks are retained; in live mode the post-processor runs once on the complete final transcript. A failed output transaction stops further rewrites rather than guessing what is left on screen.

**Dependency:** #713 is still open, so this branch contains its five commits unchanged. My patch is just [d30148b](https://github.com/sanxi33/voxtype/commit/d30148ba4d1d020cee8bee153a3a84ac9b886cc9), touching six files. This is a draft against `dev`, not a replacement for #713; the single commit can also be cherry-picked into that branch.

## Related issue

Fixes #756.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --release --offline --all-targets --no-deps -- -D warnings`
- Full release-profile test suite: 1,149 passed, 2 ignored, none failed.
- Added synthetic cases for provisional revisions, changed stability metadata, unchanged/empty finals, Unicode suffix edits, file-output bookkeeping, failed output, and final-only post-processing.

Checks ran on Linux x86_64. The release checks used four build jobs, LTO disabled, and 16 codegen units. No cloud credentials or recordings are required by the tests. I have not tested this patch on macOS.

## Scope

Manual dictation testing was on a broader local build, which also contains focus, audio-drain, and keyboard fixes. For this extracted patch, the reproducible coverage is the automated suite above.

I kept the stop behavior, compositor-specific caret probe, request tuning, and keyboard pacing out of this PR. #494 already addresses a related backspace-pacing problem. I'd like to discuss the focus and drain behavior separately before proposing changes to it here.

## Pre-merge checklist

- [x] Targets `dev`
- [x] Regression tests and Seed-ASR documentation updated
- [ ] Resolve dependency on #713
- [ ] Wait for `ci-success` before marking ready for review
